### PR TITLE
Add new stellar-abyss-glass example site

### DIFF
--- a/examples/stellar-abyss-glass/AGENTS.md
+++ b/examples/stellar-abyss-glass/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/stellar-abyss-glass/archetypes/default.md
+++ b/examples/stellar-abyss-glass/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/stellar-abyss-glass/config.toml
+++ b/examples/stellar-abyss-glass/config.toml
@@ -1,0 +1,55 @@
+
+title = "Stellar Abyss Glass"
+description = "A deep space dark-themed glassmorphism Hwaro example"
+base_url = "http://localhost:3000"
+language = "en"
+default_layout = "page"
+# theme = "default"
+
+[author]
+name = "Hwaro User"
+email = "user@example.com"
+
+[server]
+port = 3000
+host = "0.0.0.0"
+
+[build]
+drafts = false
+output_dir = "public"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+
+[series]
+enabled = false
+
+[related]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[llms]
+enabled = false
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = true
+
+[plugins.highlight]
+enabled = true
+theme = "base16-ocean.dark"

--- a/examples/stellar-abyss-glass/content/about/index.md
+++ b/examples/stellar-abyss-glass/content/about/index.md
@@ -1,0 +1,8 @@
++++
+title = "About Stellar Abyss Glass"
+description = "More information about this unique design."
++++
+
+Stellar Abyss Glass was crafted to provide an immersive, cosmic experience on the web. Using simple CSS backdrops combined with deep blue and purple gradients, it creates a void-like environment illuminated by starlight.
+
+Feel free to use this template as a starting point for your personal portfolios, blogs, or futuristic web applications.

