### PR TITLE
Fix 404 links in herald example theme

### DIFF
--- a/examples/herald/content/about.md
+++ b/examples/herald/content/about.md
@@ -1,0 +1,7 @@
++++
+title = "About Us"
+description = "Learn more about The Herald"
++++
+
+# About Us
+Welcome to The Herald.

--- a/examples/herald/content/contact.md
+++ b/examples/herald/content/contact.md
@@ -1,0 +1,7 @@
++++
+title = "Contact Us"
+description = "Get in touch with The Herald"
++++
+
+# Contact Us
+Reach out to us at contact@theherald.example.com.

--- a/examples/herald/content/terms.md
+++ b/examples/herald/content/terms.md
@@ -1,0 +1,7 @@
++++
+title = "Terms of Service"
+description = "Terms and conditions for using The Herald"
++++
+
+# Terms of Service
+Please read our terms of service carefully.


### PR DESCRIPTION
Fix 404 links in herald example theme

Created missing `about.md`, `contact.md`, and `terms.md` files in the `examples/herald/content/` directory to resolve 404 errors for links present in the theme's header and footer.

---
*PR created automatically by Jules for task [2165008813026974609](https://jules.google.com/task/2165008813026974609) started by @chei-l*