### PR TITLE
Add crystalline-void-nexus example

### DIFF
--- a/examples/crystalline-void-nexus/AGENTS.md
+++ b/examples/crystalline-void-nexus/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/crystalline-void-nexus/archetypes/default.md
+++ b/examples/crystalline-void-nexus/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/crystalline-void-nexus/config.toml
+++ b/examples/crystalline-void-nexus/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Crystalline Void Nexus"
+description = "Welcome to my new Hwaro site."
+base_url = "https://crystalline-void-nexus.example.com"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/crystalline-void-nexus/content/about/index.md
+++ b/examples/crystalline-void-nexus/content/about/index.md
@@ -1,0 +1,11 @@
++++
+title = "About the Nexus"
+description = "Information about the Crystalline Void Nexus."
+date = 2023-10-25
++++
+
+## Forging the Void
+
+The Crystalline Void Nexus is an experimental site demonstrating a futuristic deep-space glassmorphism aesthetic using the Hwaro static site generator.
+
+Here we harness the power of glowing gradients, frosted glass panels, and void-like backgrounds to create an ethereal user experience.

--- a/examples/crystalline-void-nexus/content/index.md
+++ b/examples/crystalline-void-nexus/content/index.md
@@ -1,0 +1,17 @@
++++
+title = "Crystalline Void Nexus"
+description = "A futuristic crystal forge in the abyss."
+date = 2023-10-25
++++
+
+## The Deep Forge
+
+Welcome to the Crystalline Void Nexus. Deep within the abyssal space, neon crystals power the ultimate glassmorphism forge.
+
+* **Resonance:** Tuning the crystal arrays.
+* **Refraction:** Bending light through the void.
+* **Synthesis:** Forging new realities.
+
+Embrace the glow.
+
+{{ alert(message="Crystal resonance at optimal levels.", type="info") }}

--- a/examples/crystalline-void-nexus/templates/404.html
+++ b/examples/crystalline-void-nexus/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div style="text-align: center; padding: 4rem 0;">
+    <h1 style="font-size: 6rem; margin-bottom: 1rem; color: var(--magenta-glow); text-shadow: 0 0 20px rgba(255,0,85,0.5);">404</h1>
+    <h2 style="font-size: 2rem; margin-bottom: 2rem;">Void Sector Not Found</h2>
+    <p style="color: var(--text-muted); margin-bottom: 3rem;">The coordinates you entered do not exist in this nexus.</p>
+    <a href="/" style="display: inline-block; padding: 1rem 2rem; background: rgba(0, 240, 255, 0.1); border: 1px solid var(--cyan-glow); border-radius: 30px; text-transform: uppercase; font-weight: 600; letter-spacing: 0.1em; transition: all 0.3s ease;">Return to Nexus</a>
+</div>
+{% endblock %}

