### PR TITLE
feat: add synth-velvet-dream example theme

### DIFF
--- a/examples/synth-velvet-dream/AGENTS.md
+++ b/examples/synth-velvet-dream/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/synth-velvet-dream/archetypes/default.md
+++ b/examples/synth-velvet-dream/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/synth-velvet-dream/config.toml
+++ b/examples/synth-velvet-dream/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Synth Velvet Dream"
+description = "Welcome to my new Hwaro site."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/synth-velvet-dream/content/about.md
+++ b/examples/synth-velvet-dream/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About the Dream"
+description = "Learn about the origins of the Synth Velvet aesthetic."
++++
+
+The **Synth Velvet Dream** theme was forged to showcase Hwaro's capabilities in building visually stunning, modern, and high-performance static websites.
+
+### The Vision
+
+We wanted to combine the nostalgic energy of *synthwave* with the luxurious, deep textures of *velvet*, all packaged within a sleek, modern *glassmorphism* UI. The result is a theme that feels both retro-futuristic and elegantly contemporary.
+
+### Built with Hwaro
+
+This site demonstrates:
+- Custom base templates with dynamic `{{ content | safe }}` block rendering.
+- Integration of `alert` shortcodes with theme-specific styling.
+- Responsive, fluid design using modern CSS.
+
+{{ alert(type="warning", body="The velvet void is vast. Don't get lost in the reflections.") }}

--- a/examples/synth-velvet-dream/content/index.md
+++ b/examples/synth-velvet-dream/content/index.md
@@ -1,0 +1,30 @@
++++
+title = "Welcome to the Synth Velvet Dream"
+description = "A glassmorphism aesthetic inspired by deep synthwave and velvet textures."
++++
+
+Enter a dimension where **deep velvet night** meets glowing *neon synthwave* echoes. This is the **Synth Velvet Dream** aesthetic for Hwaro.
+
+## Features of the Void
+
+- 🌌 **Deep Velvet Void**: A rich, dark background infused with subtle glowing orbs.
+- 🔮 **Glassmorphism Panels**: Translucent UI components with a frosted glass effect (`backdrop-filter`).
+- ⚡ **Neon Accents**: Cybernetic pulses of Cyan (`#00f0ff`) and Magenta (`#ff0055`) illuminating the dark.
+- 📐 **Modern Typography**: Featuring *Space Grotesk* for bold headers and *Inter* for clean body text.
+
+### Code in the Dark
+
+```javascript
+function initiateDreamSequence(user) {
+  const aesthetic = {
+    background: "velvet_void",
+    accents: ["cyan", "magenta", "purple"],
+    style: "glassmorphism"
+  };
+
+  console.log(`Welcome, ${user}. Loading dream sequence...`);
+  return aesthetic;
+}
+```
+
+{{ alert(type="info", body="This site uses Hwaro shortcodes. The above is an example of syntax highlighting combined with our custom glass-panel styling.") }}

--- a/examples/synth-velvet-dream/templates/404.html
+++ b/examples/synth-velvet-dream/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel" style="text-align: center; padding: 4rem 2rem;">
+  <h1 style="font-size: 5rem; margin-bottom: 0;">404</h1>
+  <h2>Void Not Found</h2>
+  <p>The signal you are looking for has faded into the velvet night.</p>
+  <a href="{{ site.base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 0.75rem 1.5rem; background: rgba(0, 240, 255, 0.1); border: 1px solid var(--accent-cyan); border-radius: 8px; font-weight: 600;">Return to Source</a>
+</div>
+{% endblock %}

