### PR TITLE
Fix /authors/ 404 in after-dark

### DIFF
--- a/examples/after-dark/content/authors/_index.md
+++ b/examples/after-dark/content/authors/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Authors"
+description = "List of authors"
++++


### PR DESCRIPTION
Added `_index.md` in `content/authors/` to resolve the 404 error when navigating to `/authors/` in the `after-dark` example.

---
*PR created automatically by Jules for task [8301766401946993426](https://jules.google.com/task/8301766401946993426) started by @chei-l*