### PR TITLE
Add Apolo Nova Example Site

### DIFF
--- a/examples/apolo-nova/AGENTS.md
+++ b/examples/apolo-nova/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/apolo-nova/archetypes/default.md
+++ b/examples/apolo-nova/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/apolo-nova/config.toml
+++ b/examples/apolo-nova/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "My Hwaro Site"
+description = "Welcome to my new Hwaro site."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/apolo-nova/content/about.md
+++ b/examples/apolo-nova/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Apolo Nova"
+description = "Mission logs and crew details."
+tags = ["about", "mission"]
++++
+
+# Mission Overview
+
+Apolo Nova was established in the year 2142 to explore the outer rim of the galaxy. Our primary directive is to map anomalies, document new phenomena, and transmit our findings back to Earth.
+
+*The universe is vast, and we are its observers.*

--- a/examples/apolo-nova/content/index.md
+++ b/examples/apolo-nova/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Apolo Nova Station"
+description = "Welcome to the edge of the cosmos."
+tags = ["welcome", "exploration"]
++++
+
+# Transmission Received
+
+Welcome to **Apolo Nova**, a cutting-edge exploration outpost built on the Hwaro network.
+
+## Current Status
+- **Systems:** Nominal
+- **Hyperdrive:** Charging
+- **Life Support:** Optimal
+
+Explore our logs and transmissions to learn more about the unknown sectors.

--- a/examples/apolo-nova/templates/404.html
+++ b/examples/apolo-nova/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="neon-box" style="text-align: center; padding: 4rem 2rem;">
+    <h1 style="color: var(--accent-secondary); font-size: 4rem; margin-bottom: 0;">404</h1>
+    <h2>Signal Lost</h2>
+    <p>The coordinates you entered do not exist in this sector.</p>
+    <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 0.5rem 1.5rem; border: 1px solid var(--accent-primary); border-radius: 4px; transition: all 0.3s;">Return to Base</a>
+  </main>
+{% include "footer.html" %}

--- a/examples/apolo-nova/templates/footer.html
+++ b/examples/apolo-nova/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="margin-top: 4rem; padding-top: 2rem; border-top: 1px solid rgba(255,255,255,0.1); text-align: center; color: var(--text-muted); font-size: 0.9rem; padding-bottom: 2rem;">
+      <p>&copy; 2024 Apolo Nova Explorer. Built with Hwaro.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/apolo-nova/templates/header.html
+++ b/examples/apolo-nova/templates/header.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page.description is defined %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    :root {
+      --bg-color: #0b0f19;
+      --accent-primary: #00f0ff;
+      --accent-secondary: #ff0055;
+      --text-main: #e0e6ed;
+      --text-muted: #8a99a8;
+      --border-glow: rgba(0, 240, 255, 0.4);
+    }
+    @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Rajdhani:wght@400;500;700&display=swap');
+    body {
+      font-family: 'Rajdhani', sans-serif;
+      background-color: var(--bg-color);
+      color: var(--text-main);
+      margin: 0;
+      padding: 0;
+      line-height: 1.6;
+      background-image: radial-gradient(circle at 50% 0%, #1a233a 0%, #0b0f19 70%);
+      background-attachment: fixed;
+    }
+    .container { max-width: 900px; margin: 0 auto; padding: 0 2rem; }
+    header {
+      padding: 2rem 0;
+      border-bottom: 1px solid rgba(255,255,255,0.1);
+      margin-bottom: 3rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .logo {
+      font-family: 'Orbitron', sans-serif;
+      font-size: 2rem;
+      font-weight: 700;
+      color: var(--accent-primary);
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      text-shadow: 0 0 10px var(--border-glow);
+    }
+    nav { display: flex; gap: 1.5rem; }
+    nav a {
+      color: var(--text-main);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 1.1rem;
+      transition: color 0.3s ease, text-shadow 0.3s ease;
+    }
+    nav a:hover {
+      color: var(--accent-secondary);
+      text-shadow: 0 0 8px rgba(255,0,85,0.6);
+    }
+    h1, h2, h3 { font-family: 'Orbitron', sans-serif; color: #fff; }
+    a { color: var(--accent-primary); text-decoration: none; }
+    a:hover { text-decoration: underline; color: var(--accent-secondary); }
+    .neon-box {
+      border: 1px solid rgba(255,255,255,0.1);
+      padding: 1.5rem;
+      border-radius: 8px;
+      background: rgba(255,255,255,0.02);
+      transition: border-color 0.3s ease, box-shadow 0.3s ease;
+      margin-bottom: 1rem;
+    }
+    .neon-box:hover {
+      border-color: var(--accent-primary);
+      box-shadow: 0 0 15px var(--border-glow);
+    }
+  </style>
+  {{ highlight_tags | safe }}
+  {{ auto_includes | safe }}
+</head>
+<body>
+  <div class="container">
+    <header>
+      <a href="{{ base_url }}/" class="logo">Apolo Nova</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </header>

--- a/examples/apolo-nova/templates/page.html
+++ b/examples/apolo-nova/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="neon-box" style="padding: 2rem;">
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/examples/apolo-nova/templates/section.html
+++ b/examples/apolo-nova/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main>
+    <h1 style="text-shadow: 0 0 10px var(--border-glow); margin-bottom: 2rem;">{{ page.title | e }}</h1>
+    {% if content %}{{ content | safe }}{% endif %}
+    <div class="posts-grid">
+      {% for p in section.pages %}
+      <article class="neon-box">
+        <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+      </article>
+      {% endfor %}
+    </div>
+    {% if pagination is defined %}
+      <div style="margin-top: 2rem;">
+        {% for p in pagination.pages %}
+          <a href="{{ p.url }}" style="padding: 0.5rem 1rem; border: 1px solid var(--border-glow); margin-right: 0.5rem;">{{ loop.index }}</a>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/examples/apolo-nova/templates/shortcodes/alert.html
+++ b/examples/apolo-nova/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/apolo-nova/templates/taxonomy.html
+++ b/examples/apolo-nova/templates/taxonomy.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main>
+    <h1>{{ section.title | default(page.title) | e }}</h1>
+    {% if content %}{{ content | safe }}{% endif %}
+    <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 1rem;">
+      {% for t in terms %}
+      <li>
+        <a href="{{ t.url }}" class="neon-box" style="display: inline-block; padding: 0.5rem 1rem;">
+          {{ t.name | e }} <span style="color: var(--text-muted); font-size: 0.8em;">({{ t.pages | length }})</span>
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/examples/apolo-nova/templates/taxonomy_term.html
+++ b/examples/apolo-nova/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main>
+    <h1>Term: <span style="color: var(--accent-secondary);">{{ page.title | e }}</span></h1>
+    <div class="posts-grid">
+      {% for p in pages %}
+      <article class="neon-box">
+        <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+      </article>
+      {% endfor %}
+    </div>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Adds a new example `apolo-nova` showing off a dark mode, space-inspired, glowing neon aesthetic built onto Hwaro's default templates. Included Playwright validation locally.

---
*PR created automatically by Jules for task [13865358359913555626](https://jules.google.com/task/13865358359913555626) started by @chei-l*