--- a/examples/synth-velvet-dream/templates/base.html
+++ b/examples/synth-velvet-dream/templates/base.html
@@ -1,0 +1,384 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is defined %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+
+  {% if site.plugins is defined and site.plugins.og is defined and site.plugins.og.enabled %}
+    {{ og_all_tags }}
+  {% endif %}
+  {{ hreflang_tags }}
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg-void: #0a0213;
+      --bg-deep: #160424;
+
+      --accent-cyan: #00f0ff;
+      --accent-magenta: #ff0055;
+      --accent-purple: #8a2be2;
+      --accent-pink: #ff007f;
+
+      --text-main: #f0f0f5;
+      --text-muted: #a0a0b5;
+
+      --glass-bg: rgba(22, 4, 36, 0.4);
+      --glass-border: rgba(255, 255, 255, 0.08);
+      --glass-highlight: rgba(255, 255, 255, 0.12);
+      --glass-blur: blur(16px);
+
+      --glow-cyan: 0 0 20px rgba(0, 240, 255, 0.4);
+      --glow-magenta: 0 0 20px rgba(255, 0, 85, 0.4);
+
+      --font-sans: 'Inter', sans-serif;
+      --font-display: 'Space Grotesk', sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      font-family: var(--font-sans);
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text-main);
+      background-color: var(--bg-void);
+      background-image:
+        radial-gradient(circle at 15% 50%, rgba(138, 43, 226, 0.15), transparent 40%),
+        radial-gradient(circle at 85% 30%, rgba(255, 0, 85, 0.15), transparent 40%),
+        radial-gradient(circle at 50% 80%, rgba(0, 240, 255, 0.1), transparent 50%);
+      background-attachment: fixed;
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+
+    /* Ambient animated orbs */
+    .ambient-orb {
+      position: fixed;
+      border-radius: 50%;
+      filter: blur(80px);
+      z-index: -1;
+      opacity: 0.5;
+      animation: float 20s infinite ease-in-out;
+    }
+
+    .orb-1 {
+      top: -10%; left: -10%;
+      width: 50vw; height: 50vw;
+      background: radial-gradient(circle, var(--accent-purple), transparent 70%);
+      animation-delay: 0s;
+    }
+
+    .orb-2 {
+      bottom: -20%; right: -10%;
+      width: 60vw; height: 60vw;
+      background: radial-gradient(circle, var(--accent-magenta), transparent 70%);
+      animation-delay: -5s;
+    }
+
+    .orb-3 {
+      top: 40%; left: 60%;
+      width: 40vw; height: 40vw;
+      background: radial-gradient(circle, var(--accent-cyan), transparent 70%);
+      animation-delay: -10s;
+      opacity: 0.3;
+    }
+
+    @keyframes float {
+      0%, 100% { transform: translate(0, 0) scale(1); }
+      25% { transform: translate(5%, 5%) scale(1.1); }
+      50% { transform: translate(0, 10%) scale(0.9); }
+      75% { transform: translate(-5%, 5%) scale(1.05); }
+    }
+
+    .site-wrapper {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+      position: relative;
+      z-index: 1;
+    }
+
+    /* Header */
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1.5rem 2rem;
+      margin: 2rem 0 3rem 0;
+      background: var(--glass-bg);
+      backdrop-filter: var(--glass-blur);
+      -webkit-backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    }
+
+    .site-logo {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1.5rem;
+      color: var(--text-main);
+      text-decoration: none;
+      letter-spacing: -0.02em;
+      background: linear-gradient(135deg, #fff, var(--accent-cyan));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      transition: all 0.3s ease;
+    }
+
+    .site-logo:hover {
+      text-shadow: var(--glow-cyan);
+    }
+
+    .site-header nav {
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    .site-header nav a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-family: var(--font-display);
+      font-weight: 500;
+      transition: all 0.3s ease;
+      padding: 0.5rem 1rem;
+      border-radius: 8px;
+    }
+
+    .site-header nav a:hover {
+      color: var(--text-main);
+      background: rgba(255, 255, 255, 0.05);
+      box-shadow: inset 0 0 0 1px var(--glass-highlight);
+    }
+
+    .site-main {
+      min-height: calc(100vh - 250px);
+    }
+
+    /* Glass Panels */
+    .glass-panel {
+      background: var(--glass-bg);
+      backdrop-filter: var(--glass-blur);
+      -webkit-backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--glass-border);
+      border-radius: 20px;
+      padding: 2.5rem;
+      margin-bottom: 2rem;
+      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .glass-panel::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+    }
+
+    /* Typography */
+    h1, h2, h3 {
+      font-family: var(--font-display);
+      line-height: 1.2;
+      margin-top: 1.5em;
+      margin-bottom: 0.75em;
+      font-weight: 700;
+      color: var(--text-main);
+    }
+
+    h1 {
+      font-size: 3rem;
+      margin-top: 0;
+      letter-spacing: -0.03em;
+      background: linear-gradient(135deg, #fff, var(--accent-magenta));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin-bottom: 1rem;
+    }
+
+    h2 { font-size: 2rem; }
+    h3 { font-size: 1.5rem; }
+    p { margin: 1.2em 0; color: var(--text-muted); font-size: 1.05rem; }
+
+    a {
+      color: var(--accent-cyan);
+      text-decoration: none;
+      transition: all 0.2s ease;
+    }
+
+    a:hover {
+      color: #fff;
+      text-shadow: var(--glow-cyan);
+    }
+
+    /* Code blocks */
+    code {
+      background: rgba(0, 0, 0, 0.3);
+      padding: 0.2em 0.4em;
+      border-radius: 6px;
+      font-size: 0.85em;
+      font-family: 'Fira Code', ui-monospace, SFMono-Regular, Consolas, monospace;
+      color: var(--accent-pink);
+      border: 1px solid var(--glass-border);
+    }
+
+    pre {
+      background: rgba(10, 2, 19, 0.8) !important;
+      padding: 1.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      border: 1px solid var(--glass-border);
+      box-shadow: inset 0 2px 10px rgba(0, 0, 0, 0.5);
+    }
+
+    pre code {
+      background: none;
+      padding: 0;
+      border: none;
+      color: inherit;
+    }
+
+    /* Lists */
+    ul.section-list {
+      list-style: none;
+      padding: 0;
+      margin: 2rem 0;
+      display: grid;
+      gap: 1rem;
+    }
+
+    ul.section-list li {
+      background: rgba(255, 255, 255, 0.03);
+      border-radius: 12px;
+      border: 1px solid var(--glass-border);
+      transition: all 0.3s ease;
+    }
+
+    ul.section-list li:hover {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: var(--accent-cyan);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4), var(--glow-cyan);
+    }
+
+    ul.section-list li a {
+      display: block;
+      padding: 1.25rem 1.5rem;
+      font-family: var(--font-display);
+      font-weight: 600;
+      font-size: 1.2rem;
+      color: var(--text-main);
+    }
+
+    ul.section-list li a:hover {
+      text-shadow: none;
+    }
+
+    /* Footer */
+    .site-footer {
+      margin-top: 4rem;
+      padding: 2rem;
+      border-top: 1px solid var(--glass-border);
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      text-align: center;
+      background: var(--glass-bg);
+      backdrop-filter: var(--glass-blur);
+      -webkit-backdrop-filter: var(--glass-blur);
+      border-radius: 16px 16px 0 0;
+    }
+
+    /* Taxonomy & Pagination */
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 2rem; font-size: 1.1rem; }
+
+    nav.pagination { margin: 3rem 0; }
+    nav.pagination .pagination-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    nav.pagination a, nav.pagination span {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 40px;
+      height: 40px;
+      padding: 0 0.75rem;
+      border-radius: 8px;
+      border: 1px solid var(--glass-border);
+      background: rgba(255, 255, 255, 0.03);
+      color: var(--text-muted);
+      text-decoration: none;
+      font-family: var(--font-display);
+      font-weight: 600;
+      transition: all 0.2s ease;
+    }
+
+    nav.pagination a:hover {
+      color: #fff;
+      border-color: var(--accent-magenta);
+      background: rgba(255, 0, 85, 0.1);
+      box-shadow: var(--glow-magenta);
+    }
+
+    .pagination-current span {
+      color: #fff;
+      border-color: var(--accent-cyan);
+      background: rgba(0, 240, 255, 0.15);
+      box-shadow: var(--glow-cyan);
+    }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .site-header {
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1.25rem;
+      }
+      .glass-panel { padding: 1.5rem; }
+      h1 { font-size: 2.25rem; }
+    }
+  </style>
+
+  {% if site.plugins is defined and site.plugins.highlight is defined and site.plugins.highlight.enabled %}
+    {{ highlight_css }}
+  {% endif %}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section | default(value='') }}">
+  <div class="ambient-orb orb-1"></div>
+  <div class="ambient-orb orb-2"></div>
+  <div class="ambient-orb orb-3"></div>
+
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ site.base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ site.base_url }}/">Home</a>
+        <a href="{{ site.base_url }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} {{ site.title }}. Built with Hwaro.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/synth-velvet-dream/templates/page.html
+++ b/examples/synth-velvet-dream/templates/page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-panel">
+  <h1>{{ page.title | e }}</h1>
+  <div class="content">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/examples/synth-velvet-dream/templates/section.html
+++ b/examples/synth-velvet-dream/templates/section.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel">
+  <h1>{{ page.title | e }}</h1>
+  <div class="content">
+    {{ content | safe }}
+  </div>
+</div>
+
+{% if section.list is defined and section.list | length > 0 %}
+<ul class="section-list">
+  {{ section.list | safe }}
+</ul>
+{% endif %}
+
+{% if pagination is defined %}
+  {{ pagination | safe }}
+{% endif %}
+{% endblock %}

