### PR TITLE
feat: Add lumina-chroma example with custom dark neon theme

### DIFF
--- a/examples/lumina-chroma/AGENTS.md
+++ b/examples/lumina-chroma/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lumina-chroma/archetypes/default.md
+++ b/examples/lumina-chroma/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lumina-chroma/archetypes/posts.md
+++ b/examples/lumina-chroma/archetypes/posts.md
@@ -1,0 +1,11 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+authors = []
+categories = []
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lumina-chroma/config.toml
+++ b/examples/lumina-chroma/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Lumina Chroma"
+description = "Welcome to my personal blog powered by Hwaro."
+base_url = ""
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = ["posts"]   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/lumina-chroma/content/about.md
+++ b/examples/lumina-chroma/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About"
+tags = ["about"]
+categories = ["pages"]
++++
+
+Welcome to my blog! I write about technology, programming, and other interesting topics.
+
+## Contact
+
+Feel free to reach out through social media or email.

--- a/examples/lumina-chroma/content/archives.md
+++ b/examples/lumina-chroma/content/archives.md
@@ -1,0 +1,5 @@
++++
+title = "Archives"
++++
+
+Browse all posts by date. Check the [Posts](/posts/) section for the complete list.

--- a/examples/lumina-chroma/content/authors/_index.md
+++ b/examples/lumina-chroma/content/authors/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Authors"
+description = "List of authors"
++++

