### PR TITLE
feat: add new quantum-weaver example project

### DIFF
--- a/examples/quantum-weaver/AGENTS.md
+++ b/examples/quantum-weaver/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/quantum-weaver/archetypes/default.md
+++ b/examples/quantum-weaver/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/quantum-weaver/config.toml
+++ b/examples/quantum-weaver/config.toml
@@ -1,0 +1,3 @@
+title = "Quantum Weaver"
+base_url = "http://localhost:3000"
+description = "Weaving the fabric of the digital cosmos."

--- a/examples/quantum-weaver/content/about.md
+++ b/examples/quantum-weaver/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "About Us"
+description = "Learn more about the weavers."
++++
+
+We are architects of the unseen, translating abstract data into tangible, glowing interfaces. Our mission is to build the tomorrow of the web, today.
+
+- **Precision**
+- **Clarity**
+- **Futurism**

--- a/examples/quantum-weaver/content/index.md
+++ b/examples/quantum-weaver/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Home"
+description = "Welcome to Quantum Weaver."
++++
+
+Welcome to the **Quantum Weaver** nexus. Here, we manipulate the digital fabric to create robust, beautiful, and futuristic web experiences.
+
+Our core philosophy revolves around elegance in code and glass-like clarity in design. Dive in and explore the possibilities.

--- a/examples/quantum-weaver/static/css/style.css
+++ b/examples/quantum-weaver/static/css/style.css
@@ -1,0 +1,123 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Inter:wght@300;400;600&display=swap');
+
+:root {
+  --bg-color: #0d0e15;
+  --text-main: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #00f0ff;
+  --accent-glow: rgba(0, 240, 255, 0.5);
+  --glass-bg: rgba(20, 22, 37, 0.6);
+  --glass-border: rgba(255, 255, 255, 0.1);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  background-image: radial-gradient(circle at 50% 0%, #1c1538 0%, transparent 50%),
+                    radial-gradient(circle at 100% 100%, #0a2133 0%, transparent 50%);
+  background-attachment: fixed;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+h1, h2, h3, .logo {
+  font-family: 'Orbitron', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+header {
+  padding: 1.5rem 2rem;
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  text-decoration: none;
+  text-shadow: 0 0 10px var(--accent-glow);
+}
+
+nav a {
+  color: var(--text-muted);
+  text-decoration: none;
+  margin-left: 2rem;
+  transition: all 0.3s ease;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+}
+
+nav a:hover {
+  color: var(--accent);
+  text-shadow: 0 0 8px var(--accent-glow);
+}
+
+main {
+  flex: 1;
+  max-width: 900px;
+  margin: 4rem auto;
+  padding: 2rem;
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+  position: relative;
+  overflow: hidden;
+}
+
+main::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle, var(--accent-glow) 0%, transparent 70%);
+  opacity: 0.1;
+  pointer-events: none;
+  animation: pulse 10s infinite alternate;
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  100% { transform: scale(1.1); }
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: #fff;
+  border-bottom: 1px solid var(--glass-border);
+  padding-bottom: 1rem;
+}
+
+p {
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  background: rgba(10, 11, 16, 0.8);
+  border-top: 1px solid var(--glass-border);
+}

--- a/examples/quantum-weaver/templates/404.html
+++ b/examples/quantum-weaver/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/quantum-weaver/templates/footer.html
+++ b/examples/quantum-weaver/templates/footer.html
@@ -1,0 +1,5 @@
+  <footer>
+    &copy; 2024 {{ site.title }}. Weaving the future.
+  </footer>
+</body>
+</html>

--- a/examples/quantum-weaver/templates/header.html
+++ b/examples/quantum-weaver/templates/header.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{% if page.title is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes | safe }}
+  {{ highlight_tags | safe }}
+</head>
+<body>
+  <header>
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/">Home</a>
+      <a href="{{ base_url }}/about">About</a>
+    </nav>
+  </header>

--- a/examples/quantum-weaver/templates/page.html
+++ b/examples/quantum-weaver/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main>
+    <h1>{{ page.title }}</h1>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/examples/quantum-weaver/templates/section.html
+++ b/examples/quantum-weaver/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/quantum-weaver/templates/shortcodes/alert.html
+++ b/examples/quantum-weaver/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/quantum-weaver/templates/taxonomy.html
+++ b/examples/quantum-weaver/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/quantum-weaver/templates/taxonomy_term.html
+++ b/examples/quantum-weaver/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -8977,5 +8977,11 @@
     "diy",
     "raw",
     "unconventional"
+  ],
+  "quantum-weaver": [
+    "futuristic",
+    "dark",
+    "glassmorphism",
+    "neon"
   ]
 }


### PR DESCRIPTION
This pull request adds a new elegant, futuristic example site named "Quantum Weaver" to the `examples/` directory. It uses a custom glassmorphism design with neon touches, tailored layout templates, and registers itself correctly in `tags.json`. All files are self-contained within the example directory.

---
*PR created automatically by Jules for task [1494983270073203458](https://jules.google.com/task/1494983270073203458) started by @chei-l*