--- a/examples/synth-velvet-dream/templates/shortcodes/alert.html
+++ b/examples/synth-velvet-dream/templates/shortcodes/alert.html
@@ -1,0 +1,8 @@
+<div style="padding: 1.25rem 1.5rem; border-left: 4px solid var(--accent-magenta); background: rgba(255, 0, 85, 0.1); border-radius: 0 8px 8px 0; margin: 1.5rem 0;">
+  {% if type == "warning" %}
+    <strong style="color: var(--accent-magenta); display: block; margin-bottom: 0.5rem; font-family: var(--font-display);">⚠️ Warning</strong>
+  {% elif type == "info" %}
+    <strong style="color: var(--accent-cyan); display: block; margin-bottom: 0.5rem; font-family: var(--font-display);">ℹ️ Info</strong>
+  {% endif %}
+  <span style="color: var(--text-main);">{{ body | safe }}</span>
+</div>

--- a/examples/synth-velvet-dream/templates/taxonomy.html
+++ b/examples/synth-velvet-dream/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel">
+  <h1>{{ taxonomy.name | capitalize | e }}</h1>
+  <p class="taxonomy-desc">Explore all {{ taxonomy.name | e }} across the site.</p>
+</div>
+
+<ul class="section-list">
+  {% if terms is defined %}
+    {% for term in terms %}
+      <li><a href="{{ term.permalink }}">{{ term.name | e }} ({{ term.pages | length }})</a></li>
+    {% endfor %}
+  {% endif %}
+</ul>
+{% endblock %}

