### PR TITLE
feat: add aurora-glass-nexus example

### DIFF
--- a/examples/aurora-glass-nexus/AGENTS.md
+++ b/examples/aurora-glass-nexus/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/aurora-glass-nexus/config.toml
+++ b/examples/aurora-glass-nexus/config.toml
@@ -1,0 +1,181 @@
+title = "Aurora Glass Nexus"
+description = "A deep space glassmorphism aesthetic with glowing neon aurora elements."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/aurora-glass-nexus/content/_index.md
+++ b/examples/aurora-glass-nexus/content/_index.md
@@ -1,0 +1,31 @@
++++
+title = "Welcome to the Nexus"
+description = "A convergence of ethereal light and synthetic glass."
+template = "page"
++++
+
+<div style="text-align: center; margin-bottom: 40px;">
+    <h2 style="font-size: 2.5rem; margin-bottom: 20px;">Explore the Unknown</h2>
+    <p style="font-size: 1.2rem; max-width: 700px; margin: 0 auto; color: var(--text-secondary);">
+        Welcome to Aurora Glass Nexus. A dimension where the organic beauty of polar lights meets the precision of synthetic frosted glass. Built with Hwaro, designed for the future.
+    </p>
+</div>
+
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-top: 40px;">
+    <div class="glass-panel" style="padding: 24px; text-align: center;">
+        <h3 style="color: var(--aurora-cyan); margin-top: 0;">Performant</h3>
+        <p>Built with Crystal, running at the speed of light.</p>
+    </div>
+    <div class="glass-panel" style="padding: 24px; text-align: center;">
+        <h3 style="color: var(--aurora-magenta); margin-top: 0;">Aesthetic</h3>
+        <p>A mesmerizing blend of neon gradients and glass UI.</p>
+    </div>
+    <div class="glass-panel" style="padding: 24px; text-align: center;">
+        <h3 style="color: var(--aurora-purple); margin-top: 0;">Extensible</h3>
+        <p>Create any layout imaginable with Crinja templates.</p>
+    </div>
+</div>
+
+<div style="text-align: center; margin-top: 60px;">
+    <a href="{{ base_url }}/posts/" style="display: inline-block; padding: 12px 30px; background: linear-gradient(45deg, var(--aurora-cyan), var(--aurora-purple)); color: white; border-radius: 30px; font-weight: bold; text-transform: uppercase; letter-spacing: 1px; transition: transform 0.3s ease; box-shadow: 0 4px 15px rgba(0, 240, 255, 0.3);">Read Transmissions</a>
+</div>

--- a/examples/aurora-glass-nexus/content/posts/_index.md
+++ b/examples/aurora-glass-nexus/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Transmissions"
+description = "Signals intercepted from the deep void."
+template = "section"
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/aurora-glass-nexus/content/posts/first-post.md
+++ b/examples/aurora-glass-nexus/content/posts/first-post.md
@@ -1,0 +1,23 @@
++++
+title = "Hello World: The First Signal"
+date = "2024-05-01"
+description = "Initiating contact sequence from the Aurora Glass Nexus."
+tags = ["contact", "nexus", "initialization"]
++++
+
+We are broadcasting live from the **Aurora Glass Nexus**. The signal strength is optimal, and the aesthetic constraints hold strong against the vacuum of the void.
+
+### The Phenomenon
+
+The *glassmorphism* aesthetic here isn't just for show. It acts as a visual filter, diffusing the intense cosmic rays of the surrounding nebula into a soft, palatable glow.
+
+```python
+def initiate_nexus_link():
+    status = "connected"
+    print(f"Aurora Link: {status}")
+    return True
+```
+
+As we continue to establish our presence, expect more transmissions detailing the intricate balance between organic fluid dynamics and rigid geometric structures.
+
+Stay tuned.

