### PR TITLE
Add Ethereal Loom example

### DIFF
--- a/examples/ethereal-loom/archetypes/default.md
+++ b/examples/ethereal-loom/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/ethereal-loom/config.toml
+++ b/examples/ethereal-loom/config.toml
@@ -1,0 +1,3 @@
+base_url = "http://localhost:3000"
+title = "Ethereal Loom"
+description = "Weaving threads of light and dark into a seamless digital tapestry."

--- a/examples/ethereal-loom/content/about.md
+++ b/examples/ethereal-loom/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About"
+description = "About the Ethereal Loom"
++++
+
+# About the Loom
+
+The Ethereal Loom is an experiment in elegant, atmospheric design, blending dark themes with translucent elements to create a mesmerizing visual journey.

--- a/examples/ethereal-loom/content/index.md
+++ b/examples/ethereal-loom/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Home"
+description = "Welcome to the Ethereal Loom"
++++
+
+# The Ethereal Loom
+
+Welcome to a realm where digital threads interweave. The Ethereal Loom crafts experiences of light, shadow, and glass. Explore the tapestry of imagination.

--- a/examples/ethereal-loom/static/css/style.css
+++ b/examples/ethereal-loom/static/css/style.css
@@ -1,0 +1,80 @@
+:root {
+    --bg-color: #0b0c10;
+    --text-color: #c5c6c7;
+    --accent-color: #66fcf1;
+    --glass-bg: rgba(31, 40, 51, 0.6);
+    --glass-border: rgba(102, 252, 241, 0.2);
+}
+body {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    line-height: 1.6;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background-image: radial-gradient(circle at top left, #1f2833, transparent 50%),
+                      radial-gradient(circle at bottom right, #1f2833, transparent 50%);
+    background-attachment: fixed;
+}
+header {
+    padding: 2rem;
+    text-align: center;
+    background: var(--glass-bg);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--glass-border);
+}
+header h1 {
+    margin: 0;
+    color: var(--accent-color);
+    text-shadow: 0 0 10px rgba(102, 252, 241, 0.5);
+    font-weight: 300;
+    letter-spacing: 2px;
+}
+nav {
+    margin-top: 1rem;
+}
+nav a {
+    color: var(--text-color);
+    text-decoration: none;
+    margin: 0 1rem;
+    transition: color 0.3s ease;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    letter-spacing: 1px;
+}
+nav a:hover {
+    color: var(--accent-color);
+}
+main {
+    flex: 1;
+    padding: 3rem 2rem;
+    max-width: 800px;
+    margin: 0 auto;
+    width: 100%;
+    box-sizing: border-box;
+}
+article {
+    background: var(--glass-bg);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid var(--glass-border);
+    border-radius: 15px;
+    padding: 2.5rem;
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+}
+h1, h2 {
+    color: var(--accent-color);
+    font-weight: 400;
+}
+footer {
+    text-align: center;
+    padding: 1.5rem;
+    background: var(--glass-bg);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-top: 1px solid var(--glass-border);
+    font-size: 0.8rem;
+}

--- a/examples/ethereal-loom/templates/404.html
+++ b/examples/ethereal-loom/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+
+{% include "footer.html" %}

--- a/examples/ethereal-loom/templates/footer.html
+++ b/examples/ethereal-loom/templates/footer.html
@@ -1,0 +1,6 @@
+    </main>
+    <footer>
+        <p>&copy; {{ site.title }}. Weaving digital dreams.</p>
+    </footer>
+</body>
+</html>

--- a/examples/ethereal-loom/templates/header.html
+++ b/examples/ethereal-loom/templates/header.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description is defined %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+    {% if highlight_tags is defined %}{{ highlight_tags | safe }}{% endif %}
+    {% if auto_includes is defined %}{{ auto_includes | safe }}{% endif %}
+</head>
+<body>
+    <header>
+        <h1>{{ site.title }}</h1>
+        <nav>
+            <a href="{{ base_url }}/">Home</a>
+            <a href="{{ base_url }}/about.html">About</a>
+        </nav>
+    </header>
+    <main>

--- a/examples/ethereal-loom/templates/page.html
+++ b/examples/ethereal-loom/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+<article>
+    {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/ethereal-loom/templates/section.html
+++ b/examples/ethereal-loom/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+
+{% include "footer.html" %}

--- a/examples/ethereal-loom/templates/shortcodes/alert.html
+++ b/examples/ethereal-loom/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/ethereal-loom/templates/taxonomy.html
+++ b/examples/ethereal-loom/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+
+{% include "footer.html" %}

--- a/examples/ethereal-loom/templates/taxonomy_term.html
+++ b/examples/ethereal-loom/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9045,5 +9045,12 @@
     "dark-mode",
     "elegant",
     "creative"
+  ],
+  "ethereal-loom": [
+    "ethereal",
+    "elegant",
+    "dark-mode",
+    "glassmorphism",
+    "weaving"
   ]
 }


### PR DESCRIPTION
This PR adds a new example named `ethereal-loom` to the `examples/` directory.

- The example is a new `hwaro` project initialized inside `examples/ethereal-loom`.
- It includes a unique, highly styled design featuring a dark theme, gradient background, and glassmorphism UI elements across the templates.
- Includes sample content reflecting an "Ethereal Loom" theme.
- The new project has been registered in the root `tags.json` with appropriate aesthetic tags.
- Verified local template rendering and layout aesthetics via Playwright.

---
*PR created automatically by Jules for task [6414483754420975131](https://jules.google.com/task/6414483754420975131) started by @chei-l*