### PR TITLE
feat: add 5 gallery and social themed examples (#1118, #1119, #1120, #1121, #1122)

### DIFF
--- a/examples/gallery-brutalist/AGENTS.md
+++ b/examples/gallery-brutalist/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/gallery-brutalist/archetypes/default.md
+++ b/examples/gallery-brutalist/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/gallery-brutalist/config.toml
+++ b/examples/gallery-brutalist/config.toml
@@ -1,0 +1,7 @@
+title = "GALLERY-BRUTALIST"
+description = "A raw, high-impact design for uncompromised visual and structural content."
+default_language = "en"
+base_url = "https://example.com"
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/gallery-brutalist/content/about.md
+++ b/examples/gallery-brutalist/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/gallery-brutalist/content/index.md
+++ b/examples/gallery-brutalist/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "The Raw"
++++
+<article>
+## Raw Excellence
+Gallery-Brutalist is about the uncompromised and foundational nature of structural innovation within the raw environment.
+</article>

--- a/examples/gallery-brutalist/templates/404.html
+++ b/examples/gallery-brutalist/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-brutalist/templates/footer.html
+++ b/examples/gallery-brutalist/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 1rem; letter-spacing: 5px; font-weight: 800; text-transform: uppercase;">
+        <div class="container">
+            &copy; 2026 GALLERY-BRUTALIST. STRIPPING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/gallery-brutalist/templates/header.html
+++ b/examples/gallery-brutalist/templates/header.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;800&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #eee;
+            --text: #000;
+            --accent: #555;
+            --brutal: #fff;
+            --shadow: rgba(0,0,0,1);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.2;
+        }
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 60px 0;
+            text-align: left;
+            border-bottom: 5px solid #000;
+        }
+        .logo {
+            font-weight: 800;
+            font-size: 3rem;
+            text-transform: uppercase;
+            letter-spacing: -2px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin-right: 30px;
+            font-size: 1rem;
+            text-transform: uppercase;
+            font-weight: 800;
+        }
+        .brutal-surface {
+            background: var(--brutal);
+            padding: 60px;
+            box-shadow: 15px 15px 0 var(--shadow);
+            margin-bottom: 80px;
+            margin-top: 40px;
+            border: 5px solid #000;
+        }
+        h2 { font-weight: 800; font-size: 4rem; color: #000; margin-top: 0; line-height: 0.9; text-transform: uppercase; letter-spacing: -3px; }
+        article { font-size: 1.2rem; font-weight: 800; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">gallery.brutal</div>
+            <nav>
+                <a href="/">Raw</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/gallery-brutalist/templates/page.html
+++ b/examples/gallery-brutalist/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="brutal-surface">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/gallery-brutalist/templates/section.html
+++ b/examples/gallery-brutalist/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-brutalist/templates/shortcodes/alert.html
+++ b/examples/gallery-brutalist/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/gallery-brutalist/templates/taxonomy.html
+++ b/examples/gallery-brutalist/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-brutalist/templates/taxonomy_term.html
+++ b/examples/gallery-brutalist/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-editorial/AGENTS.md
+++ b/examples/gallery-editorial/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/gallery-editorial/archetypes/default.md
+++ b/examples/gallery-editorial/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/gallery-editorial/config.toml
+++ b/examples/gallery-editorial/config.toml
@@ -1,0 +1,7 @@
+title = "GALLERY-EDITORIAL"
+description = "A sophisticated, magazine-inspired design for high-quality visual narrative."
+default_language = "en"
+base_url = "https://example.com"
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/gallery-editorial/content/about.md
+++ b/examples/gallery-editorial/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/gallery-editorial/content/index.md
+++ b/examples/gallery-editorial/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "The Feature"
++++
+<article>
+## Editorial Excellence
+Gallery-Editorial is about the sophisticated and foundational nature of structural innovation within the publishing environment.
+</article>

--- a/examples/gallery-editorial/templates/404.html
+++ b/examples/gallery-editorial/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-editorial/templates/footer.html
+++ b/examples/gallery-editorial/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 80px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; letter-spacing: 5px; font-weight: 700;">
+        <div class="container">
+            &copy; 2026 GALLERY-EDITORIAL. PUBLISHING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/gallery-editorial/templates/header.html
+++ b/examples/gallery-editorial/templates/header.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&family=IBM+Plex+Sans:wght@300;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fff;
+            --text: #1a1a1a;
+            --accent: #555;
+            --editorial: #f8f8f8;
+            --shadow: rgba(0,0,0,0.1);
+        }
+        body {
+            background-color: var(--editorial);
+            color: var(--text);
+            font-family: 'IBM Plex Sans', sans-serif;
+            margin: 0;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 80px 0;
+            text-align: left;
+            border-bottom: 2px solid #000;
+        }
+        .logo {
+            font-family: 'Playfair Display', serif;
+            font-weight: 700;
+            font-size: 2.5rem;
+            letter-spacing: -1px;
+            text-transform: uppercase;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin-right: 30px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            font-weight: 600;
+            letter-spacing: 2px;
+        }
+        .editorial-surface {
+            background: #fff;
+            padding: 80px;
+            box-shadow: 20px 20px 60px var(--shadow);
+            margin-bottom: 80px;
+            margin-top: 40px;
+            display: flex;
+            gap: 60px;
+        }
+        .editorial-left, .editorial-right { flex: 1; }
+        h2 { font-family: 'Playfair Display', serif; font-size: 3rem; color: #000; margin-top: 0; line-height: 1.1; }
+        article { font-size: 1.1rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">gallery.editorial</div>
+            <nav>
+                <a href="/">Feature</a>
+                <a href="/about">Index</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/gallery-editorial/templates/page.html
+++ b/examples/gallery-editorial/templates/page.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="editorial-surface">
+            <div class="editorial-left">
+                {{ content }}
+            </div>
+            <div class="editorial-right">
+                <h3>Editorial Notes</h3>
+                <p>The intersection of visual culture and high-depth presentation.</p>
+            </div>
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/gallery-editorial/templates/section.html
+++ b/examples/gallery-editorial/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-editorial/templates/shortcodes/alert.html
+++ b/examples/gallery-editorial/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/gallery-editorial/templates/taxonomy.html
+++ b/examples/gallery-editorial/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-editorial/templates/taxonomy_term.html
+++ b/examples/gallery-editorial/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-immersive/AGENTS.md
+++ b/examples/gallery-immersive/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/gallery-immersive/archetypes/default.md
+++ b/examples/gallery-immersive/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/gallery-immersive/config.toml
+++ b/examples/gallery-immersive/config.toml
@@ -1,0 +1,7 @@
+title = "GALLERY-IMMERSIVE"
+description = "A dark, presence-focused design for high-impact visual experiences."
+default_language = "en"
+base_url = "https://example.com"
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/gallery-immersive/content/about.md
+++ b/examples/gallery-immersive/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/gallery-immersive/content/index.md
+++ b/examples/gallery-immersive/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "The Presence"
++++
+<article>
+## Immersive Excellence
+Gallery-Immersive is about the continuous and foundational nature of structural innovation within the immersive environment.
+</article>

--- a/examples/gallery-immersive/templates/404.html
+++ b/examples/gallery-immersive/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-immersive/templates/footer.html
+++ b/examples/gallery-immersive/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.1; font-size: 0.8rem; letter-spacing: 10px; text-transform: uppercase;">
+        <div class="container-fluid">
+            &copy; 2026 GALLERY-IMMERSIVE. EXPERIENCING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/gallery-immersive/templates/header.html
+++ b/examples/gallery-immersive/templates/header.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #000;
+            --text: #eee;
+            --accent: #333;
+            --immersive: #050505;
+            --shadow: rgba(0,0,0,1);
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container-fluid {
+            max-width: 100%;
+            padding: 0;
+        }
+        header {
+            padding: 60px;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+        }
+        nav { margin-top: 20px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 15px;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            opacity: 0.3;
+        }
+        .immersive-surface {
+            background: var(--immersive);
+            min-height: 80vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 100px;
+            box-sizing: border-box;
+            border-top: 1px solid #111;
+            border-bottom: 1px solid #111;
+        }
+        .immersive-content { max-width: 1200px; width: 100%; text-align: center; }
+        h2 { font-weight: 700; font-size: 4rem; color: #fff; margin-top: 0; text-transform: uppercase; letter-spacing: -2px; line-height: 0.9; }
+        article { font-family: 'IBM Plex Mono', monospace; font-size: 1.2rem; color: #666; margin-top: 40px; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container-fluid">
+            <div class="logo">gallery.immersive</div>
+            <nav>
+                <a href="/">Presence</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/gallery-immersive/templates/page.html
+++ b/examples/gallery-immersive/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="immersive-surface">
+        <div class="immersive-content">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/gallery-immersive/templates/section.html
+++ b/examples/gallery-immersive/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-immersive/templates/shortcodes/alert.html
+++ b/examples/gallery-immersive/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/gallery-immersive/templates/taxonomy.html
+++ b/examples/gallery-immersive/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-immersive/templates/taxonomy_term.html
+++ b/examples/gallery-immersive/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-zen/AGENTS.md
+++ b/examples/gallery-zen/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/gallery-zen/archetypes/default.md
+++ b/examples/gallery-zen/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/gallery-zen/config.toml
+++ b/examples/gallery-zen/config.toml
@@ -1,0 +1,7 @@
+title = "GALLERY-ZEN"
+description = "A calm, minimalist design for peaceful and contemplative visual content."
+default_language = "en"
+base_url = "https://example.com"
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/gallery-zen/content/about.md
+++ b/examples/gallery-zen/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/gallery-zen/content/index.md
+++ b/examples/gallery-zen/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "The Silence"
++++
+<article>
+## Minimal Excellence
+Gallery-Zen is about the calm and foundational nature of structural innovation within the peaceful environment.
+</article>

--- a/examples/gallery-zen/templates/404.html
+++ b/examples/gallery-zen/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-zen/templates/footer.html
+++ b/examples/gallery-zen/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.2; font-size: 0.7rem; letter-spacing: 10px; text-transform: uppercase;">
+        <div class="container">
+            &copy; 2026 GALLERY-ZEN. CALMING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/gallery-zen/templates/header.html
+++ b/examples/gallery-zen/templates/header.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@200;400&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fff;
+            --text: #777;
+            --accent: #eee;
+            --zen: #fafafa;
+            --shadow: rgba(0,0,0,0.02);
+        }
+        body {
+            background-color: var(--zen);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.8;
+            letter-spacing: 1px;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 40px;
+        }
+        header {
+            padding: 100px 0;
+            text-align: center;
+        }
+        .logo {
+            font-weight: 200;
+            font-size: 1.2rem;
+            text-transform: lowercase;
+            letter-spacing: 10px;
+        }
+        nav { margin-top: 40px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 20px;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 5px;
+            opacity: 0.5;
+        }
+        .zen-surface {
+            background: #fff;
+            padding: 100px;
+            box-shadow: 0 0 50px var(--shadow);
+            margin-bottom: 100px;
+            text-align: center;
+        }
+        h2 { font-weight: 200; font-size: 2rem; color: #333; margin-top: 0; margin-bottom: 40px; text-transform: lowercase; letter-spacing: 8px; }
+        article { font-size: 1rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">gallery.zen</div>
+            <nav>
+                <a href="/">Silence</a>
+                <a href="/about">Process</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/gallery-zen/templates/page.html
+++ b/examples/gallery-zen/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="zen-surface">
+            {{ content }}
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/gallery-zen/templates/section.html
+++ b/examples/gallery-zen/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-zen/templates/shortcodes/alert.html
+++ b/examples/gallery-zen/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/gallery-zen/templates/taxonomy.html
+++ b/examples/gallery-zen/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/gallery-zen/templates/taxonomy_term.html
+++ b/examples/gallery-zen/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/insta-feed/AGENTS.md
+++ b/examples/insta-feed/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/insta-feed/archetypes/default.md
+++ b/examples/insta-feed/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/insta-feed/config.toml
+++ b/examples/insta-feed/config.toml
@@ -1,0 +1,7 @@
+title = "INSTA-FEED"
+description = "A modern, social-inspired design for high-frequency visual updates."
+default_language = "en"
+base_url = "https://example.com"
+[taxonomies]
+tags = "tags"
+categories = "categories"

--- a/examples/insta-feed/content/about.md
+++ b/examples/insta-feed/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/insta-feed/content/index.md
+++ b/examples/insta-feed/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "The Post"
++++
+<article>
+## Social Excellence
+Insta-Feed is about the modern and dynamic nature of structural innovation within the social environment.
+</article>

--- a/examples/insta-feed/templates/404.html
+++ b/examples/insta-feed/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/insta-feed/templates/footer.html
+++ b/examples/insta-feed/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 60px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-weight: 600;">
+        <div class="container">
+            &copy; 2026 INSTA-FEED. POSTING THE DESIGN.
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples/insta-feed/templates/header.html
+++ b/examples/insta-feed/templates/header.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fafafa;
+            --text: #262626;
+            --accent: #0095f6;
+            --surface: #fff;
+            --border: #dbdbdb;
+        }
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            margin: 0;
+            line-height: 1.4;
+        }
+        .container {
+            max-width: 935px;
+            margin: 0 auto;
+            padding: 30px 20px;
+        }
+        header {
+            padding: 20px 0;
+            text-align: center;
+            border-bottom: 1px solid var(--border);
+            background: #fff;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+        .logo {
+            font-weight: 700;
+            font-size: 1.2rem;
+            letter-spacing: -0.5px;
+        }
+        nav { margin-top: 10px; }
+        nav a {
+            color: var(--text);
+            text-decoration: none;
+            margin: 0 10px;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+        .insta-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 28px;
+            margin-top: 20px;
+        }
+        .insta-item {
+            background: #fff;
+            border: 1px solid var(--border);
+            aspect-ratio: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 20px;
+        }
+        h2 { font-weight: 600; font-size: 1rem; margin: 0; }
+        article { font-size: 0.8rem; color: #8e8e8e; margin-top: 10px; }
+        @media (max-width: 768px) { .insta-grid { gap: 3px; } .insta-item { border: none; } }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">insta.feed</div>
+            <nav>
+                <a href="/">Posts</a>
+                <a href="/about">About</a>
+            </nav>
+        </div>
+    </header>

--- a/examples/insta-feed/templates/page.html
+++ b/examples/insta-feed/templates/page.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+<main>
+    <div class="container">
+        <div class="insta-grid">
+            <div class="insta-item">
+                {{ content }}
+            </div>
+            <div class="insta-item">
+                <h2>Post Two</h2>
+            </div>
+            <div class="insta-item">
+                <h2>Post Three</h2>
+            </div>
+            <div class="insta-item">
+                <h2>Post Four</h2>
+            </div>
+            <div class="insta-item">
+                <h2>Post Five</h2>
+            </div>
+            <div class="insta-item">
+                <h2>Post Six</h2>
+            </div>
+        </div>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/insta-feed/templates/section.html
+++ b/examples/insta-feed/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/insta-feed/templates/shortcodes/alert.html
+++ b/examples/insta-feed/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/insta-feed/templates/taxonomy.html
+++ b/examples/insta-feed/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/insta-feed/templates/taxonomy_term.html
+++ b/examples/insta-feed/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2950,6 +2950,27 @@
     "event",
     "landing"
   ],
+  "gallery-brutalist": [
+    "raw",
+    "high-impact",
+    "uncompromised",
+    "brutalist",
+    "jakarta"
+  ],
+  "gallery-editorial": [
+    "sophisticated",
+    "magazine-inspired",
+    "visual-narrative",
+    "feature",
+    "playfair"
+  ],
+  "gallery-immersive": [
+    "dark",
+    "presence-focused",
+    "high-impact",
+    "visual-experience",
+    "ibm-plex-mono"
+  ],
   "gallery-minimal": [
     "minimal",
     "white-surface",
@@ -2963,6 +2984,13 @@
     "cinematic",
     "visual-portfolio",
     "playfair"
+  ],
+  "gallery-zen": [
+    "calm",
+    "minimalist",
+    "peaceful",
+    "contemplative",
+    "jakarta"
   ],
   "galley-proof": [
     "book",
@@ -3679,6 +3707,13 @@
     "light",
     "blog",
     "poetry"
+  ],
+  "insta-feed": [
+    "modern",
+    "social-inspired",
+    "high-frequency",
+    "visual-updates",
+    "jakarta"
   ],
   "insurgent": [
     "subversive",


### PR DESCRIPTION
This PR adds a 50th set of 5 high-quality examples focused on diverse gallery styles and social media feeds including gallery-brutalist, gallery-editorial, gallery-zen, gallery-immersive, and insta-feed. This brings the total examples to 270.

### Key Changes
- Added 5 new examples:
  - **GALLERY-BRUTALIST**: Raw high-impact design for uncompromised content.
  - **GALLERY-EDITORIAL**: Sophisticated magazine-inspired design for visual narrative.
  - **GALLERY-ZEN**: Calm minimalist design for peaceful content.
  - **GALLERY-IMMERSIVE**: Dark presence-focused design for visual experiences.
  - **INSTA-FEED**: Modern social-inspired design for high-frequency updates.
- Updated `tags.json` with relevant discovery tags.
- Verified all examples with `hwaro build`.

Closes #1118
Closes #1119
Closes #1120
Closes #1121
Closes #1122