### PR TITLE
fix: Resolve 404 for /categories/ in neon-gaze example

### DIFF
--- a/examples/neon-gaze/content/index.md
+++ b/examples/neon-gaze/content/index.md
@@ -2,6 +2,7 @@
 title = "Welcome to Neon Gaze"
 description = "Enter the cyber grid with the Neon Gaze theme."
 tags = ["welcome", "cyberpunk"]
+categories = ["system", "updates"]
 +++
 
 # Initiate System Sequence


### PR DESCRIPTION
Fixes a 404 dead link in the `neon-gaze` example by populating the `categories` taxonomy in its content.

---
*PR created automatically by Jules for task [12998394020987445613](https://jules.google.com/task/12998394020987445613) started by @chei-l*