--- a/examples/crystalline-void-nexus/templates/base.html
+++ b/examples/crystalline-void-nexus/templates/base.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined and page.title %}{{ page.title }} | {% endif %}Crystalline Void Nexus</title>
+    <meta name="description" content="{% if page is defined and page.description %}{{ page.description }}{% else %}A futuristic crystal forge in the abyss.{% endif %}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --bg-void: #020108;
+            --bg-deep: #050314;
+
+            /* Glowing accents */
+            --cyan-glow: #00f0ff;
+            --magenta-glow: #ff0055;
+            --purple-glow: #8a2be2;
+
+            /* Glassmorphism */
+            --glass-bg: rgba(255, 255, 255, 0.03);
+            --glass-border: rgba(255, 255, 255, 0.08);
+            --glass-blur: blur(16px);
+
+            --text-main: #f0f0f5;
+            --text-muted: #a0a0b5;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Inter', sans-serif;
+            background-color: var(--bg-void);
+            color: var(--text-main);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            position: relative;
+            overflow-x: hidden;
+            line-height: 1.6;
+        }
+
+        /* Animated Background Orbs */
+        .orb {
+            position: fixed;
+            border-radius: 50%;
+            filter: blur(80px);
+            opacity: 0.4;
+            z-index: -1;
+            animation: float 20s infinite alternate ease-in-out;
+        }
+
+        .orb-1 {
+            width: 400px;
+            height: 400px;
+            background: radial-gradient(circle, var(--cyan-glow), transparent 70%);
+            top: -100px;
+            left: -100px;
+        }
+
+        .orb-2 {
+            width: 500px;
+            height: 500px;
+            background: radial-gradient(circle, var(--purple-glow), transparent 70%);
+            bottom: -150px;
+            right: -100px;
+            animation-delay: -5s;
+        }
+
+        .orb-3 {
+            width: 300px;
+            height: 300px;
+            background: radial-gradient(circle, var(--magenta-glow), transparent 70%);
+            top: 40%;
+            left: 50%;
+            transform: translateX(-50%);
+            animation-duration: 25s;
+            opacity: 0.2;
+        }
+
+        @keyframes float {
+            0% { transform: translate(0, 0) scale(1); }
+            50% { transform: translate(30px, 50px) scale(1.1); }
+            100% { transform: translate(-20px, 20px) scale(0.9); }
+        }
+
+        /* Glass Container */
+        .glass-panel {
+            background: var(--glass-bg);
+            backdrop-filter: var(--glass-blur);
+            -webkit-backdrop-filter: var(--glass-blur);
+            border: 1px solid var(--glass-border);
+            border-radius: 24px;
+            box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+            position: relative;
+            overflow: hidden;
+        }
+
+        /* Inner reflection */
+        .glass-panel::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 1px;
+            background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700;
+            margin-top: 0;
+            background: linear-gradient(to right, #fff, #a0a0b5);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            letter-spacing: -0.02em;
+        }
+
+        a {
+            color: var(--cyan-glow);
+            text-decoration: none;
+            transition: color 0.3s ease, text-shadow 0.3s ease;
+        }
+
+        a:hover {
+            color: #fff;
+            text-shadow: 0 0 10px var(--cyan-glow);
+        }
+
+        header {
+            padding: 2rem 5%;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 1px solid var(--glass-border);
+            background: rgba(2, 1, 8, 0.5);
+            backdrop-filter: blur(10px);
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+
+        .site-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            font-family: 'Space Grotesk', sans-serif;
+            margin: 0;
+            color: #fff;
+            text-decoration: none;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            -webkit-text-fill-color: initial;
+            background: none;
+        }
+
+        .site-title::before {
+            content: '';
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            background: var(--cyan-glow);
+            border-radius: 50%;
+            box-shadow: 0 0 10px var(--cyan-glow);
+        }
+
+        nav a {
+            margin-left: 2rem;
+            color: var(--text-main);
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        main {
+            flex-grow: 1;
+            width: 100%;
+            max-width: 800px;
+            margin: 4rem auto;
+            padding: 2.5rem;
+        }
+
+        footer {
+            text-align: center;
+            padding: 2rem;
+            color: var(--text-muted);
+            border-top: 1px solid var(--glass-border);
+            background: rgba(2, 1, 8, 0.5);
+            backdrop-filter: blur(10px);
+            font-size: 0.85rem;
+            margin-top: auto;
+        }
+
+        /* Content Styling */
+        .content {
+            font-size: 1.1rem;
+            color: var(--text-main);
+        }
+
+        .content p {
+            margin-bottom: 1.5rem;
+        }
+
+        .content ul, .content ol {
+            margin-bottom: 1.5rem;
+            padding-left: 1.5rem;
+        }
+
+        .content li {
+            margin-bottom: 0.5rem;
+        }
+
+        .content li::marker {
+            color: var(--cyan-glow);
+        }
+
+        code {
+            background: rgba(0, 0, 0, 0.5);
+            padding: 0.2em 0.4em;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 0.9em;
+            color: var(--magenta-glow);
+        }
+
+        pre {
+            background: rgba(0, 0, 0, 0.5) !important;
+            padding: 1.5rem;
+            border-radius: 12px;
+            overflow-x: auto;
+            border: 1px solid var(--glass-border);
+        }
+
+        pre code {
+            background: transparent;
+            color: inherit;
+            padding: 0;
+        }
+
+        /* Blockquote */
+        blockquote {
+            margin: 2rem 0;
+            padding: 1rem 1.5rem;
+            border-left: 3px solid var(--purple-glow);
+            background: linear-gradient(90deg, rgba(138, 43, 226, 0.1), transparent);
+            border-radius: 0 8px 8px 0;
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+    <div class="orb orb-1"></div>
+    <div class="orb orb-2"></div>
+    <div class="orb orb-3"></div>
+
+    <header>
+        <a href="/" class="site-title">Crystalline Void Nexus</a>
+        <nav>
+            <a href="/">Home</a>
+            <a href="/about/">About</a>
+        </nav>
+    </header>
+
+    <main class="glass-panel">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        <p>&copy; {{ now() | date(format="%Y") }} Crystalline Void Nexus. Built with <a href="https://hwaro.hahwul.com" target="_blank">Hwaro</a>.</p>
+    </footer>
+</body>
+</html>

--- a/examples/crystalline-void-nexus/templates/page.html
+++ b/examples/crystalline-void-nexus/templates/page.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="content">
+    {% if page is defined and page.title %}
+    <header style="margin-bottom: 2rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 1rem;">
+        <h1 style="font-size: 2.5rem; margin-bottom: 0.5rem;">{{ page.title }}</h1>
+        {% if page.date %}
+        <time style="color: var(--text-muted); font-size: 0.9rem;">{{ page.date | date(format="%B %d, %Y") }}</time>
+        {% endif %}
+    </header>
+    {% endif %}
+
+    {% if page is defined %}
+    {{ content | safe }}
+    {% endif %}
+</article>
+{% endblock %}

--- a/examples/crystalline-void-nexus/templates/section.html
+++ b/examples/crystalline-void-nexus/templates/section.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="content">
+    {% if section is defined and section.title %}
+    <header style="margin-bottom: 2rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 1rem;">
+        <h1 style="font-size: 2.5rem; margin-bottom: 0.5rem;">{{ section.title }}</h1>
+    </header>
+    {% endif %}
+
+    {% if section is defined %}
+    {{ content | safe }}
+    {% endif %}
+
+    {% if section is defined and section.pages %}
+    <div style="margin-top: 3rem; display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));">
+        {% for p in section.pages %}
+        <article style="background: rgba(255,255,255,0.02); border: 1px solid var(--glass-border); border-radius: 16px; padding: 1.5rem; transition: transform 0.3s ease, box-shadow 0.3s ease;">
+            <h2 style="font-size: 1.4rem; margin-bottom: 0.5rem;">
+                <a href="{{ p.permalink }}">{{ p.title }}</a>
+            </h2>
+            {% if p.date %}
+            <time style="color: var(--text-muted); font-size: 0.85rem; display: block; margin-bottom: 1rem;">{{ p.date | date(format="%B %d, %Y") }}</time>
+            {% endif %}
+            {% if p.description %}
+            <p style="margin: 0; font-size: 0.95rem; color: var(--text-muted);">{{ p.description }}</p>
+            {% endif %}
+        </article>
+        {% endfor %}
+    </div>
+    {% endif %}
+</section>
+{% endblock %}

--- a/examples/crystalline-void-nexus/templates/shortcodes/alert.html
+++ b/examples/crystalline-void-nexus/templates/shortcodes/alert.html
@@ -1,0 +1,12 @@
+<div style="margin: 2rem 0; padding: 1.5rem; background: rgba(0, 240, 255, 0.05); border: 1px solid var(--cyan-glow); border-radius: 12px; box-shadow: 0 0 15px rgba(0, 240, 255, 0.1); display: flex; align-items: center; gap: 1rem;">
+    <div style="color: var(--cyan-glow); font-size: 1.5rem; display: flex; align-items: center; justify-content: center;">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"></circle>
+            <line x1="12" y1="16" x2="12" y2="12"></line>
+            <line x1="12" y1="8" x2="12.01" y2="8"></line>
+        </svg>
+    </div>
+    <div style="flex-grow: 1;">
+        {% if type %}<strong>{{ type | capitalize }}:</strong> {% endif %}{{ message }}
+    </div>
+</div>

--- a/examples/crystalline-void-nexus/templates/taxonomy.html
+++ b/examples/crystalline-void-nexus/templates/taxonomy.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="content">
+    <header style="margin-bottom: 2rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 1rem;">
+        <h1 style="font-size: 2.5rem; margin-bottom: 0.5rem;">
+            {% if taxonomy is defined and taxonomy.name %}
+            {{ taxonomy.name | capitalize }}
+            {% else %}
+            Taxonomy
+            {% endif %}
+        </h1>
+    </header>
+
+    {% if terms is defined %}
+    <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 1rem;">
+        {% for term in terms %}
+        <li>
+            <a href="{{ term.permalink }}" style="display: inline-block; padding: 0.5rem 1rem; background: rgba(255,255,255,0.05); border: 1px solid var(--glass-border); border-radius: 20px; text-decoration: none;">
+                {{ term.name }} ({{ term.pages | length }})
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</section>
+{% endblock %}

--- a/examples/crystalline-void-nexus/templates/taxonomy_term.html
+++ b/examples/crystalline-void-nexus/templates/taxonomy_term.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="content">
+    <header style="margin-bottom: 2rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 1rem;">
+        <h1 style="font-size: 2.5rem; margin-bottom: 0.5rem;">
+            {% if term is defined and term.name %}
+            {{ term.name }}
+            {% else %}
+            Term
+            {% endif %}
+        </h1>
+    </header>
+
+    {% if term is defined and term.pages %}
+    <ul style="list-style: none; padding: 0;">
+        {% for p in term.pages %}
+        <li style="margin-bottom: 1rem; padding: 1rem; background: rgba(255,255,255,0.02); border-radius: 8px;">
+            <a href="{{ p.permalink }}" style="font-size: 1.2rem; display: block; margin-bottom: 0.5rem;">{{ p.title }}</a>
+            {% if p.date %}
+            <time style="color: var(--text-muted); font-size: 0.85rem;">{{ p.date | date(format="%B %d, %Y") }}</time>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
Add crystalline-void-nexus example

This adds a new Hwaro example site featuring a dark, deep-space glassmorphism aesthetic with glowing neon orbs and futuristic typography.

- Initializes structure
- configures config.toml
- creates custom base.html with responsive design and theme
- refactors core templates to use base.html
- removes unused basic html components

---
*PR created automatically by Jules for task [3672473935666942440](https://jules.google.com/task/3672473935666942440) started by @hahwul*