### PR TITLE
feat: add z-mystic-nova example

### DIFF
--- a/examples/z-mystic-nova/AGENTS.md
+++ b/examples/z-mystic-nova/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/z-mystic-nova/archetypes/default.md
+++ b/examples/z-mystic-nova/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/z-mystic-nova/archetypes/posts.md
+++ b/examples/z-mystic-nova/archetypes/posts.md
@@ -1,0 +1,11 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+authors = []
+categories = []
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/z-mystic-nova/config.toml
+++ b/examples/z-mystic-nova/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "My Blog"
+description = "Welcome to my personal blog powered by Hwaro."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = ["posts"]   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/z-mystic-nova/content/about.md
+++ b/examples/z-mystic-nova/content/about.md
@@ -1,0 +1,12 @@
++++
+description = "A mystic nova page"
+title = "About"
+tags = ["about"]
+categories = ["pages"]
++++
+
+Welcome to my blog! I write about technology, programming, and other interesting topics.
+
+## Contact
+
+Feel free to reach out through social media or email.

--- a/examples/z-mystic-nova/content/archives.md
+++ b/examples/z-mystic-nova/content/archives.md
@@ -1,0 +1,6 @@
++++
+description = "A mystic nova archive"
+title = "Archives"
++++
+
+Browse all posts by date. Check the [Posts](/posts/) section for the complete list.

