### PR TITLE
feat: add cyber-neo example site

### DIFF
--- a/examples/cyber-neo/AGENTS.md
+++ b/examples/cyber-neo/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/cyber-neo/archetypes/default.md
+++ b/examples/cyber-neo/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/cyber-neo/config.toml
+++ b/examples/cyber-neo/config.toml
@@ -1,0 +1,20 @@
+title = "Cyber Neo"
+base_url = "http://localhost:3000"
+description = "A futuristic, cyber-themed portfolio with glowing neon and glassmorphic elements."
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+filename = "rss.xml"

--- a/examples/cyber-neo/content/about.md
+++ b/examples/cyber-neo/content/about.md
@@ -1,0 +1,14 @@
++++
+title = "About"
+template = "page"
++++
+# DECRYPTING BIO...
+
+**SUBJECT:** Anonymous Operative
+**STATUS:** ACTIVE
+
+We build digital constructs. Our expertise lies in creating fast, static, and highly optimized web interfaces using Hwaro.
+
+> "The net is vast and infinite."
+
+Return to [Home](/).

--- a/examples/cyber-neo/content/index.md
+++ b/examples/cyber-neo/content/index.md
@@ -1,0 +1,11 @@
++++
+title = "Home"
+template = "page"
++++
+# SYSTEM // INITIALIZED
+
+Welcome to **Cyber Neo**. This is a secure nexus point for digital wanderers.
+
+The aesthetic draws heavy inspiration from classic cyberpunk themes: glowing neon on dark backgrounds, monospaced typography, and brutalist geometric elements, all wrapped in a modern glassmorphic UI.
+
+Explore the [About](/about/) section to decrypt more information.

--- a/examples/cyber-neo/content/posts/_index.md
+++ b/examples/cyber-neo/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Data Logs"
+template = "section"
+sort_by = "date"
+reverse = true
++++

--- a/examples/cyber-neo/content/posts/first-log.md
+++ b/examples/cyber-neo/content/posts/first-log.md
@@ -1,0 +1,6 @@
++++
+title = "Log 001: Connection Established"
+date = "2024-05-01"
+template = "page"
++++
+Connection successful. Handshake protocol completed. The neon grid awaits.

--- a/examples/cyber-neo/templates/404.html
+++ b/examples/cyber-neo/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-neo/templates/footer.html
+++ b/examples/cyber-neo/templates/footer.html
@@ -1,0 +1,16 @@
+    </main>
+    <style>
+        footer {
+            text-align: center;
+            padding: 2rem;
+            border-top: 1px solid var(--glass-border);
+            margin-top: 3rem;
+            font-size: 0.9rem;
+            color: var(--neon-blue-dim);
+        }
+    </style>
+    <footer>
+        <p>&copy; 2024 {{ site.title }} // System Online</p>
+    </footer>
+</body>
+</html>

