### PR TITLE
feat: add Spectral Loom Glass example

### DIFF
--- a/examples/spectral-loom-glass/AGENTS.md
+++ b/examples/spectral-loom-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/spectral-loom-glass/archetypes/default.md
+++ b/examples/spectral-loom-glass/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/spectral-loom-glass/config.toml
+++ b/examples/spectral-loom-glass/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Spectral Loom Glass"
+description = "A dark-themed glassmorphism portfolio featuring animated spectral gradients and frosted glass panels."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/spectral-loom-glass/content/about.md
+++ b/examples/spectral-loom-glass/content/about.md
@@ -1,0 +1,13 @@
++++
+title = "About Spectral Loom"
+description = "Information about the design and the framework"
+template = "page"
++++
+
+Spectral Loom Glass is designed as an elegant and futuristic portfolio template for the Hwaro static site generator.
+
+The aesthetic draws heavy inspiration from cyberpunk and futuristic void styles, utilizing deep, almost pitch-black backgrounds contrasted with intense, highly saturated neon colors (#00f0ff and #ff0055).
+
+### Architecture
+
+This project uses an entirely customized layout. All default structural HTML files have been overridden to extend a centralized `base.html` layout, keeping the application scalable, simple to navigate, and exceptionally clean.

--- a/examples/spectral-loom-glass/content/index.md
+++ b/examples/spectral-loom-glass/content/index.md
@@ -1,0 +1,17 @@
++++
+title = "Spectral Loom Glass"
+description = "A dark-themed portfolio featuring glassmorphism and animated spectral flows."
+template = "page"
++++
+
+Welcome to Spectral Loom Glass, an ethereal intersection of deep void aesthetics and shimmering frosted glass.
+
+This is a demonstration of Hwaro's rendering capabilities through a meticulously crafted dark theme, showcasing animated gradient orbs passing gracefully behind translucent, blurred containers (`backdrop-filter`).
+
+## Immersive Elements
+
+* **Dynamic Spectral Gradients**: Animated cyan and magenta orbs that float infinitely in the background void.
+* **Glassmorphism Panels**: Frosted overlays that blur and refract the elements beneath them, accented with subtle highlights.
+* **Modern Typography**: Bold `Space Grotesk` headings paired with legible, clean `Inter` body text.
+
+{{ alert(type="info", message="Experience the deep dark void and vibrant neon highlights directly from this layout.") }}

--- a/examples/spectral-loom-glass/templates/404.html
+++ b/examples/spectral-loom-glass/templates/404.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page glass-panel">
+  <header class="page-header">
+    <h1 class="page-title">404 Not Found</h1>
+  </header>
+
+  <div class="page-content">
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </div>
+</article>
+{% endblock %}

--- a/examples/spectral-loom-glass/templates/base.html
+++ b/examples/spectral-loom-glass/templates/base.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
+
+  {% include "header.html" %}
+</head>
+<body>
+  <div class="background-animation">
+    <div class="glow-orb orb-1"></div>
+    <div class="glow-orb orb-2"></div>
+    <div class="glow-orb orb-3"></div>
+  </div>
+
+  <div class="container">
+    <nav class="nav-bar glass-panel">
+      <a href="{{ base_url }}/" class="logo">Spectral<span class="highlight">Loom</span></a>
+      <ul class="nav-links">
+        <li><a href="{{ base_url }}/">Home</a></li>
+        <li><a href="{{ base_url }}/about/">About</a></li>
+      </ul>
+    </nav>
+
+    <main class="main-content">
+      {% block content %}{% endblock %}
+    </main>
+
+    {% include "footer.html" %}
+  </div>
+</body>
+</html>

--- a/examples/spectral-loom-glass/templates/footer.html
+++ b/examples/spectral-loom-glass/templates/footer.html
@@ -1,0 +1,4 @@
+<footer class="site-footer">
+  <p>&copy; {{ current_year }} {{ site.title }}. All rights reserved.</p>
+  <p>Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+</footer>

--- a/examples/spectral-loom-glass/templates/header.html
+++ b/examples/spectral-loom-glass/templates/header.html
@@ -1,0 +1,267 @@
+<style>
+  :root {
+    --bg-dark: #03010A;
+    --bg-surface: rgba(255, 255, 255, 0.03);
+    --border-glass: rgba(255, 255, 255, 0.08);
+    --text-main: #f0f0f5;
+    --text-muted: #a0a0b0;
+
+    --neon-cyan: #00f0ff;
+    --neon-magenta: #ff0055;
+    --neon-purple: #8a2be2;
+
+    --font-heading: 'Space Grotesk', sans-serif;
+    --font-body: 'Inter', sans-serif;
+  }
+
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    font-family: var(--font-body);
+    background-color: var(--bg-dark);
+    color: var(--text-main);
+    line-height: 1.6;
+    overflow-x: hidden;
+    position: relative;
+    min-height: 100vh;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 1rem;
+    letter-spacing: -0.02em;
+  }
+
+  a {
+    color: var(--neon-cyan);
+    text-decoration: none;
+    transition: color 0.3s ease;
+  }
+
+  a:hover {
+    color: var(--neon-magenta);
+  }
+
+  /* Background Animation */
+  .background-animation {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .glow-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(120px);
+    opacity: 0.6;
+    animation: float 20s infinite alternate ease-in-out;
+  }
+
+  .orb-1 {
+    top: -10%;
+    left: -10%;
+    width: 50vw;
+    height: 50vw;
+    background: radial-gradient(circle, var(--neon-purple), transparent 70%);
+    animation-delay: 0s;
+  }
+
+  .orb-2 {
+    bottom: -20%;
+    right: -10%;
+    width: 60vw;
+    height: 60vw;
+    background: radial-gradient(circle, var(--neon-cyan), transparent 70%);
+    animation-delay: -5s;
+    opacity: 0.4;
+  }
+
+  .orb-3 {
+    top: 30%;
+    left: 40%;
+    width: 40vw;
+    height: 40vw;
+    background: radial-gradient(circle, var(--neon-magenta), transparent 70%);
+    animation-delay: -10s;
+    opacity: 0.3;
+  }
+
+  @keyframes float {
+    0% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(5%, 5%) scale(1.1); }
+    100% { transform: translate(-5%, -5%) scale(0.9); }
+  }
+
+  /* Layout container */
+  .container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  .main-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    margin-top: 2rem;
+  }
+
+  /* Glassmorphism Panel */
+  .glass-panel {
+    background: var(--bg-surface);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--border-glass);
+    border-radius: 16px;
+    padding: 2.5rem;
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .glass-panel::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+  }
+
+  /* Navigation */
+  .nav-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 2rem;
+  }
+
+  .logo {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-main);
+    letter-spacing: -0.05em;
+  }
+
+  .logo .highlight {
+    color: var(--neon-magenta);
+    text-shadow: 0 0 10px rgba(255, 0, 85, 0.5);
+  }
+
+  .nav-links {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .nav-links a {
+    color: var(--text-main);
+    font-weight: 500;
+    font-size: 0.95rem;
+  }
+
+  .nav-links a:hover {
+    color: var(--neon-cyan);
+    text-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+  }
+
+  /* Typography / Content */
+  .page-title {
+    font-size: 3rem;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(90deg, #fff, var(--text-muted));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .page-meta {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+  }
+
+  .page-content p {
+    margin-bottom: 1.5rem;
+    color: #d0d0dc;
+    font-size: 1.1rem;
+  }
+
+  .page-content h2 {
+    margin-top: 2.5rem;
+    font-size: 2rem;
+  }
+
+  /* Grid Layout for Posts */
+  .post-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+    margin-top: 2rem;
+  }
+
+  .post-card {
+    display: block;
+    padding: 2rem;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    text-decoration: none;
+  }
+
+  .post-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgba(0, 240, 255, 0.3);
+    color: var(--text-main);
+  }
+
+  .post-card h2 {
+    font-size: 1.5rem;
+    margin-bottom: 0.75rem;
+    color: #fff;
+  }
+
+  .post-card .post-summary {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+  }
+
+  /* Footer */
+  .site-footer {
+    margin-top: 4rem;
+    text-align: center;
+    padding: 2rem 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    border-top: 1px solid var(--border-glass);
+  }
+
+  .site-footer a {
+    color: var(--text-muted);
+    text-decoration: underline;
+  }
+
+  .site-footer a:hover {
+    color: var(--neon-cyan);
+  }
+
+  /* Responsive */
+  @media (max-width: 768px) {
+    .page-title { font-size: 2.2rem; }
+    .nav-bar { flex-direction: column; gap: 1rem; }
+    .container { padding: 1rem; }
+    .glass-panel { padding: 1.5rem; }
+  }
+</style>

--- a/examples/spectral-loom-glass/templates/page.html
+++ b/examples/spectral-loom-glass/templates/page.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page glass-panel">
+  <header class="page-header">
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    {% if page.date %}
+      <div class="page-meta">{{ page.date | date("%B %d, %Y") }}</div>
+    {% endif %}
+  </header>
+
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/examples/spectral-loom-glass/templates/section.html
+++ b/examples/spectral-loom-glass/templates/section.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="section">
+  <div class="section-intro glass-panel">
+    <h1 class="section-title">{{ section.title | e }}</h1>
+    {% if section.description %}
+      <p class="section-desc">{{ section.description | e }}</p>
+    {% endif %}
+    {{ content | safe }}
+  </div>
+
+  <div class="post-grid">
+    {% for page in section.pages %}
+      <a href="{{ page.url }}" class="post-card glass-panel">
+        <h2 class="post-title">{{ page.title | e }}</h2>
+        {% if page.summary %}
+          <p class="post-summary">{{ page.summary | strip_html | truncate_words(30) }}</p>
+        {% endif %}
+      </a>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/examples/spectral-loom-glass/templates/shortcodes/alert.html
+++ b/examples/spectral-loom-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert glass-panel" style="padding: 1.5rem; border-left: 4px solid var(--neon-cyan); margin: 2rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ message | safe }}
+</div>

