### PR TITLE
feat: add 5 analytical reference and report themed examples (#1415, #1416, #1417, #1418, #1419)

### DIFF
--- a/examples/autopsy-report/AGENTS.md
+++ b/examples/autopsy-report/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/autopsy-report/archetypes/default.md
+++ b/examples/autopsy-report/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/autopsy-report/config.toml
+++ b/examples/autopsy-report/config.toml
@@ -1,0 +1,4 @@
+title = "AUTOPSY-REPORT"
+description = "Analytical reference for autopsy-report."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/autopsy-report/content/about.md
+++ b/examples/autopsy-report/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/autopsy-report/content/index.md
+++ b/examples/autopsy-report/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Autopsy"
++++
+## Post-Mortem Analysis
+Structural integrity within the post-observational environment.

--- a/examples/autopsy-report/templates/404.html
+++ b/examples/autopsy-report/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/autopsy-report/templates/footer.html
+++ b/examples/autopsy-report/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase; letter-spacing: 5px;">
+        &copy; 2026 AUTOPSY-REPORT.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/autopsy-report/templates/header.html
+++ b/examples/autopsy-report/templates/header.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #eee; --text: #1a1a1a; --accent: #ff0000; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; margin: 0; }
+        .container { max-width: 800px; margin: 0 auto; padding: 60px 40px; background: #fff; border: 1px solid #ddd; box-shadow: 0 10px 30px rgba(0,0,0,0.02); margin-top: 40px; }
+        header { border-bottom: 4px solid #000; padding-bottom: 20px; margin-bottom: 40px; text-align: left; }
+        .logo { font-weight: 700; font-size: 1.5rem; text-transform: uppercase; }
+        .case-num { font-family: 'IBM Plex Mono'; font-size: 0.7rem; font-weight: 700; background: #000; color: #fff; padding: 5px 10px; margin-top: 10px; display: inline-block; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">autopsy.report</div><div class="case-num">CASE_ID: AUTO_v1.0</div></header>

--- a/examples/autopsy-report/templates/page.html
+++ b/examples/autopsy-report/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main>
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/autopsy-report/templates/section.html
+++ b/examples/autopsy-report/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/autopsy-report/templates/shortcodes/alert.html
+++ b/examples/autopsy-report/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/autopsy-report/templates/taxonomy.html
+++ b/examples/autopsy-report/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/autopsy-report/templates/taxonomy_term.html
+++ b/examples/autopsy-report/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/furnace-docs/AGENTS.md
+++ b/examples/furnace-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/furnace-docs/archetypes/default.md
+++ b/examples/furnace-docs/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/furnace-docs/config.toml
+++ b/examples/furnace-docs/config.toml
@@ -1,0 +1,4 @@
+title = "FURNACE-DOCS"
+description = "Analytical reference for furnace-docs."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/furnace-docs/content/about.md
+++ b/examples/furnace-docs/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/furnace-docs/content/index.md
+++ b/examples/furnace-docs/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Furnace"
++++
+## Thermal Standards
+The foundational nature of structural integrity in high-energy environments.

--- a/examples/furnace-docs/templates/404.html
+++ b/examples/furnace-docs/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/furnace-docs/templates/footer.html
+++ b/examples/furnace-docs/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase; letter-spacing: 5px;">
+        &copy; 2026 FURNACE-DOCS.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/furnace-docs/templates/header.html
+++ b/examples/furnace-docs/templates/header.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600;800&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #1a1a1a; --text: #fff; --accent: #ff4500; --furnace: #0c0c0c; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; margin: 0; }
+        .container { max-width: 900px; margin: 0 auto; padding: 60px 40px; }
+        header { text-align: center; border-bottom: 2px solid var(--accent); padding-bottom: 40px; margin-bottom: 60px; }
+        .logo { font-weight: 800; font-size: 2rem; text-transform: uppercase; color: var(--accent); letter-spacing: 5px; }
+        .furnace-surface { background: var(--furnace); padding: 80px; border: 1px solid #333; box-shadow: inset 0 0 100px rgba(255, 69, 0, 0.1); position: relative; }
+    </style>
+ head>
+<body>
+    <div class="container">
+    <header><div class="logo">furnace.docs</div></header>

--- a/examples/furnace-docs/templates/page.html
+++ b/examples/furnace-docs/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main class="furnace-surface">
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/furnace-docs/templates/section.html
+++ b/examples/furnace-docs/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/furnace-docs/templates/shortcodes/alert.html
+++ b/examples/furnace-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/furnace-docs/templates/taxonomy.html
+++ b/examples/furnace-docs/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/furnace-docs/templates/taxonomy_term.html
+++ b/examples/furnace-docs/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/hex-dump/AGENTS.md
+++ b/examples/hex-dump/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/hex-dump/archetypes/default.md
+++ b/examples/hex-dump/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/hex-dump/config.toml
+++ b/examples/hex-dump/config.toml
@@ -1,0 +1,4 @@
+title = "HEX-DUMP"
+description = "Analytical reference for hex-dump."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/hex-dump/content/about.md
+++ b/examples/hex-dump/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/hex-dump/content/index.md
+++ b/examples/hex-dump/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Hex"
++++
+## Binary Exposure
+Tracing the lowest-level boundaries of data honesty.

--- a/examples/hex-dump/templates/404.html
+++ b/examples/hex-dump/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/hex-dump/templates/footer.html
+++ b/examples/hex-dump/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase; letter-spacing: 5px;">
+        &copy; 2026 HEX-DUMP.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/hex-dump/templates/header.html
+++ b/examples/hex-dump/templates/header.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #050505; --text: #00ff41; --accent: #008f11; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'IBM Plex Mono', monospace; margin: 0; }
+        .container { max-width: 1000px; margin: 0 auto; padding: 40px; border-left: 1px solid var(--accent); }
+        header { border-bottom: 1px solid var(--accent); padding-bottom: 20px; margin-bottom: 40px; }
+        .logo { font-weight: 700; font-size: 1.2rem; text-transform: uppercase; }
+        .dump-surface { background: #0c0c0c; padding: 40px; border: 1px solid #111; position: relative; }
+        .addr { opacity: 0.3; margin-right: 20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">hex.dump</div></header>

--- a/examples/hex-dump/templates/page.html
+++ b/examples/hex-dump/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main class="dump-surface">
+    <div style="display: flex; margin-bottom: 20px;">
+        <span class="addr">00000000:</span>
+        <span>48 77 61 72 6f 20 53 53 47 20 44 75 6d 70</span>
+    </div>
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/hex-dump/templates/section.html
+++ b/examples/hex-dump/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/hex-dump/templates/shortcodes/alert.html
+++ b/examples/hex-dump/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/hex-dump/templates/taxonomy.html
+++ b/examples/hex-dump/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/hex-dump/templates/taxonomy_term.html
+++ b/examples/hex-dump/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/isotope-docs/AGENTS.md
+++ b/examples/isotope-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/isotope-docs/archetypes/default.md
+++ b/examples/isotope-docs/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/isotope-docs/config.toml
+++ b/examples/isotope-docs/config.toml
@@ -1,0 +1,4 @@
+title = "ISOTOPE-DOCS"
+description = "Analytical reference for isotope-docs."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/isotope-docs/content/about.md
+++ b/examples/isotope-docs/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/isotope-docs/content/index.md
+++ b/examples/isotope-docs/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Isotope"
++++
+## Atomic Standards
+Tracing the elemental boundaries of structural precision.

--- a/examples/isotope-docs/templates/404.html
+++ b/examples/isotope-docs/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/isotope-docs/templates/footer.html
+++ b/examples/isotope-docs/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase; letter-spacing: 5px;">
+        &copy; 2026 ISOTOPE-DOCS.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/isotope-docs/templates/header.html
+++ b/examples/isotope-docs/templates/header.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #fff; --text: #333; --accent: #0084ff; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; margin: 0; }
+        .container { max-width: 900px; margin: 0 auto; padding: 60px 40px; }
+        header { border-bottom: 2px solid #000; padding-bottom: 20px; margin-bottom: 60px; display: flex; justify-content: space-between; align-items: center; }
+        .logo { font-weight: 700; font-size: 1.2rem; text-transform: uppercase; letter-spacing: 5px; }
+        .isotope-surface { padding: 60px; background: #fafafa; border: 1px solid #eee; position: relative; }
+        .atom { width: 10px; height: 10px; border-radius: 50%; background: var(--accent); position: absolute; top: 10px; left: 10px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">isotope.docs</div></header>

--- a/examples/isotope-docs/templates/page.html
+++ b/examples/isotope-docs/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<main class="isotope-surface">
+    <div class="atom"></div>
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/isotope-docs/templates/section.html
+++ b/examples/isotope-docs/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/isotope-docs/templates/shortcodes/alert.html
+++ b/examples/isotope-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/isotope-docs/templates/taxonomy.html
+++ b/examples/isotope-docs/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/isotope-docs/templates/taxonomy_term.html
+++ b/examples/isotope-docs/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-ref/AGENTS.md
+++ b/examples/monolith-ref/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/monolith-ref/archetypes/default.md
+++ b/examples/monolith-ref/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/monolith-ref/config.toml
+++ b/examples/monolith-ref/config.toml
@@ -1,0 +1,4 @@
+title = "MONOLITH-REF"
+description = "Analytical reference for monolith-ref."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/monolith-ref/content/about.md
+++ b/examples/monolith-ref/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/monolith-ref/content/index.md
+++ b/examples/monolith-ref/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Monolith"
++++
+## Singular Structure
+The foundational nature of permanent structural innovation.

--- a/examples/monolith-ref/templates/404.html
+++ b/examples/monolith-ref/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-ref/templates/footer.html
+++ b/examples/monolith-ref/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase; letter-spacing: 5px;">
+        &copy; 2026 MONOLITH-REF.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/monolith-ref/templates/header.html
+++ b/examples/monolith-ref/templates/header.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;800&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #000; --text: #fff; --accent: #333; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; margin: 0; }
+        .container { max-width: 800px; margin: 0 auto; padding: 100px 40px; }
+        header { text-align: center; margin-bottom: 100px; }
+        .logo { font-weight: 800; font-size: 2.5rem; text-transform: uppercase; letter-spacing: 20px; }
+        .monolith-surface { background: #0a0a0a; padding: 100px; border: 1px solid #1a1a1a; box-shadow: 0 0 100px rgba(0,0,0,1); position: relative; }
+        .monolith-surface::after { content: ''; position: absolute; bottom: 0; left: 50%; transform: translateX(-50%); width: 2px; height: 100px; background: #fff; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">monolith</div></header>

--- a/examples/monolith-ref/templates/page.html
+++ b/examples/monolith-ref/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main class="monolith-surface">
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/monolith-ref/templates/section.html
+++ b/examples/monolith-ref/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-ref/templates/shortcodes/alert.html
+++ b/examples/monolith-ref/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/monolith-ref/templates/taxonomy.html
+++ b/examples/monolith-ref/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-ref/templates/taxonomy_term.html
+++ b/examples/monolith-ref/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -600,6 +600,13 @@
     "high-contrast",
     "no-excess"
   ],
+  "autopsy-report": [
+    "analysis",
+    "clinical",
+    "stark",
+    "report",
+    "jakarta"
+  ],
   "avalanche-event": [
     "event",
     "dark",
@@ -3050,6 +3057,13 @@
     "docs",
     "performance"
   ],
+  "furnace-docs": [
+    "thermal",
+    "high-energy",
+    "dark",
+    "industrial",
+    "jakarta"
+  ],
   "fuse-box": [
     "electrical",
     "box",
@@ -3617,6 +3631,13 @@
     "blog",
     "minimal"
   ],
+  "hex-dump": [
+    "binary",
+    "low-level",
+    "green",
+    "technical",
+    "ibm-plex-mono"
+  ],
   "hibiscus": [
     "dark",
     "blog",
@@ -3950,6 +3971,13 @@
     "3d",
     "dashboard",
     "ui"
+  ],
+  "isotope-docs": [
+    "atomic",
+    "precision",
+    "scientific",
+    "docs",
+    "jakarta"
   ],
   "isthmus": [
     "light",
@@ -5028,6 +5056,13 @@
     "bold",
     "monolithic",
     "minimal"
+  ],
+  "monolith-ref": [
+    "singular",
+    "monolithic",
+    "dark",
+    "stark",
+    "jakarta"
   ],
   "monolithic-dark": [
     "dark",


### PR DESCRIPTION
This PR adds a 62nd set of 5 high-quality examples focused on analytical references, isotope documentation, and binary dumps including monolith-ref, isotope-docs, autopsy-report, hex-dump, and furnace-docs. This brings the total examples to 330.

### Key Changes
- Added 5 new examples:
  - **MONOLITH-REF**: Singular monolithic stark design.
  - **ISOTOPE-DOCS**: Atomic precision scientific design.
  - **AUTOPSY-REPORT**: Clinical post-mortem analysis design.
  - **HEX-DUMP**: Binary exposure low-level design.
  - **FURNACE-DOCS**: Dark thermal industrial design.
- Updated `tags.json` with relevant discovery tags.
- Verified all examples with `hwaro build`.

Closes #1415
Closes #1416
Closes #1417
Closes #1418
Closes #1419