--- a/examples/z-mystic-nova/content/index.md
+++ b/examples/z-mystic-nova/content/index.md
@@ -1,0 +1,13 @@
++++
+description = "A mystic nova page"
+title = "Home"
+tags = ["home"]
++++
+
+This is a blog powered by [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator.
+
+Check out the latest posts in the [Posts](/posts/) section, or browse by:
+
+- [Tags](/tags/)
+- [Categories](/categories/)
+- [Authors](/authors/)

--- a/examples/z-mystic-nova/content/posts/_index.md
+++ b/examples/z-mystic-nova/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+description = "A mystic nova archive"
+title = "Posts"
++++
+
+Browse all blog posts below.

--- a/examples/z-mystic-nova/content/posts/getting-started-with-hwaro.md
+++ b/examples/z-mystic-nova/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,36 @@
++++
+title = "Getting Started with Hwaro"
+date = "2026-04-16"
+tags = ["tutorial", "getting-started", "hwaro"]
+categories = ["tutorials"]
+authors = ["admin"]
+description = "A beginner's guide to building websites with Hwaro."
++++
+
+In this post, I'll walk you through the basics of setting up and using Hwaro.
+
+## Installation
+
+First, make sure you have Crystal installed. Then:
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards build
+```
+
+## Creating Your First Site
+
+```bash
+hwaro init my-blog --scaffold blog
+cd my-blog
+hwaro serve
+```
+
+That's it! Your blog is now running at `http://localhost:3000`.
+
+## Next Steps
+
+- Customize your templates in the `templates/` directory
+- Add new posts in `content/posts/`
+- Configure your site in `config.toml`

--- a/examples/z-mystic-nova/content/posts/hello-world.md
+++ b/examples/z-mystic-nova/content/posts/hello-world.md
@@ -1,0 +1,20 @@
++++
+title = "Hello World"
+date = "2026-04-11"
+tags = ["introduction", "hello"]
+categories = ["general"]
+authors = ["admin"]
+description = "My first blog post using Hwaro static site generator."
++++
+
+Welcome to my first blog post! This blog is powered by Hwaro, a fast and lightweight static site generator written in Crystal.
+
+## Why Hwaro?
+
+Hwaro offers a simple yet powerful way to create static websites:
+
+- **Fast**: Built with Crystal for blazing fast build times
+- **Simple**: Easy to understand directory structure
+- **Flexible**: Supports custom templates and shortcodes
+
+Stay tuned for more posts!

--- a/examples/z-mystic-nova/content/posts/markdown-tips.md
+++ b/examples/z-mystic-nova/content/posts/markdown-tips.md
@@ -1,0 +1,48 @@
++++
+title = "Markdown Tips and Tricks"
+date = "2026-04-21"
+tags = ["markdown", "writing", "tips"]
+categories = ["tutorials"]
+authors = ["admin"]
+description = "Learn useful Markdown formatting techniques for your blog posts."
++++
+
+Hwaro uses Markdown for content. Here are some useful formatting tips.
+
+## Text Formatting
+
+- **Bold text** using `**bold**`
+- *Italic text* using `*italic*`
+- `Inline code` using backticks
+
+## Code Blocks
+
+Use triple backticks for code blocks:
+
+```crystal
+puts "Hello from Crystal!"
+```
+
+## Lists
+
+Ordered lists:
+1. First item
+2. Second item
+3. Third item
+
+Unordered lists:
+- Item one
+- Item two
+- Item three
+
+## Links and Images
+
+- [Link text](https://example.com) using `[text](url)`
+- Image syntax: `![Alt text](path/to/image.jpg)`
+
+## Blockquotes
+
+> This is a blockquote.
+> It can span multiple lines.
+
+Happy writing!

--- a/examples/z-mystic-nova/static/css/style.css
+++ b/examples/z-mystic-nova/static/css/style.css
@@ -1,0 +1,88 @@
+:root {
+  --bg: #0a0a0f;
+  --bg-secondary: #12121a;
+  --bg-code: #1c1c28;
+  --text: #e0e0e8;
+  --text-secondary: #a0a0b8;
+  --text-muted: #6b6b80;
+  --primary: #8a2be2;
+  --primary-hover: #b05bff;
+  --border: #2a2a3f;
+  --border-light: #1f1f33;
+  --content-max-w: 800px;
+  --header-h: 64px;
+  --radius: 12px;
+  --radius-sm: 8px;
+  --glow: 0 0 15px rgba(138, 43, 226, 0.4);
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.blog-header {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--header-h);
+  background: rgba(10, 10, 15, 0.85);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
+  border-bottom: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1.5rem;
+  z-index: 100;
+}
+.blog-header-inner { display: flex; align-items: center; width: 100%; max-width: var(--content-max-w); }
+.blog-header .logo { font-weight: 700; font-size: 1.2rem; color: var(--text); text-decoration: none; letter-spacing: 0.05em; margin-right: 2.5rem; text-shadow: var(--glow); transition: text-shadow 0.2s; }
+.blog-header .logo:hover { text-shadow: 0 0 25px rgba(138, 43, 226, 0.8); }
+.blog-header nav { display: flex; gap: 1.25rem; }
+.blog-header nav a { color: var(--text-secondary); text-decoration: none; font-size: 0.9rem; font-weight: 500; padding: 0.25rem 0; transition: color 0.2s; }
+.blog-header nav a:hover { color: var(--text); text-shadow: 0 0 8px rgba(224, 224, 232, 0.5); }
+.header-right { margin-left: auto; display: flex; align-items: center; gap: 1rem; padding-left: 1.25rem; }
+.blog-container { padding-top: var(--header-h); min-height: 100vh; }
+.blog-main { max-width: var(--content-max-w); margin: 0 auto; padding: 2.5rem 1.5rem; }
+.blog-main h1 { font-size: 2.5rem; font-weight: 800; margin: 0 0 1rem 0; letter-spacing: -0.02em; line-height: 1.2; background: linear-gradient(90deg, #b05bff, #e0e0e8); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+.blog-main h2 { font-size: 1.75rem; font-weight: 700; margin: 2.5rem 0 1rem 0; letter-spacing: -0.01em; color: var(--text); }
+.blog-main h3 { font-size: 1.3rem; font-weight: 600; margin: 2rem 0 0.75rem 0; color: var(--text); }
+.blog-main p { margin-bottom: 1.25rem; line-height: 1.8; color: var(--text-secondary); }
+.blog-main ul, .blog-main ol { margin-bottom: 1.25rem; padding-left: 1.5rem; color: var(--text-secondary); }
+.blog-main li { margin-bottom: 0.5rem; line-height: 1.7; }
+a { color: var(--primary); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--primary-hover); text-decoration: underline; }
+code { background: var(--bg-code); padding: 0.2rem 0.4rem; border-radius: 4px; font-size: 0.85em; font-family: "SF Mono", monospace; color: var(--primary-hover); border: 1px solid var(--border-light); }
+pre { padding: 1.25rem; border-radius: var(--radius); overflow-x: auto; background: var(--bg-secondary); border: 1px solid var(--border); margin: 1rem 0 1.5rem 0; line-height: 1.6; }
+pre code { background: none; padding: 0; font-size: 0.9rem; color: var(--text); border: none; }
+blockquote { border-left: 4px solid var(--primary); padding: 0.75rem 1.25rem; margin: 1.5rem 0; background: var(--bg-secondary); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; color: var(--text-secondary); font-style: italic; }
+img { max-width: 100%; height: auto; border-radius: var(--radius); border: 1px solid var(--border-light); }
+.post-item { padding: 1.5rem 0; border-bottom: 1px solid var(--border-light); transition: background 0.2s; }
+.post-title { margin: 0 0 0.5rem 0; font-size: 1.4rem; font-weight: 700; line-height: 1.3; }
+.post-title a { color: var(--text); text-decoration: none; transition: color 0.2s; }
+.post-title a:hover { color: var(--primary-hover); }
+.post-meta { color: var(--text-muted); font-size: 0.85rem; margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.75rem; }
+.post-header { margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border-light); }
+ul.section-list { list-style: none; padding: 0; }
+ul.section-list li { margin-bottom: 0.75rem; padding: 1rem; background: var(--bg-secondary); border-radius: var(--radius-sm); border: 1px solid var(--border-light); transition: border-color 0.2s, box-shadow 0.2s; }
+ul.section-list li:hover { border-color: var(--primary); box-shadow: var(--glow); }
+ul.section-list li a { font-weight: 600; color: var(--text); }
+ul.section-list li a:hover { text-decoration: none; color: var(--primary-hover); }
+.blog-footer { margin-top: 4rem; padding-top: 2rem; border-top: 1px solid var(--border-light); color: var(--text-muted); font-size: 0.85rem; text-align: center; }
+.search-trigger { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.8rem; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-secondary); color: var(--text-secondary); font-size: 0.85rem; cursor: pointer; transition: all 0.2s; }
+.search-trigger:hover { border-color: var(--primary); color: var(--text); box-shadow: 0 0 10px rgba(138, 43, 226, 0.2); }
+.search-trigger kbd { font-size: 0.7rem; padding: 0.1rem 0.4rem; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text-muted); }
+.search-overlay { display: none; position: fixed; inset: 0; background: rgba(0, 0, 0, 0.6); backdrop-filter: blur(8px); z-index: 200; justify-content: center; padding-top: 12vh; }
+.search-overlay.active { display: flex; }
+.search-modal { width: 600px; max-width: 90vw; max-height: 70vh; background: var(--bg-secondary); border-radius: var(--radius); box-shadow: 0 20px 80px rgba(0, 0, 0, 0.5); display: flex; flex-direction: column; overflow: hidden; align-self: flex-start; border: 1px solid var(--border-light); }
+.search-input-wrap { display: flex; align-items: center; gap: 0.8rem; padding: 1rem 1.25rem; border-bottom: 1px solid var(--border-light); background: var(--bg); }
+.search-input-wrap svg { color: var(--primary); }
+.search-input-wrap input { flex: 1; border: none; outline: none; font-size: 1.1rem; color: var(--text); background: transparent; }
+.search-results { overflow-y: auto; padding: 0.75rem; }
+.search-result-item { display: block; padding: 0.8rem 1rem; border-radius: var(--radius-sm); text-decoration: none; color: var(--text); cursor: pointer; transition: background 0.2s; }
+.search-result-item:hover { background: var(--bg); }
+@media (max-width: 640px) { .blog-header nav { display: none; } .blog-main { padding: 1.5rem 1rem; } .blog-main h1 { font-size: 1.8rem; } }

