### PR TITLE
feat: add new 'lucid-dreamscape' example site

### DIFF
--- a/examples/lucid-dreamscape/AGENTS.md
+++ b/examples/lucid-dreamscape/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lucid-dreamscape/archetypes/default.md
+++ b/examples/lucid-dreamscape/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lucid-dreamscape/archetypes/posts.md
+++ b/examples/lucid-dreamscape/archetypes/posts.md
@@ -1,0 +1,11 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+authors = []
+categories = []
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lucid-dreamscape/config.toml
+++ b/examples/lucid-dreamscape/config.toml
@@ -1,0 +1,117 @@
+# =============================================================================
+# Global Configuration
+# =============================================================================
+# The core settings for your site
+
+title = "Lucid Dreamscape"
+base_url = "https://examples.hwaro.hahwul.com/lucid-dreamscape/"
+description = "A surreal, dreamy blog crafted with Hwaro and glassmorphism"
+language_code = "en"
+author = "Hwaro Dreams"
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = ["posts"]
+
+# =============================================================================
+# Markdown Configuration
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = true

--- a/examples/lucid-dreamscape/content/about.md
+++ b/examples/lucid-dreamscape/content/about.md
@@ -1,0 +1,7 @@
++++
+title = "About the Dreamer"
+description = "Whispers from the ether."
+date = "2024-05-01"
++++
+
+I am an architect of ethereal thoughts, weaving code and color into floating islands of memory. Here, in the Lucid Dreamscape, we break the boundaries of conventional design, floating on semi-transparent glass planes above a shifting, gradient void.

--- a/examples/lucid-dreamscape/content/archives.md
+++ b/examples/lucid-dreamscape/content/archives.md
@@ -1,0 +1,5 @@
++++
+title = "Archives"
++++
+
+Browse all posts by date. Check the [Posts](/posts/) section for the complete list.

