### PR TITLE
feat: add ethereal-plasma-glass example

### DIFF
--- a/examples/ethereal-plasma-glass/AGENTS.md
+++ b/examples/ethereal-plasma-glass/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/ethereal-plasma-glass/archetypes/default.md
+++ b/examples/ethereal-plasma-glass/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/ethereal-plasma-glass/config.toml
+++ b/examples/ethereal-plasma-glass/config.toml
@@ -1,0 +1,51 @@
+base_url = "http://localhost:3000"
+title = "Ethereal Plasma Glass"
+description = "A dark glassmorphism plasma aesthetic"
+
+# =============================================================================
+# Custom Site Data (site.data.*)
+# =============================================================================
+[data]
+author = "Hwaro"
+
+# =============================================================================
+# Built-in Options
+# =============================================================================
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+
+[series]
+enabled = false
+
+[related]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = false
+sitemap = false
+
+[sitemap]
+enabled = false
+
+[robots]
+enabled = false
+
+[llms]
+enabled = false
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/examples/ethereal-plasma-glass/content/_index.md
+++ b/examples/ethereal-plasma-glass/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Ethereal Plasma Glass"
+template = "section"
++++
+
+Welcome to the **Ethereal Plasma Glass** aesthetic. Drift through a deep void illuminated by shifting fields of cyan, magenta, and purple plasma. Let the frosted glass interfaces anchor you as you explore this luminous nexus.
+
+This is a sanctuary of luminous motion.

--- a/examples/ethereal-plasma-glass/content/about.md
+++ b/examples/ethereal-plasma-glass/content/about.md
@@ -1,0 +1,14 @@
++++
+title = "About the Nexus"
+template = "page"
++++
+
+This project is a demonstration of pure **dark glassmorphism** combined with **ethereal plasma fields**.
+
+The design emphasizes:
+- A deep, abyssal background palette.
+- Animated, multi-layered glowing plasma orbs that blend using CSS techniques.
+- Translucent, frosted glass containers that catch the glow.
+- Sleek typography with **Space Grotesk** and **Inter**.
+
+Embrace the flow of light and shadow.