--- a/examples/lumina-chroma/content/index.md
+++ b/examples/lumina-chroma/content/index.md
@@ -1,0 +1,12 @@
++++
+title = "Home"
+tags = ["home"]
++++
+
+This is a blog powered by [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator.
+
+Check out the latest posts in the [Posts](/posts/) section, or browse by:
+
+- [Tags](/tags/)
+- [Categories](/categories/)
+- [Authors](/authors/)

--- a/examples/lumina-chroma/content/posts/_index.md
+++ b/examples/lumina-chroma/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
++++
+
+Browse all blog posts below.

--- a/examples/lumina-chroma/content/posts/getting-started-with-hwaro.md
+++ b/examples/lumina-chroma/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,36 @@
++++
+title = "Getting Started with Hwaro"
+date = "2026-04-15"
+tags = ["tutorial", "getting-started", "hwaro"]
+categories = ["tutorials"]
+authors = ["admin"]
+description = "A beginner's guide to building websites with Hwaro."
++++
+
+In this post, I'll walk you through the basics of setting up and using Hwaro.
+
+## Installation
+
+First, make sure you have Crystal installed. Then:
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards build
+```
+
+## Creating Your First Site
+
+```bash
+hwaro init my-blog --scaffold blog
+cd my-blog
+hwaro serve
+```
+
+That's it! Your blog is now running at `http://localhost:3000`.
+
+## Next Steps
+
+- Customize your templates in the `templates/` directory
+- Add new posts in `content/posts/`
+- Configure your site in `config.toml`

--- a/examples/lumina-chroma/content/posts/hello-world.md
+++ b/examples/lumina-chroma/content/posts/hello-world.md
@@ -1,0 +1,20 @@
++++
+title = "Hello World"
+date = "2026-04-10"
+tags = ["introduction", "hello"]
+categories = ["general"]
+authors = ["admin"]
+description = "My first blog post using Hwaro static site generator."
++++
+
+Welcome to my first blog post! This blog is powered by Hwaro, a fast and lightweight static site generator written in Crystal.
+
+## Why Hwaro?
+
+Hwaro offers a simple yet powerful way to create static websites:
+
+- **Fast**: Built with Crystal for blazing fast build times
+- **Simple**: Easy to understand directory structure
+- **Flexible**: Supports custom templates and shortcodes
+
+Stay tuned for more posts!

--- a/examples/lumina-chroma/content/posts/markdown-tips.md
+++ b/examples/lumina-chroma/content/posts/markdown-tips.md
@@ -1,0 +1,48 @@
++++
+title = "Markdown Tips and Tricks"
+date = "2026-04-20"
+tags = ["markdown", "writing", "tips"]
+categories = ["tutorials"]
+authors = ["admin"]
+description = "Learn useful Markdown formatting techniques for your blog posts."
++++
+
+Hwaro uses Markdown for content. Here are some useful formatting tips.
+
+## Text Formatting
+
+- **Bold text** using `**bold**`
+- *Italic text* using `*italic*`
+- `Inline code` using backticks
+
+## Code Blocks
+
+Use triple backticks for code blocks:
+
+```crystal
+puts "Hello from Crystal!"
+```
+
+## Lists
+
+Ordered lists:
+1. First item
+2. Second item
+3. Third item
+
+Unordered lists:
+- Item one
+- Item two
+- Item three
+
+## Links and Images
+
+- [Link text](https://example.com) using `[text](url)`
+- Image syntax: `![Alt text](path/to/image.jpg)`
+
+## Blockquotes
+
+> This is a blockquote.
+> It can span multiple lines.
+
+Happy writing!

--- a/examples/lumina-chroma/static/css/style.css
+++ b/examples/lumina-chroma/static/css/style.css
@@ -1,0 +1,68 @@
+
+:root {
+  --bg-color: #0b0c10;
+  --text-color: #c5c6c7;
+  --accent-1: #66fcf1;
+  --accent-2: #45a29e;
+  --accent-hover: #ffffff;
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --neon-shadow: 0 0 10px var(--accent-1), 0 0 20px var(--accent-1);
+  --panel-bg: rgba(31, 40, 51, 0.8);
+}
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--font-sans);
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+a { color: var(--accent-1); text-decoration: none; transition: 0.3s ease; }
+a:hover { color: var(--accent-hover); text-shadow: var(--neon-shadow); }
+
+.blog-header {
+  background-color: var(--panel-bg);
+  padding: 1rem 2rem;
+  border-bottom: 2px solid var(--accent-2);
+  box-shadow: 0 0 15px rgba(69, 162, 158, 0.4);
+}
+.blog-header-inner {
+  max-width: 900px; margin: 0 auto;
+  display: flex; justify-content: space-between; align-items: center;
+}
+.logo {
+  font-size: 1.8rem; font-weight: 800; color: var(--accent-1);
+  text-transform: uppercase; letter-spacing: 2px; text-shadow: var(--neon-shadow);
+}
+.blog-header nav a { margin-left: 1.5rem; font-weight: 600; text-transform: uppercase; }
+.search-trigger {
+  background: transparent; border: 1px solid var(--accent-1); color: var(--accent-1);
+  padding: 0.4rem 0.8rem; border-radius: 4px; cursor: pointer;
+  display: flex; align-items: center; gap: 0.5rem; transition: 0.3s;
+}
+.search-trigger:hover { background: var(--accent-1); color: var(--bg-color); box-shadow: var(--neon-shadow); }
+
+.blog-container {
+  max-width: 800px; margin: 3rem auto; padding: 2rem;
+  background: var(--panel-bg); border-radius: 8px; border: 1px solid rgba(102, 252, 241, 0.2);
+  box-shadow: 0 0 20px rgba(0,0,0,0.5);
+}
+.blog-main h1 { color: var(--accent-1); border-bottom: 1px solid var(--accent-2); padding-bottom: 0.5rem; }
+.post-header h1 { margin-bottom: 0.2rem; border-bottom: none; }
+.post-meta { color: var(--accent-2); font-size: 0.9rem; margin-bottom: 1.5rem; }
+
+.search-overlay {
+  display: none; position: fixed; inset: 0; background: rgba(11, 12, 16, 0.9);
+  z-index: 100; align-items: flex-start; justify-content: center; padding-top: 10vh;
+}
+.search-modal {
+  background: var(--panel-bg); width: 100%; max-width: 600px; border-radius: 8px;
+  border: 1px solid var(--accent-1); padding: 1.5rem; box-shadow: var(--neon-shadow);
+}
+.search-input-wrap { display: flex; align-items: center; gap: 1rem; border-bottom: 1px solid var(--accent-2); padding-bottom: 1rem; }
+#searchInput { background: transparent; border: none; color: var(--text-color); font-size: 1.2rem; width: 100%; outline: none; }
+.search-results { margin-top: 1rem; max-height: 60vh; overflow-y: auto; }
+.search-results a { display: block; padding: 0.5rem; border-bottom: 1px solid rgba(255,255,255,0.1); }
+.search-results a:hover { background: rgba(102, 252, 241, 0.1); }
+
+.blog-footer { text-align: center; margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--accent-2); color: var(--accent-2); }

--- a/examples/lumina-chroma/static/js/search.js
+++ b/examples/lumina-chroma/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/examples/lumina-chroma/templates/404.html
+++ b/examples/lumina-chroma/templates/404.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="document.getElementById('searchOverlay').style.display='flex'">
+        <span>Search</span>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)this.style.display='none'">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <input type="text" id="searchInput" placeholder="Search..." autocomplete="off">
+      <kbd style="cursor:pointer;" onclick="document.getElementById('searchOverlay').style.display='none'">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+{% include "footer.html" %}

--- a/examples/lumina-chroma/templates/footer.html
+++ b/examples/lumina-chroma/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="blog-footer">
+      <p>Powered by Hwaro | Lumina Chroma Theme</p>
+    </footer>
+  </main>
+</div>
+<script src="{{ base_url }}/js/search.js"></script>
+</body>
+</html>