--- a/examples/stellar-abyss-glass/content/index.md
+++ b/examples/stellar-abyss-glass/content/index.md
@@ -1,0 +1,17 @@
++++
+title = "Stellar Abyss Glass"
+description = "A deep space dark-themed glassmorphism aesthetic."
++++
+
+Welcome to the Stellar Abyss Glass template. This design focuses on a deep, dark space environment augmented with elegant glowing neon orbs and translucent frosted glass panels.
+
+This is a demonstration of what you can build with Hwaro, keeping the UI clean, modern, and cosmic.
+
+![Aesthetic Preview](https://picsum.photos/seed/abyss/800/400)
+
+### Features
+
+- Dark-themed glassmorphism
+- Neon glowing orbs
+- Smooth frosted glass panels
+- Modern typography

--- a/examples/stellar-abyss-glass/templates/404.html
+++ b/examples/stellar-abyss-glass/templates/404.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>404 - Not Found</h1>
+    <p>The page you are looking for has been lost in the stellar abyss.</p>
+    <p><a href="/">Return to Base</a></p>
+{% endblock %}

--- a/examples/stellar-abyss-glass/templates/base.html
+++ b/examples/stellar-abyss-glass/templates/base.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="{{ site.language | default(default="en") }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined %}{{ page.title }} - {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --color-bg-dark: #020108;
+            --color-glass-bg: rgba(20, 15, 30, 0.25);
+            --color-glass-border: rgba(255, 255, 255, 0.08);
+            --color-text-main: #e0e0e8;
+            --color-text-muted: #8b8a9c;
+
+            --glow-cyan: #00f0ff;
+            --glow-magenta: #ff0055;
+            --glow-purple: #8a2be2;
+
+            --font-body: 'Inter', sans-serif;
+            --font-display: 'Space Grotesk', sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--color-bg-dark);
+            color: var(--color-text-main);
+            font-family: var(--font-body);
+            line-height: 1.6;
+            min-height: 100vh;
+            overflow-x: hidden;
+            position: relative;
+        }
+
+        /* Cosmic Background Orbs */
+        .cosmic-orb {
+            position: fixed;
+            border-radius: 50%;
+            filter: blur(80px);
+            opacity: 0.4;
+            z-index: -1;
+            animation: float 20s infinite ease-in-out alternate;
+        }
+
+        .orb-1 {
+            width: 400px;
+            height: 400px;
+            background: radial-gradient(circle, var(--glow-cyan), transparent 70%);
+            top: -10%;
+            left: -10%;
+        }
+
+        .orb-2 {
+            width: 500px;
+            height: 500px;
+            background: radial-gradient(circle, var(--glow-purple), transparent 70%);
+            bottom: -20%;
+            right: -10%;
+            animation-delay: -5s;
+        }
+
+        .orb-3 {
+            width: 300px;
+            height: 300px;
+            background: radial-gradient(circle, var(--glow-magenta), transparent 70%);
+            top: 40%;
+            left: 50%;
+            transform: translateX(-50%);
+            animation-duration: 25s;
+            opacity: 0.2;
+        }
+
+        @keyframes float {
+            0% { transform: translate(0, 0) scale(1); }
+            100% { transform: translate(30px, 50px) scale(1.1); }
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+
+        /* Glassmorphism Header */
+        header {
+            padding: 2rem 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        header .logo {
+            font-family: var(--font-display);
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: #fff;
+            text-decoration: none;
+            letter-spacing: -0.02em;
+        }
+
+        nav a {
+            color: var(--color-text-main);
+            text-decoration: none;
+            margin-left: 2rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+        }
+
+        nav a:hover {
+            color: var(--glow-cyan);
+        }
+
+        /* Main Content Glass Panel */
+        main {
+            flex: 1;
+            background: var(--color-glass-bg);
+            backdrop-filter: blur(16px);
+            -webkit-backdrop-filter: blur(16px);
+            border: 1px solid var(--color-glass-border);
+            border-radius: 24px;
+            padding: 3rem;
+            margin-top: 2rem;
+            margin-bottom: 4rem;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+        }
+
+        h1, h2, h3 {
+            font-family: var(--font-display);
+            color: #fff;
+            margin-bottom: 1.5rem;
+        }
+
+        h1 {
+            font-size: 3rem;
+            line-height: 1.2;
+            letter-spacing: -0.03em;
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+            font-size: 1.1rem;
+            color: var(--color-text-muted);
+        }
+
+        a {
+            color: var(--glow-cyan);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        img {
+            max-width: 100%;
+            border-radius: 12px;
+            margin: 2rem 0;
+            border: 1px solid var(--color-glass-border);
+        }
+
+        footer {
+            padding: 2rem 0;
+            text-align: center;
+            color: var(--color-text-muted);
+            border-top: 1px solid var(--color-glass-border);
+            margin-top: auto;
+        }
+
+        /* Glass Cards for lists (if needed) */
+        .glass-card {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid var(--color-glass-border);
+            border-radius: 16px;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+            transition: transform 0.3s ease, background 0.3s ease;
+        }
+
+        .glass-card:hover {
+            transform: translateY(-5px);
+            background: rgba(255, 255, 255, 0.06);
+        }
+
+    </style>
+</head>
+<body>
+    <div class="cosmic-orb orb-1"></div>
+    <div class="cosmic-orb orb-2"></div>
+    <div class="cosmic-orb orb-3"></div>
+
+    <div class="container">
+        <header>
+            <a href="/" class="logo">{{ site.title }}</a>
+            <nav>
+                <a href="/">Home</a>
+                <a href="/about/">About</a>
+            </nav>
+        </header>
+
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer>
+            <p>&copy; {{ site.title }}. Built with Hwaro.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/stellar-abyss-glass/templates/index.html
+++ b/examples/stellar-abyss-glass/templates/index.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+{% endblock %}

--- a/examples/stellar-abyss-glass/templates/page.html
+++ b/examples/stellar-abyss-glass/templates/page.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+{% endblock %}

--- a/examples/stellar-abyss-glass/templates/section.html
+++ b/examples/stellar-abyss-glass/templates/section.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{% if section is defined %}{{ section.title }}{% else %}Section{% endif %}</h1>
+    <div class="content">
+        {% if content is defined and content %}
+            {{ content | safe }}
+        {% endif %}
+    </div>
+
+    <div class="pages-list">
+        {% if section is defined and section.pages is defined %}
+            {% for p in section.pages %}
+                <div class="glass-card">
+                    <h2><a href="{{ p.permalink }}">{{ p.title }}</a></h2>
+                    {% if p.description is defined %}
+                        <p>{{ p.description }}</p>
+                    {% endif %}
+                </div>
+            {% endfor %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/examples/stellar-abyss-glass/templates/shortcodes/alert.html
+++ b/examples/stellar-abyss-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/stellar-abyss-glass/templates/taxonomy.html
+++ b/examples/stellar-abyss-glass/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Taxonomies</h1>
+    <ul>
+        {% if taxonomies is defined %}
+            {% for name, tax in taxonomies %}
+                <li><a href="/{{ name }}/">{{ name | capitalize }}</a></li>
+            {% endfor %}
+        {% endif %}
+    </ul>
+{% endblock %}

--- a/examples/stellar-abyss-glass/templates/taxonomy_term.html
+++ b/examples/stellar-abyss-glass/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ term.name | capitalize }}</h1>
+    <ul>
+        {% if term is defined and term.pages is defined %}
+            {% for page in term.pages %}
+                <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+            {% endfor %}
+        {% endif %}
+    </ul>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -6229,6 +6229,13 @@
     "landing",
     "status"
   ],
+  "stellar-abyss-glass": [
+    "dark",
+    "glassmorphism",
+    "minimal",
+    "portfolio",
+    "cyberpunk"
+  ],
   "stellar-bloom": [
     "dark",
     "elegant",


### PR DESCRIPTION
This PR adds a new sample site to the `examples/` directory called `stellar-abyss-glass`. It was built to showcase a highly stylized, dark-themed "glassmorphism" aesthetic with glowing cosmic neon orbs using pure CSS in custom layouts. 

The example provides a complete, modern UI template while maintaining minimal content as requested. It passes `hwaro tool doctor --fix` and builds successfully with no template errors. It has also been tagged properly in `tags.json` for CI deployment.

---
*PR created automatically by Jules for task [18014289032717091755](https://jules.google.com/task/18014289032717091755) started by @hahwul*