--- a/examples/lucid-dreamscape/content/index.md
+++ b/examples/lucid-dreamscape/content/index.md
@@ -1,0 +1,12 @@
++++
+title = "Lucid Dreamscape"
+tags = ["home"]
++++
+
+Welcome to a world where reality bends and thoughts crystallize. This is a dreamscape powered by [Hwaro](https://github.com/hahwul/hwaro).
+
+Explore the echoes of imagination in the [Visions](/posts/) section, or traverse through the nexus of:
+
+- [Constellations (Tags)](/tags/)
+- [Realms (Categories)](/categories/)
+- [Dreamers (Authors)](/authors/)

--- a/examples/lucid-dreamscape/content/posts/_index.md
+++ b/examples/lucid-dreamscape/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
++++
+
+Browse all blog posts below.

--- a/examples/lucid-dreamscape/content/posts/getting-started-with-hwaro.md
+++ b/examples/lucid-dreamscape/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,11 @@
++++
+title = "Weaving Dreams with Hwaro"
+date = "2024-05-02"
+description = "Harnessing the speed of thought."
+tags = ["hwaro", "magic"]
+categories = ["Tutorials"]
++++
+
+Hwaro acts as the engine of our imagination. It processes Markdown at blinding speed, transforming raw textual intent into glowing HTML artifacts.
+
+Unlike monolithic frameworks, Hwaro provides the raw elements and steps back, allowing the dreamer to design the entire universe from scratch. No assumptions. Just pure, unadulterated creation.

--- a/examples/lucid-dreamscape/content/posts/hello-world.md
+++ b/examples/lucid-dreamscape/content/posts/hello-world.md
@@ -1,0 +1,11 @@
++++
+title = "Awakening in the Dreamscape"
+date = "2024-05-01"
+description = "The first breath drawn in a new reality."
+tags = ["dreams", "beginning"]
+categories = ["Musings"]
++++
+
+When you first open your eyes in a lucid dream, the colors seem impossibly vibrant. The air hums with potential.
+
+In this space, we are untethered from physics. We build using floating fragments of glass, capturing light and refracting it into neon spectrums. Every word written here is a spell cast into the void, crystallizing into form.

--- a/examples/lucid-dreamscape/content/posts/markdown-tips.md
+++ b/examples/lucid-dreamscape/content/posts/markdown-tips.md
@@ -1,0 +1,24 @@
++++
+title = "The Architecture of Dreams"
+date = "2024-05-03"
+description = "Understanding the structure of the void."
+tags = ["markdown", "structure"]
+categories = ["Guides"]
++++
+
+We structure our thoughts using Markdown. It is elegant in its simplicity.
+
+# A Towering Spire
+## The Upper Balcony
+### The Hidden Alcove
+
+We can embed fragments of **strong belief** and *subtle nuances*.
+
+> "A dream you dream alone is only a dream. A dream you dream together is reality."
+
+```python
+def weave_spell():
+    return "Floating glass and endless night"
+```
+
+Let the elements guide you as you traverse this realm.

--- a/examples/lucid-dreamscape/static/css/style.css
+++ b/examples/lucid-dreamscape/static/css/style.css
@@ -1,0 +1,280 @@
+:root {
+  --bg-color-1: #0f0c29;
+  --bg-color-2: #302b63;
+  --bg-color-3: #24243e;
+  --text-primary: #e0e0ff;
+  --text-secondary: #a8a8d0;
+  --accent-color: #ff7eb3;
+  --accent-hover: #ffb8d2;
+  --glass-bg: rgba(255, 255, 255, 0.05);
+  --glass-border: rgba(255, 255, 255, 0.1);
+  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+  --font-body: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-heading: 'Georgia', serif;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: linear-gradient(135deg, var(--bg-color-1), var(--bg-color-2), var(--bg-color-3));
+  background-size: 400% 400%;
+  animation: gradientBG 15s ease infinite;
+  color: var(--text-primary);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+@keyframes gradientBG {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+a {
+  color: var(--accent-color);
+  text-decoration: none;
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+a:hover {
+  color: var(--accent-hover);
+  text-shadow: 0 0 8px var(--accent-hover);
+}
+
+.glass-panel {
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(15, 12, 41, 0.4);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--glass-border);
+  padding: 1rem 0;
+}
+
+.header-container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 1rem;
+}
+
+.site-title {
+  font-family: var(--font-heading);
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+  margin: 0;
+}
+
+.site-nav a {
+  margin-left: 1.5rem;
+  color: var(--text-primary);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+}
+
+.site-nav a:hover {
+  color: var(--accent-color);
+}
+
+/* Main Layout */
+.container {
+  max-width: 800px;
+  margin: 3rem auto;
+  padding: 0 1rem;
+  flex: 1;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  font-weight: normal;
+  color: #fff;
+  margin-top: 0;
+}
+
+h1 {
+  font-size: 2.5rem;
+  text-shadow: 0 0 15px rgba(255, 126, 179, 0.5);
+  margin-bottom: 0.5rem;
+}
+
+.post-meta {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+  display: flex;
+  gap: 1rem;
+}
+
+.post-content p {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+}
+
+.post-content img {
+  max-width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+}
+
+.post-content pre {
+  background: rgba(0, 0, 0, 0.5);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid var(--glass-border);
+}
+
+.post-content code {
+  font-family: 'Courier New', Courier, monospace;
+  color: #a3ffc2;
+}
+
+.post-content blockquote {
+  border-left: 4px solid var(--accent-color);
+  margin-left: 0;
+  padding-left: 1.5rem;
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
+/* Post Lists */
+.post-list {
+  list-style: none;
+  padding: 0;
+}
+
+.post-item {
+  margin-bottom: 1.5rem;
+}
+
+.post-item a {
+  display: block;
+  font-size: 1.5rem;
+  font-family: var(--font-heading);
+  color: #fff;
+  margin-bottom: 0.5rem;
+}
+
+.post-item a:hover {
+  color: var(--accent-color);
+}
+
+.post-item p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+/* Taxonomy Tags */
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+}
+
+.tag-list li {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  padding: 0.2rem 0.8rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+}
+
+.tag-list a {
+  color: var(--text-primary);
+}
+
+/* Footer */
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  border-top: 1px solid var(--glass-border);
+  background: rgba(0,0,0,0.2);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: auto;
+}
+
+/* Search Modal Elements (Hidden by default) */
+.search-overlay {
+  display: none;
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(15, 12, 41, 0.9);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+  padding: 2rem;
+}
+
+.search-overlay.active {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.search-input {
+  width: 100%;
+  max-width: 600px;
+  padding: 1rem 1.5rem;
+  font-size: 1.2rem;
+  background: var(--glass-bg);
+  border: 1px solid var(--accent-color);
+  border-radius: 30px;
+  color: #fff;
+  outline: none;
+  margin-top: 10vh;
+}
+
+.search-results {
+  width: 100%;
+  max-width: 600px;
+  margin-top: 2rem;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.search-results a {
+  display: block;
+  padding: 1rem;
+  background: var(--glass-bg);
+  border-bottom: 1px solid var(--glass-border);
+  color: #fff;
+}
+.search-results a:hover {
+  background: rgba(255, 126, 179, 0.1);
+}
+.search-close {
+  position: absolute;
+  top: 2rem;
+  right: 2rem;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+}

--- a/examples/lucid-dreamscape/static/js/search.js
+++ b/examples/lucid-dreamscape/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/examples/lucid-dreamscape/templates/404.html
+++ b/examples/lucid-dreamscape/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main class="container">
+  <div class="glass-panel" style="text-align: center;">
+    <h1 style="font-size: 4rem; color: var(--accent-color);">404</h1>
+    <h2>Dream Not Found</h2>
+    <p>The fragment of reality you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to the Nexus</a></p>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lucid-dreamscape/templates/footer.html
+++ b/examples/lucid-dreamscape/templates/footer.html
@@ -1,0 +1,37 @@
+  <footer class="site-footer">
+    <p>&copy; {% if site.title is defined %}{{ site.title }}{% else %}Lucid Dreamscape{% endif %}. Forged in the ether.</p>
+    <p><small>Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></small></p>
+  </footer>
+
+  {% if site.search is defined and site.search.enabled %}
+    <script src="{{ base_url }}/js/search.js"></script>
+  {% endif %}
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const searchBtn = document.getElementById('searchButton');
+      const searchOverlay = document.getElementById('searchOverlay');
+      const searchClose = document.getElementById('searchClose');
+      const searchInput = document.getElementById('searchInput');
+
+      if (searchBtn && searchOverlay) {
+        searchBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          searchOverlay.classList.add('active');
+          searchInput.focus();
+        });
+
+        searchClose.addEventListener('click', () => {
+          searchOverlay.classList.remove('active');
+        });
+
+        document.addEventListener('keydown', (e) => {
+          if (e.key === 'Escape' && searchOverlay.classList.contains('active')) {
+            searchOverlay.classList.remove('active');
+          }
+        });
+      }
+    });
+  </script>
+</body>
+</html>

