### PR TITLE
Add new Prism Wave example theme

### DIFF
--- a/examples/prism-wave/AGENTS.md
+++ b/examples/prism-wave/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/prism-wave/archetypes/default.md
+++ b/examples/prism-wave/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/prism-wave/config.toml
+++ b/examples/prism-wave/config.toml
@@ -1,0 +1,19 @@
+title = "Prism Wave"
+description = "A striking and uniquely styled sample site."
+base_url = "https://example.com"
+language_code = "en"
+
+[author]
+name = "Prism Architect"
+
+[extra]
+logo = "PW"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"

--- a/examples/prism-wave/content/about.md
+++ b/examples/prism-wave/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About"
+description = "The architecture behind the wave."
++++
+Prism Wave is an exploration of color, light, and depth in web design.
+
+By layering semi-transparent interfaces over complex, dynamic backgrounds, we create a sense of hierarchy and immersion without relying on heavy shadows or flat solid colors.
+
+> "Color is the keyboard, the eyes are the harmonies, the soul is the piano with many strings. The artist is the hand that plays, touching one key or another, to cause vibrations in the soul."
+> — Wassily Kandinsky
+
+This theme is perfectly suited for creative portfolios, design blogs, or any project that demands a highly visual and atmospheric presence.

--- a/examples/prism-wave/content/index.md
+++ b/examples/prism-wave/content/index.md
@@ -1,0 +1,14 @@
++++
+title = "Home"
+description = "Welcome to Prism Wave, where light meets logic."
++++
+Welcome to a digital space designed through the lens of refraction and luminescence.
+
+This sample site demonstrates a modern glassmorphism aesthetic combined with vibrant, ethereal gradients, built entirely on top of the **Hwaro** static site generator.
+
+### Features
+* **Glassmorphism UI:** Translucent cards with subtle blurs and borders.
+* **Vibrant Accents:** Iridescent gradient text and background highlights.
+* **Modern Typography:** Utilizing the clean geometric sans-serif, *Outfit*.
+
+Explore the [Articles](/posts/) to see how content is rendered within this spectrum.

--- a/examples/prism-wave/content/posts/_index.md
+++ b/examples/prism-wave/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Articles"
+description = "Thoughts on light and color"
++++

--- a/examples/prism-wave/content/posts/first-light.md
+++ b/examples/prism-wave/content/posts/first-light.md
@@ -1,0 +1,8 @@
++++
+title = "First Light"
+description = "The beginning of the spectrum"
+date = "2023-10-01"
+[taxonomies]
+tags = ["light", "origins"]
++++
+The journey begins where the light hits the glass.

--- a/examples/prism-wave/templates/404.html
+++ b/examples/prism-wave/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main" style="display: flex; align-items: center; justify-content: center; text-align: center; min-height: 50vh;">
+    <div class="glass-card">
+      <h1 style="font-size: 6rem; margin: 0; background: linear-gradient(90deg, var(--accent1), var(--accent2)); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">404</h1>
+      <p style="font-size: 1.5rem; margin-bottom: 2rem;">The wavelength you are looking for does not exist.</p>
+      <a href="{{ base_url }}/" style="padding: 0.8rem 2rem; background: var(--glass-bg); border: 1px solid var(--glass-border); border-radius: 30px; color: var(--text); font-weight: 600; transition: background 0.3s;">Return to Source</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-wave/templates/footer.html
+++ b/examples/prism-wave/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer style="margin-top: 4rem; padding: 2rem 0; text-align: center; color: var(--text-muted); font-size: 0.9rem; border-top: 1px solid var(--glass-border);">
+      <p>&copy; 2024 Prism Wave. Powered by <a href="https://hwaro.hahwul.com" target="_blank">Hwaro</a>.</p>
+    </footer>
+  </div>
+  {{ highlight_tags | safe }}
+  {{ auto_includes | safe }}
+</body>
+</html>