--- a/examples/cyber-neo/templates/header.html
+++ b/examples/cyber-neo/templates/header.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined and page.title is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{{ site.description }}">
+    {% if highlight_tags is defined %}{{ highlight_tags | safe }}{% endif %}
+    {% if auto_includes is defined %}{{ auto_includes | safe }}{% endif %}
+    <style>
+        :root {
+            --bg-color: #0b0c10;
+            --text-color: #c5c6c7;
+            --neon-blue: #66fcf1;
+            --neon-blue-dim: #45a29e;
+            --glass-bg: rgba(11, 12, 16, 0.7);
+            --glass-border: rgba(102, 252, 241, 0.2);
+            --font-main: 'Courier New', Courier, monospace;
+        }
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: var(--font-main);
+            margin: 0;
+            padding: 0;
+            line-height: 1.6;
+        }
+        header {
+            background: var(--glass-bg);
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+            border-bottom: 1px solid var(--glass-border);
+            padding: 1.5rem;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
+        }
+        .logo a {
+            color: var(--neon-blue);
+            text-decoration: none;
+            font-size: 1.8rem;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            text-shadow: 0 0 10px var(--neon-blue);
+        }
+        nav ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            gap: 1.5rem;
+        }
+        nav a {
+            color: var(--text-color);
+            text-decoration: none;
+            font-size: 1.1rem;
+            transition: all 0.3s ease;
+            position: relative;
+        }
+        nav a:hover {
+            color: var(--neon-blue);
+            text-shadow: 0 0 8px var(--neon-blue);
+        }
+        nav a::before {
+            content: '[';
+            opacity: 0;
+            transition: opacity 0.3s;
+            color: var(--neon-blue-dim);
+            margin-right: 5px;
+        }
+        nav a::after {
+            content: ']';
+            opacity: 0;
+            transition: opacity 0.3s;
+            color: var(--neon-blue-dim);
+            margin-left: 5px;
+        }
+        nav a:hover::before, nav a:hover::after {
+            opacity: 1;
+        }
+        main {
+            max-width: 900px;
+            margin: 3rem auto;
+            padding: 0 1.5rem;
+        }
+        .content-card {
+            background: rgba(255, 255, 255, 0.02);
+            border: 1px solid var(--glass-border);
+            border-radius: 8px;
+            padding: 2rem;
+            margin-bottom: 2rem;
+            backdrop-filter: blur(5px);
+            box-shadow: 0 0 15px rgba(0,0,0,0.5);
+            transition: transform 0.3s, box-shadow 0.3s;
+        }
+        .content-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 0 20px rgba(102, 252, 241, 0.2);
+            border-color: var(--neon-blue-dim);
+        }
+        h1, h2, h3 {
+            color: var(--neon-blue);
+            font-weight: normal;
+        }
+        h1 {
+            text-shadow: 0 0 10px rgba(102, 252, 241, 0.5);
+            border-bottom: 1px solid var(--glass-border);
+            padding-bottom: 0.5rem;
+        }
+        a {
+            color: var(--neon-blue-dim);
+            text-decoration: none;
+        }
+        a:hover {
+            color: var(--neon-blue);
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="logo">
+            <a href="{{ base_url }}/">{{ site.title }}</a>
+        </div>
+        <nav>
+            <ul>
+                <li><a href="{{ base_url }}/">Home</a></li>
+                <li><a href="{{ base_url }}/about/">About</a></li>
+                <li><a href="{{ base_url }}/posts/">Posts</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>

--- a/examples/cyber-neo/templates/page.html
+++ b/examples/cyber-neo/templates/page.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<article class="content-card">
+    <h1>{% if page is defined and page.title is defined %}{{ page.title }}{% endif %}</h1>
+    {% if page is defined and page.date is defined %}
+    <p style="color: var(--neon-blue-dim); font-size: 0.9rem;">SYS.DATE: {{ page.date | date("%Y-%m-%d") }}</p>
+    {% endif %}
+    <div class="content-body">
+        {% if content is defined %}{{ content | safe }}{% endif %}
+    </div>
+</article>
+{% include "footer.html" %}

--- a/examples/cyber-neo/templates/section.html
+++ b/examples/cyber-neo/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<div class="section-container">
+    <h1>{% if section is defined and section.title is defined %}{{ section.title }}{% endif %}</h1>
+    {% if section is defined and section.pages is defined %}
+    <div class="grid">
+        {% for post in section.pages %}
+        <article class="content-card">
+            <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            {% if post.date is defined %}
+            <p style="color: var(--neon-blue-dim); font-size: 0.8rem;">SYS.DATE: {{ post.date | date("%Y-%m-%d") }}</p>
+            {% endif %}
+            {% if post.summary is defined %}
+            <p>{{ post.summary | strip_html | truncate_words(30) }}</p>
+            {% endif %}
+            <a href="{{ post.url }}" style="display: inline-block; margin-top: 1rem; border: 1px solid var(--neon-blue); padding: 0.3rem 0.8rem; border-radius: 4px; text-transform: uppercase; font-size: 0.8rem;">> Access Data</a>
+        </article>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+{% include "footer.html" %}

--- a/examples/cyber-neo/templates/shortcodes/alert.html
+++ b/examples/cyber-neo/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/cyber-neo/templates/taxonomy.html
+++ b/examples/cyber-neo/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-neo/templates/taxonomy_term.html
+++ b/examples/cyber-neo/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9071,5 +9071,11 @@
     "parallax",
     "dark-mode",
     "elegant"
+  ],
+  "cyber-neo": [
+    "dark",
+    "cyberpunk",
+    "portfolio",
+    "neon"
   ]
 }


### PR DESCRIPTION
Created a new example site `cyber-neo` showcasing a cyberpunk and glassmorphic aesthetic using Hwaro. The example includes custom HTML templates with inline CSS, sample markdown content, proper config, and tags integration. Verified visually using Playwright.

---
*PR created automatically by Jules for task [3917642945143412943](https://jules.google.com/task/3917642945143412943) started by @chei-l*