### PR TITLE
Add cyber-lotus-2077 example site

### DIFF
--- a/examples/cyber-lotus-2077/AGENTS.md
+++ b/examples/cyber-lotus-2077/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/cyber-lotus-2077/config.toml
+++ b/examples/cyber-lotus-2077/config.toml
@@ -1,0 +1,13 @@
+title = "Cyber Lotus 2077"
+base_url = "http://localhost:3000"
+language = "en"
+compile_sass = true
+minify_html = true
+
+[taxonomies]
+tag = "tags"
+category = "categories"
+
+[extra]
+author = "Jules"
+description = "A neon-drenched cyberpunk lotus portfolio."

--- a/examples/cyber-lotus-2077/content/about.md
+++ b/examples/cyber-lotus-2077/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "Operator Profile"
+description = "Information about the primary operator."
+template = "page"
++++
+
+### IDENT: JULES // CL: OMEGA
+
+The primary operator of this node specializes in high-fidelity cybernetic architectures and aesthetic synthetics.
+
+**Skills:**
+*   Quantum HTML Manipulation
+*   CSS-Grid Subversion
+*   Neon Protocol Implementation
+
+Contact the grid administrator if errors persist in the visual cortex.

--- a/examples/cyber-lotus-2077/content/index.md
+++ b/examples/cyber-lotus-2077/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Main Terminal"
+description = "Welcome to the Cyber Lotus network."
+template = "page"
++++
+
+**SYS_MSG:** Connection established. Encryption verified.
+
+Welcome to the **Cyber Lotus** mainframe. This node serves as a central repository for hyper-threaded neural data and synthetic flora research.
+
+### Current Objectives
+*   Monitor neon-fluid levels in the lower sectors.
+*   Optimize glassmorphism UI subroutines.
+*   Maintain the digital lotus bloom sequence.
+
+> "In the neon glow, the lotus still blooms." — *Unknown Operator*

--- a/examples/cyber-lotus-2077/templates/404.html
+++ b/examples/cyber-lotus-2077/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-lotus-2077/templates/footer.html
+++ b/examples/cyber-lotus-2077/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="margin-top: 4rem; text-align: center; font-family: 'Orbitron', sans-serif; color: var(--secondary); font-size: 0.8rem; letter-spacing: 2px; border-top: 1px solid var(--border); padding-top: 2rem;">
+      SYS.VER 2.0.77 // POWERED BY HWARO
+    </footer>
+  </div>
+  {{ auto_includes | safe }}
+</body>
+</html>