--- a/examples/aurora-glass-nexus/content/posts/second-post.md
+++ b/examples/aurora-glass-nexus/content/posts/second-post.md
@@ -1,0 +1,31 @@
++++
+title = "Designing the Synthetic Aurora"
+date = "2024-05-15"
+description = "A deep dive into the color science behind our ambient backgrounds."
+tags = ["design", "color-theory", "css"]
++++
+
+Creating an ambient background that doesn't distract from the core content requires a delicate balance of blur, opacity, and slow-moving animations.
+
+### The Palette
+
+Our primary colors consist of three vivid neon shades against a deep void background (`#03010a`):
+
+1. **Cyan** (`#00f0ff`): Represents clarity and technology.
+2. **Magenta** (`#ff0055`): Brings energy and contrast.
+3. **Deep Purple** (`#8a2be2`): Bridges the gap between the dark void and the vibrant neon.
+
+### Implementation
+
+We use heavy CSS filters to achieve this effect.
+
+```css
+.ambient-purple {
+    background: radial-gradient(circle, var(--aurora-purple) 0%, transparent 50%);
+    filter: blur(120px);
+    opacity: 0.4;
+    animation: drift-slow 25s infinite alternate ease-in-out;
+}
+```
+
+The result is a dynamic, living canvas that breathes life into the rigid glass panels resting above it.

--- a/examples/aurora-glass-nexus/templates/404.html
+++ b/examples/aurora-glass-nexus/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="glass-panel" style="text-align: center; padding: 60px 20px;">
+    <h1 style="font-size: 5rem; margin: 0; color: var(--aurora-magenta);">404</h1>
+    <h2 style="font-size: 2rem; margin-top: 10px;">Lost in the Void</h2>
+    <p style="color: var(--text-secondary); margin: 20px auto 40px; max-width: 500px;">The transmission you are looking for has been scattered to the cosmic winds. It either never existed, or has been intercepted.</p>
+    <a href="{{ base_url }}/" style="display: inline-block; padding: 12px 30px; background: linear-gradient(45deg, var(--aurora-cyan), var(--aurora-purple)); color: white; border-radius: 30px; font-weight: bold; text-transform: uppercase; letter-spacing: 1px;">Return to Nexus</a>
+</div>
+{% endblock %}