--- a/examples/ethereal-plasma-glass/static/css/style.css
+++ b/examples/ethereal-plasma-glass/static/css/style.css
@@ -1,0 +1,217 @@
+:root {
+    --void-bg: #03040a;
+    --plasma-cyan: #00f0ff;
+    --plasma-magenta: #ff0055;
+    --plasma-purple: #8a2be2;
+    --text-main: #f0f4f8;
+    --text-muted: #9ba1b0;
+    --glass-bg: rgba(10, 12, 22, 0.45);
+    --glass-border: rgba(255, 255, 255, 0.08);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Inter', sans-serif;
+    background-color: var(--void-bg);
+    color: var(--text-main);
+    line-height: 1.6;
+    overflow-x: hidden;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    margin-bottom: 1rem;
+    color: #fff;
+}
+
+a {
+    color: var(--plasma-cyan);
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+
+a:hover {
+    color: var(--plasma-magenta);
+    text-shadow: 0 0 8px rgba(255, 0, 85, 0.6);
+}
+
+/* Background Animation */
+.plasma-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -1;
+    overflow: hidden;
+    background: radial-gradient(circle at center, var(--void-bg) 0%, #010103 100%);
+}
+
+.orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.6;
+    animation: drift 20s infinite alternate ease-in-out;
+}
+
+.orb-1 {
+    width: 400px;
+    height: 400px;
+    background: var(--plasma-cyan);
+    top: -10%;
+    left: 10%;
+    animation-delay: 0s;
+    animation-duration: 25s;
+}
+
+.orb-2 {
+    width: 500px;
+    height: 500px;
+    background: var(--plasma-purple);
+    bottom: -20%;
+    right: -10%;
+    animation-delay: -5s;
+    animation-duration: 30s;
+}
+
+.orb-3 {
+    width: 300px;
+    height: 300px;
+    background: var(--plasma-magenta);
+    top: 40%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    animation-delay: -10s;
+    animation-duration: 22s;
+    opacity: 0.4;
+}
+
+@keyframes drift {
+    0% {
+        transform: translate(0, 0) scale(1);
+    }
+    33% {
+        transform: translate(15%, 10%) scale(1.1);
+    }
+    66% {
+        transform: translate(-10%, 20%) scale(0.9);
+    }
+    100% {
+        transform: translate(5%, -15%) scale(1.2);
+    }
+}
+
+/* Layout */
+.navbar {
+    padding: 2rem 5%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.navbar .logo {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.navbar .nav-links a {
+    margin-left: 2rem;
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    letter-spacing: 0.05em;
+}
+
+.navbar .nav-links a:hover {
+    color: #fff;
+}
+
+main.container {
+    flex: 1;
+    max-width: 900px;
+    margin: 4rem auto;
+    padding: 0 2rem;
+    position: relative;
+    z-index: 10;
+}
+
+/* Glass Panels */
+.glass-panel {
+    background: var(--glass-bg);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: 1px solid var(--glass-border);
+    border-radius: 24px;
+    padding: 3rem;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    margin-bottom: 2rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.glass-panel::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+}
+
+.glass-panel h1 {
+    font-size: 3rem;
+    background: linear-gradient(to right, #fff, var(--text-muted));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 1.5rem;
+}
+
+.glass-panel p {
+    font-size: 1.1rem;
+    color: var(--text-muted);
+    margin-bottom: 1.5rem;
+}
+
+.glass-panel ul {
+    margin-left: 1.5rem;
+    margin-bottom: 1.5rem;
+    color: var(--text-muted);
+}
+
+.glass-panel li {
+    margin-bottom: 0.5rem;
+}
+
+/* Footer */
+footer {
+    text-align: center;
+    padding: 3rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    border-top: 1px solid var(--glass-border);
+    margin-top: auto;
+    position: relative;
+    z-index: 10;
+    background: rgba(3, 4, 10, 0.8);
+    backdrop-filter: blur(10px);
+}

--- a/examples/ethereal-plasma-glass/templates/404.html
+++ b/examples/ethereal-plasma-glass/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main class="container">
+    <div class="glass-panel text-center">
+        <h1>404</h1>
+        <p>The luminous path you seek cannot be found in this nexus.</p>
+        <p><a href="{{ base_url }}/" class="btn">Return Home</a></p>
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/ethereal-plasma-glass/templates/footer.html
+++ b/examples/ethereal-plasma-glass/templates/footer.html
@@ -1,0 +1,5 @@
+    <footer>
+        <p>&copy; {{ current_year }} {{ site.title }}. Powered by Hwaro.</p>
+    </footer>
+</body>
+</html>

--- a/examples/ethereal-plasma-glass/templates/header.html
+++ b/examples/ethereal-plasma-glass/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site.title }}</title>
+    {% if page.description %}
+    <meta name="description" content="{{ page.description }}">
+    {% elif site.description %}
+    <meta name="description" content="{{ site.description }}">
+    {% endif %}
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+    <div class="plasma-background">
+        <div class="orb orb-1"></div>
+        <div class="orb orb-2"></div>
+        <div class="orb orb-3"></div>
+    </div>
+
+    <nav class="navbar">
+        <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+        <div class="nav-links">
+            <a href="{{ base_url }}/">Home</a>
+            <a href="{{ base_url }}/about">About</a>
+        </div>
+    </nav>

--- a/examples/ethereal-plasma-glass/templates/page.html
+++ b/examples/ethereal-plasma-glass/templates/page.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+
+<main class="container">
+    <article class="glass-panel">
+        <h1>{{ page.title }}</h1>
+        <div class="content">
+            {{ content | safe }}
+        </div>
+    </article>
+</main>
+
+{% include "footer.html" %}

--- a/examples/ethereal-plasma-glass/templates/section.html
+++ b/examples/ethereal-plasma-glass/templates/section.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+
+<main class="container">
+    <div class="glass-panel">
+        <h1>{{ section.title }}</h1>
+        <div class="content">
+            {{ content | safe }}
+        </div>
+    </div>
+
+    {% if section.pages %}
+    <div class="pages-list">
+        {% for page in section.pages %}
+        <article class="glass-panel">
+            <h2><a href="{{ page.url }}">{{ page.title }}</a></h2>
+            {% if page.date %}
+            <p class="date">{{ page.date | date("%B %d, %Y") }}</p>
+            {% endif %}
+            {% if page.summary %}
+            <p class="summary">{{ page.summary | strip_html | truncate_words(30) }}</p>
+            {% endif %}
+        </article>
+        {% endfor %}
+    </div>
+    {% endif %}
+</main>
+
+{% include "footer.html" %}

--- a/examples/ethereal-plasma-glass/templates/shortcodes/alert.html
+++ b/examples/ethereal-plasma-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/ethereal-plasma-glass/templates/taxonomy.html
+++ b/examples/ethereal-plasma-glass/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<main class="container">
+    <div class="glass-panel">
+        <h1>{{ page_title | default(taxonomy_name | capitalize) }}</h1>
+        <div class="content">
+            {{ content | safe }}
+        </div>
+        {% if terms is defined %}
+        <ul class="taxonomy-list">
+            {% for term in terms %}
+            <li><a href="{{ term.url }}">{{ term.name }}</a> ({{ term.pages_count }})</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/examples/ethereal-plasma-glass/templates/taxonomy_term.html
+++ b/examples/ethereal-plasma-glass/templates/taxonomy_term.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<main class="container">
+    <div class="glass-panel">
+        <h1>{{ page_title | default(taxonomy_term.name | capitalize) }}</h1>
+        <div class="content">
+            {{ content | safe }}
+        </div>
+        {% if taxonomy_pages %}
+        <ul class="taxonomy-list">
+            {% for page in taxonomy_pages %}
+            <li><a href="{{ page.url }}">{{ page.title }}</a></li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+</main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9227,6 +9227,13 @@
     "void",
     "elegant"
   ],
+  "ethereal-plasma-glass": [
+    "dark",
+    "glassmorphism",
+    "plasma",
+    "portfolio",
+    "elegant"
+  ],
   "z-mystic-nova-plus": [
     "mystic",
     "dark",


### PR DESCRIPTION
Adds a new Hwaro example site named `ethereal-plasma-glass`. It features a dark-themed glassmorphism UI with animated, multi-colored plasma orbs and frosted glass elements. The new example is self-contained under `examples/ethereal-plasma-glass` and registered in `tags.json`. All built-in templates have been correctly integrated with the new style.

---
*PR created automatically by Jules for task [15555032834778811370](https://jules.google.com/task/15555032834778811370) started by @hahwul*