### PR TITLE
feat: add lumina-quartz-forge example site

### DIFF
--- a/examples/lumina-quartz-forge/AGENTS.md
+++ b/examples/lumina-quartz-forge/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lumina-quartz-forge/archetypes/default.md
+++ b/examples/lumina-quartz-forge/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lumina-quartz-forge/config.toml
+++ b/examples/lumina-quartz-forge/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Lumina Quartz Forge"
+description = "A dark-themed glassmorphism aesthetic portfolio."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/lumina-quartz-forge/content/about.md
+++ b/examples/lumina-quartz-forge/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Us"
+description = "Information about Lumina Quartz Forge"
+date = "2025-01-15"
++++
+
+## The Art of Crystalline Design
+
+We are creators focused on bridging the gap between digital minimalism and deep-space wonder. The **Lumina Quartz Forge** aesthetic heavily relies on frosted glass layers (`backdrop-filter`) and vibrant, organic glowing orbs that float silently in the void.
+
+This template is built with **Hwaro**, designed for exceptional performance and modern styling using raw CSS.

--- a/examples/lumina-quartz-forge/content/index.md
+++ b/examples/lumina-quartz-forge/content/index.md
@@ -1,0 +1,13 @@
++++
+title = "Lumina Quartz Forge"
+description = "A dark-themed glassmorphism aesthetic portfolio."
+date = "2025-01-15"
++++
+
+# Welcome to Lumina Quartz Forge
+
+Discover the ethereal convergence of deep void aesthetics and translucent crystalline structures. Lumina Quartz Forge is a portfolio template designed with the elegant harmony of deep darkness and vivid, luminous quartz elements.
+
+Step into the future where glass meets glowing plasma.
+
+[Explore Portfolio](/portfolio/)

--- a/examples/lumina-quartz-forge/content/portfolio/_index.md
+++ b/examples/lumina-quartz-forge/content/portfolio/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Portfolio"
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "section"
+generate_feeds = false
+transparent = false
++++
+
+This is our digital gallery showcasing works forged in luminous quartz.

--- a/examples/lumina-quartz-forge/content/portfolio/project-alpha.md
+++ b/examples/lumina-quartz-forge/content/portfolio/project-alpha.md
@@ -1,0 +1,7 @@
++++
+title = "Project Alpha"
+date = "2025-01-14"
+description = "First luminous project."
++++
+
+Project Alpha is a study in cyan fluorescence. We explored how cyan light interacts with frosted glass surfaces in a zero-gravity void environment.

--- a/examples/lumina-quartz-forge/content/portfolio/project-beta.md
+++ b/examples/lumina-quartz-forge/content/portfolio/project-beta.md
@@ -1,0 +1,7 @@
++++
+title = "Project Beta"
+date = "2025-01-15"
+description = "Second luminous project."
++++
+
+Project Beta explores the deep magenta and purple spectrum, crafting crystalline geometries that bend and refract neon light into unpredictable patterns.