--- a/examples/z-mystic-nova/static/js/search.js
+++ b/examples/z-mystic-nova/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/examples/z-mystic-nova/templates/404.html
+++ b/examples/z-mystic-nova/templates/404.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="openSearch()" title="Search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span>Search</span>
+        <kbd>&#8984;K</kbd>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search posts..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+{% include "footer.html" %}

--- a/examples/z-mystic-nova/templates/footer.html
+++ b/examples/z-mystic-nova/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="blog-footer">
+      <p>Powered by Hwaro</p>
+    </footer>
+  </main>
+</div>
+<script src="{{ base_url }}/js/search.js"></script>
+</body>
+</html>

--- a/examples/z-mystic-nova/templates/header.html
+++ b/examples/z-mystic-nova/templates/header.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">

--- a/examples/z-mystic-nova/templates/page.html
+++ b/examples/z-mystic-nova/templates/page.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="openSearch()" title="Search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span>Search</span>
+        <kbd>&#8984;K</kbd>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search posts..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content | safe }}
+{% include "footer.html" %}

--- a/examples/z-mystic-nova/templates/post.html
+++ b/examples/z-mystic-nova/templates/post.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="openSearch()" title="Search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span>Search</span>
+        <kbd>&#8984;K</kbd>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search posts..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <article class="post">
+      <header class="post-header">
+        <h1>{{ page.title | e }}</h1>
+        <div class="post-meta">
+          <time>{{ page.date }}</time>
+        </div>
+      </header>
+      <div class="post-content">
+        {{ content | safe }}
+      </div>
+    </article>
+{% include "footer.html" %}