--- a/examples/lumina-chroma/templates/header.html
+++ b/examples/lumina-chroma/templates/header.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ site.description | e }}">
+  <title>{% if page is defined %}{{ page.title | e }} - {% elif section is defined %}{{ section.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_tags | safe }}
+  {{ auto_includes | safe }}
+</head>
+<body>

--- a/examples/lumina-chroma/templates/page.html
+++ b/examples/lumina-chroma/templates/page.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="document.getElementById('searchOverlay').style.display='flex'">
+        <span>Search</span>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)this.style.display='none'">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <input type="text" id="searchInput" placeholder="Search posts..." autocomplete="off">
+      <kbd style="cursor:pointer;" onclick="document.getElementById('searchOverlay').style.display='none'">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content | safe }}
+{% include "footer.html" %}

--- a/examples/lumina-chroma/templates/post.html
+++ b/examples/lumina-chroma/templates/post.html
@@ -1,0 +1,39 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="document.getElementById('searchOverlay').style.display='flex'">
+        <span>Search</span>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)this.style.display='none'">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <input type="text" id="searchInput" placeholder="Search posts..." autocomplete="off">
+      <kbd style="cursor:pointer;" onclick="document.getElementById('searchOverlay').style.display='none'">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <article class="post">
+      <header class="post-header">
+        <h1>{{ page.title | e }}</h1>
+        <div class="post-meta">
+          <time>{{ page.date }}</time>
+        </div>
+      </header>
+      <div class="post-content">
+        {{ content | safe }}
+      </div>
+    </article>
+{% include "footer.html" %}

--- a/examples/lumina-chroma/templates/section.html
+++ b/examples/lumina-chroma/templates/section.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="document.getElementById('searchOverlay').style.display='flex'">
+        <span>Search</span>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)this.style.display='none'">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <input type="text" id="searchInput" placeholder="Search..." autocomplete="off">
+      <kbd style="cursor:pointer;" onclick="document.getElementById('searchOverlay').style.display='none'">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>{{ section.title | e }}</h1>
+    {{ content | safe }}
+    <ul class="section-list">
+      {% for p in section.pages %}
+        <li><a href="{{ p.url }}">{{ p.title | e }}</a></li>
+      {% endfor %}
+    </ul>
+{% include "footer.html" %}

--- a/examples/lumina-chroma/templates/shortcodes/alert.html
+++ b/examples/lumina-chroma/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/lumina-chroma/templates/taxonomy.html
+++ b/examples/lumina-chroma/templates/taxonomy.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="document.getElementById('searchOverlay').style.display='flex'">
+        <span>Search</span>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)this.style.display='none'">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <input type="text" id="searchInput" placeholder="Search..." autocomplete="off">
+      <kbd style="cursor:pointer;" onclick="document.getElementById('searchOverlay').style.display='none'">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content | safe }}
+{% include "footer.html" %}

--- a/examples/lumina-chroma/templates/taxonomy_term.html
+++ b/examples/lumina-chroma/templates/taxonomy_term.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="document.getElementById('searchOverlay').style.display='flex'">
+        <span>Search</span>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)this.style.display='none'">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <input type="text" id="searchInput" placeholder="Search..." autocomplete="off">
+      <kbd style="cursor:pointer;" onclick="document.getElementById('searchOverlay').style.display='none'">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Pages for this term:</p>
+    <ul class="section-list">
+      {% for p in pages %}
+        <li><a href="{{ p.url }}">{{ p.title | e }}</a></li>
+      {% endfor %}
+    </ul>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2510,6 +2510,14 @@
     "minimal",
     "portfolio"
   ],
+  "ethereal-cyber-bloom": [
+    "dark",
+    "blog",
+    "portfolio",
+    "cyberpunk",
+    "neon",
+    "floral"
+  ],
   "ethereal-echoes": [
     "ethereal",
     "glassmorphism",
@@ -4051,6 +4059,13 @@
     "aesthetic",
     "glow",
     "fluid"
+  ],
+  "lumina-chroma": [
+    "blog",
+    "dark",
+    "neon",
+    "cyberpunk",
+    "colorful"
   ],
   "lumina-chrome-forge": [
     "dark",
@@ -8179,13 +8194,5 @@
     "diy",
     "raw",
     "unconventional"
-  ],
-  "ethereal-cyber-bloom": [
-    "dark",
-    "blog",
-    "portfolio",
-    "cyberpunk",
-    "neon",
-    "floral"
   ]
 }


### PR DESCRIPTION
This PR introduces a new example site, `lumina-chroma`, to the `examples/` directory. The example demonstrates how to build a highly customized, styled blog theme (dark neon/cyberpunk aesthetics) from the default `blog` scaffold. It features custom Jinja templates, updated taxonomy pages, and is fully registered in `tags.json`.

---
*PR created automatically by Jules for task [7729936584614900054](https://jules.google.com/task/7729936584614900054) started by @chei-l*