### PR TITLE
feat: add aurora-canvas example site

### DIFF
--- a/examples/aurora-canvas/AGENTS.md
+++ b/examples/aurora-canvas/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/aurora-canvas/archetypes/default.md
+++ b/examples/aurora-canvas/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/aurora-canvas/config.toml
+++ b/examples/aurora-canvas/config.toml
@@ -1,0 +1,3 @@
+title = "Aurora Canvas"
+description = "A creative and vibrant theme featuring animated aurora gradients and glassmorphism"
+base_url = "https://example.com"

--- a/examples/aurora-canvas/content/about.md
+++ b/examples/aurora-canvas/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
+description = "About Aurora Canvas"
++++
+
+Aurora Canvas is an example theme created to demonstrate creative web design capabilities within Hwaro. The theme utilizes pure CSS for the animated gradient background and backdrop filters for the frosted glass effect.

--- a/examples/aurora-canvas/content/index.md
+++ b/examples/aurora-canvas/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Welcome"
+description = "Welcome to Aurora Canvas"
++++
+
+This is a beautiful new theme featuring an animated gradient aurora effect in the background, complemented by sleek glassmorphism UI containers. It's designed to be visually striking while remaining highly legible.

--- a/examples/aurora-canvas/static/css/style.css
+++ b/examples/aurora-canvas/static/css/style.css
@@ -1,0 +1,53 @@
+:root {
+  --glass-bg: rgba(20, 20, 25, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.1);
+  --text-primary: #f8f8f8;
+  --text-secondary: #c0c0c0;
+}
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--text-primary);
+  background-color: #0b0b0f;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.aurora-bg {
+  position: fixed;
+  top: 0; left: 0; width: 100vw; height: 100vh;
+  z-index: -1;
+  background: linear-gradient(45deg, #ff007f, #7f00ff, #00d2ff, #ff007f);
+  background-size: 400% 400%;
+  animation: aurora 15s ease infinite;
+  opacity: 0.5;
+  filter: blur(80px);
+}
+@keyframes aurora {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+.glass-container {
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 24px;
+  padding: 2rem;
+  margin: 2rem auto;
+  max-width: 800px;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+}
+header {
+  padding: 2rem;
+  text-align: center;
+}
+header h1 a { color: var(--text-primary); text-decoration: none; font-size: 2.5rem; font-weight: 800; letter-spacing: -1px; }
+nav a { color: var(--text-secondary); text-decoration: none; margin: 0 1rem; font-weight: 500; transition: color 0.3s; }
+nav a:hover { color: var(--text-primary); }
+main { flex: 1; padding: 0 2rem; }
+h1, h2, h3 { margin-top: 0; }
+a { color: #00d2ff; text-decoration: none; }
+a:hover { text-decoration: underline; }
+footer { text-align: center; padding: 2rem; color: var(--text-secondary); font-size: 0.9rem; }

--- a/examples/aurora-canvas/templates/404.html
+++ b/examples/aurora-canvas/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+
+{% include "footer.html" %}

--- a/examples/aurora-canvas/templates/footer.html
+++ b/examples/aurora-canvas/templates/footer.html
@@ -1,0 +1,6 @@
+  </main>
+  <footer>
+    <p>&copy; {{ site.title }}</p>
+  </footer>
+</body>
+</html>

--- a/examples/aurora-canvas/templates/header.html
+++ b/examples/aurora-canvas/templates/header.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page is defined and page.title is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes | safe }}
+  {{ highlight_tags | safe }}
+</head>
+<body>
+  <div class="aurora-bg"></div>
+  <header>
+    <h1><a href="{{ base_url }}/">{{ site.title }}</a></h1>
+    <nav>
+      <a href="{{ base_url }}/">Home</a>
+      <a href="{{ base_url }}/about.html">About</a>
+    </nav>
+  </header>
+  <main class="glass-container">

--- a/examples/aurora-canvas/templates/page.html
+++ b/examples/aurora-canvas/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<article>
+  {% if page is defined and page.title is defined %}
+    <h1>{{ page.title }}</h1>
+  {% endif %}
+  <div class="content">
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/aurora-canvas/templates/section.html
+++ b/examples/aurora-canvas/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+
+{% include "footer.html" %}

--- a/examples/aurora-canvas/templates/shortcodes/alert.html
+++ b/examples/aurora-canvas/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/aurora-canvas/templates/taxonomy.html
+++ b/examples/aurora-canvas/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+
+{% include "footer.html" %}

--- a/examples/aurora-canvas/templates/taxonomy_term.html
+++ b/examples/aurora-canvas/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9105,5 +9105,12 @@
     "vibrant",
     "prism",
     "wave"
+  ],
+  "aurora-canvas": [
+    "dark",
+    "aurora",
+    "gradient",
+    "glassmorphism",
+    "creative"
   ]
 }


### PR DESCRIPTION
This PR adds a new example site named `aurora-canvas` to the repository. It has been built using a creative glassmorphism design approach with a pure CSS animated gradient aurora background. It also registers the example inside `tags.json` and ensures proper Hwaro validation.

---
*PR created automatically by Jules for task [15964265778949895661](https://jules.google.com/task/15964265778949895661) started by @chei-l*