### PR TITLE
feat: add 10 neumorphic and bloom themed examples (#1021, #1022, #1023, #1025, #1026, #1027, #1028, #1029, #1031, #1032)

### DIFF
--- a/examples/clay-ui/AGENTS.md
+++ b/examples/clay-ui/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/clay-ui/config.toml
+++ b/examples/clay-ui/config.toml
@@ -1,0 +1,8 @@
+title = "CLAY-UI"
+description = "A molded, high-depth design focused on material honesty and form."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/clay-ui/content/about.md
+++ b/examples/clay-ui/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/clay-ui/content/index.md
+++ b/examples/clay-ui/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "The Form"
++++
+
+<div class="clay-hero">
+    <h1>MOLDED.</h1>
+</div>
+
+<article>
+
+## Material Honesty
+
+Clay-UI is about the tactile nature of structural innovation. We believe that design should feel like it was molded by hand. By focusing on high-depth shadows and highlights that mimic the look of soft clay, we create a design that feels both organic and deeply substantial. Our focus is on the form and the integrity of the material.
+
+### Molded Innovation
+
+- **Form**: The clear definition of shape through light and shadow.
+- **Depth**: A design that feels three-dimensional and tactile.
+- **Honesty**: A commitment to the essential nature of the material.
+
+<div class="spec-item">REF: CLAY_v1.0 // MATERIAL: ESSENTIAL_FORM // STATUS: VERIFIED</div>
+
+---
+
+> "To mold is to find the soul of the material."
+</article>

--- a/examples/clay-ui/templates/404.html
+++ b/examples/clay-ui/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/clay-ui/templates/footer.html
+++ b/examples/clay-ui/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 2px;">
+        <div class="container">
+            &copy; 2026 CLAY-UI. MOLDED IN DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/clay-ui/templates/header.html
+++ b/examples/clay-ui/templates/header.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;700&family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #d9d9d9;
+            --text: #4a4a4a;
+            --accent: #666;
+            --shadow: rgba(0,0,0,0.1);
+            --highlight: rgba(255,255,255,0.4);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.5rem;
+            letter-spacing: 5px;
+            text-transform: uppercase;
+            color: var(--accent);
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            opacity: 0.6;
+        }
+        .clay-hero {
+            padding: 80px 0;
+            background: var(--bg);
+            border-radius: 40px;
+            text-align: center;
+            margin-bottom: 60px;
+            box-shadow: 20px 20px 60px var(--shadow), -20px -20px 60px var(--highlight);
+        }
+        .clay-hero h1 {
+            font-size: 4rem;
+            font-weight: 300;
+            margin: 0;
+        }
+        article {
+            background: var(--bg);
+            padding: 60px;
+            border-radius: 30px;
+            box-shadow: inset 10px 10px 30px var(--shadow), inset -10px -10px 30px var(--highlight);
+        }
+        h2 { font-weight: 700; font-size: 2rem; color: var(--accent); margin-top: 0; }
+        .spec-item { font-family: 'IBM Plex Mono', monospace; font-size: 0.75rem; color: #888; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">clay.ui</div>
+            <nav>
+                <a href="/">Molded</a>
+                <a href="/about">Form</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/clay-ui/templates/page.html
+++ b/examples/clay-ui/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/clay-ui/templates/section.html
+++ b/examples/clay-ui/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/clay-ui/templates/shortcodes/alert.html
+++ b/examples/clay-ui/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/clay-ui/templates/taxonomy.html
+++ b/examples/clay-ui/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/clay-ui/templates/taxonomy_term.html
+++ b/examples/clay-ui/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/emboss-light/AGENTS.md
+++ b/examples/emboss-light/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/emboss-light/config.toml
+++ b/examples/emboss-light/config.toml
@@ -1,0 +1,8 @@
+title = "EMBOSS-LIGHT"
+description = "A light, embossed design focused on relief and subtle shadows."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/emboss-light/content/about.md
+++ b/examples/emboss-light/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/emboss-light/content/index.md
+++ b/examples/emboss-light/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "The Relief"
++++
+
+<div class="emboss-hero">
+    <h1>RAISED.</h1>
+</div>
+
+<article>
+
+<span class="data-meta">SPEC: RELIEF_v1.0 // STATUS: VERIFIED</span>
+
+## Subtle Relief
+
+Emboss-Light is an exploration of the tactile nature of structural innovation. We believe that clarity can be achieved through subtle, light-based relief. By focusing on embossed shadows and highlights that mimic the look of raised paper, we create a design that feels both organic and deeply refined. Our focus is on the interplay of light and the integrity of the embossed form.
+
+### Relief Innovation
+
+- **Relief**: The clear definition of shape through subtle highlights.
+- **Translucency**: Using light to define the boundaries of the raised areas.
+- **Integrity**: A commitment to the structural honesty of the light form.
+
+---
+
+> "The most important innovations are the ones that stand out just enough."
+</article>

--- a/examples/emboss-light/templates/404.html
+++ b/examples/emboss-light/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/emboss-light/templates/footer.html
+++ b/examples/emboss-light/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 60px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 2px;">
+        <div class="container">
+            &copy; 2026 EMBOSS-LIGHT. RAISED IN DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/emboss-light/templates/header.html
+++ b/examples/emboss-light/templates/header.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #f0f0f0;
+            --text: #444;
+            --accent: #888;
+            --shadow: rgba(0,0,0,0.1);
+            --highlight: rgba(255,255,255,0.7);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.5rem;
+            letter-spacing: 5px;
+            text-transform: uppercase;
+            color: var(--text);
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            opacity: 0.6;
+        }
+        .emboss-hero {
+            padding: 80px 0;
+            background: var(--bg);
+            border-radius: 40px;
+            text-align: center;
+            margin-bottom: 60px;
+            box-shadow: 10px 10px 30px var(--shadow), -10px -10px 30px var(--highlight);
+        }
+        .emboss-hero h1 {
+            font-size: 4rem;
+            font-weight: 300;
+            margin: 0;
+        }
+        article {
+            background: var(--bg);
+            padding: 60px;
+            border-radius: 30px;
+            box-shadow: inset 5px 5px 15px var(--shadow), inset -5px -5px 15px var(--highlight);
+        }
+        h2 { font-weight: 700; font-size: 2rem; color: var(--text); margin-top: 0; }
+        .data-meta { font-family: 'IBM Plex Mono', monospace; font-size: 0.7rem; color: #999; margin-bottom: 20px; display: block; text-transform: uppercase; letter-spacing: 2px; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">emboss.light</div>
+            <nav>
+                <a href="/">Relief</a>
+                <a href="/about">Shadow</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/emboss-light/templates/page.html
+++ b/examples/emboss-light/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/emboss-light/templates/section.html
+++ b/examples/emboss-light/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/emboss-light/templates/shortcodes/alert.html
+++ b/examples/emboss-light/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/emboss-light/templates/taxonomy.html
+++ b/examples/emboss-light/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/emboss-light/templates/taxonomy_term.html
+++ b/examples/emboss-light/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/glass-bloom/AGENTS.md
+++ b/examples/glass-bloom/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/glass-bloom/config.toml
+++ b/examples/glass-bloom/config.toml
@@ -1,0 +1,8 @@
+title = "GLASS-BLOOM"
+description = "A fresh, petal-inspired glassmorphic design for organic and curated content."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/glass-bloom/content/about.md
+++ b/examples/glass-bloom/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/glass-bloom/content/index.md
+++ b/examples/glass-bloom/content/index.md
@@ -1,0 +1,24 @@
++++
+title = "The Bloom"
++++
+
+<div class="bloom-hero">
+    <h1>softly.</h1>
+</div>
+
+<article>
+
+## Organic Translucency
+
+Glass-Bloom is about the delicate expansion of innovation. We believe that ideas should be allowed to open and unfold like the petals of a flower. By using light, pink-tinted translucent elements and organic, rounded forms, we create a design that feels both protective and deeply celebratory.
+
+### Petal Innovation
+
+- **Softness**: Rounded forms and light colors that reduce visual stress.
+- **Translucency**: Using light to define the layers of the unfolding work.
+- **Growth**: A design that reflects the natural evolution of the core idea.
+
+---
+
+> "In the glass bloom, every petal is a facet of the whole."
+</article>

--- a/examples/glass-bloom/templates/404.html
+++ b/examples/glass-bloom/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/glass-bloom/templates/footer.html
+++ b/examples/glass-bloom/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer style="padding: 60px 0; text-align: center; font-size: 0.8rem; opacity: 0.4; letter-spacing: 2px; text-transform: uppercase;">
+        <div class="container">
+            &copy; 2026 GLASS-BLOOM. BLOOMING IN LIGHT.
+        </div>
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/glass-bloom/templates/header.html
+++ b/examples/glass-bloom/templates/header.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=Fraunces:ital,wght@0,300;1,300&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fdfafb;
+            --text: #4a3a3d;
+            --accent: #ff8fa3;
+            --glass: rgba(255, 255, 255, 0.5);
+        }
+        body {
+            background-color: var(--bg);
+            background-image: 
+                radial-gradient(at 0% 0%, rgba(255, 143, 163, 0.1) 0, transparent 50%), 
+                radial-gradient(at 100% 100%, rgba(255, 143, 163, 0.1) 0, transparent 50%);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 40px 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: lowercase;
+            letter-spacing: 2px;
+            color: var(--accent);
+        }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin-left: 30px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 700;
+            opacity: 0.6;
+        }
+        .bloom-hero {
+            padding: 100px 0;
+            text-align: center;
+        }
+        .bloom-hero h1 {
+            font-family: 'Fraunces', serif;
+            font-size: 5rem;
+            font-weight: 300;
+            margin: 0;
+            font-style: italic;
+            letter-spacing: -2px;
+            color: var(--accent);
+        }
+        article {
+            background: var(--glass);
+            backdrop-filter: blur(10px);
+            padding: 60px;
+            border-radius: 40px;
+            border: 1px solid rgba(255, 255, 255, 0.6);
+            box-shadow: 0 20px 50px rgba(255, 143, 163, 0.05);
+            margin-bottom: 80px;
+        }
+        h2 { font-family: 'Fraunces', serif; font-size: 2.5rem; color: var(--accent); font-style: italic; margin-top: 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header>
+        <div class="logo">glass.bloom</div>
+        <nav>
+            <a href="/">Petal</a>
+            <a href="/about">Growth</a>
+        </nav>
+    </header>

--- a/examples/glass-bloom/templates/page.html
+++ b/examples/glass-bloom/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main>
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/glass-bloom/templates/section.html
+++ b/examples/glass-bloom/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/glass-bloom/templates/shortcodes/alert.html
+++ b/examples/glass-bloom/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/glass-bloom/templates/taxonomy.html
+++ b/examples/glass-bloom/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/glass-bloom/templates/taxonomy_term.html
+++ b/examples/glass-bloom/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/indent-ui/AGENTS.md
+++ b/examples/indent-ui/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/indent-ui/config.toml
+++ b/examples/indent-ui/config.toml
@@ -1,0 +1,8 @@
+title = "INDENT-UI"
+description = "A recessed, high-depth design focused on structural hierarchy and form."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/indent-ui/content/about.md
+++ b/examples/indent-ui/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/indent-ui/content/index.md
+++ b/examples/indent-ui/content/index.md
@@ -1,0 +1,24 @@
++++
+title = "The Recess"
++++
+
+<div class="indent-hero">
+    <h1>RECESSED.</h1>
+</div>
+
+<article>
+
+## Structural Hierarchy
+
+Indent-UI is about the tactile nature of structural innovation through recession. We believe that innovation can be defined by the depth of the field. By focusing on high-depth, recessed shadows and highlights that mimic the look of indented material, we create a design that feels both organic and deeply substantial.
+
+### Recessed Innovation
+
+- **Recession**: The clear definition of shape through internal shadows.
+- **Depth**: A design that feels like it has been pressed into the page.
+- **Hierarchy**: Using depth to define the importance of different content areas.
+
+---
+
+> "To indent is to make a permanent mark in the structure of the world."
+</article>

--- a/examples/indent-ui/templates/404.html
+++ b/examples/indent-ui/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/indent-ui/templates/footer.html
+++ b/examples/indent-ui/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 2px;">
+        <div class="container">
+            &copy; 2026 INDENT-UI. RECESSED IN DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/indent-ui/templates/header.html
+++ b/examples/indent-ui/templates/header.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #f8f9fa;
+            --text: #333;
+            --accent: #4a5568;
+            --shadow: rgba(0,0,0,0.05);
+            --highlight: rgba(255,255,255,0.8);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.5rem;
+            letter-spacing: 5px;
+            text-transform: uppercase;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            opacity: 0.6;
+        }
+        .indent-hero {
+            padding: 80px 0;
+            background: var(--bg);
+            border-radius: 40px;
+            text-align: center;
+            margin-bottom: 60px;
+            box-shadow: inset 10px 10px 30px var(--shadow), inset -10px -10px 30px var(--highlight);
+        }
+        .indent-hero h1 {
+            font-size: 4rem;
+            font-weight: 300;
+            margin: 0;
+        }
+        article {
+            background: var(--bg);
+            padding: 60px;
+            border-radius: 30px;
+            box-shadow: 10px 10px 30px var(--shadow), -10px -10px 30px var(--highlight);
+        }
+        h2 { font-weight: 600; font-size: 2rem; color: var(--accent); margin-top: 0; }
+        .meta-tag { font-family: 'IBM Plex Mono', monospace; font-size: 0.7rem; color: #adb5bd; border: 1px solid #ddd; padding: 2px 10px; border-radius: 50px; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">indent.ui</div>
+            <nav>
+                <a href="/">Recess</a>
+                <a href="/about">Depth</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/indent-ui/templates/page.html
+++ b/examples/indent-ui/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/indent-ui/templates/section.html
+++ b/examples/indent-ui/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/indent-ui/templates/shortcodes/alert.html
+++ b/examples/indent-ui/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/indent-ui/templates/taxonomy.html
+++ b/examples/indent-ui/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/indent-ui/templates/taxonomy_term.html
+++ b/examples/indent-ui/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-dashboard/AGENTS.md
+++ b/examples/neu-dashboard/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/neu-dashboard/config.toml
+++ b/examples/neu-dashboard/config.toml
@@ -1,0 +1,8 @@
+title = "NEU-DASHBOARD"
+description = "A comprehensive, neumorphic dashboard design for data-heavy content."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/neu-dashboard/content/about.md
+++ b/examples/neu-dashboard/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/neu-dashboard/content/index.md
+++ b/examples/neu-dashboard/content/index.md
@@ -1,0 +1,39 @@
++++
+title = "The Metrics"
++++
+
+<div class="dashboard-grid">
+    <div class="card">
+        <span>INNOVATION</span>
+        <b>92.4%</b>
+    </div>
+    <div class="card">
+        <span>EFFICIENCY</span>
+        <b>88.1%</b>
+    </div>
+    <div class="card">
+        <span>STABILITY</span>
+        <b>99.9%</b>
+    </div>
+    <div class="card">
+        <span>IMPACT</span>
+        <b>HIGH</b>
+    </div>
+</div>
+
+<article>
+
+## Neumorphic Data Analysis
+
+Neu-Dashboard is about the tactile presentation of complex metrics. We believe that data analysis should be as intuitive and comfortable as possible. By focusing on neumorphic-inspired shadows and highlights and a clean, structured layout, we create a dashboard that feels both modern and deeply functional. Our focus is on the clarity of the metrics and the integrity of the data structure.
+
+### Metrics Innovation
+
+- **Tactility**: A design that feels three-dimensional and responsive.
+- **Clarity**: High-contrast typography that ensures data is easy to scan.
+- **Structure**: A logical organization of metrics within the dashboard grid.
+
+---
+
+> "The most important metrics are the ones that lead to clear action."
+</article>

--- a/examples/neu-dashboard/templates/404.html
+++ b/examples/neu-dashboard/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-dashboard/templates/footer.html
+++ b/examples/neu-dashboard/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer style="padding: 60px 0; text-align: center; font-size: 0.8rem; opacity: 0.3; letter-spacing: 2px;">
+        <div class="container">
+            &copy; 2026 NEU-DASHBOARD. METRICS IN DEPTH.
+        </div>
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/neu-dashboard/templates/header.html
+++ b/examples/neu-dashboard/templates/header.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;700&family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #f0f2f5;
+            --text: #4a5568;
+            --accent: #2d3748;
+            --shadow: rgba(0,0,0,0.1);
+            --highlight: rgba(255,255,255,0.7);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 40px 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            color: var(--accent);
+        }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin-left: 30px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 700;
+            opacity: 0.6;
+        }
+        .dashboard-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 20px;
+            margin-top: 40px;
+        }
+        .card {
+            background: var(--bg);
+            padding: 30px;
+            border-radius: 20px;
+            box-shadow: 10px 10px 30px var(--shadow), -10px -10px 30px var(--highlight);
+            text-align: center;
+        }
+        .card span { font-family: 'IBM Plex Mono', monospace; font-size: 0.7rem; color: #a0aec0; display: block; margin-bottom: 10px; }
+        .card b { font-size: 1.5rem; color: var(--accent); }
+        article {
+            background: var(--bg);
+            padding: 60px;
+            border-radius: 30px;
+            box-shadow: 15px 15px 40px var(--shadow), -15px -15px 40px var(--highlight);
+            margin-top: 60px;
+            margin-bottom: 100px;
+        }
+        h2 { font-weight: 700; font-size: 2.2rem; color: var(--accent); margin-top: 0; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">neu.dashboard</div>
+            <nav>
+                <a href="/">Metrics</a>
+                <a href="/about">Analysis</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/neu-dashboard/templates/page.html
+++ b/examples/neu-dashboard/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/neu-dashboard/templates/section.html
+++ b/examples/neu-dashboard/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-dashboard/templates/shortcodes/alert.html
+++ b/examples/neu-dashboard/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/neu-dashboard/templates/taxonomy.html
+++ b/examples/neu-dashboard/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-dashboard/templates/taxonomy_term.html
+++ b/examples/neu-dashboard/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-folio/AGENTS.md
+++ b/examples/neu-folio/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/neu-folio/config.toml
+++ b/examples/neu-folio/config.toml
@@ -1,0 +1,8 @@
+title = "NEU-FOLIO"
+description = "A creative, neumorphic portfolio design for high-depth visual work."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/neu-folio/content/about.md
+++ b/examples/neu-folio/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/neu-folio/content/index.md
+++ b/examples/neu-folio/content/index.md
@@ -1,0 +1,30 @@
++++
+title = "The Portfolio"
++++
+
+<div class="folio-hero">
+    <h1>crafted.</h1>
+</div>
+
+<div class="folio-grid">
+    <div class="folio-item">PROJECT_01</div>
+    <div class="folio-item">PROJECT_02</div>
+    <div class="folio-item">PROJECT_03</div>
+</div>
+
+<article>
+
+## High-Depth Presentation
+
+Neu-Folio is about the tactile display of creative innovation. We believe that visual work deserves a presentation that reflects its depth and complexity. By focusing on neumorphic-inspired soft shadows and highlights, we create a design that feels both modern and deeply substantial. Our focus is on the clarity of the work and the integrity of the portfolio structure.
+
+### Curated Innovation
+
+- **Tactility**: A design that feels three-dimensional and responsive to the user.
+- **Depth**: Using subtle shadows to define the boundaries of the creative space.
+- **Presence**: A clear, authoritative layout that anchors the collection.
+
+---
+
+> "In the portfolio, the work is refined until only the brilliance remains."
+</article>

--- a/examples/neu-folio/templates/404.html
+++ b/examples/neu-folio/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-folio/templates/footer.html
+++ b/examples/neu-folio/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer style="padding: 60px 0; text-align: center; font-size: 0.8rem; opacity: 0.3; letter-spacing: 5px;">
+        <div class="container">
+            &copy; 2026 NEU-FOLIO. CRAFTED WITH DEPTH.
+        </div>
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/neu-folio/templates/header.html
+++ b/examples/neu-folio/templates/header.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #f0f0f0;
+            --text: #1a1a1a;
+            --accent: #555;
+            --shadow: rgba(0,0,0,0.1);
+            --highlight: rgba(255,255,255,0.7);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 40px 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin-left: 30px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            opacity: 0.6;
+        }
+        .folio-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 30px;
+            margin-top: 40px;
+        }
+        .folio-item {
+            background: var(--bg);
+            aspect-ratio: 1;
+            border-radius: 20px;
+            box-shadow: 10px 10px 30px var(--shadow), -10px -10px 30px var(--highlight);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            color: #888;
+        }
+        .folio-hero {
+            padding: 80px 0;
+            text-align: center;
+        }
+        .folio-hero h1 {
+            font-size: 5rem;
+            font-weight: 300;
+            margin: 0;
+            letter-spacing: -2px;
+        }
+        article {
+            background: var(--bg);
+            padding: 60px;
+            border-radius: 4px;
+            box-shadow: inset 10px 10px 30px var(--shadow), inset -10px -10px 30px var(--highlight);
+            margin-top: 60px;
+            margin-bottom: 100px;
+        }
+        h2 { font-weight: 600; font-size: 2.2rem; margin-top: 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header>
+        <div class="logo">neu.folio</div>
+        <nav>
+            <a href="/">Works</a>
+            <a href="/about">Process</a>
+        </nav>
+    </header>

--- a/examples/neu-folio/templates/page.html
+++ b/examples/neu-folio/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main>
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/neu-folio/templates/section.html
+++ b/examples/neu-folio/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-folio/templates/shortcodes/alert.html
+++ b/examples/neu-folio/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/neu-folio/templates/taxonomy.html
+++ b/examples/neu-folio/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-folio/templates/taxonomy_term.html
+++ b/examples/neu-folio/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-mono/AGENTS.md
+++ b/examples/neu-mono/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/neu-mono/config.toml
+++ b/examples/neu-mono/config.toml
@@ -1,0 +1,8 @@
+title = "NEU-MONO"
+description = "A monospaced, neumorphic design for technical and structured content."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/neu-mono/content/about.md
+++ b/examples/neu-mono/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/neu-mono/content/index.md
+++ b/examples/neu-mono/content/index.md
@@ -1,0 +1,30 @@
++++
+title = "The System"
++++
+
+<div class="mono-hero">
+    <h1>MONO.</h1>
+</div>
+
+<article>
+
+## Monospaced Tactility
+
+Neu-Mono is about the technical and structured nature of innovation in a tactile environment. We believe that clarity is achieved through the precise alignment of elements. By focusing on monospaced typography and neumorphic-inspired soft shadows, we create a design that feels both utilitarian and deeply sophisticated. Our focus is on the integrity of the code and the way it is presented.
+
+<div class="code-block">
+    // INITIALIZING_SYSTEM_v1.0<br>
+    STATUS: [OPTIMIZED]<br>
+    FOCUS: [CLARITY]
+</div>
+
+### Technical Innovation
+
+- **Precision**: Every character carries equal weight and space.
+- **Depth**: Using subtle shadows to define the boundaries of the technical space.
+- **Structure**: A logical, grid-based arrangement of information.
+
+---
+
+> "In the monospaced world, every detail is visible."
+</article>

--- a/examples/neu-mono/templates/404.html
+++ b/examples/neu-mono/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-mono/templates/footer.html
+++ b/examples/neu-mono/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer style="padding: 60px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; letter-spacing: 5px;">
+        <div class="container">
+            &copy; 2026 NEU-MONO. MONOSPACED DEPTH.
+        </div>
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/neu-mono/templates/header.html
+++ b/examples/neu-mono/templates/header.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #eee;
+            --text: #555;
+            --accent: #000;
+            --shadow: rgba(0,0,0,0.1);
+            --highlight: rgba(255,255,255,0.7);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'IBM Plex Mono', monospace;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+            color: var(--accent);
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+        }
+        .mono-hero {
+            padding: 100px 0;
+            background: var(--bg);
+            border-radius: 4px;
+            text-align: center;
+            margin-bottom: 60px;
+            box-shadow: 10px 10px 30px var(--shadow), -10px -10px 30px var(--highlight);
+        }
+        .mono-hero h1 {
+            font-size: 4rem;
+            font-weight: 700;
+            margin: 0;
+            color: var(--accent);
+        }
+        article {
+            background: var(--bg);
+            padding: 60px;
+            border-radius: 4px;
+            box-shadow: inset 5px 5px 15px var(--shadow), inset -5px -5px 15px var(--highlight);
+        }
+        h2 { font-weight: 700; font-size: 1.5rem; color: var(--accent); text-transform: uppercase; margin-top: 0; }
+        .code-block {
+            background: var(--bg);
+            padding: 20px;
+            box-shadow: 2px 2px 5px var(--shadow), -2px -2px 5px var(--highlight);
+            margin-top: 20px;
+            font-size: 0.8rem;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">neu.mono</div>
+            <nav>
+                <a href="/">Static</a>
+                <a href="/about">Code</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/neu-mono/templates/page.html
+++ b/examples/neu-mono/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/neu-mono/templates/section.html
+++ b/examples/neu-mono/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-mono/templates/shortcodes/alert.html
+++ b/examples/neu-mono/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/neu-mono/templates/taxonomy.html
+++ b/examples/neu-mono/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-mono/templates/taxonomy_term.html
+++ b/examples/neu-mono/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-reader/AGENTS.md
+++ b/examples/neu-reader/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/neu-reader/config.toml
+++ b/examples/neu-reader/config.toml
@@ -1,0 +1,8 @@
+title = "NEU-READER"
+description = "A minimalist, neumorphic design optimized for long-form reading and prose."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/neu-reader/content/about.md
+++ b/examples/neu-reader/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/neu-reader/content/index.md
+++ b/examples/neu-reader/content/index.md
@@ -1,0 +1,24 @@
++++
+title = "The Prose"
++++
+
+<div class="reader-hero">
+    <h1>readable.</h1>
+</div>
+
+<article>
+
+## The Power of the Word
+
+Neu-Reader is about the relationship between the reader and the text in a tactile environment. We believe that long-form reading should be as comfortable and engaging as possible. By focusing on neumorphic-inspired soft shadows and elegant serif typography, we create an environment where the prose itself is the primary focus.
+
+### Tactile Innovation
+
+- **Comfort**: A design that respects the reader's time and reduces visual strain.
+- **Presence**: Using subtle depth to define the field of information.
+- **Clarity**: High-legibility typography that priorities the natural flow of reading.
+
+---
+
+> "To read is to find the soul of the innovation."
+</article>

--- a/examples/neu-reader/templates/404.html
+++ b/examples/neu-reader/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-reader/templates/footer.html
+++ b/examples/neu-reader/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 60px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 5px;">
+        <div class="container">
+            &copy; 2026 NEU-READER. READABLE TACTILITY.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/neu-reader/templates/header.html
+++ b/examples/neu-reader/templates/header.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=Fraunces:ital,wght@0,400;1,400&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #f5f6f8;
+            --text: #334155;
+            --accent: #4a5568;
+            --shadow: rgba(0,0,0,0.1);
+            --highlight: rgba(255,255,255,0.7);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.8;
+        }
+        .container {
+            max-width: 700px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-family: 'Fraunces', serif;
+            font-weight: 700;
+            font-size: 1.5rem;
+            text-transform: lowercase;
+            letter-spacing: 5px;
+            color: var(--accent);
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            opacity: 0.6;
+        }
+        .reader-hero {
+            padding: 80px 0;
+            background: var(--bg);
+            border-radius: 40px;
+            text-align: center;
+            margin-bottom: 60px;
+            box-shadow: 10px 10px 30px var(--shadow), -10px -10px 30px var(--highlight);
+        }
+        .reader-hero h1 {
+            font-family: 'Fraunces', serif;
+            font-size: 4rem;
+            font-weight: 400;
+            font-style: italic;
+            margin: 0;
+        }
+        article {
+            background: var(--bg);
+            padding: 60px;
+            border-radius: 30px;
+            box-shadow: inset 5px 5px 15px var(--shadow), inset -5px -5px 15px var(--highlight);
+            font-size: 1.2rem;
+        }
+        h2 { font-family: 'Fraunces', serif; font-weight: 700; font-size: 2rem; color: var(--accent); margin-top: 0; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">neu.reader</div>
+            <nav>
+                <a href="/">Prose</a>
+                <a href="/about">Focus</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/neu-reader/templates/page.html
+++ b/examples/neu-reader/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/neu-reader/templates/section.html
+++ b/examples/neu-reader/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-reader/templates/shortcodes/alert.html
+++ b/examples/neu-reader/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/neu-reader/templates/taxonomy.html
+++ b/examples/neu-reader/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/neu-reader/templates/taxonomy_term.html
+++ b/examples/neu-reader/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/soft-press/AGENTS.md
+++ b/examples/soft-press/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/soft-press/config.toml
+++ b/examples/soft-press/config.toml
@@ -1,0 +1,8 @@
+title = "SOFT-PRESS"
+description = "A tactile, neumorphic-inspired design for soft and welcoming content."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/soft-press/content/about.md
+++ b/examples/soft-press/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/soft-press/content/index.md
+++ b/examples/soft-press/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "The Surface"
++++
+
+<div class="press-hero">
+    <h1>WELCOMING.</h1>
+</div>
+
+<article>
+
+<span class="metadata">PROCEDURE_LOG: SOFT_v1.0</span>
+
+## Tactile Innovation
+
+Soft-Press is about the physical sensation of the digital environment. We believe that innovation doesn't need to be sharp or high-tension to be effective. By focusing on neumorphic-inspired soft shadows and a light, welcoming palette, we create a design that feels both comforting and deeply sophisticated.
+
+### The Soft Approach
+
+- **Comfort**: A design that welcomes the user and reduces visual strain.
+- **Presence**: Using subtle depth to define the boundaries of the content.
+- **Integrity**: A commitment to the structural honesty of the soft form.
+
+---
+
+> "The most important innovations are the ones that make us feel at ease."
+</article>

--- a/examples/soft-press/templates/404.html
+++ b/examples/soft-press/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/soft-press/templates/footer.html
+++ b/examples/soft-press/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 2px;">
+        <div class="container">
+            &copy; 2026 SOFT-PRESS. TACTILE INNOVATION.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/soft-press/templates/header.html
+++ b/examples/soft-press/templates/header.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #f8f9fa;
+            --text: #343a40;
+            --accent: #adb5bd;
+            --soft: #ffffff;
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.5rem;
+            letter-spacing: 5px;
+            text-transform: uppercase;
+            color: var(--text);
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            opacity: 0.6;
+        }
+        .press-hero {
+            padding: 80px 0;
+            background: var(--soft);
+            border-radius: 40px;
+            text-align: center;
+            margin-bottom: 60px;
+            box-shadow: 10px 10px 30px rgba(0,0,0,0.02), -10px -10px 30px rgba(255,255,255,0.8);
+        }
+        .press-hero h1 {
+            font-size: 4rem;
+            font-weight: 300;
+            margin: 0;
+            color: var(--text);
+        }
+        article {
+            background: var(--soft);
+            padding: 60px;
+            border-radius: 30px;
+            box-shadow: inset 5px 5px 15px rgba(0,0,0,0.02), inset -5px -5px 15px rgba(255,255,255,0.8);
+        }
+        h2 { font-weight: 600; font-size: 2rem; margin-top: 0; }
+        .metadata { font-family: 'IBM Plex Sans', sans-serif; font-size: 0.7rem; color: #adb5bd; margin-bottom: 20px; display: block; text-transform: uppercase; letter-spacing: 2px; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">soft.press</div>
+            <nav>
+                <a href="/">Tactile</a>
+                <a href="/about">Surface</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/soft-press/templates/page.html
+++ b/examples/soft-press/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/soft-press/templates/section.html
+++ b/examples/soft-press/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/soft-press/templates/shortcodes/alert.html
+++ b/examples/soft-press/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/soft-press/templates/taxonomy.html
+++ b/examples/soft-press/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/soft-press/templates/taxonomy_term.html
+++ b/examples/soft-press/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/soft-toggle/AGENTS.md
+++ b/examples/soft-toggle/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/soft-toggle/config.toml
+++ b/examples/soft-toggle/config.toml
@@ -1,0 +1,8 @@
+title = "SOFT-TOGGLE"
+description = "A minimalist, neumorphic design focused on states and interaction."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/soft-toggle/content/about.md
+++ b/examples/soft-toggle/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/soft-toggle/content/index.md
+++ b/examples/soft-toggle/content/index.md
@@ -1,0 +1,28 @@
++++
+title = "The State"
++++
+
+<div class="toggle-hero">
+    <h1>SWITCH.</h1>
+</div>
+
+<div class="toggle-box">
+    <div class="toggle-switch"></div>
+</div>
+
+<article>
+
+## Interactive States
+
+Soft-Toggle is about the clarity of interaction. We believe that every state change should be felt by the user. By focusing on neumorphic-inspired soft shadows and highlights to define the "On" and "Off" positions, we create a design that feels both responsive and deeply intuitive. Our focus is on the transition and the integrity of the interactive form.
+
+### Toggle Innovation
+
+- **State**: The clear definition of the current mode of operation.
+- **Transition**: The subtle visual shift that accompanies the user's action.
+- **Feedback**: A design that provides immediate, tactile confirmation.
+
+---
+
+> "The smallest switch can change the entire environment."
+</article>

--- a/examples/soft-toggle/templates/404.html
+++ b/examples/soft-toggle/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/soft-toggle/templates/footer.html
+++ b/examples/soft-toggle/templates/footer.html
@@ -1,0 +1,5 @@
+    <footer style="margin-top: 60px; font-size: 0.6rem; opacity: 0.2; letter-spacing: 5px; text-transform: uppercase;">
+        &copy; 2026 SOFT-TOGGLE. SWITCHING THE LIGHT.
+    </footer>
+</body>
+</html>

--- a/examples/soft-toggle/templates/header.html
+++ b/examples/soft-toggle/templates/header.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #f8fbff;
+            --text: #4a5568;
+            --accent: #a0aec0;
+            --shadow: rgba(0,0,0,0.05);
+            --highlight: rgba(255,255,255,0.8);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.8;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+        .container {
+            max-width: 600px;
+            padding: 0 40px;
+            text-align: center;
+        }
+        header { margin-bottom: 60px; }
+        .logo { font-weight: 600; font-size: 1rem; text-transform: uppercase; letter-spacing: 15px; color: var(--accent); }
+        nav { margin-top: 30px; }
+        nav a { color: var(--text); text-decoration: none; margin: 0 20px; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 4px; opacity: 0.5; }
+        .toggle-box {
+            width: 200px;
+            height: 100px;
+            background: var(--bg);
+            border-radius: 50px;
+            margin: 40px auto;
+            box-shadow: 10px 10px 30px var(--shadow), -10px -10px 30px var(--highlight);
+            display: flex;
+            align-items: center;
+            padding: 0 10px;
+        }
+        .toggle-switch {
+            width: 80px;
+            height: 80px;
+            background: var(--bg);
+            border-radius: 50%;
+            box-shadow: 5px 5px 15px var(--shadow), -5px -5px 15px var(--highlight);
+        }
+        .toggle-hero h1 { font-size: 4rem; font-weight: 300; margin: 0; letter-spacing: -2px; }
+        article { margin-top: 60px; font-size: 1.1rem; line-height: 1.6; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="logo">soft.toggle</div>
+        <nav>
+            <a href="/">On</a>
+            <a href="/about">Off</a>
+        </nav>
+    </header>

--- a/examples/soft-toggle/templates/page.html
+++ b/examples/soft-toggle/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/soft-toggle/templates/section.html
+++ b/examples/soft-toggle/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/soft-toggle/templates/shortcodes/alert.html
+++ b/examples/soft-toggle/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/soft-toggle/templates/taxonomy.html
+++ b/examples/soft-toggle/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/soft-toggle/templates/taxonomy_term.html
+++ b/examples/soft-toggle/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,39 +1,4 @@
 {
-  "glass-terrace": [
-    "spacious",
-    "light",
-    "multi-column",
-    "glassmorphic",
-    "outfit"
-  ],
-  "cloud-glass": [
-    "floating",
-    "light",
-    "ethereal",
-    "translucency",
-    "jakarta"
-  ],
-  "glass-vault": [
-    "secure",
-    "dark",
-    "permanent",
-    "glassmorphic",
-    "outfit"
-  ],
-  "glass-atelier": [
-    "creative",
-    "light",
-    "artisanal",
-    "glassmorphic",
-    "jakarta"
-  ],
-  "winter-glass": [
-    "frost-tinted",
-    "light",
-    "quiet",
-    "glassmorphic",
-    "playfair"
-  ],
   "abstract-noir": [
     "paper",
     "dark",
@@ -1376,6 +1341,13 @@
     "minimal",
     "typography"
   ],
+  "clay-ui": [
+    "molded",
+    "light",
+    "material-honesty",
+    "depth",
+    "jakarta"
+  ],
   "clean-seoul": [
     "light",
     "blog",
@@ -1404,6 +1376,13 @@
     "error",
     "499",
     "minimal"
+  ],
+  "cloud-glass": [
+    "floating",
+    "light",
+    "ethereal",
+    "translucency",
+    "jakarta"
   ],
   "cloudnest": [
     "light",
@@ -1784,6 +1763,13 @@
     "dark",
     "futuristic"
   ],
+  "cyber-lumina-spark": [
+    "cyberpunk",
+    "glow",
+    "neon",
+    "dark",
+    "futuristic"
+  ],
   "cyber-nexus": [
     "dark",
     "cyberpunk",
@@ -2125,6 +2111,13 @@
     "dark",
     "blog",
     "minimal"
+  ],
+  "emboss-light": [
+    "embossed",
+    "light",
+    "relief",
+    "minimalist",
+    "jakarta"
   ],
   "embroidery": [
     "dark",
@@ -2669,12 +2662,26 @@
     "glam",
     "metallic"
   ],
+  "glass-atelier": [
+    "creative",
+    "light",
+    "artisanal",
+    "glassmorphic",
+    "jakarta"
+  ],
   "glass-aurora": [
     "dark",
     "aurora",
     "glassmorphism",
     "portfolio",
     "elegant"
+  ],
+  "glass-bloom": [
+    "botanical",
+    "translucent",
+    "light",
+    "petal",
+    "fraunces"
   ],
   "glass-lotus": [
     "glassmorphism",
@@ -2687,12 +2694,26 @@
     "glassmorphism",
     "transparent"
   ],
+  "glass-terrace": [
+    "spacious",
+    "light",
+    "multi-column",
+    "glassmorphic",
+    "outfit"
+  ],
   "glass-tower": [
     "light",
     "docs",
     "precise",
     "vertical",
     "clarity"
+  ],
+  "glass-vault": [
+    "secure",
+    "dark",
+    "permanent",
+    "glassmorphic",
+    "outfit"
   ],
   "glass-vial": [
     "delicate",
@@ -3075,6 +3096,13 @@
     "incunabulum",
     "early-print",
     "revolutionary"
+  ],
+  "indent-ui": [
+    "recessed",
+    "light",
+    "depth",
+    "hierarchy",
+    "jakarta"
   ],
   "index-card": [
     "book",
@@ -4430,6 +4458,20 @@
     "meta-analysis",
     "comparative"
   ],
+  "neu-dashboard": [
+    "dashboard",
+    "neumorphic",
+    "light",
+    "metrics",
+    "jakarta"
+  ],
+  "neu-folio": [
+    "portfolio",
+    "neumorphic",
+    "light",
+    "high-depth",
+    "jakarta"
+  ],
   "neu-garden": [
     "botanical",
     "neumorphic",
@@ -4437,12 +4479,26 @@
     "organic",
     "jakarta"
   ],
+  "neu-mono": [
+    "monospaced",
+    "neumorphic",
+    "light",
+    "technical",
+    "ibm-plex-mono"
+  ],
   "neu-music": [
     "sonic",
     "neumorphic",
     "dark",
     "immersive",
     "syncopate"
+  ],
+  "neu-reader": [
+    "minimalist",
+    "neumorphic",
+    "light",
+    "prose",
+    "fraunces"
   ],
   "neu-recipe": [
     "culinary",
@@ -5942,6 +5998,20 @@
     "warm",
     "serif"
   ],
+  "soft-press": [
+    "tactile",
+    "light",
+    "neumorphic",
+    "welcoming",
+    "jakarta"
+  ],
+  "soft-toggle": [
+    "minimalist",
+    "neumorphic",
+    "light",
+    "interactive",
+    "jakarta"
+  ],
   "solar-punk": [
     "light",
     "blog",
@@ -6984,6 +7054,13 @@
     "os",
     "nostalgia"
   ],
+  "winter-glass": [
+    "frost-tinted",
+    "light",
+    "quiet",
+    "glassmorphic",
+    "playfair"
+  ],
   "wireframe-blog": [
     "light",
     "blog",
@@ -7072,12 +7149,5 @@
     "diy",
     "raw",
     "unconventional"
-  ],
-  "cyber-lumina-spark": [
-    "cyberpunk",
-    "glow",
-    "neon",
-    "dark",
-    "futuristic"
   ]
 }


### PR DESCRIPTION
This PR adds the final set of 10 high-quality examples, bringing the total number of new examples to 150 across 29 PRs.

### Key Changes
- Added 10 new examples in two themes:
  - **Neumorphic Series**: `SOFT-PRESS`, `CLAY-UI`, `EMBOSS-LIGHT`, `NEU-DASHBOARD`, `NEU-READER`, `NEU-FOLIO`, `SOFT-TOGGLE`, `NEU-MONO`, `INDENT-UI`.
  - **Glass & Flora**: `GLASS-BLOOM`.
- These examples focus on tactile, three-dimensional digital interfaces and organic translucency.
- Updated `tags.json` with relevant discovery tags.
- Verified all examples with `hwaro build`.

Closes #1021
Closes #1022
Closes #1023
Closes #1025
Closes #1026
Closes #1027
Closes #1028
Closes #1029
Closes #1031
Closes #1032