### PR TITLE
feat: add 3 final orbital and launch themed examples (#1445, #1446, #1447)

### DIFF
--- a/examples/detonator-launch/AGENTS.md
+++ b/examples/detonator-launch/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/detonator-launch/archetypes/default.md
+++ b/examples/detonator-launch/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/detonator-launch/config.toml
+++ b/examples/detonator-launch/config.toml
@@ -1,0 +1,4 @@
+title = "DETONATOR-LAUNCH"
+description = "High-energy design for detonator-launch."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/detonator-launch/content/about.md
+++ b/examples/detonator-launch/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/detonator-launch/content/index.md
+++ b/examples/detonator-launch/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Detonator"
++++
+## Critical Activation
+Tracing the absolute boundaries of structural energy.

--- a/examples/detonator-launch/templates/404.html
+++ b/examples/detonator-launch/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/detonator-launch/templates/footer.html
+++ b/examples/detonator-launch/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; font-weight: 800; text-transform: uppercase; letter-spacing: 10px;">
+        &copy; 2026 DETONATOR-LAUNCH.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/detonator-launch/templates/header.html
+++ b/examples/detonator-launch/templates/header.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;800&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #050505; --text: #ff0000; --accent: #ff0000; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'IBM Plex Mono', monospace; margin: 0; }
+        .container { max-width: 900px; margin: 0 auto; padding: 60px 40px; }
+        header { text-align: center; border-bottom: 10px solid var(--text); padding-bottom: 40px; margin-bottom: 60px; }
+        .logo { font-weight: 800; font-size: 2rem; text-transform: uppercase; letter-spacing: 10px; }
+        .detonator-surface { background: #0c0c0c; padding: 60px; border: 2px solid var(--text); box-shadow: 0 0 50px rgba(255,0,0,0.2); }
+        .timer { font-size: 3rem; font-weight: 700; color: var(--text); margin-bottom: 40px; text-align: center; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">detonator</div></header>

--- a/examples/detonator-launch/templates/page.html
+++ b/examples/detonator-launch/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<main class="detonator-surface">
+    <div class="timer">00:00:01</div>
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/detonator-launch/templates/section.html
+++ b/examples/detonator-launch/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/detonator-launch/templates/shortcodes/alert.html
+++ b/examples/detonator-launch/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/detonator-launch/templates/taxonomy.html
+++ b/examples/detonator-launch/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/detonator-launch/templates/taxonomy_term.html
+++ b/examples/detonator-launch/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-launch/AGENTS.md
+++ b/examples/monolith-launch/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/monolith-launch/archetypes/default.md
+++ b/examples/monolith-launch/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/monolith-launch/config.toml
+++ b/examples/monolith-launch/config.toml
@@ -1,0 +1,4 @@
+title = "MONOLITH-LAUNCH"
+description = "High-energy design for monolith-launch."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/monolith-launch/content/about.md
+++ b/examples/monolith-launch/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/monolith-launch/content/index.md
+++ b/examples/monolith-launch/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Monolith"
++++
+## Vertical Ascent
+Foundational permanence within the elevated structural environment.

--- a/examples/monolith-launch/templates/404.html
+++ b/examples/monolith-launch/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-launch/templates/footer.html
+++ b/examples/monolith-launch/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; font-weight: 800; text-transform: uppercase; letter-spacing: 10px;">
+        &copy; 2026 MONOLITH-LAUNCH.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/monolith-launch/templates/header.html
+++ b/examples/monolith-launch/templates/header.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;800&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #000; --text: #fff; --accent: #fff; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; margin: 0; }
+        .container { max-width: 800px; margin: 0 auto; padding: 100px 40px; }
+        header { text-align: center; margin-bottom: 100px; }
+        .logo { font-weight: 800; font-size: 2.5rem; text-transform: uppercase; letter-spacing: 20px; }
+        .launch-surface { background: #0a0a0a; padding: 100px; border: 1px solid #1a1a1a; position: relative; text-align: center; }
+        .thrust { height: 2px; background: #fff; width: 100%; margin-top: 60px; box-shadow: 0 0 20px #fff; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">monolith</div></header>

--- a/examples/monolith-launch/templates/page.html
+++ b/examples/monolith-launch/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<main class="launch-surface">
+    {{ content }}
+    <div class="thrust"></div>
+</main>
+{% include "footer.html" %}

--- a/examples/monolith-launch/templates/section.html
+++ b/examples/monolith-launch/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-launch/templates/shortcodes/alert.html
+++ b/examples/monolith-launch/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/monolith-launch/templates/taxonomy.html
+++ b/examples/monolith-launch/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-launch/templates/taxonomy_term.html
+++ b/examples/monolith-launch/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/titan-drop/AGENTS.md
+++ b/examples/titan-drop/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/titan-drop/archetypes/default.md
+++ b/examples/titan-drop/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/titan-drop/config.toml
+++ b/examples/titan-drop/config.toml
@@ -1,0 +1,4 @@
+title = "TITAN-DROP"
+description = "High-energy design for titan-drop."
+default_language = "en"
+base_url = "https://example.com"

--- a/examples/titan-drop/content/about.md
+++ b/examples/titan-drop/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/titan-drop/content/index.md
+++ b/examples/titan-drop/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Titan"
++++
+## Orbital Insertion
+Structural integrity through the extreme environment of impact.

--- a/examples/titan-drop/templates/404.html
+++ b/examples/titan-drop/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/titan-drop/templates/footer.html
+++ b/examples/titan-drop/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer style="padding: 100px 0; text-align: center; opacity: 0.3; font-size: 0.8rem; font-weight: 800; text-transform: uppercase; letter-spacing: 10px;">
+        &copy; 2026 TITAN-DROP.
+    </footer>
+    </div>
+</body>
+</html>

--- a/examples/titan-drop/templates/header.html
+++ b/examples/titan-drop/templates/header.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;800&family=IBM+Plex+Mono:wght@700&display=swap" rel="stylesheet">
+    <style>
+        :root { --bg: #1a1a1a; --text: #fff; --accent: #ff4500; }
+        body { background-color: var(--bg); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; margin: 0; }
+        .container { max-width: 1000px; margin: 0 auto; padding: 0; border-left: 1px solid #333; border-right: 1px solid #333; min-height: 100vh; }
+        header { padding: 100px 60px; text-align: left; border-bottom: 20px solid var(--accent); }
+        .logo { font-weight: 800; font-size: 4rem; text-transform: uppercase; letter-spacing: -2px; }
+        .drop-surface { padding: 80px 60px; position: relative; }
+    </style>
+</head>
+<body>
+    <div class="container">
+    <header><div class="logo">titan.drop</div></header>

--- a/examples/titan-drop/templates/page.html
+++ b/examples/titan-drop/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<main class="drop-surface">
+    {{ content }}
+</main>
+{% include "footer.html" %}

--- a/examples/titan-drop/templates/section.html
+++ b/examples/titan-drop/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/titan-drop/templates/shortcodes/alert.html
+++ b/examples/titan-drop/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/titan-drop/templates/taxonomy.html
+++ b/examples/titan-drop/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/titan-drop/templates/taxonomy_term.html
+++ b/examples/titan-drop/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2361,6 +2361,13 @@
     "radial",
     "magenta"
   ],
+  "detonator-launch": [
+    "critical",
+    "active",
+    "dark",
+    "red",
+    "ibm-plex-mono"
+  ],
   "devconf": [
     "dark",
     "event",
@@ -5147,6 +5154,13 @@
     "bold",
     "monolithic",
     "minimal"
+  ],
+  "monolith-launch": [
+    "vertical",
+    "permanent",
+    "dark",
+    "stark",
+    "jakarta"
   ],
   "monolith-ref": [
     "singular",
@@ -8327,6 +8341,13 @@
     "chronological",
     "feed",
     "structured",
+    "jakarta"
+  ],
+  "titan-drop": [
+    "heavy",
+    "orbital",
+    "impact",
+    "dark",
     "jakarta"
   ],
   "titanium": [


### PR DESCRIPTION
This PR adds a 68th set of 3 final high-quality examples focused on orbital drops and monolith launches including titan-drop, monolith-launch, and detonator-launch. This brings the total examples to 358.

### Key Changes
- Added 3 final examples:
  - **TITAN-DROP**: Heavy orbital impact design.
  - **MONOLITH-LAUNCH**: Vertical permanent stark design.
  - **DETONATOR-LAUNCH**: Critical active red design.
- Updated `tags.json` with relevant discovery tags.
- Verified all examples with `hwaro build`.

Closes #1445
Closes #1446
Closes #1447