### PR TITLE
feat: add astral-blueprint example project

### DIFF
--- a/examples/astral-blueprint/AGENTS.md
+++ b/examples/astral-blueprint/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/astral-blueprint/archetypes/default.md
+++ b/examples/astral-blueprint/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/astral-blueprint/config.toml
+++ b/examples/astral-blueprint/config.toml
@@ -1,0 +1,3 @@
+title = "Astral Blueprint"
+description = "A refined cosmic layout"
+base_url = "https://example.com"

--- a/examples/astral-blueprint/content/about.md
+++ b/examples/astral-blueprint/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About the Blueprint"
+description = "Information about the Astral Blueprint project."
++++
+The Astral Blueprint was forged in the void, combining dark matter aesthetics with luminous accents.
+It is a minimal, yet powerful, template designed for modern web exploration.

--- a/examples/astral-blueprint/content/index.md
+++ b/examples/astral-blueprint/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Stellar Schematics"
+description = "Welcome to the Astral Blueprint."
++++
+Welcome to the Astral Blueprint. Here, we chart the cosmos through elegant design and refined typography.
+This layout is engineered for both beauty and precision, acting as a canvas for your most ambitious projects.

--- a/examples/astral-blueprint/static/css/style.css
+++ b/examples/astral-blueprint/static/css/style.css
@@ -1,0 +1,99 @@
+:root {
+  --bg: #0a0e17;
+  --fg: #e2e8f0;
+  --accent: #38bdf8;
+  --accent-glow: rgba(56, 189, 248, 0.4);
+  --border: #1e293b;
+  --surface: #0f172a;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--fg);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.6;
+  background-image:
+    radial-gradient(circle at 50% 0%, var(--surface), transparent 50%),
+    linear-gradient(to right, rgba(255,255,255,0.02) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255,255,255,0.02) 1px, transparent 1px);
+  background-size: 100% 100%, 40px 40px, 40px 40px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--border);
+  background-color: rgba(10, 14, 23, 0.8);
+  backdrop-filter: blur(10px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.nav-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--fg);
+  text-decoration: none;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.nav-links a {
+  color: #94a3b8;
+  text-decoration: none;
+  margin-left: 1.5rem;
+  transition: color 0.2s ease;
+  font-size: 0.9rem;
+}
+
+.nav-links a:hover {
+  color: var(--accent);
+  text-shadow: 0 0 8px var(--accent-glow);
+}
+
+main {
+  max-width: 800px;
+  margin: 3rem auto;
+  padding: 0 2rem;
+  flex: 1;
+}
+
+h1 {
+  font-size: 2.5rem;
+  color: var(--fg);
+  margin-bottom: 1rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+h1::after {
+  content: '';
+  display: block;
+  width: 60px;
+  height: 4px;
+  background: var(--accent);
+  margin-top: 1rem;
+  box-shadow: 0 0 10px var(--accent-glow);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  border-top: 1px solid var(--border);
+  color: #64748b;
+  font-size: 0.875rem;
+  margin-top: auto;
+}

--- a/examples/astral-blueprint/templates/404.html
+++ b/examples/astral-blueprint/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+    <article>
+        <h1>404 - Not Found</h1>
+        <div class="content">
+            <p>The stellar coordinates you requested could not be found.</p>
+        </div>
+    </article>
+</main>
+{% include "footer.html" %}

--- a/examples/astral-blueprint/templates/footer.html
+++ b/examples/astral-blueprint/templates/footer.html
@@ -1,0 +1,5 @@
+    <footer class="site-footer">
+        <p>&copy; {{ site.title }}. Designed for the stars.</p>
+    </footer>
+</body>
+</html>

--- a/examples/astral-blueprint/templates/header.html
+++ b/examples/astral-blueprint/templates/header.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined and page.title is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    {% if page is defined and page.description is defined %}
+    <meta name="description" content="{{ page.description }}">
+    {% endif %}
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+    {{ highlight_tags | safe }}
+    {{ auto_includes | safe }}
+</head>
+<body>
+    <header class="site-header">
+        <nav class="nav-container">
+            <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+            <div class="nav-links">
+                <a href="{{ base_url }}/">Home</a>
+                <a href="{{ base_url }}/about.html">About</a>
+            </div>
+        </nav>
+    </header>

--- a/examples/astral-blueprint/templates/page.html
+++ b/examples/astral-blueprint/templates/page.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main>
+    <article>
+        {% if page is defined and page.title is defined %}
+        <h1>{{ page.title }}</h1>
+        {% endif %}
+        <div class="content">
+            {{ content | safe }}
+        </div>
+    </article>
+</main>
+{% include "footer.html" %}

--- a/examples/astral-blueprint/templates/section.html
+++ b/examples/astral-blueprint/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<main>
+    <article>
+        {% if section is defined and section.title is defined %}
+        <h1>{{ section.title }}</h1>
+        {% endif %}
+        <div class="content">
+            {{ content | safe }}
+        </div>
+
+        <ul class="post-list">
+        {% if section is defined and section.pages is defined %}
+            {% for p in section.pages %}
+            <li>
+                <a href="{{ p.url }}">{{ p.title }}</a>
+                {% if p.description is defined %}
+                <p>{{ p.description }}</p>
+                {% endif %}
+            </li>
+            {% endfor %}
+        {% endif %}
+        </ul>
+    </article>
+</main>
+{% include "footer.html" %}

--- a/examples/astral-blueprint/templates/shortcodes/alert.html
+++ b/examples/astral-blueprint/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/astral-blueprint/templates/taxonomy.html
+++ b/examples/astral-blueprint/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<main>
+    <article>
+        <h1>Taxonomy</h1>
+        <div class="content">
+            <ul>
+            {% if terms is defined %}
+                {% for t in terms %}
+                <li><a href="{{ t.url }}">{{ t.name }}</a> ({{ t.pages | length }})</li>
+                {% endfor %}
+            {% endif %}
+            </ul>
+        </div>
+    </article>
+</main>
+{% include "footer.html" %}

--- a/examples/astral-blueprint/templates/taxonomy_term.html
+++ b/examples/astral-blueprint/templates/taxonomy_term.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<main>
+    <article>
+        <h1>Pages for term</h1>
+        <div class="content">
+            <ul>
+            {% if pages is defined %}
+                {% for p in pages %}
+                <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+                {% endfor %}
+            {% endif %}
+            </ul>
+        </div>
+    </article>
+</main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -442,6 +442,12 @@
     "terminal",
     "ascii"
   ],
+  "astral-blueprint": [
+    "space",
+    "blueprint",
+    "elegant",
+    "dark-mode"
+  ],
   "astral-crystal-forge": [
     "dark",
     "glassmorphism",


### PR DESCRIPTION
Adds a new Hwaro example project named `astral-blueprint`. Features a custom elegant dark theme with glowing accents, responsive layouts, modular templates, and simple dummy content. Registered in `tags.json` and validated.

---
*PR created automatically by Jules for task [6708064888440201705](https://jules.google.com/task/6708064888440201705) started by @chei-l*