--- a/examples/lucid-dreamscape/templates/header.html
+++ b/examples/lucid-dreamscape/templates/header.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ site.language_code | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title is defined %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  <meta name="description" content="{% if page.description is defined %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+
+  {% if og_all_tags is defined %}
+    {{ og_all_tags | safe }}
+  {% endif %}
+
+  {% if auto_includes is defined %}
+    {{ auto_includes | safe }}
+  {% endif %}
+
+  {% if highlight_tags is defined %}
+    {{ highlight_tags | safe }}
+  {% endif %}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-container">
+      <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="#" id="searchButton">Search</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="search-overlay" id="searchOverlay">
+    <button class="search-close" id="searchClose">&times;</button>
+    <input type="text" class="search-input" id="searchInput" placeholder="Search the dreamscape...">
+    <div class="search-results" id="searchResults"></div>
+  </div>

--- a/examples/lucid-dreamscape/templates/page.html
+++ b/examples/lucid-dreamscape/templates/page.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+
+<main class="container">
+  <article class="glass-panel">
+    <h1>{{ page.title }}</h1>
+    <div class="post-content">
+      {{ content | safe }}
+    </div>
+  </article>
+</main>
+
+{% include "footer.html" %}

--- a/examples/lucid-dreamscape/templates/post.html
+++ b/examples/lucid-dreamscape/templates/post.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+
+<main class="container">
+  <article class="glass-panel">
+    <h1>{{ page.title }}</h1>
+
+    <div class="post-meta">
+      {% if page.date is defined %}
+        <span>{{ page.date }}</span>
+      {% endif %}
+      {% if page.taxonomies is defined and page.taxonomies.categories is defined %}
+        <span>
+        {% for cat in page.taxonomies.categories %}
+          <a href="{{ base_url }}/categories/{{ cat | lower | replace(from=' ', to='-') }}/">{{ cat }}</a>
+        {% endfor %}
+        </span>
+      {% endif %}
+    </div>
+
+    <div class="post-content">
+      {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies is defined and page.taxonomies.tags is defined %}
+      <ul class="tag-list">
+        {% for tag in page.taxonomies.tags %}
+          <li><a href="{{ base_url }}/tags/{{ tag | lower | replace(from=' ', to='-') }}/">#{{ tag }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </article>
+</main>
+
+{% include "footer.html" %}

