### PR TITLE
feat: add 5 panoramic and visual gallery themed examples (#1113, #1114, #1115, #1116, #1117)

### DIFF
--- a/examples/dark-gallery/AGENTS.md
+++ b/examples/dark-gallery/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/dark-gallery/archetypes/default.md
+++ b/examples/dark-gallery/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/dark-gallery/config.toml
+++ b/examples/dark-gallery/config.toml
@@ -1,0 +1,8 @@
+title = "DARK-GALLERY"
+description = "A dark, atmospheric design for high-impact visual archives and structural reviews."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/dark-gallery/content/about.md
+++ b/examples/dark-gallery/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/dark-gallery/content/index.md
+++ b/examples/dark-gallery/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Archive"
++++
+
+<article>
+
+## Narrative Depth
+
+Dark-Gallery is about the atmospheric and foundational nature of structural innovation within the immersive environment. We believe that visual stories deserve a presentation that captures the authority of a classic dark gallery. By focusing on dark backgrounds, high-depth shadows, and bold monospaced typography, we create an environment that feels both expansive and deeply clear. Our focus is on the integrity of the archive.
+
+### Gallery Principles
+
+- **Depth**: A design that prioritizes the clear presentation of visual units.
+- **Tactility**: Using dark textures to define the boundaries of the cinematic space.
+- **Authority**: A layout that reflects the solid, uncompromised nature of the primary narrative.
+
+---
+
+> "In the dark gallery, every frame is a facet of the whole archive."
+</article>

--- a/examples/dark-gallery/templates/404.html
+++ b/examples/dark-gallery/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/dark-gallery/templates/footer.html
+++ b/examples/dark-gallery/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; letter-spacing: 5px;">
+        <div class="container">
+            &copy; 2026 DARK-GALLERY. ARCHIVING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/dark-gallery/templates/header.html
+++ b/examples/dark-gallery/templates/header.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #111;
+            --text: #eee;
+            --accent: #555;
+            --gallery: #1a1a1a;
+            --shadow: rgba(0,0,0,0.8);
+        }
+        body {
+            background-color: #0c0c0c;
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            opacity: 0.5;
+        }
+        .gallery-surface {
+            background: var(--gallery);
+            padding: 100px;
+            box-shadow: 20px 20px 60px var(--shadow);
+            margin-bottom: 80px;
+            border: 1px solid #333;
+        }
+        h2 { font-weight: 700; font-size: 2.2rem; color: #fff; margin-top: 0; border-bottom: 1px solid #333; padding-bottom: 10px; text-transform: uppercase; }
+        article { font-family: 'IBM Plex Mono', monospace; font-size: 1rem; color: #aaa; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">dark.gallery</div>
+            <nav>
+                <a href="/">Archive</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/dark-gallery/templates/page.html
+++ b/examples/dark-gallery/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="gallery-surface">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/dark-gallery/templates/section.html
+++ b/examples/dark-gallery/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/dark-gallery/templates/shortcodes/alert.html
+++ b/examples/dark-gallery/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/dark-gallery/templates/taxonomy.html
+++ b/examples/dark-gallery/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/dark-gallery/templates/taxonomy_term.html
+++ b/examples/dark-gallery/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-minimal/AGENTS.md
+++ b/examples/gallery-minimal/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/gallery-minimal/archetypes/default.md
+++ b/examples/gallery-minimal/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/gallery-minimal/config.toml
+++ b/examples/gallery-minimal/config.toml
@@ -1,0 +1,8 @@
+title = "GALLERY-MINIMAL"
+description = "A minimal, white-surface design for high-clarity visual portfolios and structural reviews."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/gallery-minimal/content/about.md
+++ b/examples/gallery-minimal/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/gallery-minimal/content/index.md
+++ b/examples/gallery-minimal/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Exhibition"
++++
+
+<article>
+
+## Curatorial Clarity
+
+Gallery-Minimal is about the refined and foundational nature of structural innovation within the exhibition environment. We believe that high-clarity visual stories deserve a presentation that captures the authority of a classic minimal gallery. By focusing on white surfaces, clear hierarchies, and impactful display typography, we create an environment that feels both sophisticated and deeply clear. Our focus is on the integrity of the exhibition.
+
+### Gallery Principles
+
+- **Clarity**: A design that prioritizes the clear presentation of visual units.
+- **Tactility**: Using natural textures to define the boundaries of the minimal space.
+- **Authority**: A layout that reflects the high-value nature of the primary review.
+
+---
+
+> "In the gallery minimal, every unit is a facet of the whole expression."
+</article>

--- a/examples/gallery-minimal/templates/404.html
+++ b/examples/gallery-minimal/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-minimal/templates/footer.html
+++ b/examples/gallery-minimal/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 5px; font-weight: 700;">
+        <div class="container">
+            &copy; 2026 GALLERY-MINIMAL. EXHIBITING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/gallery-minimal/templates/header.html
+++ b/examples/gallery-minimal/templates/header.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fff;
+            --text: #1a1a1a;
+            --accent: #555;
+            --gallery: #fdfdfd;
+            --shadow: rgba(0,0,0,0.05);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 80px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 20px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 600;
+        }
+        .gallery-surface {
+            background: #fff;
+            padding: 100px;
+            box-shadow: 10px 10px 30px var(--shadow);
+            margin-bottom: 100px;
+            border: 1px solid #eee;
+        }
+        h2 { font-weight: 700; font-size: 2.2rem; color: #000; margin-top: 0; border-bottom: 1px solid #eee; padding-bottom: 10px; text-transform: uppercase; }
+        article { font-size: 1.1rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">gallery.minimal</div>
+            <nav>
+                <a href="/">Exhibition</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/gallery-minimal/templates/page.html
+++ b/examples/gallery-minimal/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="gallery-surface">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/gallery-minimal/templates/section.html
+++ b/examples/gallery-minimal/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-minimal/templates/shortcodes/alert.html
+++ b/examples/gallery-minimal/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/gallery-minimal/templates/taxonomy.html
+++ b/examples/gallery-minimal/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-minimal/templates/taxonomy_term.html
+++ b/examples/gallery-minimal/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lightroom-strip/AGENTS.md
+++ b/examples/lightroom-strip/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lightroom-strip/archetypes/default.md
+++ b/examples/lightroom-strip/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lightroom-strip/config.toml
+++ b/examples/lightroom-strip/config.toml
@@ -1,0 +1,8 @@
+title = "LIGHTROOM-STRIP"
+description = "A horizontal, sequence-focused design for high-clarity visual development and structural content."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/lightroom-strip/content/about.md
+++ b/examples/lightroom-strip/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/lightroom-strip/content/index.md
+++ b/examples/lightroom-strip/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Develop"
++++
+
+<article>
+
+## Developmental Structure
+
+Lightroom-Strip is about the organized and foundational nature of structural innovation within the developmental environment. We believe that visual stories deserve a presentation that captures the authority of a classic lightroom film strip. By focusing on white surfaces, horizontal grids, and clear hierarchies, we create an environment that feels both utilitarian and deeply clear. Our focus is on the integrity of the developmental process.
+
+### Strip Principles
+
+- **Progression**: A design that prioritizes the clear presentation of visual units in sequence.
+- **Tactility**: Using horizontal grids to define the boundaries of the developmental space.
+- **Clarity**: A layout that reflects the logical nature of structural storytelling.
+
+---
+
+> "In the lightroom strip, every frame is a facet of the whole development."
+</article>

--- a/examples/lightroom-strip/templates/404.html
+++ b/examples/lightroom-strip/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/lightroom-strip/templates/footer.html
+++ b/examples/lightroom-strip/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; letter-spacing: 5px; font-weight: 700;">
+        <div class="container">
+            &copy; 2026 LIGHTROOM-STRIP. DEVELOPING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/lightroom-strip/templates/header.html
+++ b/examples/lightroom-strip/templates/header.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fff;
+            --text: #1a1a1a;
+            --accent: #555;
+            --lightroom: #f4f4f4;
+            --shadow: rgba(0,0,0,0.05);
+        }
+        body {
+            background-color: var(--lightroom);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: left;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin-right: 30px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 600;
+        }
+        .lightroom-surface {
+            display: flex;
+            gap: 2px;
+            margin-bottom: 80px;
+            overflow-x: auto;
+            padding-bottom: 20px;
+        }
+        .lightroom-item {
+            background: #fff;
+            padding: 40px;
+            min-width: 300px;
+            border: 1px solid #ddd;
+            flex-shrink: 0;
+        }
+        h2 { font-weight: 700; font-size: 1.2rem; color: #000; margin-top: 0; border-bottom: 1px solid #eee; padding-bottom: 10px; text-transform: uppercase; }
+        article { font-size: 0.9rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">lightroom.strip</div>
+            <nav>
+                <a href="/">Develop</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/lightroom-strip/templates/page.html
+++ b/examples/lightroom-strip/templates/page.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="lightroom-surface">
+            <div class="lightroom-item">
+                {{ content }}
+            </div>
+            <div class="lightroom-item">
+                <h2>Frame Two</h2>
+                <p>Developing the structural integrity.</p>
+            </div>
+            <div class="lightroom-item">
+                <h2>Frame Three</h2>
+                <p>The sequence of visual narrative.</p>
+            </div>
+            <div class="lightroom-item">
+                <h2>Frame Four</h2>
+            </div>
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lightroom-strip/templates/section.html
+++ b/examples/lightroom-strip/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lightroom-strip/templates/shortcodes/alert.html
+++ b/examples/lightroom-strip/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/lightroom-strip/templates/taxonomy.html
+++ b/examples/lightroom-strip/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lightroom-strip/templates/taxonomy_term.html
+++ b/examples/lightroom-strip/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/panorama-gallery/AGENTS.md
+++ b/examples/panorama-gallery/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/panorama-gallery/archetypes/default.md
+++ b/examples/panorama-gallery/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/panorama-gallery/config.toml
+++ b/examples/panorama-gallery/config.toml
@@ -1,0 +1,8 @@
+title = "PANORAMA-GALLERY"
+description = "A wide, expansive design for high-impact visual horizons and structural reviews."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/panorama-gallery/content/about.md
+++ b/examples/panorama-gallery/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/panorama-gallery/content/index.md
+++ b/examples/panorama-gallery/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Horizon"
++++
+
+<article>
+
+## Expansive Structure
+
+Panorama-Gallery is about the expansive and foundational nature of structural innovation within the visual environment. We believe that panoramic stories deserve a presentation that captures the authority of a classic wide-format gallery. By focusing on white surfaces, ultra-wide layouts, and elegant sans-serif typography, we create an environment that feels both sophisticated and deeply immersive. Our focus is on the integrity of the horizon.
+
+### Gallery Principles
+
+- **Breadth**: A design that prioritizes the clear presentation of visual units across a wide horizon.
+- **Tactility**: Using natural textures to define the boundaries of the expansive space.
+- **Authority**: A layout that reflects the high-value nature of the primary narrative.
+
+---
+
+> "In the panorama gallery, every frame is a facet of the whole horizon."
+</article>

--- a/examples/panorama-gallery/templates/404.html
+++ b/examples/panorama-gallery/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/panorama-gallery/templates/footer.html
+++ b/examples/panorama-gallery/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 5px; font-weight: 700;">
+        <div class="container-fluid">
+            &copy; 2026 PANORAMA-GALLERY. EXPANDING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/panorama-gallery/templates/header.html
+++ b/examples/panorama-gallery/templates/header.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fff;
+            --text: #1a1a1a;
+            --accent: #555;
+            --panorama: #fdfdfd;
+            --shadow: rgba(0,0,0,0.05);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container-fluid {
+            max-width: 100%;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 600;
+        }
+        .panorama-surface {
+            background: #fff;
+            padding: 100px;
+            box-shadow: 10px 10px 30px var(--shadow);
+            margin-bottom: 80px;
+            width: 100%;
+            box-sizing: border-box;
+            border-top: 1px solid #eee;
+            border-bottom: 1px solid #eee;
+        }
+        h2 { font-weight: 700; font-size: 3rem; color: #000; margin-top: 0; border-bottom: 1px solid #eee; padding-bottom: 10px; text-transform: uppercase; letter-spacing: -1px; }
+        article { font-size: 1.2rem; max-width: 1200px; margin: 0 auto; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container-fluid">
+            <div class="logo">panorama.gallery</div>
+            <nav>
+                <a href="/">Horizon</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/panorama-gallery/templates/page.html
+++ b/examples/panorama-gallery/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="panorama-surface">
+        <div class="container-fluid">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/panorama-gallery/templates/section.html
+++ b/examples/panorama-gallery/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/panorama-gallery/templates/shortcodes/alert.html
+++ b/examples/panorama-gallery/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/panorama-gallery/templates/taxonomy.html
+++ b/examples/panorama-gallery/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/panorama-gallery/templates/taxonomy_term.html
+++ b/examples/panorama-gallery/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/slide-projector/AGENTS.md
+++ b/examples/slide-projector/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/slide-projector/archetypes/default.md
+++ b/examples/slide-projector/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/slide-projector/config.toml
+++ b/examples/slide-projector/config.toml
@@ -1,0 +1,8 @@
+title = "SLIDE-PROJECTOR"
+description = "A dark, cycle-focused design for high-impact visual analysis and storytelling."
+default_language = "en"
+base_url = "https://example.com"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/slide-projector/content/about.md
+++ b/examples/slide-projector/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/slide-projector/content/index.md
+++ b/examples/slide-projector/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "The Flash"
++++
+
+<article>
+
+## Sequential Radiance
+
+Slide-Projector is about the continuous and foundational nature of structural innovation within the immersive environment. We believe that high-impact visual stories deserve a presentation that captures the authority of a classic slide projector. By focusing on dark backgrounds, high-depth shadows, and bold monospaced typography, we create an environment that feels both expansive and deeply clear. Our focus is on the integrity of the sequence.
+
+### Projector Principles
+
+- **Dynamics**: A design that prioritizes the clear "flash" of visual units.
+- **Tactility**: Using dark textures to define the boundaries of the cinematic space.
+- **Authority**: A layout that reflects the solid, uncompromised nature of the primary narrative.
+
+---
+
+> "In the slide projector, every frame is a facet of the whole cycle."
+</article>

--- a/examples/slide-projector/templates/404.html
+++ b/examples/slide-projector/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/slide-projector/templates/footer.html
+++ b/examples/slide-projector/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; letter-spacing: 5px;">
+        <div class="container">
+            &copy; 2026 SLIDE-PROJECTOR. FLASHING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/slide-projector/templates/header.html
+++ b/examples/slide-projector/templates/header.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #111;
+            --text: #eee;
+            --accent: #555;
+            --projector: #0c0c0c;
+            --shadow: rgba(0,0,0,0.8);
+            --highlight: rgba(255,255,255,0.05);
+        }
+        body {
+            background-color: #0c0c0c;
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: center;
+        }
+        .logo {
+            font-family: 'IBM Plex Mono', monospace;
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            opacity: 0.6;
+        }
+        .projector-surface {
+            background: #111;
+            padding: 100px;
+            box-shadow: 20px 20px 60px var(--shadow), inset -5px -5px 15px var(--highlight);
+            margin-bottom: 80px;
+            border: 1px solid #333;
+            text-align: center;
+            position: relative;
+        }
+        .projector-surface::after {
+            content: 'SLIDE_v1.0';
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.6rem;
+            color: #444;
+        }
+        h2 { font-family: 'IBM Plex Mono', monospace; font-size: 2rem; color: #fff; margin-top: 0; border-bottom: 1px solid #333; padding-bottom: 10px; text-transform: uppercase; text-align: left; }
+        article { font-family: 'IBM Plex Mono', monospace; font-size: 0.9rem; color: #aaa; text-align: left; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">slide.projector</div>
+            <nav>
+                <a href="/">Flash</a>
+                <a href="/about">Analysis</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/slide-projector/templates/page.html
+++ b/examples/slide-projector/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="projector-surface">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/slide-projector/templates/section.html
+++ b/examples/slide-projector/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/slide-projector/templates/shortcodes/alert.html
+++ b/examples/slide-projector/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/slide-projector/templates/taxonomy.html
+++ b/examples/slide-projector/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/slide-projector/templates/taxonomy_term.html
+++ b/examples/slide-projector/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2110,6 +2110,13 @@
     "luxury",
     "glamorous"
   ],
+  "dark-gallery": [
+    "dark",
+    "atmospheric",
+    "visual-archive",
+    "immersive",
+    "ibm-plex-mono"
+  ],
   "dark-manual": [
     "docs",
     "dark",
@@ -2942,6 +2949,13 @@
     "dark",
     "event",
     "landing"
+  ],
+  "gallery-minimal": [
+    "minimal",
+    "white-surface",
+    "high-clarity",
+    "curatorial",
+    "jakarta"
   ],
   "gallery-noir": [
     "dark",
@@ -4020,6 +4034,13 @@
     "light",
     "docs",
     "directory"
+  ],
+  "lightroom-strip": [
+    "horizontal",
+    "sequence-focused",
+    "visual-development",
+    "structural",
+    "ibm-plex-mono"
   ],
   "limelight": [
     "light",
@@ -5623,6 +5644,13 @@
     "radial",
     "experimental"
   ],
+  "panorama-gallery": [
+    "expansive",
+    "wide-format",
+    "horizon-focused",
+    "immersive",
+    "jakarta"
+  ],
   "pantry": [
     "light",
     "docs",
@@ -6924,6 +6952,13 @@
     "dark",
     "docs",
     "presentation"
+  ],
+  "slide-projector": [
+    "dark",
+    "cycle-focused",
+    "high-impact",
+    "storytelling",
+    "ibm-plex-mono"
   ],
   "snowfall": [
     "light",

--- a/tags.json
+++ b/tags.json
@@ -1,10 +1,4 @@
 {
-  "jade-nebula-glass": [
-    "dark",
-    "portfolio",
-    "glassmorphism",
-    "minimal"
-  ],
   "abecedary": [
     "alphabet-book",
     "educational",
@@ -3773,6 +3767,12 @@
     "rhythmic",
     "dark",
     "yellow"
+  ],
+  "jade-nebula-glass": [
+    "dark",
+    "portfolio",
+    "glassmorphism",
+    "minimal"
   ],
   "jade-palace": [
     "dark",


### PR DESCRIPTION
This PR adds a 49th set of 5 high-quality examples focused on panoramic views and digital gallery layouts including slide-projector, gallery-minimal, dark-gallery, lightroom-strip, and panorama-gallery. This brings the total examples to 265.

### Key Changes
- Added 5 new examples:
  - **SLIDE-PROJECTOR**: Dark cycle-focused design for high-impact stories.
  - **GALLERY-MINIMAL**: White-surface design for high-clarity portfolios.
  - **DARK-GALLERY**: Dark atmospheric design for visual archives.
  - **LIGHTROOM-STRIP**: Horizontal sequence-focused design for visual development.
  - **PANORAMA-GALLERY**: Expansive wide-format design for visual horizons.
- Updated `tags.json` with relevant discovery tags.
- Verified all examples with `hwaro build`.

Closes #1113
Closes #1114
Closes #1115
Closes #1116
Closes #1117