### PR TITLE
feat(examples): add new `astral-veil-glass` theme example

### DIFF
--- a/examples/astral-veil-glass/AGENTS.md
+++ b/examples/astral-veil-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/astral-veil-glass/config.toml
+++ b/examples/astral-veil-glass/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Astral Veil Glass"
+description = "A deep dark glassmorphism theme for Hwaro"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/astral-veil-glass/content/about.md
+++ b/examples/astral-veil-glass/content/about.md
@@ -1,0 +1,25 @@
++++
+title = "About Astral Veil"
+description = "Learn more about the Astral Veil Glass theme for Hwaro"
+date = 2024-05-20
++++
+
+# The Void and The Glass
+
+Astral Veil is a custom, deep dark glassmorphism theme designed for [Hwaro](https://github.com/hahwul/hwaro), combining extreme readability with breathtaking ambient aesthetics.
+
+## Design Philosophy
+
+The core of Astral Veil relies on a few key concepts:
+* **Deep Darkness**: Backgrounds are pushed to extreme depths (`#030408`) to ensure that UI elements stand out vibrantly.
+* **Ambient Glow**: Soft, blurred, and animated orbs create a feeling of floating in a nebula or the deep void.
+* **Translucency**: Frosted glass panels allow the ambient background to bleed through softly without overwhelming the content.
+
+### Typography
+
+* **Headings**: `Space Grotesk` - Provides a unique, slightly geometric, and futuristic feel.
+* **Body**: `Inter` - Highly legible, neutral sans-serif perfect for long-form reading.
+
+> "To see the light, one must first look into the darkness."
+
+We hope you enjoy building your next site with Astral Veil Glass.

--- a/examples/astral-veil-glass/content/index.md
+++ b/examples/astral-veil-glass/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Home"
+description = "A deep dark glassmorphism theme for Hwaro"
+template = "index"
++++
+
+## Getting Started
+
+To use this theme in your Hwaro project, copy the `templates` and `config.toml` files to your site's root directory.
+
+```bash
+cp -r examples/astral-veil-glass/templates/* your-site/templates/
+cp examples/astral-veil-glass/config.toml your-site/
+```
+
+This theme is perfect for personal blogs, portfolios, and futuristic web projects.

--- a/examples/astral-veil-glass/templates/404.html
+++ b/examples/astral-veil-glass/templates/404.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel" style="text-align: center; padding: 4rem 2rem;">
+    <h1 class="gradient-text" style="font-size: 5rem; margin-bottom: 1rem;">404</h1>
+    <h2 style="font-size: 2rem; margin-bottom: 2rem;">Page Not Found</h2>
+    <p style="color: var(--color-text-muted); font-size: 1.2rem; margin-bottom: 3rem;">
+        The page you are looking for has drifted into the void.
+    </p>
+    <a href="{{ base_url }}/" style="background: rgba(0, 242, 254, 0.1); border: 1px solid var(--color-accent-cyan); color: var(--color-accent-cyan); padding: 0.75rem 2rem; border-radius: 8px; font-weight: 500; font-family: 'Space Grotesk', sans-serif;">
+        Return to Home
+    </a>
+</div>
+{% endblock %}

--- a/examples/astral-veil-glass/templates/base.html
+++ b/examples/astral-veil-glass/templates/base.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page is defined and page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --color-bg-base: #030408;
+            --color-bg-alt: #05070e;
+            --color-text-main: #e2e8f0;
+            --color-text-muted: #94a3b8;
+
+            --color-accent-cyan: #00f2fe;
+            --color-accent-blue: #4facfe;
+            --color-accent-purple: #8a2be2;
+
+            --glass-bg: rgba(10, 15, 30, 0.4);
+            --glass-border: rgba(255, 255, 255, 0.08);
+            --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: var(--color-bg-base);
+            color: var(--color-text-main);
+            line-height: 1.6;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            overflow-x: hidden;
+            position: relative;
+        }
+
+        /* Abstract Background Elements */
+        .ambient-bg {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            z-index: -1;
+            overflow: hidden;
+            background: radial-gradient(circle at 50% 50%, var(--color-bg-alt) 0%, var(--color-bg-base) 100%);
+        }
+
+        .ambient-orb {
+            position: absolute;
+            border-radius: 50%;
+            filter: blur(80px);
+            opacity: 0.5;
+            animation: float 20s infinite alternate ease-in-out;
+        }
+
+        .orb-1 {
+            top: -10%;
+            left: -10%;
+            width: 50vw;
+            height: 50vw;
+            background: radial-gradient(circle, var(--color-accent-cyan) 0%, transparent 70%);
+            animation-delay: 0s;
+        }
+
+        .orb-2 {
+            bottom: -20%;
+            right: -10%;
+            width: 60vw;
+            height: 60vw;
+            background: radial-gradient(circle, var(--color-accent-purple) 0%, transparent 70%);
+            animation-delay: -5s;
+        }
+
+        .orb-3 {
+            top: 40%;
+            left: 60%;
+            width: 40vw;
+            height: 40vw;
+            background: radial-gradient(circle, var(--color-accent-blue) 0%, transparent 70%);
+            opacity: 0.3;
+            animation-delay: -10s;
+        }
+
+        @keyframes float {
+            0% { transform: translate(0, 0) scale(1); }
+            50% { transform: translate(5%, 5%) scale(1.1); }
+            100% { transform: translate(-5%, -5%) scale(0.9); }
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700;
+            margin-bottom: 1rem;
+            color: #ffffff;
+            letter-spacing: -0.02em;
+        }
+
+        a {
+            color: var(--color-accent-cyan);
+            text-decoration: none;
+            transition: color 0.3s ease, text-shadow 0.3s ease;
+        }
+
+        a:hover {
+            color: #ffffff;
+            text-shadow: 0 0 8px var(--color-accent-cyan);
+        }
+
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            width: 100%;
+        }
+
+        /* Glassmorphism Components */
+        .glass-panel {
+            background: var(--glass-bg);
+            backdrop-filter: blur(16px);
+            -webkit-backdrop-filter: blur(16px);
+            border: 1px solid var(--glass-border);
+            border-radius: 16px;
+            padding: 2rem;
+            box-shadow: var(--glass-shadow);
+            margin-bottom: 2rem;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .glass-panel::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 1px;
+            background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+        }
+
+        header {
+            padding: 2rem 0;
+            margin-bottom: 3rem;
+            border-bottom: 1px solid var(--glass-border);
+            background: rgba(3, 4, 8, 0.6);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+
+        nav {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .site-title {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: #fff;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .site-title span {
+            background: linear-gradient(90deg, var(--color-accent-cyan), var(--color-accent-blue));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 1.5rem;
+        }
+
+        .nav-links a {
+            color: var(--color-text-main);
+            font-size: 0.95rem;
+            font-weight: 500;
+            padding: 0.5rem 1rem;
+            border-radius: 8px;
+            transition: all 0.3s ease;
+        }
+
+        .nav-links a:hover {
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--color-accent-cyan);
+            text-shadow: none;
+        }
+
+        main {
+            flex-grow: 1;
+            padding-bottom: 4rem;
+        }
+
+        /* Post lists */
+        .post-list {
+            list-style: none;
+            display: grid;
+            gap: 2rem;
+        }
+
+        .post-card {
+            display: block;
+            color: inherit;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            text-decoration: none;
+        }
+
+        .post-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.4);
+            color: inherit;
+            text-shadow: none;
+        }
+
+        .post-card:hover .post-title {
+            color: var(--color-accent-cyan);
+        }
+
+        .post-card .glass-panel {
+            margin-bottom: 0;
+            height: 100%;
+        }
+
+        .post-meta {
+            font-size: 0.85rem;
+            color: var(--color-text-muted);
+            margin-bottom: 0.5rem;
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .post-title {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+            transition: color 0.3s ease;
+        }
+
+        .post-summary {
+            color: var(--color-text-muted);
+            font-size: 0.95rem;
+        }
+
+        /* Content Markdown Styling */
+        .content {
+            font-size: 1.1rem;
+        }
+
+        .content h1 { font-size: 2.5rem; margin-top: 2rem; }
+        .content h2 { font-size: 2rem; margin-top: 2.5rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--glass-border); }
+        .content h3 { font-size: 1.5rem; margin-top: 2rem; }
+
+        .content p { margin-bottom: 1.5rem; }
+        .content ul, .content ol { margin-bottom: 1.5rem; padding-left: 1.5rem; color: var(--color-text-muted); }
+        .content li { margin-bottom: 0.5rem; }
+
+        .content code {
+            font-family: monospace;
+            background: rgba(0, 0, 0, 0.3);
+            padding: 0.2rem 0.4rem;
+            border-radius: 4px;
+            font-size: 0.9em;
+            color: var(--color-accent-cyan);
+        }
+
+        .content pre {
+            background: rgba(0, 0, 0, 0.5);
+            padding: 1.5rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: 1.5rem;
+            border: 1px solid rgba(255,255,255,0.05);
+        }
+
+        .content pre code {
+            background: transparent;
+            padding: 0;
+            color: inherit;
+        }
+
+        .content blockquote {
+            border-left: 4px solid var(--color-accent-cyan);
+            padding-left: 1.5rem;
+            margin-bottom: 1.5rem;
+            font-style: italic;
+            color: var(--color-text-muted);
+            background: linear-gradient(90deg, rgba(0, 242, 254, 0.05), transparent);
+            padding-top: 0.5rem;
+            padding-bottom: 0.5rem;
+        }
+
+        footer {
+            padding: 3rem 0;
+            text-align: center;
+            color: var(--color-text-muted);
+            border-top: 1px solid var(--glass-border);
+            background: rgba(3, 4, 8, 0.6);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            font-size: 0.9rem;
+        }
+
+        .footer-content {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .glow-divider {
+            height: 1px;
+            width: 100px;
+            background: linear-gradient(90deg, transparent, var(--color-accent-cyan), transparent);
+            margin: 1rem auto;
+        }
+
+        /* Typography overrides */
+        .gradient-text {
+            background: linear-gradient(90deg, var(--color-accent-cyan), var(--color-accent-purple));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            display: inline-block;
+        }
+
+        @media (max-width: 768px) {
+            .glass-panel { padding: 1.5rem; }
+            .content h1 { font-size: 2rem; }
+            .content h2 { font-size: 1.75rem; }
+        }
+    </style>
+</head>
+<body>
+    <div class="ambient-bg">
+        <div class="ambient-orb orb-1"></div>
+        <div class="ambient-orb orb-2"></div>
+        <div class="ambient-orb orb-3"></div>
+    </div>
+
+    <header>
+        <div class="container">
+            <nav>
+                <a href="{{ base_url }}/" class="site-title">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M12 2L2 7L12 12L22 7L12 2Z" stroke="url(#paint0_linear)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        <path d="M2 17L12 22L22 17" stroke="url(#paint1_linear)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        <path d="M2 12L12 17L22 12" stroke="url(#paint2_linear)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        <defs>
+                            <linearGradient id="paint0_linear" x1="2" y1="7" x2="22" y2="7" gradientUnits="userSpaceOnUse">
+                                <stop stop-color="#00f2fe"/>
+                                <stop offset="1" stop-color="#4facfe"/>
+                            </linearGradient>
+                            <linearGradient id="paint1_linear" x1="2" y1="19.5" x2="22" y2="19.5" gradientUnits="userSpaceOnUse">
+                                <stop stop-color="#00f2fe"/>
+                                <stop offset="1" stop-color="#4facfe"/>
+                            </linearGradient>
+                            <linearGradient id="paint2_linear" x1="2" y1="14.5" x2="22" y2="14.5" gradientUnits="userSpaceOnUse">
+                                <stop stop-color="#00f2fe"/>
+                                <stop offset="1" stop-color="#4facfe"/>
+                            </linearGradient>
+                        </defs>
+                    </svg>
+                    <span>Astral Veil</span>
+                </a>
+                <div class="nav-links">
+                    <a href="{{ base_url }}/">Home</a>
+                    <a href="{{ base_url }}/about/">About</a>
+                </div>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        <div class="container footer-content">
+            <div class="glow-divider"></div>
+            <p>&copy; {{ site.time | date("%Y") }} {{ site.title }}. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/astral-veil-glass/templates/index.html
+++ b/examples/astral-veil-glass/templates/index.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel" style="text-align: center; padding: 4rem 2rem; margin-bottom: 4rem;">
+    <h1 class="gradient-text" style="font-size: 4rem; margin-bottom: 1rem; line-height: 1.2;">
+        Welcome to<br>Astral Veil
+    </h1>
+    <p style="font-size: 1.25rem; color: var(--color-text-muted); max-width: 600px; margin: 0 auto 2rem;">
+        {% if page is defined and page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}
+    </p>
+
+    <div style="display: flex; gap: 1rem; justify-content: center;">
+        <a href="{{ base_url }}/about/" style="background: rgba(0, 242, 254, 0.1); border: 1px solid var(--color-accent-cyan); color: var(--color-accent-cyan); padding: 0.75rem 2rem; border-radius: 8px; font-weight: 500; font-family: 'Space Grotesk', sans-serif;">
+            About Theme
+        </a>
+    </div>
+</div>
+
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem;">
+    <div class="glass-panel">
+        <h3 style="display: flex; align-items: center; gap: 0.5rem; color: var(--color-accent-cyan);">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+            Glassmorphism UI
+        </h3>
+        <p style="color: var(--color-text-muted);">Beautiful translucent frosted glass panels using `backdrop-filter: blur()`, complete with subtle borders and shadows to create depth on deep dark backgrounds.</p>
+    </div>
+
+    <div class="glass-panel">
+        <h3 style="display: flex; align-items: center; gap: 0.5rem; color: var(--color-accent-purple);">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>
+            Ambient Animations
+        </h3>
+        <p style="color: var(--color-text-muted);">Immersive floating animated radial orbs and neon accents that breathe life into the void, creating an ethereal and dynamic reading experience.</p>
+    </div>
+
+    <div class="glass-panel">
+        <h3 style="display: flex; align-items: center; gap: 0.5rem; color: var(--color-accent-blue);">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
+            Typography Focused
+        </h3>
+        <p style="color: var(--color-text-muted);">Clean layout using 'Inter' for highly readable body text and 'Space Grotesk' for distinct, futuristic headings. Ready for markdown content.</p>
+    </div>
+</div>
+
+{% if page is defined %}
+<div class="glass-panel" style="margin-top: 3rem;">
+    <div class="content">
+        {{ content | safe }}
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/examples/astral-veil-glass/templates/page.html
+++ b/examples/astral-veil-glass/templates/page.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-panel">
+    <header class="post-header" style="margin-bottom: 2rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 1.5rem;">
+        <h1 class="post-title gradient-text" style="font-size: 3rem; margin-bottom: 0.5rem;">{{ page.title }}</h1>
+        <div class="post-meta">
+            {% if page.date is defined %}
+                <time datetime="{{ page.date | date("%Y-%m-%d") }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+
+            {% if page.taxonomies is defined and page.taxonomies.tags is defined %}
+                <span class="meta-separator">•</span>
+                <span class="tags">
+                    {% for tag in page.taxonomies.tags %}
+                        <a href="{{ base_url }}/tags/{{ tag | slugify }}/" style="margin-right: 0.5rem;">#{{ tag }}</a>
+                    {% endfor %}
+                </span>
+            {% endif %}
+        </div>
+    </header>
+
+    <div class="content">
+        {{ content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/examples/astral-veil-glass/templates/section.html
+++ b/examples/astral-veil-glass/templates/section.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel" style="margin-bottom: 3rem; text-align: center;">
+    <h1 class="gradient-text" style="font-size: 3rem; margin-bottom: 1rem;">{{ section.title | default(value="Posts") }}</h1>
+    {% if section.description is defined and section.description %}
+    <p class="post-summary" style="font-size: 1.1rem; max-width: 600px; margin: 0 auto;">{{ section.description }}</p>
+    {% endif %}
+</div>
+
+{% if paginator is defined %}
+    {% set pages = paginator.pages %}
+{% else %}
+    {% set pages = section.pages %}
+{% endif %}
+
+<ul class="post-list">
+    {% for page in pages %}
+    <li>
+        <a href="{{ base_url }}{{ page.url }}" class="post-card">
+            <article class="glass-panel">
+                <h2 class="post-title">{{ page.title }}</h2>
+                <div class="post-meta">
+                    {% if page.date is defined %}
+                    <time datetime="{{ page.date | date("%Y-%m-%d") }}">{{ page.date | date("%B %d, %Y") }}</time>
+                    {% endif %}
+                </div>
+                {% if page.description is defined and page.description %}
+                <p class="post-summary">{{ page.description }}</p>
+                {% endif %}
+            </article>
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+
+{% if paginator is defined and paginator.total_pages > 1 %}
+<nav class="pagination glass-panel" style="margin-top: 3rem; display: flex; justify-content: center; gap: 1rem; padding: 1rem;">
+    {% if paginator.previous %}
+        <a href="{{ base_url }}{{ paginator.previous }}" class="btn">&larr; Previous</a>
+    {% endif %}
+
+    <span class="page-indicator" style="color: var(--color-text-muted); align-self: center;">
+        Page {{ paginator.current_index }} of {{ paginator.total_pages }}
+    </span>
+
+    {% if paginator.next %}
+        <a href="{{ base_url }}{{ paginator.next }}" class="btn">Next &rarr;</a>
+    {% endif %}
+</nav>
+{% endif %}
+
+{% endblock %}

--- a/examples/astral-veil-glass/templates/shortcodes/alert.html
+++ b/examples/astral-veil-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/astral-veil-glass/templates/taxonomy.html
+++ b/examples/astral-veil-glass/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel" style="margin-bottom: 3rem; text-align: center;">
+    <h1 class="gradient-text" style="font-size: 3rem; margin-bottom: 1rem;">{{ page.title | e }}</h1>
+    <p class="post-summary" style="font-size: 1.1rem;">Browse all terms in this taxonomy.</p>
+</div>
+
+<div class="glass-panel">
+    <div class="content">
+        {{ content }}
+    </div>
+</div>
+{% endblock %}

--- a/examples/astral-veil-glass/templates/taxonomy_term.html
+++ b/examples/astral-veil-glass/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel" style="margin-bottom: 3rem; text-align: center;">
+    <h1 class="gradient-text" style="font-size: 3rem; margin-bottom: 1rem;">{{ page.title | e }}</h1>
+    <p class="post-summary" style="font-size: 1.1rem;">Posts associated with this term.</p>
+</div>
+
+<div class="content">
+    {{ content }}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -6142,5 +6142,11 @@
     "glassmorphism",
     "portfolio",
     "elegant"
+  ],
+  "astral-veil-glass": [
+    "dark",
+    "glassmorphism",
+    "astral",
+    "portfolio"
   ]
 }


### PR DESCRIPTION
Adds the `astral-veil-glass` project as a new dark-themed Hwaro example. The aesthetic is heavily focused on glassmorphism with ambient glowing floating elements.

Included in this addition:
- `base.html` template handling the complex layout without `header.html` and `footer.html`.
- Custom `index.html` template.
- Updated `page.html`, `section.html`, `taxonomy.html`, `taxonomy_term.html`, and `404.html` adapting to the new base.
- Basic sample markdown content (`index.md` and `about.md`).
- Fully validated with `hwaro tool doctor --fix` and `hwaro tool validate`.

---
*PR created automatically by Jules for task [7402399274211731881](https://jules.google.com/task/7402399274211731881) started by @hahwul*