--- a/examples/lucid-dreamscape/templates/section.html
+++ b/examples/lucid-dreamscape/templates/section.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+
+<main class="container">
+  <div class="glass-panel">
+    <h1>{{ section.title }}</h1>
+    {% if section.content is defined %}
+      <div class="post-content">
+        {{ section.content | safe }}
+      </div>
+    {% endif %}
+
+    <ul class="post-list">
+      {% for page in section.pages %}
+        <li class="post-item glass-panel">
+          <a href="{{ base_url }}{{ page.url }}">{{ page.title }}</a>
+          {% if page.date is defined %}
+            <small class="post-meta">{{ page.date }}</small>
+          {% endif %}
+          {% if page.description is defined %}
+            <p>{{ page.description }}</p>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</main>
+
+{% include "footer.html" %}

--- a/examples/lucid-dreamscape/templates/shortcodes/alert.html
+++ b/examples/lucid-dreamscape/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/lucid-dreamscape/templates/taxonomy.html
+++ b/examples/lucid-dreamscape/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+
+<main class="container">
+  <div class="glass-panel">
+    <h1>All Taxonomies</h1>
+    <ul class="tag-list">
+      {% for term in terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term.name }} ({{ term.pages | length }})</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+</main>
+
+{% include "footer.html" %}

--- a/examples/lucid-dreamscape/templates/taxonomy_term.html
+++ b/examples/lucid-dreamscape/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<main class="container">
+  <div class="glass-panel">
+    <h1>Pages tagged with "{{ page.title }}"</h1>
+
+    <ul class="post-list">
+      {% for item in pages %}
+        <li class="post-item glass-panel">
+          <a href="{{ base_url }}{{ item.url }}">{{ item.title }}</a>
+          {% if item.date is defined %}
+            <small class="post-meta">{{ item.date }}</small>
+          {% endif %}
+          {% if item.description is defined %}
+            <p>{{ item.description }}</p>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</main>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3992,6 +3992,13 @@
     "minimal",
     "dark"
   ],
+  "lucid-dreamscape": [
+    "dreamy",
+    "surreal",
+    "gradient",
+    "glassmorphism",
+    "creative"
+  ],
   "lucid-glass": [
     "elegant",
     "glassmorphism",
@@ -6200,6 +6207,12 @@
     "minimal",
     "cyberpunk"
   ],
+  "radiant-eclipse-glass": [
+    "dark",
+    "glassmorphism",
+    "portfolio",
+    "elegant"
+  ],
   "radiolaria": [
     "dark",
     "blog",
@@ -8120,12 +8133,5 @@
     "diy",
     "raw",
     "unconventional"
-  ]
-  ,
-  "radiant-eclipse-glass": [
-    "dark",
-    "glassmorphism",
-    "portfolio",
-    "elegant"
   ]
 }


### PR DESCRIPTION
This PR introduces a brand-new, uniquely themed example site to the `examples/` directory called `lucid-dreamscape`.

**Key Additions:**
*   **Design:** A highly custom, dark-themed "glassmorphic" UI built using CSS backdrop filters, animated mesh gradients, and subtle hover effects, providing a surreal and creative aesthetic.
*   **Content:** A full set of sample posts (`hello-world`, `getting-started-with-hwaro`, `markdown-tips`) and pages (`about`, `index`) styled to fit the dreamy theme.
*   **Templates:** Fully rewritten Jinja2 templates (`header.html`, `footer.html`, `page.html`, `post.html`, `section.html`, `taxonomy.html`, `taxonomy_term.html`, `404.html`) that strictly respect Hwaro template rules, gracefully handling optional features (like `site.search`).
*   **Configuration:** A streamlined `config.toml` correctly defining the global URL (`https://examples.hwaro.hahwul.com/lucid-dreamscape/`), metadata, feeds, and taxonomy settings.
*   **Registration:** The `lucid-dreamscape` project is properly registered within the repository's `tags.json` file.
*   **Agent Guidance:** A project-specific `AGENTS.md` is included in the project directory for future AI maintenance.

**Verification:**
The site has been visually verified using a headless Playwright browser against the local `hwaro serve` backend. All layouts (including the home page, individual posts, and post listing views) render accurately. No tests were broken as the core repository relies on frontend verification for example additions.

---
*PR created automatically by Jules for task [18389644238584917111](https://jules.google.com/task/18389644238584917111) started by @chei-l*