### PR TITLE
Add celestial-loom-glass example site

### DIFF
--- a/examples/celestial-loom-glass/AGENTS.md
+++ b/examples/celestial-loom-glass/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/celestial-loom-glass/config.toml
+++ b/examples/celestial-loom-glass/config.toml
@@ -1,0 +1,191 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Celestial Loom Glass"
+description = "A cosmic glassmorphism showcase for Hwaro."
+base_url = "http://localhost:3000"
+language = "en"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[[taxonomies]]
+name = "tags"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+# [plugins]
+# processors = ["markdown"]
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/celestial-loom-glass/content/about.md
+++ b/examples/celestial-loom-glass/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "About"
+description = "About the celestial loom glass."
++++
+
+The **Celestial Loom** is a conceptual design space where digital threads weave together light and void.
+
+It is built on top of [Hwaro](https://github.com/hahwul/hwaro), leveraging its static site generation capabilities to deliver a blazing fast, yet visually intricate experience. The design patterns here prioritize depth, ethereal glows, and clear typography.
+
+### Core Principles
+
+1.  **Depth through Refraction:** Using `backdrop-filter: blur(16px)` to create layers.
+2.  **Ambient Illumination:** Glowing backgrounds that suggest cosmic bodies or deep-sea luminescence.
+3.  **Stark Contrast:** Bright neon accents against deep obsidian backgrounds.
+
+Feel free to explore the void.

--- a/examples/celestial-loom-glass/content/index.md
+++ b/examples/celestial-loom-glass/content/index.md
@@ -1,0 +1,27 @@
++++
+title = "Home"
+description = "A cosmic glassmorphism showcase for Hwaro."
++++
+
+Welcome to the **Celestial Loom**. This design explores the boundaries of deep cosmic voids, combining ambient glowing orbs with translucent, frosted glass panels.
+
+The aesthetic utilizes:
+*   A deep dark background `#05070f`
+*   Floating radial gradients (Cyan, Magenta, Deep Purple)
+*   Glassmorphism UI elements via `backdrop-filter`
+*   Typography driven by *Space Grotesk* and *Inter*
+
+<div style="background: rgba(0, 240, 255, 0.05); border-left: 4px solid var(--accent-cyan); padding: 1.5rem; margin: 1.5rem 0; border-radius: 0 8px 8px 0; font-weight: 500;">
+  <strong style="color: var(--accent-cyan); display: block; margin-bottom: 0.5rem;">NOTICE</strong>
+  This is a custom alert seamlessly integrated into the glassmorphism theme.
+</div>
+
+### Code Example
+
+```python
+def celestial_pulse():
+    while True:
+        emit_glow(color="#00f0ff")
+        refract_light(intensity=0.8)
+        yield "Starlight"
+```

--- a/examples/celestial-loom-glass/templates/404.html
+++ b/examples/celestial-loom-glass/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel content" style="text-align: center; padding: 4rem 2rem;">
+  <h1 style="font-size: 4rem; margin-bottom: 1rem;">404</h1>
+  <p style="font-size: 1.2rem; color: var(--text-muted);">Lost in the cosmic void.</p>
+  <a href="{{ base_url | default(value='') }}/" style="display: inline-block; margin-top: 2rem; padding: 0.8rem 2rem; background: rgba(0, 240, 255, 0.1); border: 1px solid var(--accent-cyan); border-radius: 8px; font-weight: 600;">Return Home</a>
+</div>
+{% endblock %}

--- a/examples/celestial-loom-glass/templates/base.html
+++ b/examples/celestial-loom-glass/templates/base.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page is defined and page.title %}{{ page.title | escape }} - {% elif section is defined and section.title %}{{ section.title | escape }} - {% endif %}{{ site.title | escape }}</title>
+  {% if page is defined and page.description %}<meta name="description" content="{{ page.description | escape }}">{% elif site.description %}<meta name="description" content="{{ site.description | escape }}">{% endif %}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+  {{ og_all_tags | default(value='') | safe }}
+  {{ canonical_tag | default(value='') | safe }}
+  <style>
+    :root {
+      --bg-color: #05070f;
+      --glass-bg: rgba(255, 255, 255, 0.03);
+      --glass-border: rgba(255, 255, 255, 0.08);
+      --text-main: #e2e8f0;
+      --text-muted: #94a3b8;
+      --accent-cyan: #00f0ff;
+      --accent-magenta: #ff0055;
+      --accent-purple: #8a2be2;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', sans-serif;
+      background-color: var(--bg-color);
+      color: var(--text-main);
+      line-height: 1.6;
+      min-height: 100vh;
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      font-family: 'Space Grotesk', sans-serif;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 1rem;
+    }
+
+    a {
+      color: var(--accent-cyan);
+      text-decoration: none;
+      transition: color 0.3s ease;
+    }
+
+    a:hover {
+      color: var(--accent-magenta);
+    }
+
+    /* Ambient Background Orbs */
+    .bg-orbs {
+      position: fixed;
+      top: 0; left: 0; width: 100%; height: 100%;
+      z-index: -1;
+      overflow: hidden;
+      background: radial-gradient(circle at 15% 50%, rgba(0, 240, 255, 0.08) 0%, transparent 50%),
+                  radial-gradient(circle at 85% 30%, rgba(255, 0, 85, 0.08) 0%, transparent 50%),
+                  radial-gradient(circle at 50% 80%, rgba(138, 43, 226, 0.08) 0%, transparent 50%);
+      filter: blur(40px);
+    }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    header {
+      padding: 2rem 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 3rem;
+    }
+
+    .logo {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #fff;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      text-shadow: 0 0 10px rgba(0, 240, 255, 0.5);
+    }
+
+    .logo:hover {
+      color: #fff;
+    }
+
+    nav {
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    nav a {
+      color: var(--text-muted);
+      font-weight: 500;
+      font-size: 0.95rem;
+    }
+
+    nav a:hover {
+      color: var(--accent-cyan);
+      text-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+    }
+
+    .glass-panel {
+      background: var(--glass-bg);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      padding: 2.5rem;
+      margin-bottom: 2rem;
+      box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+    }
+
+    main {
+      min-height: 60vh;
+    }
+
+    /* Content Typography */
+    .content p { margin-bottom: 1.5rem; }
+    .content h1 { font-size: 2.5rem; background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+    .content h2 { font-size: 2rem; margin-top: 2rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 0.5rem; }
+    .content ul, .content ol { margin-bottom: 1.5rem; padding-left: 1.5rem; }
+    .content li { margin-bottom: 0.5rem; }
+
+    .content code {
+      background: rgba(255, 255, 255, 0.1);
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      font-family: monospace;
+      font-size: 0.9em;
+    }
+
+    .content pre {
+      background: rgba(0, 0, 0, 0.4);
+      padding: 1.5rem;
+      border-radius: 8px;
+      border: 1px solid var(--glass-border);
+      overflow-x: auto;
+      margin-bottom: 1.5rem;
+    }
+
+    .content pre code {
+      background: none;
+      padding: 0;
+    }
+
+    footer {
+      text-align: center;
+      padding: 3rem 0;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      border-top: 1px solid var(--glass-border);
+      margin-top: 4rem;
+    }
+  </style>
+  {{ highlight_tags | default(value='') | safe }}
+</head>
+<body>
+  <div class="bg-orbs"></div>
+
+  <div class="container">
+    <header>
+      <a href="{{ base_url | default(value='') }}/" class="logo">{{ site.title | escape }}</a>
+      <nav>
+        <a href="{{ base_url | default(value='') }}/">Home</a>
+        <a href="{{ base_url | default(value='') }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+      &copy; {{ site.title | escape }}. A Hwaro glassmorphism showcase.
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/celestial-loom-glass/templates/page.html
+++ b/examples/celestial-loom-glass/templates/page.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-panel content">
+  <h1>{{ page.title | escape }}</h1>
+  {% if page.date %}
+    <p style="color: var(--text-muted); font-size: 0.9rem; margin-top: -1rem; margin-bottom: 2rem;">{{ page.date | date("%B %d, %Y") }}</p>
+  {% endif %}
+  {{ content | safe }}
+</article>
+{% endblock %}

--- a/examples/celestial-loom-glass/templates/section.html
+++ b/examples/celestial-loom-glass/templates/section.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel content">
+  <h1>{{ section.title | escape }}</h1>
+  {% if section.content %}
+    {{ section.content | safe }}
+  {% endif %}
+
+  <div style="margin-top: 2rem; display: flex; flex-direction: column; gap: 1rem;">
+    {% for page in section.pages %}
+      <div style="padding: 1.5rem; background: rgba(255,255,255,0.02); border: 1px solid var(--glass-border); border-radius: 8px;">
+        <h2 style="margin: 0 0 0.5rem 0; font-size: 1.5rem; border: none; padding: 0;"><a href="{{ page.url }}">{{ page.title | escape }}</a></h2>
+        {% if page.description %}
+          <p style="margin: 0; color: var(--text-muted);">{{ page.description | escape }}</p>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/examples/celestial-loom-glass/templates/shortcodes/alert.html
+++ b/examples/celestial-loom-glass/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div style="background: rgba(0, 240, 255, 0.05); border-left: 4px solid var(--accent-cyan); padding: 1.5rem; margin: 1.5rem 0; border-radius: 0 8px 8px 0; font-weight: 500;">
+  <strong style="color: var(--accent-cyan); display: block; margin-bottom: 0.5rem;">{{ type | upper }}</strong>
+  {{ body }}
+</div>

--- a/examples/celestial-loom-glass/templates/taxonomy.html
+++ b/examples/celestial-loom-glass/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel content">
+  <h1>{{ taxonomy.name | upper }}</h1>
+  <div style="display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 2rem;">
+    {% if terms is defined %}
+      {% for term in terms %}
+        <a href="{{ term.url }}" style="padding: 0.5rem 1rem; background: rgba(255,255,255,0.05); border: 1px solid var(--accent-cyan); border-radius: 20px; text-decoration: none;">
+          {{ term.name }} ({{ term.pages_count }})
+        </a>
+      {% endfor %}
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/examples/celestial-loom-glass/templates/taxonomy_term.html
+++ b/examples/celestial-loom-glass/templates/taxonomy_term.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel content">
+  <h1>{{ term.name | escape }}</h1>
+  <div style="margin-top: 2rem; display: flex; flex-direction: column; gap: 1rem;">
+    {% if term is defined and term.pages is defined %}
+      {% for page in term.pages %}
+        <div style="padding: 1.5rem; background: rgba(255,255,255,0.02); border: 1px solid var(--glass-border); border-radius: 8px;">
+          <h2 style="margin: 0 0 0.5rem 0; font-size: 1.5rem; border: none; padding: 0;"><a href="{{ page.url }}">{{ page.title | escape }}</a></h2>
+        </div>
+      {% endfor %}
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -6109,5 +6109,12 @@
     "prism",
     "portfolio",
     "glow"
+  ],
+  "celestial-loom-glass": [
+    "dark",
+    "glassmorphism",
+    "celestial",
+    "cosmic",
+    "portfolio"
   ]
 }


### PR DESCRIPTION
This PR adds a new example named `celestial-loom-glass`. It features a highly creative "cosmic glassmorphism" aesthetic with a deep dark background (#05070f), ambient glowing radial gradients (Cyan, Magenta, Deep Purple), semi-transparent frosted glass UI elements via `backdrop-filter`, and clean typography using Space Grotesk and Inter fonts. The example adheres strictly to Hwaro guidelines (e.g. TOML frontmatter with `+++`, correct config options).

---
*PR created automatically by Jules for task [6124422677985421456](https://jules.google.com/task/6124422677985421456) started by @hahwul*