### PR TITLE
feat: add 5 observation reference and press themed examples (#1425, #1426, #1427, #1428, #1429)

### DIFF
--- a/examples/broadcast-spec/AGENTS.md
+++ b/examples/broadcast-spec/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/broadcast-spec/archetypes/default.md
+++ b/examples/broadcast-spec/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/broadcast-spec/config.toml
+++ b/examples/broadcast-spec/config.toml
@@ -1,0 +1,4 @@
+title = "BROADCAST-SPEC"
+description = "Specialized design for broadcast-spec."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/broadcast-spec/content/about.md
+++ b/examples/broadcast-spec/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/broadcast-spec/content/index.md
+++ b/examples/broadcast-spec/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Broadcast"
++++
+## On-Air Standards
+The foundational nature of real-time structural communication.

--- a/examples/broadcast-spec/templates/404.html
+++ b/examples/broadcast-spec/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/broadcast-spec/templates/footer.html
+++ b/examples/broadcast-spec/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase;">
+        &copy; 2026 BROADCAST-SPEC.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/broadcast-spec/templates/header.html
+++ b/examples/broadcast-spec/templates/header.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #fff; --text: #000; --accent: #ff0000; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'IBM Plex Mono', monospace; margin: 0; }
+        .container { max-width: 900px; margin: 0 auto; padding: 60px 40px; border: 2px solid #000; }
+        header { border-bottom: 10px solid #000; padding-bottom: 20px; margin-bottom: 40px; display: flex; justify-content: space-between; align-items: center; }
+        .logo { font-weight: 700; font-size: 1.2rem; text-transform: uppercase; }
+        .live { color: var(--accent); font-weight: 700; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">broadcast.spec</div><div class="live">ON AIR</div></header>

--- a/examples/broadcast-spec/templates/page.html
+++ b/examples/broadcast-spec/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main>
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/broadcast-spec/templates/section.html
+++ b/examples/broadcast-spec/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/broadcast-spec/templates/shortcodes/alert.html
+++ b/examples/broadcast-spec/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/broadcast-spec/templates/taxonomy.html
+++ b/examples/broadcast-spec/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/broadcast-spec/templates/taxonomy_term.html
+++ b/examples/broadcast-spec/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/colophon-press/AGENTS.md
+++ b/examples/colophon-press/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/colophon-press/archetypes/default.md
+++ b/examples/colophon-press/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/colophon-press/config.toml
+++ b/examples/colophon-press/config.toml
@@ -1,0 +1,4 @@
+title = "COLOPHON-PRESS"
+description = "Specialized design for colophon-press."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/colophon-press/content/about.md
+++ b/examples/colophon-press/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/colophon-press/content/index.md
+++ b/examples/colophon-press/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Colophon"
++++
+## Typographic Heritage
+Structural integrity within the refined environment of publishing history.

--- a/examples/colophon-press/templates/404.html
+++ b/examples/colophon-press/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/colophon-press/templates/footer.html
+++ b/examples/colophon-press/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase;">
+        &copy; 2026 COLOPHON-PRESS.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/colophon-press/templates/header.html
+++ b/examples/colophon-press/templates/header.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&family=IBM+Plex+Sans:wght@300;600&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #fff; --text: #1a1a1a; --accent: #555; --paper: #f9f7f2; }
+        body { background-color: var(--paper); color: var(--text); font-family: 'IBM Plex Sans', sans-serif; margin: 0; }
+        .container { max-width: 800px; margin: 0 auto; padding: 80px 40px; border: 1px solid #eee; background: #fff; }
+        header { text-align: center; border-bottom: 1px solid #000; padding-bottom: 40px; margin-bottom: 60px; }
+        .logo { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 2rem; text-transform: lowercase; font-style: italic; }
+        .colophon-surface { padding: 40px 0; font-family: 'Playfair Display', serif; font-size: 1.1rem; line-height: 1.8; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">colophon.press</div></header>

--- a/examples/colophon-press/templates/page.html
+++ b/examples/colophon-press/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main class="colophon-surface">
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/colophon-press/templates/section.html
+++ b/examples/colophon-press/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/colophon-press/templates/shortcodes/alert.html
+++ b/examples/colophon-press/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/colophon-press/templates/taxonomy.html
+++ b/examples/colophon-press/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/colophon-press/templates/taxonomy_term.html
+++ b/examples/colophon-press/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/guillotine-docs/AGENTS.md
+++ b/examples/guillotine-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/guillotine-docs/archetypes/default.md
+++ b/examples/guillotine-docs/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/guillotine-docs/config.toml
+++ b/examples/guillotine-docs/config.toml
@@ -1,0 +1,4 @@
+title = "GUILLOTINE-DOCS"
+description = "Specialized design for guillotine-docs."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/guillotine-docs/content/about.md
+++ b/examples/guillotine-docs/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/guillotine-docs/content/index.md
+++ b/examples/guillotine-docs/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Guillotine"
++++
+## Decisive Cuts
+Defining the structural boundaries of impactful transitions.

--- a/examples/guillotine-docs/templates/404.html
+++ b/examples/guillotine-docs/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/guillotine-docs/templates/footer.html
+++ b/examples/guillotine-docs/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase;">
+        &copy; 2026 GUILLOTINE-DOCS.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/guillotine-docs/templates/header.html
+++ b/examples/guillotine-docs/templates/header.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;800&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #eee; --text: #000; --accent: #555; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; margin: 0; }
+        .container { max-width: 800px; margin: 0 auto; padding: 0; border-left: 5px solid #000; border-right: 5px solid #000; min-height: 100vh; background: #fff; }
+        header { border-bottom: 20px solid #000; padding: 60px 40px; text-align: center; }
+        .logo { font-weight: 800; font-size: 3rem; text-transform: uppercase; letter-spacing: -2px; }
+        .docs-surface { padding: 80px 40px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">guillotine</div></header>

--- a/examples/guillotine-docs/templates/page.html
+++ b/examples/guillotine-docs/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main class="docs-surface">
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/guillotine-docs/templates/section.html
+++ b/examples/guillotine-docs/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/guillotine-docs/templates/shortcodes/alert.html
+++ b/examples/guillotine-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/guillotine-docs/templates/taxonomy.html
+++ b/examples/guillotine-docs/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/guillotine-docs/templates/taxonomy_term.html
+++ b/examples/guillotine-docs/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/periscope-docs/AGENTS.md
+++ b/examples/periscope-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/periscope-docs/archetypes/default.md
+++ b/examples/periscope-docs/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/periscope-docs/config.toml
+++ b/examples/periscope-docs/config.toml
@@ -1,0 +1,4 @@
+title = "PERISCOPE-DOCS"
+description = "Specialized design for periscope-docs."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/periscope-docs/content/about.md
+++ b/examples/periscope-docs/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/periscope-docs/content/index.md
+++ b/examples/periscope-docs/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Periscope"
++++
+## Submerged Observation
+Tracing the nocturnal boundaries of hidden innovation.

--- a/examples/periscope-docs/templates/404.html
+++ b/examples/periscope-docs/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/periscope-docs/templates/footer.html
+++ b/examples/periscope-docs/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; letter-spacing: 5px;">
+        &copy; 2026 PERISCOPE-DOCS. SCANNING THE DESIGN.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/periscope-docs/templates/header.html
+++ b/examples/periscope-docs/templates/header.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;600&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #0c0c0c; --text: #00ff41; --accent: #008f11; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; margin: 0; }
+        .container { max-width: 900px; margin: 0 auto; padding: 60px 40px; }
+        header { text-align: center; border-bottom: 2px solid var(--text); padding-bottom: 40px; margin-bottom: 80px; }
+        .logo { font-family: 'IBM Plex Mono'; font-weight: 700; font-size: 1.2rem; text-transform: uppercase; letter-spacing: 10px; }
+        .scope-surface { background: #000; border-radius: 50%; width: 600px; height: 600px; margin: 0 auto; border: 4px solid var(--text); position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+        .crosshair { position: absolute; background: var(--text); }
+        .h { width: 100%; height: 1px; top: 50%; left: 0; }
+        .v { width: 1px; height: 100%; top: 0; left: 50%; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">periscope</div></header>

--- a/examples/periscope-docs/templates/page.html
+++ b/examples/periscope-docs/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main class="scope-surface">
+    <div class="crosshair h"></div>
+    <div class="crosshair v"></div>
+    <div style="z-index: 10; padding: 100px; text-align: center;">
+        {{ content }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/periscope-docs/templates/section.html
+++ b/examples/periscope-docs/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/periscope-docs/templates/shortcodes/alert.html
+++ b/examples/periscope-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/periscope-docs/templates/taxonomy.html
+++ b/examples/periscope-docs/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/periscope-docs/templates/taxonomy_term.html
+++ b/examples/periscope-docs/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/solenoid-ref/AGENTS.md
+++ b/examples/solenoid-ref/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/solenoid-ref/archetypes/default.md
+++ b/examples/solenoid-ref/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/solenoid-ref/config.toml
+++ b/examples/solenoid-ref/config.toml
@@ -1,0 +1,4 @@
+title = "SOLENOID-REF"
+description = "Specialized design for solenoid-ref."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/solenoid-ref/content/about.md
+++ b/examples/solenoid-ref/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/solenoid-ref/content/index.md
+++ b/examples/solenoid-ref/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Solenoid"
++++
+## Magnetic Force
+Tracing the mechanical boundaries of structural activation.

--- a/examples/solenoid-ref/templates/404.html
+++ b/examples/solenoid-ref/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/solenoid-ref/templates/footer.html
+++ b/examples/solenoid-ref/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.7rem; font-family: 'IBM Plex Mono'; text-transform: uppercase;">
+        &copy; 2026 SOLENOID-REF.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/solenoid-ref/templates/header.html
+++ b/examples/solenoid-ref/templates/header.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #111; --text: #fff; --accent: #ffcc00; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'IBM Plex Mono', monospace; margin: 0; }
+        .container { max-width: 800px; margin: 0 auto; padding: 60px 40px; border-bottom: 1px solid #222; }
+        header { border-bottom: 2px solid var(--accent); padding-bottom: 20px; margin-bottom: 60px; text-align: left; }
+        .logo { font-weight: 700; font-size: 1.2rem; text-transform: uppercase; color: var(--accent); }
+        .coil { height: 10px; background-image: repeating-linear-gradient(90deg, var(--accent), var(--accent) 10px, transparent 10px, transparent 20px); margin-bottom: 40px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">solenoid.ref</div></header>
+    <div class="coil"></div>

--- a/examples/solenoid-ref/templates/page.html
+++ b/examples/solenoid-ref/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main>
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/solenoid-ref/templates/section.html
+++ b/examples/solenoid-ref/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/solenoid-ref/templates/shortcodes/alert.html
+++ b/examples/solenoid-ref/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/solenoid-ref/templates/taxonomy.html
+++ b/examples/solenoid-ref/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/solenoid-ref/templates/taxonomy_term.html
+++ b/examples/solenoid-ref/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -949,6 +949,13 @@
     "executive",
     "jakarta"
   ],
+  "broadcast-spec": [
+    "real-time",
+    "communication",
+    "standard",
+    "red",
+    "ibm-plex-mono"
+  ],
   "broadsheet": [
     "light",
     "blog",
@@ -1743,6 +1750,13 @@
     "light",
     "minimal",
     "ibm-plex-mono"
+  ],
+  "colophon-press": [
+    "typographic",
+    "heritage",
+    "refined",
+    "press",
+    "playfair"
   ],
   "colosseum": [
     "light",
@@ -3505,6 +3519,13 @@
     "minimalist",
     "light",
     "serif"
+  ],
+  "guillotine-docs": [
+    "decisive",
+    "industrial",
+    "sharp",
+    "docs",
+    "jakarta"
   ],
   "gunmetal": [
     "dark",
@@ -6097,6 +6118,13 @@
     "neon-cyan",
     "monospace"
   ],
+  "periscope-docs": [
+    "submerged",
+    "observation",
+    "dark",
+    "green",
+    "ibm-plex-mono"
+  ],
   "permafrost": [
     "light",
     "archive",
@@ -7465,6 +7493,13 @@
     "blog",
     "light",
     "warm"
+  ],
+  "solenoid-ref": [
+    "mechanical",
+    "magnetic",
+    "active",
+    "industrial",
+    "ibm-plex-mono"
   ],
   "soliloquy-glass": [
     "dark",


### PR DESCRIPTION
This PR adds a 64th set of 5 high-quality examples focused on periscope observation, colophon press, and magnetic solenoids including broadcast-spec, guillotine-docs, solenoid-ref, colophon-press, and periscope-docs. This brings the total examples to 340.

### Key Changes
- Added 5 new examples:
  - **BROADCAST-SPEC**: Real-time red communication design.
  - **GUILLOTINE-DOCS**: Decisive industrial sharp design.
  - **SOLENOID-REF**: Mechanical magnetic industrial design.
  - **COLOPHON-PRESS**: Typographic heritage refined design.
  - **PERISCOPE-DOCS**: Submerged dark green observation design.
- Updated `tags.json` with relevant discovery tags.
- Verified all examples with `hwaro build`.

Closes #1425
Closes #1426
Closes #1427
Closes #1428
Closes #1429