--- a/examples/lumina-quartz-forge/static/css/style.css
+++ b/examples/lumina-quartz-forge/static/css/style.css
@@ -1,0 +1,314 @@
+:root {
+    --bg-dark: #020108;
+    --glass-bg: rgba(20, 10, 40, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    --glass-highlight: rgba(255, 255, 255, 0.2);
+    --text-main: #f0f0f5;
+    --text-muted: #a09eb5;
+
+    --glow-cyan: #00f0ff;
+    --glow-magenta: #ff0055;
+    --glow-purple: #8a2be2;
+
+    --font-heading: 'Space Grotesk', sans-serif;
+    --font-body: 'Inter', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-dark);
+    color: var(--text-main);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    min-height: 100vh;
+    overflow-x: hidden;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Glowing Orbs */
+.orb {
+    position: fixed;
+    border-radius: 50%;
+    filter: blur(80px);
+    z-index: -1;
+    animation: drift 20s infinite alternate ease-in-out;
+}
+
+.orb-1 {
+    width: 40vw;
+    height: 40vw;
+    background: radial-gradient(circle, var(--glow-cyan) 0%, transparent 70%);
+    top: -10%;
+    left: -10%;
+    opacity: 0.3;
+}
+
+.orb-2 {
+    width: 35vw;
+    height: 35vw;
+    background: radial-gradient(circle, var(--glow-magenta) 0%, transparent 70%);
+    bottom: -10%;
+    right: -10%;
+    opacity: 0.2;
+    animation-delay: -5s;
+}
+
+.orb-3 {
+    width: 30vw;
+    height: 30vw;
+    background: radial-gradient(circle, var(--glow-purple) 0%, transparent 70%);
+    top: 40%;
+    left: 40%;
+    opacity: 0.25;
+    animation-delay: -10s;
+}
+
+@keyframes drift {
+    0% { transform: translate(0, 0) scale(1); }
+    100% { transform: translate(50px, 30px) scale(1.1); }
+}
+
+/* Glass Navigation */
+.glass-nav {
+    background: var(--glass-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--glass-border);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.nav-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.logo {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-main);
+    text-decoration: none;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    background: linear-gradient(90deg, var(--glow-cyan), var(--glow-magenta));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 2rem;
+}
+
+.nav-links a {
+    color: var(--text-main);
+    text-decoration: none;
+    font-family: var(--font-heading);
+    font-weight: 400;
+    transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+.nav-links a:hover {
+    color: var(--glow-cyan);
+    text-shadow: 0 0 10px rgba(0, 240, 255, 0.5);
+}
+
+/* Layout Container */
+.container {
+    max-width: 1000px;
+    margin: 4rem auto;
+    padding: 0 2rem;
+    flex: 1;
+}
+
+/* Glass Panels (Reusable) */
+.glass-panel {
+    background: var(--glass-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--glass-border);
+    border-radius: 24px;
+    padding: 3rem;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    margin-bottom: 2rem;
+}
+
+.glass-card {
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--glass-border);
+    border-radius: 16px;
+    padding: 2rem;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+    display: flex;
+    flex-direction: column;
+}
+
+.glass-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 40px rgba(0, 240, 255, 0.15);
+    border-color: var(--glass-highlight);
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+    margin-bottom: 1.5rem;
+    color: var(--text-main);
+}
+
+.glow-text {
+    font-size: 3rem;
+    background: linear-gradient(135deg, #fff, var(--glow-cyan));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    text-shadow: 0 0 20px rgba(0, 240, 255, 0.2);
+    margin-bottom: 1rem;
+}
+
+p {
+    margin-bottom: 1.5rem;
+    color: var(--text-muted);
+}
+
+a {
+    color: var(--glow-cyan);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* Section Header */
+.section-header p {
+    font-size: 1.2rem;
+    max-width: 800px;
+}
+
+/* Portfolio Grid */
+.portfolio-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 2rem;
+}
+
+.glass-card h2 {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.glass-card h2 a {
+    color: var(--text-main);
+    text-decoration: none;
+}
+
+.glass-card h2 a:hover {
+    color: var(--glow-cyan);
+    text-decoration: none;
+}
+
+.glass-card .meta {
+    font-family: var(--font-heading);
+    font-size: 0.9rem;
+    color: var(--glow-purple);
+    margin-bottom: 1rem;
+}
+
+.glass-card .read-more {
+    margin-top: auto;
+    display: inline-block;
+    color: var(--glow-magenta);
+    font-family: var(--font-heading);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 0.9rem;
+    padding-top: 1rem;
+}
+
+/* Content Body for Markdown */
+.content-body h1 { font-size: 2.5rem; }
+.content-body h2 { font-size: 2rem; }
+.content-body h3 { font-size: 1.5rem; }
+
+.content-body a {
+    color: var(--glow-cyan);
+    border-bottom: 1px solid rgba(0, 240, 255, 0.3);
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+.content-body a:hover {
+    border-bottom-color: var(--glow-cyan);
+    text-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+}
+
+.content-body code {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 0.9em;
+}
+
+.content-body pre {
+    background: rgba(0, 0, 0, 0.5);
+    padding: 1.5rem;
+    border-radius: 12px;
+    overflow-x: auto;
+    border: 1px solid var(--glass-border);
+    margin-bottom: 1.5rem;
+}
+
+.content-body pre code {
+    background: transparent;
+    padding: 0;
+}
+
+/* Footer */
+.glass-footer {
+    background: var(--glass-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-top: 1px solid var(--glass-border);
+    padding: 2rem 0;
+    margin-top: auto;
+    text-align: center;
+}
+
+.glass-footer p {
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .glow-text {
+        font-size: 2.5rem;
+    }
+
+    .nav-container {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .glass-panel {
+        padding: 2rem;
+    }
+}

--- a/examples/lumina-quartz-forge/templates/404.html
+++ b/examples/lumina-quartz-forge/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-quartz-forge/templates/footer.html
+++ b/examples/lumina-quartz-forge/templates/footer.html
@@ -1,0 +1,9 @@
+    </main>
+
+    <footer class="glass-footer">
+        <div class="footer-content">
+            <p>&copy; {{ current_year | default("2025") }} {{ site.title }}. Forged in the void.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/lumina-quartz-forge/templates/header.html
+++ b/examples/lumina-quartz-forge/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title | default(site.title) }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;600;700&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+    <div class="orb orb-1"></div>
+    <div class="orb orb-2"></div>
+    <div class="orb orb-3"></div>
+
+    <header class="glass-nav">
+        <div class="nav-container">
+            <a href="{{ base_url }}/" class="logo">Lumina Quartz</a>
+            <nav>
+                <ul class="nav-links">
+                    <li><a href="{{ base_url }}/about/">About</a></li>
+                    <li><a href="{{ base_url }}/portfolio/">Portfolio</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container">

--- a/examples/lumina-quartz-forge/templates/page.html
+++ b/examples/lumina-quartz-forge/templates/page.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+
+<article class="glass-panel page-content">
+    <header class="page-header">
+        <h1 class="glow-text">{{ page.title }}</h1>
+        {% if page.description %}
+            <p class="page-description">{{ page.description }}</p>
+        {% endif %}
+        {% if page.date %}
+            <div class="page-meta">
+                <span class="date">{{ page.date | date("%B %d, %Y") }}</span>
+            </div>
+        {% endif %}
+    </header>
+
+    <div class="content-body">
+        {{ content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/lumina-quartz-forge/templates/section.html
+++ b/examples/lumina-quartz-forge/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+
+<div class="glass-panel section-header">
+    <h1 class="glow-text">{{ section.title }}</h1>
+    <div class="content-body">
+        {{ content | safe }}
+    </div>
+</div>
+
+<div class="portfolio-grid">
+    {% for page in section.pages %}
+    <article class="glass-card">
+        <h2><a href="{{ page.url | default(base_url ~ page.permalink) }}">{{ page.title }}</a></h2>
+        {% if page.date %}
+            <div class="meta">{{ page.date | date("%Y-%m-%d") }}</div>
+        {% endif %}
+        {% if page.description %}
+            <p>{{ page.description }}</p>
+        {% elif page.summary %}
+            <p>{{ page.summary | strip_html | truncate_words(20) }}</p>
+        {% endif %}
+        <a href="{{ page.url | default(base_url ~ page.permalink) }}" class="read-more">View Project &rarr;</a>
+    </article>
+    {% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/lumina-quartz-forge/templates/shortcodes/alert.html
+++ b/examples/lumina-quartz-forge/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/lumina-quartz-forge/templates/taxonomy.html
+++ b/examples/lumina-quartz-forge/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-quartz-forge/templates/taxonomy_term.html
+++ b/examples/lumina-quartz-forge/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,9 +1,4 @@
 {
-  "nebulous-void-glass": [
-    "dark",
-    "portfolio",
-    "cyberpunk"
-  ],
   "abecedary": [
     "alphabet-book",
     "educational",
@@ -4219,6 +4214,11 @@
     "modern",
     "glowing"
   ],
+  "lumina-quartz-forge": [
+    "dark",
+    "portfolio",
+    "glassmorphism"
+  ],
   "lumina-shard": [
     "dark",
     "neon",
@@ -5015,6 +5015,11 @@
     "cosmos",
     "purple",
     "elegant"
+  ],
+  "nebulous-void-glass": [
+    "dark",
+    "portfolio",
+    "cyberpunk"
   ],
   "negative-space": [
     "absence",


### PR DESCRIPTION
This PR adds a new example site to the `examples/` directory called `lumina-quartz-forge`. 

It explores a dark-themed glassmorphism aesthetic inspired by deep void environments and glowing crystalline structures. The project heavily relies on standard CSS properties like `backdrop-filter: blur()`, glowing animations, and custom typography (Space Grotesk and Inter). 

All standard setup procedures have been followed:
- Content pages updated
- Styling applied in `static/css/style.css`
- Templates overhauled to reflect the desired design
- Example mapped correctly in `tags.json`
- Config validated through `hwaro tool doctor`

---
*PR created automatically by Jules for task [13782881090847756396](https://jules.google.com/task/13782881090847756396) started by @hahwul*