### PR TITLE
feat: add lumina-canvas hwaro example project

### DIFF
--- a/examples/lumina-canvas/AGENTS.md
+++ b/examples/lumina-canvas/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lumina-canvas/archetypes/default.md
+++ b/examples/lumina-canvas/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/lumina-canvas/config.toml
+++ b/examples/lumina-canvas/config.toml
@@ -1,0 +1,17 @@
+title = "Lumina Canvas"
+description = "A luminescent, modern gallery theme for Hwaro"
+base_url = "https://example.com"
+language_code = "en"
+
+[auto_includes]
+enabled = true
+dirs = ["css"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5

--- a/examples/lumina-canvas/content/about.md
+++ b/examples/lumina-canvas/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About Us"
+description = "Learn more about the creators"
++++
+
+# The Vision
+
+We believe in the power of contrast. By utilizing deep dark backgrounds and sharp neon highlights, your content takes center stage.

--- a/examples/lumina-canvas/content/gallery/_index.md
+++ b/examples/lumina-canvas/content/gallery/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Gallery"
+description = "A collection of beautiful works."
++++
+
+Browse our latest visual experiments.

--- a/examples/lumina-canvas/content/gallery/post-1.md
+++ b/examples/lumina-canvas/content/gallery/post-1.md
@@ -1,0 +1,7 @@
++++
+title = "Neon Nights"
+description = "An exploration of urban lights."
+date = "2024-04-20"
++++
+
+This piece reflects the vibrant energy of a city that never sleeps.

--- a/examples/lumina-canvas/content/index.md
+++ b/examples/lumina-canvas/content/index.md
@@ -1,0 +1,11 @@
++++
+title = "Welcome to Lumina Canvas"
+description = "Home page of the Lumina Canvas example"
+tags = ["home", "welcome"]
++++
+
+# Step into the Light
+
+Lumina Canvas is a sleek, dark-mode gallery theme focusing on neon accents and smooth interactions.
+
+It's designed to showcase visual works with an elegant and modern touch.

--- a/examples/lumina-canvas/static/css/01-style.css
+++ b/examples/lumina-canvas/static/css/01-style.css
@@ -1,0 +1,53 @@
+:root {
+  --bg-color: #0d0d0f;
+  --text-color: #e0e0e0;
+  --accent: #00f0ff;
+  --accent-glow: rgba(0, 240, 255, 0.3);
+  --border-color: rgba(255, 255, 255, 0.1);
+  --card-bg: #16161a;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-color); color: var(--text-color);
+  line-height: 1.6;
+}
+.site-wrapper {
+  max-width: 900px; margin: 0 auto; padding: 2rem;
+}
+.site-header {
+  display: flex; justify-content: space-between; align-items: center;
+  padding-bottom: 1.5rem; border-bottom: 1px solid var(--border-color);
+  margin-bottom: 3rem;
+}
+.site-logo {
+  font-size: 1.8rem; font-weight: 700; text-transform: uppercase;
+  color: var(--text-color); text-decoration: none; letter-spacing: 2px;
+  position: relative;
+}
+.site-logo::after {
+  content: ''; position: absolute; bottom: -5px; left: 0; width: 40%;
+  height: 2px; background: var(--accent); box-shadow: 0 0 10px var(--accent-glow);
+}
+nav a {
+  color: #aaa; text-decoration: none; margin-left: 1.5rem;
+  font-size: 0.9rem; letter-spacing: 1px; transition: color 0.3s;
+}
+nav a:hover { color: var(--accent); text-shadow: 0 0 8px var(--accent-glow); }
+h1, h2, h3 { color: #fff; font-weight: 600; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.card {
+  background: var(--card-bg); padding: 1.5rem; border-radius: 8px;
+  border: 1px solid var(--border-color); margin-bottom: 1.5rem;
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 20px rgba(0,0,0,0.5), 0 0 15px var(--accent-glow);
+  border-color: var(--accent);
+}
+.site-footer {
+  margin-top: 4rem; padding-top: 2rem; border-top: 1px solid var(--border-color);
+  text-align: center; color: #777; font-size: 0.8rem;
+}

--- a/examples/lumina-canvas/templates/404.html
+++ b/examples/lumina-canvas/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-canvas/templates/footer.html
+++ b/examples/lumina-canvas/templates/footer.html
@@ -1,0 +1,7 @@
+    </main>
+    <footer class="site-footer">
+      <p>&copy; 2024 {{ site.title }}. Designed with light.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/lumina-canvas/templates/header.html
+++ b/examples/lumina-canvas/templates/header.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page is defined and page.description is defined %}{{ page.description | e }}{% else %}A luminescent theme{% endif %}">
+  <title>{% if page is defined and page.title is defined %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  {{ highlight_tags | safe }}
+  {{ auto_includes | safe }}
+</head>
+<body {% if page is defined and page.section is defined %}data-section="{{ page.section }}"{% endif %}>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/gallery/">Gallery</a>
+      </nav>
+    </header>
+    <main class="site-main">

--- a/examples/lumina-canvas/templates/page.html
+++ b/examples/lumina-canvas/templates/page.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+<article class="card">
+  <header>
+    <h1>{{ page.title | e }}</h1>
+    {% if page.date is defined %}
+      <div style="color: #777; font-size: 0.85rem; margin-bottom: 1rem;">{{ page.date }}</div>
+    {% endif %}
+  </header>
+  <div class="content">
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/lumina-canvas/templates/section.html
+++ b/examples/lumina-canvas/templates/section.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<div class="section-container">
+  <h1>{{ section.title | e }}</h1>
+  {% if section.description is defined %}
+    <p>{{ section.description | e }}</p>
+  {% endif %}
+  <div class="section-content">
+    {{ content | safe }}
+  </div>
+  <div class="page-list">
+    {% if section.pages is defined %}
+      {% for p in section.pages %}
+        <div class="card">
+          <h2><a href="{{ p.url }}">{{ p.title | e }}</a></h2>
+          {% if p.description is defined %}
+            <p>{{ p.description | e }}</p>
+          {% endif %}
+        </div>
+      {% endfor %}
+    {% endif %}
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/lumina-canvas/templates/shortcodes/alert.html
+++ b/examples/lumina-canvas/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/lumina-canvas/templates/taxonomy.html
+++ b/examples/lumina-canvas/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-canvas/templates/taxonomy_term.html
+++ b/examples/lumina-canvas/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9142,5 +9142,10 @@
     "neon",
     "cyberpunk",
     "holographic"
+  ],
+  "lumina-canvas": [
+    "elegant",
+    "gallery",
+    "dark-mode"
   ]
 }


### PR DESCRIPTION
Adds a new example project named `lumina-canvas` not found in existing branches or PRs. This design fulfills the user's request for a unique, elegant layout using a dark mode aesthetic with luminescent neon accents. The template ensures proper variable checking, utilizes the `safe` filter correctly to avoid HTML escaping, and registers the example in `tags.json`.

---
*PR created automatically by Jules for task [3248781325077226064](https://jules.google.com/task/3248781325077226064) started by @chei-l*