### PR TITLE
Add lumina-flow example template

### DIFF
--- a/examples/lumina-flow/AGENTS.md
+++ b/examples/lumina-flow/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lumina-flow/archetypes/default.md
+++ b/examples/lumina-flow/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lumina-flow/config.toml
+++ b/examples/lumina-flow/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Lumina Flow"
+description = "A luminescent, flowing theme"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/lumina-flow/content/about.md
+++ b/examples/lumina-flow/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About Us"
+description = "The creators of Lumina Flow."
++++
+
+We build radiant digital experiences. Lumina Flow is designed to make your content shine brightly against the void.
+
+Join us on our journey to the stars.

--- a/examples/lumina-flow/content/index.md
+++ b/examples/lumina-flow/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Welcome to Lumina Flow"
+description = "A radiant journey through digital space."
++++
+
+Welcome to a world illuminated by elegant, flowing light. This theme embodies the energy of neon and the calm of deep space.
+
+Let the light guide your reading experience.
+
+[Discover more about us](/about/)

--- a/examples/lumina-flow/static/css/style.css
+++ b/examples/lumina-flow/static/css/style.css
@@ -1,0 +1,44 @@
+:root {
+  --primary: #00e5ff;
+  --secondary: #b000ff;
+  --bg: #09090b;
+  --bg-subtle: #18181b;
+  --text: #e4e4e7;
+  --text-muted: #a1a1aa;
+  --border: #27272a;
+}
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  color: var(--text);
+  background: var(--bg);
+  background-image: radial-gradient(circle at 50% -20%, rgba(0, 229, 255, 0.15) 0%, transparent 50%),
+                    radial-gradient(circle at 100% 80%, rgba(176, 0, 255, 0.1) 0%, transparent 50%);
+  min-height: 100vh;
+}
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+.site-header { display: flex; align-items: center; justify-content: space-between; padding: 2rem 0; margin-bottom: 3rem; }
+.site-logo {
+  font-weight: 800; font-size: 1.5rem; color: var(--text); text-decoration: none;
+  letter-spacing: -0.05em;
+  background: linear-gradient(90deg, var(--primary), var(--secondary));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.site-header nav { display: flex; gap: 1.5rem; }
+.site-header nav a {
+  color: var(--text-muted); text-decoration: none; font-size: 0.95rem; font-weight: 500;
+  transition: color 0.2s ease;
+}
+.site-header nav a:hover { color: var(--primary); text-shadow: 0 0 10px rgba(0, 229, 255, 0.5); }
+.site-main { min-height: calc(100vh - 250px); }
+.site-footer {
+  margin-top: 4rem; padding: 2rem 0; border-top: 1px solid var(--border);
+  color: var(--text-muted); font-size: 0.85rem; text-align: center;
+}
+h1, h2, h3 { line-height: 1.2; margin-top: 1.5em; margin-bottom: 0.5em; font-weight: 700; color: #fff; }
+h1 { font-size: 2.5rem; letter-spacing: -0.02em; }
+p { margin: 1em 0; font-size: 1.1rem; color: #d4d4d8; }
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; text-shadow: 0 0 8px rgba(0, 229, 255, 0.4); }

--- a/examples/lumina-flow/templates/404.html
+++ b/examples/lumina-flow/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-flow/templates/footer.html
+++ b/examples/lumina-flow/templates/footer.html
@@ -1,0 +1,8 @@
+  </div> <!-- .site-wrapper -->
+  <footer class="site-footer">
+    <div class="site-wrapper">
+      &copy; {{ site.title | e }} - A luminescent experience
+    </div>
+  </footer>
+</body>
+</html>

--- a/examples/lumina-flow/templates/header.html
+++ b/examples/lumina-flow/templates/header.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default('en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page is defined and page.description is defined %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page is defined and page.title is defined %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_tags | safe }}
+  {{ auto_includes | safe }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/examples/lumina-flow/templates/page.html
+++ b/examples/lumina-flow/templates/page.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main class="site-main">
+  <article>
+    <header class="post-header">
+      {% if page is defined and page.title is defined %}<h1>{{ page.title | e }}</h1>{% endif %}
+    </header>
+    <div class="post-content">
+      {{ content | safe }}
+    </div>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/lumina-flow/templates/section.html
+++ b/examples/lumina-flow/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-flow/templates/shortcodes/alert.html
+++ b/examples/lumina-flow/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/lumina-flow/templates/taxonomy.html
+++ b/examples/lumina-flow/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-flow/templates/taxonomy_term.html
+++ b/examples/lumina-flow/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9052,5 +9052,11 @@
     "dark-mode",
     "glassmorphism",
     "weaving"
+  ],
+  "lumina-flow": [
+    "dark",
+    "portfolio",
+    "neon",
+    "inter"
   ]
 }


### PR DESCRIPTION
This patch adds a new standalone Hwaro example template named `lumina-flow`. The design focuses on an elegant, luminescent dark theme with glowing neon accents and a clean modern layout. It includes the complete directory structure, CSS styling, HTML templates, minimal placeholder content, and a generated AGENTS.md, all safely integrated into the examples directory and registered in tags.json.

---
*PR created automatically by Jules for task [10713214798755561270](https://jules.google.com/task/10713214798755561270) started by @chei-l*