### PR TITLE
Add jade-nebula-glass example

### DIFF
--- a/examples/jade-nebula-glass/AGENTS.md
+++ b/examples/jade-nebula-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/jade-nebula-glass/archetypes/default.md
+++ b/examples/jade-nebula-glass/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/jade-nebula-glass/config.toml
+++ b/examples/jade-nebula-glass/config.toml
@@ -1,0 +1,206 @@
+title = "Jade Nebula Glass"
+description = "A deep void dark-themed glassmorphism aesthetic with glowing emerald and cyan orbs."
+base_url = "http://localhost:3000"
+
+[build]
+output_dir = "public"
+clean = true
+
+[plugins]
+[plugins.highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+# [sitemap]
+# enabled = true
+# filename = "sitemap.xml"
+# changefreq = "weekly"
+# priority = 0.5
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/jade-nebula-glass/content/_index.md
+++ b/examples/jade-nebula-glass/content/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Home"
+template = "index"
++++

--- a/examples/jade-nebula-glass/content/about/index.md
+++ b/examples/jade-nebula-glass/content/about/index.md
@@ -1,0 +1,13 @@
++++
+title = "About Jade Nebula Glass"
+template = "page"
+date = "2024-05-10"
++++
+
+This is a demonstration of the **Jade Nebula Glass** aesthetic using Hwaro. It features a cosmic void background with drifting glowing orbs of jade, emerald, and cyan. The frosted glass panels provide structure while maintaining the depth of the void.
+
+This theme highlights:
+- `backdrop-filter` for glassmorphism
+- Animated pure CSS glowing orbs
+- Space Grotesk and Inter font combinations
+- Dark mode first design

--- a/examples/jade-nebula-glass/content/posts/_index.md
+++ b/examples/jade-nebula-glass/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/examples/jade-nebula-glass/content/posts/first-post.md
+++ b/examples/jade-nebula-glass/content/posts/first-post.md
@@ -1,0 +1,16 @@
++++
+title = "The Void Beckons"
+date = "2024-05-11"
+summary = "An exploration of the deep dark void and the jade glowing anomalies within."
+template = "page"
++++
+
+The void is not empty. It is filled with drifting colors, glowing emerald shapes, and frosted glass structures. This post demonstrates a simple markdown content rendered in the glassmorphism aesthetic.
+
+## Secondary Heading
+
+Notice how the `Space Grotesk` font gives headers a unique, modern feel, while `Inter` keeps the body text readable.
+
+- Point one
+- Point two
+- Point three

--- a/examples/jade-nebula-glass/templates/404.html
+++ b/examples/jade-nebula-glass/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/jade-nebula-glass/templates/footer.html
+++ b/examples/jade-nebula-glass/templates/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>&copy; {{ current_year }} {{ site.title }}. Built with Hwaro.</p>
+</footer>

--- a/examples/jade-nebula-glass/templates/header.html
+++ b/examples/jade-nebula-glass/templates/header.html
@@ -1,0 +1,7 @@
+<header class="glass-panel">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/">Home</a>
+    <a href="{{ base_url }}/about/">About</a>
+  </nav>
+</header>

--- a/examples/jade-nebula-glass/templates/index.html
+++ b/examples/jade-nebula-glass/templates/index.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ site.title }}</title>
+  <meta name="description" content="{{ site.description }}">
+
+  <!-- Google Fonts: Space Grotesk for headings, Inter for body -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      /* Deep void background */
+      --bg-color: #020508;
+
+      /* Typography */
+      --text-main: #e2e8f0;
+      --text-muted: #94a3b8;
+
+      /* Orb glowing colors */
+      --jade: #00ff88;
+      --emerald: #059669;
+      --cyan: #00f0ff;
+
+      /* Glass properties */
+      --glass-bg: rgba(2, 8, 12, 0.4);
+      --glass-border: rgba(0, 255, 136, 0.15);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+
+      /* Layout constraints */
+      --max-width: 1100px;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background-color: var(--bg-color);
+      color: var(--text-main);
+      font-family: 'Inter', sans-serif;
+      line-height: 1.6;
+      min-height: 100vh;
+      overflow-x: hidden;
+      position: relative;
+    }
+
+    /* Animated Glowing Orbs Background */
+    .bg-orbs {
+      position: fixed;
+      top: 0; left: 0; width: 100vw; height: 100vh;
+      z-index: -1;
+      overflow: hidden;
+      background: radial-gradient(circle at center, #020508 0%, #010204 100%);
+    }
+
+    .orb {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(100px);
+      opacity: 0.5;
+      animation: drift 25s infinite alternate ease-in-out;
+    }
+
+    .orb-jade {
+      width: 400px; height: 400px;
+      background: var(--jade);
+      top: -100px; left: -100px;
+      animation-duration: 30s;
+    }
+
+    .orb-emerald {
+      width: 500px; height: 500px;
+      background: var(--emerald);
+      bottom: -150px; right: -100px;
+      animation-duration: 25s;
+    }
+
+    .orb-cyan {
+      width: 300px; height: 300px;
+      background: var(--cyan);
+      top: 40%; left: 60%;
+      opacity: 0.3;
+      animation-duration: 35s;
+    }
+
+    @keyframes drift {
+      0% { transform: translate(0, 0) scale(1); }
+      50% { transform: translate(100px, 50px) scale(1.2); }
+      100% { transform: translate(-50px, 150px) scale(0.9); }
+    }
+
+    /* Container and Glass Elements */
+    .container {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 2rem;
+    }
+
+    .glass-panel {
+      background: var(--glass-bg);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--glass-border);
+      border-radius: 24px;
+      box-shadow: var(--glass-shadow);
+      padding: 3rem;
+      margin-bottom: 3rem;
+      transition: transform 0.3s ease, border-color 0.3s ease;
+    }
+
+    .glass-panel:hover {
+      border-color: rgba(0, 255, 136, 0.4);
+      transform: translateY(-5px);
+    }
+
+    /* Header Navigation */
+    header.glass-panel {
+      padding: 1.5rem 3rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 2rem;
+    }
+
+    .logo {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #fff;
+      text-decoration: none;
+      letter-spacing: -0.5px;
+      background: linear-gradient(90deg, var(--jade), var(--cyan));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    nav a {
+      color: var(--text-muted);
+      text-decoration: none;
+      margin-left: 2rem;
+      font-weight: 500;
+      transition: color 0.3s ease;
+    }
+
+    nav a:hover {
+      color: var(--jade);
+    }
+
+    /* Hero Section */
+    .hero {
+      text-align: center;
+      padding: 6rem 2rem;
+    }
+
+    .hero h1 {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 4rem;
+      line-height: 1.1;
+      margin-bottom: 1.5rem;
+      color: #fff;
+    }
+
+    .hero h1 span {
+      background: linear-gradient(90deg, var(--jade), var(--cyan));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    .hero p {
+      font-size: 1.25rem;
+      color: var(--text-muted);
+      max-width: 600px;
+      margin: 0 auto 3rem;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 1rem 2.5rem;
+      border-radius: 50px;
+      text-decoration: none;
+      font-family: 'Space Grotesk', sans-serif;
+      font-weight: 600;
+      font-size: 1.1rem;
+      transition: all 0.3s ease;
+    }
+
+    .btn-primary {
+      background: linear-gradient(90deg, var(--emerald), var(--cyan));
+      color: #000;
+      box-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
+    }
+
+    .btn-primary:hover {
+      box-shadow: 0 0 30px rgba(0, 255, 136, 0.6);
+      transform: scale(1.05);
+    }
+
+    /* Grid layout for features/posts */
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 2rem;
+    }
+
+    .card {
+      padding: 2rem;
+    }
+
+    .card h3 {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 1.5rem;
+      margin-bottom: 1rem;
+      color: #fff;
+    }
+
+    .card a {
+      display: inline-block;
+      margin-top: 1rem;
+      color: var(--jade);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .card a:hover {
+      text-decoration: underline;
+    }
+
+    /* Footer */
+    footer {
+      text-align: center;
+      padding: 3rem;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      border-top: 1px solid var(--glass-border);
+      margin-top: 4rem;
+    }
+
+    @media (max-width: 768px) {
+      .hero h1 { font-size: 2.5rem; }
+      header.glass-panel { flex-direction: column; gap: 1rem; }
+      nav a { margin: 0 1rem; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Background Orbs -->
+  <div class="bg-orbs">
+    <div class="orb orb-jade"></div>
+    <div class="orb orb-emerald"></div>
+    <div class="orb orb-cyan"></div>
+  </div>
+
+  <div class="container">
+    {% include "header.html" %}
+
+    <main>
+      <section class="hero glass-panel">
+        <h1>Welcome to the <br><span>Jade Nebula</span></h1>
+        <p>{{ site.description }}</p>
+        <a href="{{ base_url }}/about/" class="btn btn-primary">Explore the Void</a>
+      </section>
+
+      {% if site.sections is defined and site.sections | length > 0 %}
+        {% for section in site.sections %}
+          {% if section.title == "Posts" and section.pages %}
+            <div class="grid">
+              {% for post in section.pages | sort_by("date", reverse=true) %}
+                <article class="glass-panel card">
+                  <h3>{{ post.title }}</h3>
+                  <p>{{ post.summary | default("Explore the latest insights from the deep void.") | strip_html | truncate_words(20) }}</p>
+                  <a href="{{ post.url }}">Read more →</a>
+                </article>
+              {% endfor %}
+            </div>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+    </main>
+
+    {% include "footer.html" %}
+  </div>
+
+</body>
+</html>

--- a/examples/jade-nebula-glass/templates/page.html
+++ b/examples/jade-nebula-glass/templates/page.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }} | {{ site.title }}</title>
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg-color: #020508;
+      --text-main: #e2e8f0;
+      --text-muted: #94a3b8;
+      --jade: #00ff88;
+      --emerald: #059669;
+      --cyan: #00f0ff;
+      --glass-bg: rgba(2, 8, 12, 0.4);
+      --glass-border: rgba(0, 255, 136, 0.15);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+      --max-width: 800px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background-color: #020508;
+      color: var(--text-main);
+      font-family: 'Inter', sans-serif;
+      line-height: 1.6;
+      min-height: 100vh;
+      overflow-x: hidden;
+      position: relative;
+    }
+
+    .bg-orbs {
+      position: fixed;
+      top: 0; left: 0; width: 100vw; height: 100vh;
+      z-index: -1;
+      overflow: hidden;
+      background: radial-gradient(circle at center, #020508 0%, #010204 100%);
+    }
+
+    .orb {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(100px);
+      opacity: 0.5;
+      animation: drift 25s infinite alternate ease-in-out;
+    }
+
+    .orb-jade { width: 400px; height: 400px; background: var(--jade); top: -100px; left: -100px; animation-duration: 30s; }
+    .orb-emerald { width: 500px; height: 500px; background: var(--emerald); bottom: -150px; right: -100px; animation-duration: 25s; }
+    .orb-cyan { width: 300px; height: 300px; background: var(--cyan); top: 40%; left: 60%; opacity: 0.3; animation-duration: 35s; }
+
+    @keyframes drift {
+      0% { transform: translate(0, 0) scale(1); }
+      50% { transform: translate(100px, 50px) scale(1.2); }
+      100% { transform: translate(-50px, 150px) scale(0.9); }
+    }
+
+    .container { max-width: 1100px; margin: 0 auto; padding: 2rem; }
+
+    .glass-panel {
+      background: var(--glass-bg);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--glass-border);
+      border-radius: 24px;
+      box-shadow: var(--glass-shadow);
+      padding: 3rem;
+      margin-bottom: 3rem;
+      transition: transform 0.3s ease, border-color 0.3s ease;
+    }
+
+    header.glass-panel {
+      padding: 1.5rem 3rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 2rem;
+    }
+
+    .logo {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #fff;
+      text-decoration: none;
+      background: linear-gradient(90deg, var(--jade), var(--cyan));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    nav a { color: var(--text-muted); text-decoration: none; margin-left: 2rem; font-weight: 500; transition: color 0.3s ease; }
+    nav a:hover { color: var(--jade); }
+
+    .content-wrapper {
+      max-width: var(--max-width);
+      margin: 0 auto;
+    }
+
+    .page-title {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 3rem;
+      color: #fff;
+      margin-bottom: 1rem;
+    }
+
+    .page-meta {
+      color: var(--text-muted);
+      margin-bottom: 2rem;
+      font-size: 0.95rem;
+      display: flex;
+      gap: 1rem;
+    }
+
+    .content {
+      font-size: 1.1rem;
+      color: var(--text-main);
+    }
+
+    .content h2 { font-family: 'Space Grotesk', sans-serif; color: #fff; margin: 2rem 0 1rem; }
+    .content p { margin-bottom: 1.5rem; }
+    .content a { color: var(--cyan); text-decoration: none; }
+    .content a:hover { text-decoration: underline; }
+
+    footer { text-align: center; padding: 3rem; color: var(--text-muted); font-size: 0.9rem; border-top: 1px solid var(--glass-border); margin-top: 4rem; }
+
+    @media (max-width: 768px) {
+      header.glass-panel { flex-direction: column; gap: 1rem; }
+      nav a { margin: 0 1rem; }
+      .page-title { font-size: 2rem; }
+      .glass-panel { padding: 1.5rem; }
+    }
+  </style>
+</head>
+<body>
+
+  <div class="bg-orbs">
+    <div class="orb orb-jade"></div>
+    <div class="orb orb-emerald"></div>
+    <div class="orb orb-cyan"></div>
+  </div>
+
+  <div class="container">
+    {% include "header.html" %}
+
+    <main class="content-wrapper">
+      <article class="glass-panel">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.date %}
+          <div class="page-meta">
+            <span>{{ page.date | date("%B %d, %Y") }}</span>
+          </div>
+        {% endif %}
+
+        <div class="content">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+
+    {% include "footer.html" %}
+  </div>
+
+</body>
+</html>

--- a/examples/jade-nebula-glass/templates/section.html
+++ b/examples/jade-nebula-glass/templates/section.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }} | {{ site.title }}</title>
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg-color: #020508;
+      --text-main: #e2e8f0;
+      --text-muted: #94a3b8;
+      --jade: #00ff88;
+      --emerald: #059669;
+      --cyan: #00f0ff;
+      --glass-bg: rgba(2, 8, 12, 0.4);
+      --glass-border: rgba(0, 255, 136, 0.15);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+      --max-width: 800px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background-color: #020508;
+      color: var(--text-main);
+      font-family: 'Inter', sans-serif;
+      line-height: 1.6;
+      min-height: 100vh;
+      overflow-x: hidden;
+      position: relative;
+    }
+
+    .bg-orbs {
+      position: fixed;
+      top: 0; left: 0; width: 100vw; height: 100vh;
+      z-index: -1;
+      overflow: hidden;
+      background: radial-gradient(circle at center, #020508 0%, #010204 100%);
+    }
+
+    .orb {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(100px);
+      opacity: 0.5;
+      animation: drift 25s infinite alternate ease-in-out;
+    }
+
+    .orb-jade { width: 400px; height: 400px; background: var(--jade); top: -100px; left: -100px; animation-duration: 30s; }
+    .orb-emerald { width: 500px; height: 500px; background: var(--emerald); bottom: -150px; right: -100px; animation-duration: 25s; }
+    .orb-cyan { width: 300px; height: 300px; background: var(--cyan); top: 40%; left: 60%; opacity: 0.3; animation-duration: 35s; }
+
+    @keyframes drift {
+      0% { transform: translate(0, 0) scale(1); }
+      50% { transform: translate(100px, 50px) scale(1.2); }
+      100% { transform: translate(-50px, 150px) scale(0.9); }
+    }
+
+    .container { max-width: 1100px; margin: 0 auto; padding: 2rem; }
+
+    .glass-panel {
+      background: var(--glass-bg);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--glass-border);
+      border-radius: 24px;
+      box-shadow: var(--glass-shadow);
+      padding: 3rem;
+      margin-bottom: 3rem;
+      transition: transform 0.3s ease, border-color 0.3s ease;
+    }
+
+    header.glass-panel {
+      padding: 1.5rem 3rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 2rem;
+    }
+
+    .logo {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #fff;
+      text-decoration: none;
+      background: linear-gradient(90deg, var(--jade), var(--cyan));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    nav a { color: var(--text-muted); text-decoration: none; margin-left: 2rem; font-weight: 500; transition: color 0.3s ease; }
+    nav a:hover { color: var(--jade); }
+
+    .content-wrapper {
+      max-width: var(--max-width);
+      margin: 0 auto;
+    }
+
+    .page-title {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 3rem;
+      color: #fff;
+      margin-bottom: 1rem;
+    }
+
+    .page-meta {
+      color: var(--text-muted);
+      margin-bottom: 2rem;
+      font-size: 0.95rem;
+      display: flex;
+      gap: 1rem;
+    }
+
+    .content {
+      font-size: 1.1rem;
+      color: var(--text-main);
+    }
+
+    .content h2 { font-family: 'Space Grotesk', sans-serif; color: #fff; margin: 2rem 0 1rem; }
+    .content p { margin-bottom: 1.5rem; }
+    .content a { color: var(--cyan); text-decoration: none; }
+    .content a:hover { text-decoration: underline; }
+
+    footer { text-align: center; padding: 3rem; color: var(--text-muted); font-size: 0.9rem; border-top: 1px solid var(--glass-border); margin-top: 4rem; }
+
+    @media (max-width: 768px) {
+      header.glass-panel { flex-direction: column; gap: 1rem; }
+      nav a { margin: 0 1rem; }
+      .page-title { font-size: 2rem; }
+      .glass-panel { padding: 1.5rem; }
+    }
+  </style>
+</head>
+<body>
+
+  <div class="bg-orbs">
+    <div class="orb orb-jade"></div>
+    <div class="orb orb-emerald"></div>
+    <div class="orb orb-cyan"></div>
+  </div>
+
+  <div class="container">
+    {% include "header.html" %}
+
+    <main class="content-wrapper">
+      <article class="glass-panel">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.date %}
+          <div class="page-meta">
+            <span>{{ page.date | date("%B %d, %Y") }}</span>
+          </div>
+        {% endif %}
+
+        <div class="content">
+          {{ content | safe }}
+        </div>
+      </article>
+
+      {% if section.pages %}
+      <div class="grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem;">
+        {% for post in section.pages | sort_by("date", reverse=true) %}
+          <article class="glass-panel" style="padding: 2rem; margin-bottom: 0;">
+            <h3 style="font-family: 'Space Grotesk', sans-serif; font-size: 1.5rem; margin-bottom: 1rem; color: #fff;">{{ post.title }}</h3>
+            <p>{{ post.summary | default("Explore the latest insights from the deep void.") | strip_html | truncate_words(20) }}</p>
+            <a href="{{ post.url }}" style="display: inline-block; margin-top: 1rem; color: var(--jade); text-decoration: none; font-weight: 500;">Read more →</a>
+          </article>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </main>
+
+    {% include "footer.html" %}
+  </div>
+
+</body>
+</html>

--- a/examples/jade-nebula-glass/templates/shortcodes/alert.html
+++ b/examples/jade-nebula-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/jade-nebula-glass/templates/taxonomy.html
+++ b/examples/jade-nebula-glass/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/jade-nebula-glass/templates/taxonomy_term.html
+++ b/examples/jade-nebula-glass/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,4 +1,10 @@
 {
+  "jade-nebula-glass": [
+    "dark",
+    "portfolio",
+    "glassmorphism",
+    "minimal"
+  ],
   "abecedary": [
     "alphabet-book",
     "educational",


### PR DESCRIPTION
This PR adds a new example site called "jade-nebula-glass" to the `examples` directory.

The site showcases a custom dark-themed glassmorphism aesthetic. Key visual elements include:
- A deep cosmic void background (`#020508`).
- Animated, glowing pure CSS orbs (Jade, Emerald, Cyan).
- Translucent frosted glass containers using `backdrop-filter: blur(16px)`.
- Typography pairings featuring `Space Grotesk` (headings) and `Inter` (body).

Included:
- All required `hwaro init` generated files (pages, config, tags, and sample content).
- Updates to the root `tags.json` file for index filtering ("dark", "portfolio", "glassmorphism", "minimal").
- Config updated with standard hwaro plugins using `hwaro tool doctor --fix`.

---
*PR created automatically by Jules for task [14900467882735695085](https://jules.google.com/task/14900467882735695085) started by @hahwul*