### PR TITLE
Add lumina-glass example site

### DIFF
--- a/examples/lumina-glass/AGENTS.md
+++ b/examples/lumina-glass/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lumina-glass/archetypes/default.md
+++ b/examples/lumina-glass/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lumina-glass/config.toml
+++ b/examples/lumina-glass/config.toml
@@ -1,0 +1,4 @@
+title = "Lumina Glass"
+description = "An elegant glassmorphism portfolio"
+base_url = "http://localhost:3000"
+theme = ""

--- a/examples/lumina-glass/content/about.md
+++ b/examples/lumina-glass/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About Lumina"
+description = "Learn more about us."
++++
+# About Lumina
+We specialize in crafting ethereal, translucent user experiences.

--- a/examples/lumina-glass/content/index.md
+++ b/examples/lumina-glass/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Lumina Glass"
+description = "Welcome to Lumina Glass."
++++
+# Welcome to Lumina Glass
+Experience the future of web design with our elegant, dark-mode glassmorphism aesthetic.

--- a/examples/lumina-glass/static/css/style.css
+++ b/examples/lumina-glass/static/css/style.css
@@ -1,0 +1,62 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: linear-gradient(135deg, #1e0033 0%, #001f3f 100%);
+    color: #e0e0e0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+header {
+    width: 100%;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+header a {
+    color: #fff;
+    text-decoration: none;
+    font-weight: bold;
+    letter-spacing: 1px;
+}
+main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 40px;
+    width: 100%;
+    max-width: 800px;
+}
+.glass-container {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 16px;
+    padding: 40px;
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
+    text-align: center;
+}
+h1 {
+    background: -webkit-linear-gradient(#ff00cc, #3333ff);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-top: 0;
+}
+footer {
+    width: 100%;
+    padding: 20px;
+    text-align: center;
+    font-size: 0.8em;
+    background: rgba(0, 0, 0, 0.2);
+    color: #888;
+}

--- a/examples/lumina-glass/templates/404.html
+++ b/examples/lumina-glass/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<main>
+    <div class="glass-container">
+        <h1>404 Not Found</h1>
+        <p>The page you are looking for does not exist.</p>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lumina-glass/templates/footer.html
+++ b/examples/lumina-glass/templates/footer.html
@@ -1,0 +1,5 @@
+<footer>
+    &copy; Lumina Glass. All rights reserved.
+</footer>
+</body>
+</html>

--- a/examples/lumina-glass/templates/header.html
+++ b/examples/lumina-glass/templates/header.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined and page.title is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+<header>
+    <a href="{{ base_url }}/">Home</a>
+    <a href="{{ base_url }}/about.html">About</a>
+</header>

--- a/examples/lumina-glass/templates/page.html
+++ b/examples/lumina-glass/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main>
+    <div class="glass-container">
+        {{ content | safe }}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lumina-glass/templates/section.html
+++ b/examples/lumina-glass/templates/section.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main>
+    <div class="glass-container">
+        <h1>{{ section.title }}</h1>
+        <ul>
+            {% for p in section.pages %}
+            <li><a href="{{ base_url }}/{{ p.path }}">{{ p.title }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lumina-glass/templates/shortcodes/alert.html
+++ b/examples/lumina-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/lumina-glass/templates/taxonomy.html
+++ b/examples/lumina-glass/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main>
+    <div class="glass-container">
+        <h1>Taxonomy</h1>
+        <ul>
+            {% for term in terms %}
+            <li>{{ term.name }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lumina-glass/templates/taxonomy_term.html
+++ b/examples/lumina-glass/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main>
+    <div class="glass-container">
+        <h1>{{ page.title }}</h1>
+        <ul>
+            {% for p in pages %}
+            <li><a href="{{ base_url }}/{{ p.path }}">{{ p.title }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9058,5 +9058,11 @@
     "portfolio",
     "neon",
     "inter"
+  ],
+  "lumina-glass": [
+    "dark",
+    "glassmorphism",
+    "portfolio",
+    "neon"
   ]
 }


### PR DESCRIPTION
This PR adds a new example site named `lumina-glass` showcasing an elegant dark-mode glassmorphism aesthetic. It registers the example in `tags.json`, sets up the core Hwaro templates and basic content, introduces custom styling with a translucent look, and ensures all structural and formatting validations pass.

Features:
- Responsive layout with a central glassmorphism container
- Playwright frontend verification 
- Successfully validates via Hwaro tool doctor & validate

---
*PR created automatically by Jules for task [11154127339954689638](https://jules.google.com/task/11154127339954689638) started by @chei-l*