--- a/examples/spectral-loom-glass/templates/taxonomy.html
+++ b/examples/spectral-loom-glass/templates/taxonomy.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="section">
+  <div class="section-intro glass-panel">
+    <h1 class="section-title">{{ page.title | e }}</h1>
+    <p class="section-desc">Browse all terms in this taxonomy:</p>
+    {{ content | safe }}
+  </div>
+</section>
+{% endblock %}

--- a/examples/spectral-loom-glass/templates/taxonomy_term.html
+++ b/examples/spectral-loom-glass/templates/taxonomy_term.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="section">
+  <div class="section-intro glass-panel">
+    <h1 class="section-title">{{ page.title | e }}</h1>
+    <p class="section-desc">Posts tagged with this term:</p>
+    {{ content | safe }}
+  </div>
+</section>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1974,6 +1974,12 @@
     "dark",
     "futuristic"
   ],
+  "cyber-lotus-2077": [
+    "dark",
+    "cyberpunk",
+    "glassmorphism",
+    "neon"
+  ],
   "cyber-lumina-spark": [
     "cyberpunk",
     "glow",
@@ -6897,6 +6903,12 @@
     "spectrum",
     "rainbow"
   ],
+  "spectral-loom-glass": [
+    "dark",
+    "portfolio",
+    "cyberpunk",
+    "glassmorphism"
+  ],
   "spectrum": [
     "light",
     "blog",
@@ -8132,11 +8144,5 @@
     "diy",
     "raw",
     "unconventional"
-  ],
-  "cyber-lotus-2077": [
-    "dark",
-    "cyberpunk",
-    "glassmorphism",
-    "neon"
   ]
 }


### PR DESCRIPTION
Creates a new `spectral-loom-glass` example project for Hwaro. It includes a custom base layout with dark theme, glassmorphism UI elements using `backdrop-filter: blur(16px)`, animated spectral CSS gradients for visual appeal, and modern typography combinations utilizing `Space Grotesk` and `Inter` from Google Fonts. Also registers the new example in the global `tags.json`.

---
*PR created automatically by Jules for task [10612725820128038095](https://jules.google.com/task/10612725820128038095) started by @hahwul*