### PR TITLE
feat: add 5 exhibition and proofing themed examples (#1108, #1109, #1110, #1111, #1112)

### DIFF
--- a/examples/contact-sheet/AGENTS.md
+++ b/examples/contact-sheet/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/contact-sheet/archetypes/default.md
+++ b/examples/contact-sheet/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/contact-sheet/config.toml
+++ b/examples/contact-sheet/config.toml
@@ -1,0 +1,8 @@
+title = "CONTACT-SHEET"
+description = "A structured, film-inspired design for high-density visual proofs and structural content."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/contact-sheet/content/about.md
+++ b/examples/contact-sheet/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/contact-sheet/content/index.md
+++ b/examples/contact-sheet/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Proof"
++++
+
+<article>
+
+## Proof Structure
+
+Contact-Sheet is about the organized and foundational nature of structural innovation within the visual environment. We believe that proofing stories deserve a presentation that captures the authority of a classic film contact sheet. By focusing on white surfaces, high-density grids, and clear hierarchies, we create an environment that feels both utilitarian and deeply clear. Our focus is on the integrity of the proofing process.
+
+### Sheet Principles
+
+- **Precision**: A design that prioritizes the clear presentation of visual units.
+- **Tactility**: Using high-density grids to define the boundaries of the proofing space.
+- **Clarity**: A layout that reflects the logical nature of structural storytelling.
+
+---
+
+> "In the contact sheet, every frame is a facet of the whole proof."
+</article>

--- a/examples/contact-sheet/templates/404.html
+++ b/examples/contact-sheet/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/contact-sheet/templates/footer.html
+++ b/examples/contact-sheet/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; letter-spacing: 5px; font-weight: 700;">
+        <div class="container">
+            &copy; 2026 CONTACT-SHEET. PROOFING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/contact-sheet/templates/header.html
+++ b/examples/contact-sheet/templates/header.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fff;
+            --text: #1a1a1a;
+            --accent: #555;
+            --contact: #f8f8f8;
+            --shadow: rgba(0,0,0,0.05);
+        }
+        body {
+            background-color: var(--contact);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: left;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin-right: 20px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 600;
+        }
+        .contact-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 20px;
+            margin-bottom: 80px;
+        }
+        .contact-item {
+            background: #fff;
+            padding: 20px;
+            border: 1px solid #ddd;
+            aspect-ratio: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            position: relative;
+        }
+        .contact-item::after {
+            content: '01';
+            position: absolute;
+            bottom: 5px;
+            right: 5px;
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.6rem;
+            color: #ccc;
+        }
+        h2 { font-weight: 700; font-size: 1rem; color: #000; margin-top: 0; text-transform: uppercase; }
+        article { font-size: 0.8rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">contact.sheet</div>
+            <nav>
+                <a href="/">Proof</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/contact-sheet/templates/page.html
+++ b/examples/contact-sheet/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="contact-grid">
+            <div class="contact-item">
+                {{ content }}
+            </div>
+            <div class="contact-item">
+                <h2>Proof Two</h2>
+            </div>
+            <div class="contact-item">
+                <h2>Proof Three</h2>
+            </div>
+            <div class="contact-item">
+                <h2>Proof Four</h2>
+            </div>
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/contact-sheet/templates/section.html
+++ b/examples/contact-sheet/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/contact-sheet/templates/shortcodes/alert.html
+++ b/examples/contact-sheet/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/contact-sheet/templates/taxonomy.html
+++ b/examples/contact-sheet/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/contact-sheet/templates/taxonomy_term.html
+++ b/examples/contact-sheet/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-noir/AGENTS.md
+++ b/examples/gallery-noir/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/gallery-noir/archetypes/default.md
+++ b/examples/gallery-noir/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/gallery-noir/config.toml
+++ b/examples/gallery-noir/config.toml
@@ -1,0 +1,8 @@
+title = "GALLERY-NOIR"
+description = "A dark, atmospheric design for cinematic visual portfolios and reviews."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/gallery-noir/content/about.md
+++ b/examples/gallery-noir/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/gallery-noir/content/index.md
+++ b/examples/gallery-noir/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Shadow"
++++
+
+<article>
+
+## Narrative Radiance
+
+Gallery-Noir is about the atmospheric and foundational nature of structural innovation within the immersive environment. We believe that visual stories deserve a presentation that captures the authority of a classic digital gallery. By focusing on dark backgrounds, flat shadows, and elegant serif typography, we create an environment that feels both expansive and deeply clear. Our focus is on the integrity of the shadow.
+
+### Noir Principles
+
+- **Atmosphere**: A design that prioritizes the clear "depth" of visual units.
+- **Tactility**: Using dark textures to define the boundaries of the cinematic space.
+- **Authority**: A layout that reflects the solid, uncompromised nature of the primary narrative.
+
+---
+
+> "In the gallery noir, every shadow is a facet of the whole expression."
+</article>

--- a/examples/gallery-noir/templates/404.html
+++ b/examples/gallery-noir/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-noir/templates/footer.html
+++ b/examples/gallery-noir/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; letter-spacing: 5px;">
+        <div class="container">
+            &copy; 2026 GALLERY-NOIR. SHADOWING THE DESIGN.
+        </div>
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/gallery-noir/templates/header.html
+++ b/examples/gallery-noir/templates/header.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=Playfair+Display:ital,wght@0,700;1,700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #050505;
+            --text: #ddd;
+            --accent: #555;
+            --noir: #111;
+            --shadow: rgba(0,0,0,0.8);
+        }
+        body {
+            background-color: #000;
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            font-family: 'Playfair Display', serif;
+            font-weight: 700;
+            font-size: 1.5rem;
+            letter-spacing: 5px;
+            color: #fff;
+            font-style: italic;
+        }
+        nav a {
+            color: #fff;
+            text-decoration: none;
+            margin-left: 30px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            opacity: 0.5;
+        }
+        .noir-surface {
+            background: var(--noir);
+            padding: 80px;
+            box-shadow: 20px 20px 60px var(--shadow);
+            margin-bottom: 80px;
+            border: 1px solid #222;
+        }
+        h2 { font-family: 'Playfair Display', serif; font-size: 2.2rem; color: #fff; margin-top: 0; border-bottom: 1px solid #333; padding-bottom: 10px; font-style: italic; }
+        article { margin-top: 40px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header>
+        <div class="logo">gallery.noir</div>
+        <nav>
+            <a href="/">Shadow</a>
+            <a href="/about">Depth</a>
+        </nav>
+    </header>

--- a/examples/gallery-noir/templates/page.html
+++ b/examples/gallery-noir/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="noir-surface">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/gallery-noir/templates/section.html
+++ b/examples/gallery-noir/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-noir/templates/shortcodes/alert.html
+++ b/examples/gallery-noir/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/gallery-noir/templates/taxonomy.html
+++ b/examples/gallery-noir/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-noir/templates/taxonomy_term.html
+++ b/examples/gallery-noir/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/salon-hang/AGENTS.md
+++ b/examples/salon-hang/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/salon-hang/archetypes/default.md
+++ b/examples/salon-hang/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/salon-hang/config.toml
+++ b/examples/salon-hang/config.toml
@@ -1,0 +1,8 @@
+title = "SALON-HANG"
+description = "A refined, gallery-inspired design for curated art and structural reviews."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/salon-hang/content/about.md
+++ b/examples/salon-hang/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/salon-hang/content/index.md
+++ b/examples/salon-hang/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Curation"
++++
+
+<article>
+
+## Curatorial Structure
+
+Salon-Hang is about the refined and foundational nature of structural innovation within the artistic environment. We believe that curated stories deserve a presentation that captures the authority of a classic salon-style hang. By focusing on white surfaces, subtle shadows, and elegant serif typography, we create an environment that feels both sophisticated and deeply creative. Our focus is on the integrity of the curatorial process.
+
+### Salon Principles
+
+- **Curation**: A design that prioritizes the clear presentation of artistic units.
+- **Tactility**: Using natural textures to define the boundaries of the creative space.
+- **Authority**: A layout that reflects the high-value nature of the primary review.
+
+---
+
+> "In the salon hang, every piece is a facet of the whole expression."
+</article>

--- a/examples/salon-hang/templates/404.html
+++ b/examples/salon-hang/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/salon-hang/templates/footer.html
+++ b/examples/salon-hang/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 5px; font-weight: 700;">
+        <div class="container">
+            &copy; 2026 SALON-HANG. CURATING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/salon-hang/templates/header.html
+++ b/examples/salon-hang/templates/header.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=Fraunces:ital,wght@0,400;1,400&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fff;
+            --text: #1a1a1a;
+            --accent: #555;
+            --salon: #fdfaf7;
+            --shadow: rgba(0,0,0,0.1);
+        }
+        body {
+            background-color: var(--salon);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-family: 'Fraunces', serif;
+            font-weight: 700;
+            font-size: 1.5rem;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 600;
+        }
+        .salon-surface {
+            background: #fff;
+            padding: 80px;
+            box-shadow: 20px 20px 60px var(--shadow);
+            margin-bottom: 80px;
+            margin-top: 40px;
+            border: 1px solid #eee;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 40px;
+            justify-content: center;
+        }
+        .salon-item {
+            border: 10px solid #fff;
+            box-shadow: 5px 5px 15px rgba(0,0,0,0.05);
+            padding: 20px;
+            background: #fafafa;
+        }
+        h2 { font-family: 'Fraunces', serif; font-size: 1.5rem; color: #000; margin-top: 0; font-style: italic; }
+        article { font-size: 1rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">salon.hang</div>
+            <nav>
+                <a href="/">Curation</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/salon-hang/templates/page.html
+++ b/examples/salon-hang/templates/page.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="salon-surface">
+            <div class="salon-item">
+                {{ content }}
+            </div>
+            <div class="salon-item">
+                <h2>Curation Two</h2>
+            </div>
+            <div class="salon-item">
+                <h2>Curation Three</h2>
+            </div>
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/salon-hang/templates/section.html
+++ b/examples/salon-hang/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/salon-hang/templates/shortcodes/alert.html
+++ b/examples/salon-hang/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/salon-hang/templates/taxonomy.html
+++ b/examples/salon-hang/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/salon-hang/templates/taxonomy_term.html
+++ b/examples/salon-hang/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/virtual-exhibit/AGENTS.md
+++ b/examples/virtual-exhibit/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/virtual-exhibit/archetypes/default.md
+++ b/examples/virtual-exhibit/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/virtual-exhibit/config.toml
+++ b/examples/virtual-exhibit/config.toml
@@ -1,0 +1,8 @@
+title = "VIRTUAL-EXHIBIT"
+description = "A dark, immersive design for digital exhibitions and virtual structural reviews."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/virtual-exhibit/content/about.md
+++ b/examples/virtual-exhibit/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/virtual-exhibit/content/index.md
+++ b/examples/virtual-exhibit/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Experience"
++++
+
+<article>
+
+## Immersive Structure
+
+Virtual-Exhibit is about the continuous and foundational nature of structural innovation within the immersive environment. We believe that digital stories deserve a presentation that captures the authority of a classic virtual exhibition. By focusing on dark backgrounds, high-depth shadows, and bold monospaced typography, we create an environment that feels both expansive and deeply clear. Our focus is on the integrity of the experience.
+
+### Exhibit Principles
+
+- **Dynamics**: A design that prioritizes the clear "experience" of visual units.
+- **Tactility**: Using dark textures to define the boundaries of the cinematic space.
+- **Authority**: A layout that reflects the solid, uncompromised nature of the primary narrative.
+
+---
+
+> "In the virtual exhibit, every unit is a facet of the whole experience."
+</article>

--- a/examples/virtual-exhibit/templates/404.html
+++ b/examples/virtual-exhibit/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/virtual-exhibit/templates/footer.html
+++ b/examples/virtual-exhibit/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; letter-spacing: 5px;">
+        <div class="container">
+            &copy; 2026 VIRTUAL-EXHIBIT. EXPERIENCING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/virtual-exhibit/templates/header.html
+++ b/examples/virtual-exhibit/templates/header.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #1a1a1a;
+            --text: #ddd;
+            --accent: #555;
+            --virtual: #0c0c0c;
+            --shadow: rgba(0,0,0,0.8);
+            --highlight: rgba(255,255,255,0.05);
+        }
+        body {
+            background-color: #0c0c0c;
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-family: 'IBM Plex Mono', monospace;
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            opacity: 0.6;
+        }
+        .virtual-surface {
+            background: #111;
+            padding: 100px;
+            box-shadow: 20px 20px 60px var(--shadow), inset -5px -5px 15px var(--highlight);
+            margin-bottom: 80px;
+            border: 1px solid #333;
+            text-align: center;
+            position: relative;
+        }
+        .virtual-surface::after {
+            content: 'VR_v1.0';
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.6rem;
+            color: #444;
+        }
+        h2 { font-family: 'IBM Plex Mono', monospace; font-size: 2rem; color: #fff; margin-top: 0; border-bottom: 1px solid #333; padding-bottom: 10px; text-transform: uppercase; text-align: left; }
+        article { font-family: 'IBM Plex Mono', monospace; font-size: 0.9rem; color: #aaa; text-align: left; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">virtual.exhibit</div>
+            <nav>
+                <a href="/">Experience</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/virtual-exhibit/templates/page.html
+++ b/examples/virtual-exhibit/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="virtual-surface">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/virtual-exhibit/templates/section.html
+++ b/examples/virtual-exhibit/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/virtual-exhibit/templates/shortcodes/alert.html
+++ b/examples/virtual-exhibit/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/virtual-exhibit/templates/taxonomy.html
+++ b/examples/virtual-exhibit/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/virtual-exhibit/templates/taxonomy_term.html
+++ b/examples/virtual-exhibit/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/white-cube/AGENTS.md
+++ b/examples/white-cube/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/white-cube/archetypes/default.md
+++ b/examples/white-cube/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/white-cube/config.toml
+++ b/examples/white-cube/config.toml
@@ -1,0 +1,8 @@
+title = "WHITE-CUBE"
+description = "A minimal, exhibition-inspired design for high-clarity visual and structural content."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/white-cube/content/about.md
+++ b/examples/white-cube/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/white-cube/content/index.md
+++ b/examples/white-cube/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Exhibition"
++++
+
+<article>
+
+## Curatorial Clarity
+
+White-Cube is about the minimal and foundational nature of structural innovation within the exhibition environment. We believe that high-clarity stories deserve a presentation that captures the authority of a classic white cube gallery. By focusing on white surfaces, clear hierarchies, and impactful display typography, we create an environment that feels both sophisticated and deeply clear. Our focus is on the integrity of the exhibition.
+
+### Cube Principles
+
+- **Clarity**: A design that prioritizes the clear presentation of visual units.
+- **Tactility**: Using natural textures to define the boundaries of the minimal space.
+- **Authority**: A layout that reflects the high-value nature of the primary review.
+
+---
+
+> "In the white cube, every unit is a facet of the whole expression."
+</article>

--- a/examples/white-cube/templates/404.html
+++ b/examples/white-cube/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/white-cube/templates/footer.html
+++ b/examples/white-cube/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 5px; font-weight: 700;">
+        <div class="container">
+            &copy; 2026 WHITE-CUBE. EXHIBITING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/white-cube/templates/header.html
+++ b/examples/white-cube/templates/header.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #f8f8f8;
+            --text: #1a1a1a;
+            --accent: #555;
+            --cube: #fff;
+            --shadow: rgba(0,0,0,0.05);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 80px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 20px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 600;
+        }
+        .cube-surface {
+            background: var(--cube);
+            padding: 100px;
+            box-shadow: 20px 20px 60px var(--shadow);
+            margin-bottom: 100px;
+            border: 1px solid #eee;
+            text-align: center;
+        }
+        h2 { font-weight: 700; font-size: 2.2rem; color: #000; margin-top: 0; border-bottom: 1px solid #eee; padding-bottom: 10px; text-transform: uppercase; }
+        article { font-size: 1.1rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">white.cube</div>
+            <nav>
+                <a href="/">Exhibition</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/white-cube/templates/page.html
+++ b/examples/white-cube/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="cube-surface">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/white-cube/templates/section.html
+++ b/examples/white-cube/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/white-cube/templates/shortcodes/alert.html
+++ b/examples/white-cube/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/white-cube/templates/taxonomy.html
+++ b/examples/white-cube/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/white-cube/templates/taxonomy_term.html
+++ b/examples/white-cube/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1751,6 +1751,13 @@
     "blog",
     "astronomy"
   ],
+  "contact-sheet": [
+    "structured",
+    "film-inspired",
+    "high-density",
+    "proofing",
+    "ibm-plex-mono"
+  ],
   "contraband": [
     "gritty",
     "dark",
@@ -2923,6 +2930,13 @@
     "dark",
     "event",
     "landing"
+  ],
+  "gallery-noir": [
+    "dark",
+    "atmospheric",
+    "cinematic",
+    "visual-portfolio",
+    "playfair"
   ],
   "galley-proof": [
     "book",
@@ -6623,6 +6637,13 @@
     "glamorous",
     "sakura"
   ],
+  "salon-hang": [
+    "refined",
+    "gallery-inspired",
+    "curated-art",
+    "structural-review",
+    "fraunces"
+  ],
   "sandcastle": [
     "light",
     "blog",
@@ -7992,6 +8013,13 @@
     "groove-focused",
     "ibm-plex-mono"
   ],
+  "virtual-exhibit": [
+    "dark",
+    "immersive",
+    "digital-exhibition",
+    "virtual",
+    "ibm-plex-mono"
+  ],
   "visceral": [
     "raw",
     "organic",
@@ -8113,6 +8141,13 @@
     "neon",
     "high-energy",
     "impact"
+  ],
+  "white-cube": [
+    "minimal",
+    "exhibition-inspired",
+    "high-clarity",
+    "curatorial",
+    "jakarta"
   ],
   "white-paper-noir": [
     "paper",


### PR DESCRIPTION
This PR adds a 48th set of 5 high-quality examples focused on exhibition curation and visual proofing aesthetics including salon-hang, contact-sheet, gallery-noir, white-cube, and virtual-exhibit. This brings the total examples to 260.

### Key Changes
- Added 5 new examples:
  - **SALON-HANG**: Refined gallery-inspired design for curated art.
  - **CONTACT-SHEET**: Structured film-inspired design for visual proofing.
  - **GALLERY-NOIR**: Dark atmospheric design for cinematic portfolios.
  - **WHITE-CUBE**: Minimal exhibition-inspired design for high-clarity content.
  - **VIRTUAL-EXHIBIT**: Dark immersive design for digital exhibitions.
- Updated `tags.json` with relevant discovery tags.
- Verified all examples with `hwaro build`.

Closes #1108
Closes #1109
Closes #1110
Closes #1111
Closes #1112