--- a/examples/aurora-glass-nexus/templates/base.html
+++ b/examples/aurora-glass-nexus/templates/base.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{{ page.description | default(value=site.description) }}">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;600;700&family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-deep: #03010a;
+            --aurora-cyan: #00f0ff;
+            --aurora-magenta: #ff0055;
+            --aurora-purple: #8a2be2;
+            --text-primary: #e0e0f0;
+            --text-secondary: #a0a0c0;
+            --glass-bg: rgba(255, 255, 255, 0.03);
+            --glass-border: rgba(255, 255, 255, 0.08);
+            --glass-highlight: rgba(255, 255, 255, 0.15);
+            --font-display: 'Space Grotesk', sans-serif;
+            --font-body: 'Inter', sans-serif;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: var(--bg-deep);
+            color: var(--text-primary);
+            font-family: var(--font-body);
+            line-height: 1.6;
+            min-height: 100vh;
+            overflow-x: hidden;
+            position: relative;
+        }
+
+        /* Ambient Aurora Background */
+        body::before, body::after {
+            content: '';
+            position: fixed;
+            width: 80vw;
+            height: 80vw;
+            border-radius: 50%;
+            filter: blur(100px);
+            z-index: -1;
+            opacity: 0.5;
+            animation: drift 20s infinite alternate ease-in-out;
+            pointer-events: none;
+        }
+
+        body::before {
+            top: -20vh;
+            left: -20vw;
+            background: radial-gradient(circle, var(--aurora-cyan) 0%, transparent 60%);
+        }
+
+        body::after {
+            bottom: -20vh;
+            right: -20vw;
+            background: radial-gradient(circle, var(--aurora-magenta) 0%, transparent 60%);
+            animation-delay: -10s;
+        }
+
+        .ambient-purple {
+            position: fixed;
+            top: 40vh;
+            left: 30vw;
+            width: 60vw;
+            height: 60vw;
+            border-radius: 50%;
+            background: radial-gradient(circle, var(--aurora-purple) 0%, transparent 50%);
+            filter: blur(120px);
+            z-index: -1;
+            opacity: 0.4;
+            animation: drift-slow 25s infinite alternate ease-in-out;
+            pointer-events: none;
+        }
+
+        @keyframes drift {
+            0% { transform: translate(0, 0) scale(1); }
+            100% { transform: translate(10vw, 5vh) scale(1.1); }
+        }
+
+        @keyframes drift-slow {
+            0% { transform: translate(0, 0) scale(1); }
+            100% { transform: translate(-5vw, -10vh) scale(1.2); }
+        }
+
+        /* Glassmorphism Classes */
+        .glass-panel {
+            background: var(--glass-bg);
+            backdrop-filter: blur(16px);
+            -webkit-backdrop-filter: blur(16px);
+            border: 1px solid var(--glass-border);
+            border-radius: 24px;
+            box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.4);
+        }
+
+        .glass-nav {
+            background: rgba(3, 1, 10, 0.5);
+            backdrop-filter: blur(24px);
+            -webkit-backdrop-filter: blur(24px);
+            border-bottom: 1px solid var(--glass-border);
+            position: fixed;
+            width: 100%;
+            top: 0;
+            z-index: 100;
+        }
+
+        /* Typography & Layout */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-display);
+            font-weight: 700;
+            margin-top: 0;
+            background: linear-gradient(to right, #fff, var(--text-secondary));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        a {
+            color: var(--aurora-cyan);
+            text-decoration: none;
+            transition: all 0.3s ease;
+        }
+
+        a:hover {
+            color: var(--aurora-magenta);
+            text-shadow: 0 0 10px rgba(255, 0, 85, 0.5);
+        }
+
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 24px;
+        }
+
+        header {
+            padding: 20px 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .site-title {
+            font-family: var(--font-display);
+            font-size: 1.5rem;
+            font-weight: 700;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            background: linear-gradient(45deg, var(--aurora-cyan), var(--aurora-purple));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        nav ul {
+            list-style: none;
+            display: flex;
+            gap: 30px;
+            margin: 0;
+            padding: 0;
+        }
+
+        nav a {
+            font-family: var(--font-display);
+            font-weight: 600;
+            text-transform: uppercase;
+            font-size: 0.9rem;
+            letter-spacing: 1px;
+            color: var(--text-primary);
+        }
+
+        nav a:hover {
+            color: var(--aurora-cyan);
+        }
+
+        main {
+            margin-top: 120px;
+            margin-bottom: 60px;
+            min-height: 60vh;
+        }
+
+        footer {
+            padding: 40px 0;
+            text-align: center;
+            border-top: 1px solid var(--glass-border);
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+            margin-top: auto;
+        }
+
+    </style>
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <div class="ambient-purple"></div>
+
+    <div class="glass-nav">
+        <div class="container">
+            <header>
+                <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+                <nav>
+                    <ul>
+                        <li><a href="{{ base_url }}/">Home</a></li>
+                        <li><a href="{{ base_url }}/posts/">Posts</a></li>
+
+                    </ul>
+                </nav>
+            </header>
+        </div>
+    </div>
+
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; {{ current_year }} {{ site.title }}. Built with Hwaro.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/aurora-glass-nexus/templates/page.html
+++ b/examples/aurora-glass-nexus/templates/page.html
@@ -1,0 +1,122 @@
+{% extends "base.html" %}
+
+{% block head %}
+<style>
+    .page-wrapper {
+        padding: 40px;
+        margin-top: 40px;
+    }
+
+    .page-header {
+        margin-bottom: 40px;
+        text-align: center;
+    }
+
+    .page-title {
+        font-size: 3rem;
+        margin-bottom: 10px;
+        background: linear-gradient(135deg, #fff, var(--aurora-cyan));
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+    }
+
+    .page-meta {
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+        display: flex;
+        justify-content: center;
+        gap: 20px;
+    }
+
+    .page-content {
+        font-size: 1.1rem;
+        line-height: 1.8;
+    }
+
+    .page-content p {
+        margin-bottom: 1.5em;
+    }
+
+    .page-content img {
+        max-width: 100%;
+        border-radius: 12px;
+        border: 1px solid var(--glass-border);
+    }
+
+    .page-content code {
+        background: rgba(0, 0, 0, 0.3);
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-family: monospace;
+        color: var(--aurora-cyan);
+    }
+
+    .page-content pre {
+        background: rgba(0, 0, 0, 0.4);
+        padding: 20px;
+        border-radius: 12px;
+        overflow-x: auto;
+        border: 1px solid var(--glass-border);
+    }
+
+    .page-content pre code {
+        background: transparent;
+        color: var(--text-primary);
+        padding: 0;
+    }
+
+    .page-tags {
+        margin-top: 40px;
+        padding-top: 20px;
+        border-top: 1px solid var(--glass-border);
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+    }
+
+    .tag {
+        background: rgba(0, 240, 255, 0.1);
+        border: 1px solid rgba(0, 240, 255, 0.2);
+        color: var(--aurora-cyan);
+        padding: 4px 12px;
+        border-radius: 20px;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+    }
+
+    .tag:hover {
+        background: rgba(255, 0, 85, 0.1);
+        border-color: rgba(255, 0, 85, 0.3);
+        color: var(--aurora-magenta);
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<article class="glass-panel page-wrapper">
+    <header class="page-header">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="page-meta">
+            <span>{{ page.date | date("%B %d, %Y") }}</span>
+            {% if page.reading_time %}
+            <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+        </div>
+        {% endif %}
+    </header>
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies is defined and page.taxonomies.tags is defined %}
+    <div class="page-tags">
+        {% for tag in page.taxonomies.tags %}
+        <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+{% endblock %}

--- a/examples/aurora-glass-nexus/templates/section.html
+++ b/examples/aurora-glass-nexus/templates/section.html
@@ -1,0 +1,128 @@
+{% extends "base.html" %}
+
+{% block head %}
+<style>
+    .section-header {
+        text-align: center;
+        margin: 60px 0;
+    }
+
+    .section-title {
+        font-size: 3.5rem;
+        background: linear-gradient(to right, var(--aurora-cyan), var(--aurora-magenta));
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        margin-bottom: 20px;
+    }
+
+    .section-description {
+        font-size: 1.2rem;
+        color: var(--text-secondary);
+        max-width: 600px;
+        margin: 0 auto;
+    }
+
+    .post-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 30px;
+        margin-bottom: 60px;
+    }
+
+    .post-card {
+        padding: 30px;
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        box-sizing: border-box;
+    }
+
+    .post-card:hover {
+        transform: translateY(-10px);
+        box-shadow: 0 15px 40px rgba(0, 240, 255, 0.2);
+        border-color: rgba(0, 240, 255, 0.4);
+    }
+
+    .post-date {
+        font-size: 0.8rem;
+        color: var(--aurora-cyan);
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        margin-bottom: 10px;
+    }
+
+    .post-title {
+        font-size: 1.5rem;
+        margin-bottom: 15px;
+        line-height: 1.3;
+    }
+
+    .post-title a {
+        color: var(--text-primary);
+        background: linear-gradient(to right, var(--text-primary), var(--text-primary));
+        background-size: 0% 2px;
+        background-repeat: no-repeat;
+        background-position: left bottom;
+        transition: background-size 0.3s ease;
+    }
+
+    .post-card:hover .post-title a {
+        background-size: 100% 2px;
+    }
+
+    .post-summary {
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+        flex-grow: 1;
+        margin-bottom: 20px;
+    }
+
+    .read-more {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        color: var(--aurora-magenta);
+    }
+
+    .read-more::after {
+        content: '→';
+        transition: transform 0.3s ease;
+    }
+
+    .post-card:hover .read-more::after {
+        transform: translateX(5px);
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="section-header">
+    <h1 class="section-title">{{ section.title }}</h1>
+    {% if section.description %}
+    <p class="section-description">{{ section.description }}</p>
+    {% endif %}
+</div>
+
+<div class="post-grid">
+    {% for post in section.pages %}
+    <article class="glass-panel post-card">
+        {% if post.date %}
+        <div class="post-date">{{ post.date | date("%B %d, %Y") }}</div>
+        {% endif %}
+        <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <div class="post-summary">
+            {% if post.summary %}
+                {{ post.summary | strip_html | safe }}
+            {% else %}
+                {{ post.description | default(value="A transmission from the nexus.") }}
+            {% endif %}
+        </div>
+        <a href="{{ post.url }}" class="read-more">Read Transmission</a>
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/examples/aurora-glass-nexus/templates/shortcodes/alert.html
+++ b/examples/aurora-glass-nexus/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/aurora-glass-nexus/templates/taxonomy.html
+++ b/examples/aurora-glass-nexus/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="glass-panel" style="padding: 40px;">
+    <h1 class="page-title" style="text-align: center; margin-bottom: 40px; background: linear-gradient(135deg, #fff, var(--aurora-cyan)); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">{{ taxonomy_name | capitalize }}</h1>
+    <div style="display: flex; flex-wrap: wrap; gap: 15px; justify-content: center;">
+        {% if taxonomy_terms is defined %}
+        {% for term in taxonomy_terms %}
+        <a href="{{ term.url }}" class="tag" style="background: rgba(0, 240, 255, 0.1); border: 1px solid rgba(0, 240, 255, 0.2); color: var(--aurora-cyan); padding: 8px 20px; border-radius: 30px; font-size: 1rem; text-transform: uppercase; letter-spacing: 1px;">{{ term.name }} ({{ term.pages | length }})</a>
+        {% endfor %}
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/examples/aurora-glass-nexus/templates/taxonomy_term.html
+++ b/examples/aurora-glass-nexus/templates/taxonomy_term.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block head %}
+<style>
+    .post-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 30px;
+        margin-top: 40px;
+    }
+    .post-card {
+        padding: 30px;
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        box-sizing: border-box;
+    }
+    .post-card:hover {
+        transform: translateY(-10px);
+        box-shadow: 0 15px 40px rgba(0, 240, 255, 0.2);
+        border-color: rgba(0, 240, 255, 0.4);
+    }
+    .post-title {
+        font-size: 1.5rem;
+        margin-bottom: 15px;
+        line-height: 1.3;
+    }
+    .post-title a {
+        color: var(--text-primary);
+        background: linear-gradient(to right, var(--text-primary), var(--text-primary));
+        background-size: 0% 2px;
+        background-repeat: no-repeat;
+        background-position: left bottom;
+        transition: background-size 0.3s ease;
+    }
+    .post-card:hover .post-title a {
+        background-size: 100% 2px;
+    }
+</style>
+{% endblock %}
+{% block content %}
+<div style="text-align: center; margin: 40px 0;">
+    <h1 style="font-size: 2.5rem; margin-bottom: 10px;">{{ taxonomy_name | capitalize }}: <span style="color: var(--aurora-cyan);">{{ taxonomy_term.name }}</span></h1>
+</div>
+<div class="post-grid">
+    {% if taxonomy_pages is defined %}
+    {% for post in taxonomy_pages %}
+    <article class="glass-panel post-card">
+        <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+    </article>
+    {% endfor %}
+    {% endif %}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -7264,5 +7264,11 @@
     "diy",
     "raw",
     "unconventional"
+  ],
+  "aurora-glass-nexus": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "glassmorphism"
   ]
 }


### PR DESCRIPTION
This PR adds a new Hwaro example site called `aurora-glass-nexus`. It showcases a dark-themed glassmorphism aesthetic with glowing animated aurora gradients and frosted glass panels.

Key features:
- Dark void background (#03010a) with animated ambient glows (cyan, magenta, purple)
- Frosted glass UI elements using `backdrop-filter`
- Google Fonts: Space Grotesk and Inter
- Complete set of overridden templates (`base`, `page`, `section`, `taxonomy`, `taxonomy_term`, `404`)
- Registered in `tags.json` under `dark`, `blog`, `cyberpunk`, and `glassmorphism` tags.

---
*PR created automatically by Jules for task [1126882887513397577](https://jules.google.com/task/1126882887513397577) started by @hahwul*