--- a/examples/synth-velvet-dream/templates/taxonomy_term.html
+++ b/examples/synth-velvet-dream/templates/taxonomy_term.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel">
+  <h1>{{ term.name | e }}</h1>
+  <p class="taxonomy-desc">Pages tagged with "{{ term.name | e }}"</p>
+</div>
+
+<ul class="section-list">
+  {% if term is defined and term.pages is defined %}
+    {% for page in term.pages %}
+      <li><a href="{{ page.permalink }}">{{ page.title | e }}</a></li>
+    {% endfor %}
+  {% endif %}
+</ul>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -6395,6 +6395,12 @@
     "cyberpunk",
     "neon"
   ],
+  "synth-velvet-dream": [
+    "dark",
+    "glassmorphism",
+    "synthwave",
+    "velvet"
+  ],
   "synthwave": [
     "dark",
     "retro",


### PR DESCRIPTION
This PR adds a new visually distinct example theme named `synth-velvet-dream` to showcase Hwaro's capabilities. 

The aesthetic is a dark-themed glassmorphism design with a deep velvet void background and glowing neon synthwave accents (cyan, magenta, purple).

Changes include:
- A new `examples/synth-velvet-dream` project scaffolded via `hwaro init`.
- A fully customized `base.html` providing the global layout, CSS variables, and animated orb background.
- Refactored page and section templates to inherit from `base.html`.
- Updated `shortcodes/alert.html` to align with the new dark aesthetic.
- Added sample content (`index.md` and `about.md`) to demonstrate features.
- Registered the new theme in `tags.json`.

---
*PR created automatically by Jules for task [3637915298730898819](https://jules.google.com/task/3637915298730898819) started by @hahwul*