--- a/examples/cyber-lotus-2077/templates/header.html
+++ b/examples/cyber-lotus-2077/templates/header.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="{{ language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Rajdhani:wght@300;500;700&display=swap');
+    :root {
+      --bg: #09090b;
+      --bg-panel: rgba(20, 20, 25, 0.7);
+      --text: #e0e0e0;
+      --primary: #ff0055;
+      --secondary: #00f0ff;
+      --accent: #b026ff;
+      --border: rgba(0, 240, 255, 0.3);
+      --glow: 0 0 10px rgba(0, 240, 255, 0.5), 0 0 20px rgba(0, 240, 255, 0.3);
+      --glow-pink: 0 0 10px rgba(255, 0, 85, 0.5), 0 0 20px rgba(255, 0, 85, 0.3);
+    }
+    body {
+      margin: 0;
+      background-color: var(--bg);
+      background-image:
+        radial-gradient(circle at 15% 50%, rgba(255, 0, 85, 0.08) 0%, transparent 50%),
+        radial-gradient(circle at 85% 30%, rgba(0, 240, 255, 0.08) 0%, transparent 50%);
+      color: var(--text);
+      font-family: 'Rajdhani', sans-serif;
+      overflow-x: hidden;
+    }
+    h1, h2, h3, h4, h5, h6 { font-family: 'Orbitron', sans-serif; text-transform: uppercase; letter-spacing: 2px; }
+    a { color: var(--secondary); text-decoration: none; transition: all 0.3s ease; }
+    a:hover { color: var(--primary); text-shadow: var(--glow-pink); }
+    .container { max-width: 900px; margin: 0 auto; padding: 2rem; position: relative; z-index: 10; }
+    header {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 1.5rem 2rem; margin-bottom: 3rem;
+      background: var(--bg-panel); backdrop-filter: blur(10px);
+      border-bottom: 1px solid var(--border); box-shadow: var(--glow);
+    }
+    .logo {
+      font-family: 'Orbitron', sans-serif; font-size: 1.8rem; font-weight: 900;
+      color: #fff; text-shadow: var(--glow-pink); letter-spacing: 3px;
+    }
+    nav { display: flex; gap: 2rem; }
+    nav a { font-weight: 700; font-size: 1.1rem; text-transform: uppercase; letter-spacing: 1px; }
+    .content-box {
+      background: var(--bg-panel); backdrop-filter: blur(12px);
+      border: 1px solid rgba(176, 38, 255, 0.3); border-radius: 4px;
+      padding: 3rem; box-shadow: 0 0 30px rgba(176, 38, 255, 0.1);
+      position: relative;
+    }
+    .content-box::before {
+      content: ''; position: absolute; top: 0; left: 0; width: 100%; height: 2px;
+      background: linear-gradient(90deg, transparent, var(--secondary), transparent);
+    }
+    /* Simple Lotus CSS Art */
+    .lotus-bg {
+      position: fixed; bottom: -100px; right: -100px; opacity: 0.1; z-index: 0; pointer-events: none;
+      width: 400px; height: 400px; background: radial-gradient(circle, var(--primary) 0%, transparent 60%);
+      filter: blur(50px);
+    }
+  </style>
+  {{ highlight_tags | safe }}
+</head>
+<body>
+  <div class="lotus-bg"></div>
+  <div class="container">
+    <header>
+      <a href="{{ base_url }}/" class="logo">CYBER_LOTUS</a>
+      <nav>
+        <a href="{{ base_url }}/">System</a>
+        <a href="{{ base_url }}/about/">Operator</a>
+      </nav>
+    </header>

--- a/examples/cyber-lotus-2077/templates/page.html
+++ b/examples/cyber-lotus-2077/templates/page.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="content-box">
+    <h1 style="color: var(--primary); text-shadow: var(--glow-pink); border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-top: 0;">{{ page.title }}</h1>
+    <div style="font-size: 1.1rem; line-height: 1.8;">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-lotus-2077/templates/section.html
+++ b/examples/cyber-lotus-2077/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="content-box">
+    <h1 style="color: var(--primary); text-shadow: var(--glow-pink); border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-top: 0;">{{ page.title }}</h1>
+    <div style="font-size: 1.1rem; line-height: 1.8;">
+      {{ content | safe }}
+    </div>
+    <ul style="list-style: none; padding: 0; margin-top: 2rem;">
+      {% for p in section.pages %}
+        <li style="margin-bottom: 1rem; padding: 1rem; border-left: 3px solid var(--secondary); background: rgba(0,240,255,0.05); transition: background 0.3s;">
+          <a href="{{ p.url }}" style="font-family: 'Orbitron', sans-serif; font-size: 1.2rem;">{{ p.title }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-lotus-2077/templates/shortcodes/alert.html
+++ b/examples/cyber-lotus-2077/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/cyber-lotus-2077/templates/taxonomy.html
+++ b/examples/cyber-lotus-2077/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-lotus-2077/templates/taxonomy_term.html
+++ b/examples/cyber-lotus-2077/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -7312,5 +7312,11 @@
     "diy",
     "raw",
     "unconventional"
+  ],
+  "cyber-lotus-2077": [
+    "dark",
+    "cyberpunk",
+    "glassmorphism",
+    "neon"
   ]
 }


### PR DESCRIPTION
Added a new Hwaro example site named `cyber-lotus-2077` to the `examples/` directory.

The site features a custom "Cyberpunk Lotus" design utilizing dark themes, neon pink/cyan accents, and glassmorphism UI elements. It includes:
* Updated basic scaffolding (`config.toml`, markdown content in `index.md` and `about.md`).
* A custom CSS layout applied via `header.html`, `footer.html`, `page.html`, and `section.html`.
* Correct registration of the example in the root `tags.json` file.
* Removed the initial regression where the root `AGENTS.md` file was mistakenly overwritten.

---
*PR created automatically by Jules for task [6079842648294457710](https://jules.google.com/task/6079842648294457710) started by @chei-l*