--- a/examples/prism-wave/templates/header.html
+++ b/examples/prism-wave/templates/header.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page is defined and page.description is defined %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page is defined and page.title is defined %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600&display=swap');
+    :root {
+      --bg: #0d0d12;
+      --text: #f0f0f5;
+      --text-muted: #8c8c9b;
+      --accent1: #ff007f;
+      --accent2: #00f0ff;
+      --accent3: #7000ff;
+      --glass-bg: rgba(255, 255, 255, 0.03);
+      --glass-border: rgba(255, 255, 255, 0.08);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: 'Outfit', sans-serif;
+      line-height: 1.7;
+      margin: 0;
+      color: var(--text);
+      background-color: var(--bg);
+      background-image:
+        radial-gradient(circle at 15% 50%, rgba(255, 0, 127, 0.12), transparent 40%),
+        radial-gradient(circle at 85% 30%, rgba(0, 240, 255, 0.12), transparent 40%),
+        radial-gradient(circle at 50% 80%, rgba(112, 0, 255, 0.12), transparent 40%);
+      background-attachment: fixed;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    .site-wrapper {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 0 2rem;
+      width: 100%;
+      flex-grow: 1;
+      display: flex;
+      flex-direction: column;
+    }
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1.5rem 2rem;
+      margin-top: 2rem;
+      margin-bottom: 3rem;
+      background: var(--glass-bg);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      border-radius: 16px;
+      border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow);
+      z-index: 10;
+    }
+    .site-logo {
+      font-weight: 600;
+      font-size: 1.5rem;
+      color: var(--text);
+      text-decoration: none;
+      letter-spacing: 1px;
+      background: linear-gradient(90deg, var(--accent2), var(--accent1));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      text-transform: uppercase;
+    }
+    .site-header nav {
+      display: flex;
+      gap: 2rem;
+    }
+    .site-header nav a {
+      color: var(--text);
+      text-decoration: none;
+      font-size: 1rem;
+      font-weight: 400;
+      transition: color 0.3s ease, text-shadow 0.3s ease;
+      position: relative;
+    }
+    .site-header nav a::after {
+      content: '';
+      position: absolute;
+      width: 0;
+      height: 2px;
+      bottom: -4px;
+      left: 0;
+      background: linear-gradient(90deg, var(--accent2), var(--accent1));
+      transition: width 0.3s ease;
+    }
+    .site-header nav a:hover::after {
+      width: 100%;
+    }
+    .site-main { flex-grow: 1; }
+
+    .glass-card {
+      background: var(--glass-bg);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      border-radius: 16px;
+      border: 1px solid var(--glass-border);
+      padding: 2.5rem;
+      box-shadow: var(--glass-shadow);
+      margin-bottom: 2rem;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+    .glass-card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.45);
+      border-color: rgba(255, 255, 255, 0.15);
+    }
+
+    h1, h2, h3 { line-height: 1.2; margin-top: 1em; margin-bottom: 0.5em; font-weight: 600; color: #fff; }
+    h1 { font-size: 2.5rem; margin-top: 0; background: linear-gradient(135deg, #fff, #a0a0b5); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+    h2 { font-size: 1.8rem; }
+    h3 { font-size: 1.3rem; }
+    p { margin: 1.2em 0; }
+    a { color: var(--accent2); text-decoration: none; transition: color 0.2s; }
+    a:hover { color: var(--accent1); }
+
+    code { background: rgba(255, 255, 255, 0.1); padding: 0.2rem 0.4rem; border-radius: 4px; font-size: 0.9em; color: var(--accent2); }
+    pre { background: rgba(0, 0, 0, 0.4); padding: 1.5rem; border-radius: 12px; overflow-x: auto; border: 1px solid var(--glass-border); }
+    pre code { background: none; padding: 0; color: #e0e0e0; }
+
+    ul.section-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 1.5rem; }
+    ul.section-list li { margin: 0; }
+    ul.section-list li a { display: block; font-size: 1.4rem; font-weight: 600; margin-bottom: 0.5rem; background: linear-gradient(90deg, #fff, #ccc); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+    ul.section-list li p { margin: 0; color: var(--text-muted); font-size: 0.95rem; }
+
+    .meta { font-size: 0.85rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 1.5rem; display: block; }
+
+    @media (max-width: 768px) {
+      .site-header { flex-direction: column; gap: 1rem; padding: 1.5rem; }
+      .site-wrapper { padding: 0 1rem; }
+      .glass-card { padding: 1.5rem; }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_tags | safe }}
+  {{ auto_includes | safe }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Articles</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/examples/prism-wave/templates/page.html
+++ b/examples/prism-wave/templates/page.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="glass-card">
+      {% if page is defined and page.title is defined %}
+        <h1>{{ page.title | e }}</h1>
+        {% if page.date is defined %}
+          <span class="meta">{{ page.date | date(format="%B %d, %Y") }}</span>
+        {% endif %}
+      {% endif %}
+      <div class="content">
+        {{ content | safe }}
+      </div>
+
+      {% if page is defined and page.taxonomies is defined and page.taxonomies.tags is defined %}
+        <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--glass-border);">
+          <span class="meta">Tags</span>
+          <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+            {% for tag in page.taxonomies.tags %}
+              <a href="{{ base_url }}/tags/{{ tag | lower | replace(from=' ', to='-') }}/" style="padding: 0.3rem 0.8rem; background: rgba(255,255,255,0.05); border: 1px solid var(--glass-border); border-radius: 20px; font-size: 0.85rem; color: var(--text);">#{{ tag }}</a>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-wave/templates/section.html
+++ b/examples/prism-wave/templates/section.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-card" style="margin-bottom: 3rem; background: transparent; border: none; box-shadow: none; padding: 0;">
+      {% if section is defined and section.title is defined %}
+        <h1 style="font-size: 3rem; margin-bottom: 0.5rem;">{{ section.title | e }}</h1>
+      {% endif %}
+      {% if section is defined and section.description is defined %}
+        <p style="color: var(--text-muted); font-size: 1.2rem;">{{ section.description | e }}</p>
+      {% endif %}
+    </div>
+
+    <ul class="section-list">
+      {% if section is defined and section.pages is defined %}
+        {% for p in section.pages %}
+          <li class="glass-card" style="margin-bottom: 0;">
+            <a href="{{ p.url }}">{{ p.title | e }}</a>
+            {% if p.description is defined %}
+              <p>{{ p.description | e }}</p>
+            {% endif %}
+            {% if p.date is defined %}
+              <span class="meta" style="margin-top: 1rem; margin-bottom: 0;">{{ p.date | date(format="%b %d, %Y") }}</span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      {% endif %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-wave/templates/shortcodes/alert.html
+++ b/examples/prism-wave/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/prism-wave/templates/taxonomy.html
+++ b/examples/prism-wave/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-card">
+      <h1>All Tags</h1>
+      <p style="color: var(--text-muted);">Explore topics across the spectrum.</p>
+      <div style="display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 2rem;">
+        {% if terms is defined %}
+          {% for term in terms %}
+            <a href="{{ base_url }}/tags/{{ term.name | lower | replace(from=' ', to='-') }}/" style="padding: 0.5rem 1rem; background: rgba(255,255,255,0.05); border: 1px solid var(--glass-border); border-radius: 8px; font-size: 1rem; color: var(--accent2); transition: all 0.2s;">
+              {{ term.name }} <span style="opacity: 0.5; font-size: 0.8em; margin-left: 0.3rem;">{{ term.pages | length }}</span>
+            </a>
+          {% endfor %}
+        {% endif %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-wave/templates/taxonomy_term.html
+++ b/examples/prism-wave/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-card" style="margin-bottom: 3rem; background: transparent; border: none; box-shadow: none; padding: 0;">
+      <h1 style="font-size: 3rem; margin-bottom: 0.5rem;"><span style="color: var(--accent1);">#</span>{{ term.name | e }}</h1>
+      <p style="color: var(--text-muted); font-size: 1.2rem;">Articles tagged with {{ term.name | e }}</p>
+    </div>
+
+    <ul class="section-list">
+      {% if pages is defined %}
+        {% for p in pages %}
+          <li class="glass-card" style="margin-bottom: 0;">
+            <a href="{{ p.url }}">{{ p.title | e }}</a>
+            {% if p.description is defined %}
+              <p>{{ p.description | e }}</p>
+            {% endif %}
+          </li>
+        {% endfor %}
+      {% endif %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9098,5 +9098,12 @@
     "cyber",
     "fluid",
     "space-grotesk"
+  ],
+  "prism-wave": [
+    "design",
+    "glassmorphism",
+    "vibrant",
+    "prism",
+    "wave"
   ]
 }


### PR DESCRIPTION
Added the `prism-wave` template example as requested, focusing on an elegant design involving glassmorphism UI, gradient text, and clean geometric typography. Registered the new example in `tags.json` and conducted successful local Playwright-based visual verification to ensure proper styling and layout without errors.

---
*PR created automatically by Jules for task [13325482190572926735](https://jules.google.com/task/13325482190572926735) started by @chei-l*