--- a/examples/z-mystic-nova/templates/section.html
+++ b/examples/z-mystic-nova/templates/section.html
@@ -1,0 +1,43 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="openSearch()" title="Search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span>Search</span>
+        <kbd>&#8984;K</kbd>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search posts..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content | safe }}
+
+    <ul class="section-list">
+      {% if section is defined and section.pages is defined %}
+      {% for p in section.pages %}
+      <li>
+        <a href="{{ p.url }}">{{ p.title }}</a>
+      </li>
+      {% endfor %}
+      {% endif %}
+    </ul>
+{% include "footer.html" %}

--- a/examples/z-mystic-nova/templates/shortcodes/alert.html
+++ b/examples/z-mystic-nova/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/z-mystic-nova/templates/taxonomy.html
+++ b/examples/z-mystic-nova/templates/taxonomy.html
@@ -1,0 +1,43 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="openSearch()" title="Search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span>Search</span>
+        <kbd>&#8984;K</kbd>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search posts..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content | safe }}
+    <ul class="section-list">
+      {% if terms is defined %}
+      {% for term in terms %}
+      <li>
+        <a href="{{ term.url }}">{{ term.name }}</a> ({{ term.pages | length }})
+      </li>
+      {% endfor %}
+      {% endif %}
+    </ul>
+{% include "footer.html" %}

--- a/examples/z-mystic-nova/templates/taxonomy_term.html
+++ b/examples/z-mystic-nova/templates/taxonomy_term.html
@@ -1,0 +1,43 @@
+{% include "header.html" %}
+<header class="blog-header">
+  <div class="blog-header-inner">
+    <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/posts/">Posts</a>
+      <a href="{{ base_url }}/archives/">Archives</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+    <div class="header-right">
+      <button class="search-trigger" onclick="openSearch()" title="Search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span>Search</span>
+        <kbd>&#8984;K</kbd>
+      </button>
+    </div>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search posts..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="blog-container">
+  <main class="blog-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content | safe }}
+    <ul class="section-list">
+      {% if pages is defined %}
+      {% for p in pages %}
+      <li>
+        <a href="{{ p.url }}">{{ p.title }}</a>
+      </li>
+      {% endfor %}
+      {% endif %}
+    </ul>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9112,5 +9112,10 @@
     "gradient",
     "glassmorphism",
     "creative"
+  ],
+  "z-mystic-nova": [
+    "mystic",
+    "nova",
+    "dark"
   ]
 }


### PR DESCRIPTION
Creates a new `z-mystic-nova` template example for Hwaro static sites featuring a "mystic nova" dark, glowing neon theme with custom templates, safe syntax, and updated registry config.

---
*PR created automatically by Jules for task [16847545648653963965](https://jules.google.com/task/16847545648653963965) started by @chei-l*