### PR TITLE
feat(examples): add neon-synth-glass example site

### DIFF
--- a/examples/neon-synth-glass/AGENTS.md
+++ b/examples/neon-synth-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/neon-synth-glass/archetypes/default.md
+++ b/examples/neon-synth-glass/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/neon-synth-glass/config.toml
+++ b/examples/neon-synth-glass/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Neon Synth Glass"
+description = "A dark-themed Hwaro example site featuring a neon synth glassmorphism aesthetic."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/neon-synth-glass/content/about.md
+++ b/examples/neon-synth-glass/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Neon Synth Glass"
+date = "2025-04-23"
+tags = ["about", "cyberpunk", "design"]
++++
+
+The **Neon Synth Glass** theme is a demonstration of Hwaro's templating capabilities combined with modern CSS techniques.
+
+By defining CSS variables at the `:root` level and utilizing pseudo-elements (`::before`, `::after`) attached to the `body`, we can create dynamic, animated backgrounds that sit behind our content.
+
+The content itself is housed within `.glass-panel` components, which use `rgba(255, 255, 255, 0.03)` as a background color combined with a `backdrop-filter` to blur the glowing orbs behind them. This creates depth and a highly stylized, futuristic aesthetic suitable for portfolios, blogs, and landing pages.

--- a/examples/neon-synth-glass/content/index.md
+++ b/examples/neon-synth-glass/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Neon Synth Glass"
+date = "2025-04-23"
+description = "A dark-themed Hwaro example site featuring a neon synth glassmorphism aesthetic."
++++
+
+Welcome to the **Neon Synth Glass** aesthetic. This Hwaro example showcases a futuristic, cyberpunk-inspired dark theme characterized by:
+
+- **Deep Void Backgrounds**: A rich `#03010b` canvas.
+- **Glowing Plasma Orbs**: Animated radial gradients in neon cyan (`#00f0ff`) and magenta (`#ff0055`) that drift slowly across the viewport.
+- **Frosted Glass Panels**: Semi-transparent containers utilizing `backdrop-filter: blur(16px)` to create a layered, translucent effect.
+- **Typography**: Clean, modern fonts including *Space Grotesk* for headings and *Inter* for body text.
+
+This layout is fully responsive and demonstrates how to build custom Jinja2 templates (`Crinja`) in Hwaro without relying on external CSS frameworks.
+
+Explore the [Blog](/posts/) section to see how sections and taxonomies are rendered within the glassmorphism aesthetic.

--- a/examples/neon-synth-glass/content/posts/_index.md
+++ b/examples/neon-synth-glass/content/posts/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Neon Synth Transmissions"
+template = "section"
+sort_by = "date"
+reverse = true
+paginate = 10
++++
+
+Explore the latest logs and transmissions broadcasted across the digital void.

--- a/examples/neon-synth-glass/content/posts/hello.md
+++ b/examples/neon-synth-glass/content/posts/hello.md
@@ -1,0 +1,23 @@
++++
+title = "Initiating the Synth Sequence"
+date = "2025-04-23"
+description = "The first log entry in our new neon synth glass system."
+tags = ["log", "system", "initialization"]
+categories = ["logs"]
++++
+
+We are now online.
+
+The system has successfully initialized the `neon-synth-glass` protocols. All visual rendering engines are nominal, and the backdrop filters are functioning at 100% capacity.
+
+## System Diagnostics
+
+```bash
+[SYSTEM] Checking environmental parameters... OK
+[SYSTEM] Validating orb trajectory physics... OK
+[SYSTEM] Measuring blur radiuses... 16px (Optimal)
+```
+
+The neon cyan and magenta accents contrast perfectly against the dark void. We will continue monitoring the system's performance.
+
+Stay tuned for more updates.

--- a/examples/neon-synth-glass/static/css/style.css
+++ b/examples/neon-synth-glass/static/css/style.css
@@ -1,0 +1,261 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;700&display=swap');
+
+:root {
+  --bg-color: #03010b;
+  --text-color: #e0e0e0;
+  --text-muted: #9e9e9e;
+  --accent-cyan: #00f0ff;
+  --accent-magenta: #ff0055;
+  --accent-purple: #8a2be2;
+  --glass-bg: rgba(255, 255, 255, 0.03);
+  --glass-border: rgba(255, 255, 255, 0.1);
+  --glass-blur: blur(16px);
+  --font-sans: 'Inter', sans-serif;
+  --font-display: 'Space Grotesk', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Background Glowing Orbs */
+body::before,
+body::after {
+  content: '';
+  position: fixed;
+  border-radius: 50%;
+  filter: blur(100px);
+  z-index: -1;
+  opacity: 0.5;
+  animation: float 20s infinite ease-in-out alternate;
+}
+
+body::before {
+  top: 10%;
+  left: 20%;
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, var(--accent-cyan), transparent 60%);
+}
+
+body::after {
+  bottom: 10%;
+  right: 20%;
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(circle, var(--accent-magenta), transparent 60%);
+  animation-delay: -10s;
+}
+
+@keyframes float {
+  0% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(50px, 30px) scale(1.1); }
+  100% { transform: translate(-30px, -50px) scale(0.9); }
+}
+
+/* Container */
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  margin-bottom: 1rem;
+  letter-spacing: -0.02em;
+}
+
+h1 {
+  font-size: 3rem;
+  background: linear-gradient(135deg, var(--text-color), var(--text-muted));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+a {
+  color: var(--accent-cyan);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  color: var(--accent-magenta);
+  text-shadow: 0 0 10px rgba(255, 0, 85, 0.5);
+}
+
+/* Header/Nav */
+.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 0;
+  margin-bottom: 3rem;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.site-title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-color);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent-cyan), var(--accent-purple));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  display: inline-block;
+}
+
+.site-nav a {
+  color: var(--text-muted);
+  margin-left: 1.5rem;
+  font-weight: 500;
+}
+
+.site-nav a:hover {
+  color: var(--text-color);
+}
+
+/* Glass Panels */
+.glass-panel {
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-panel:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(0, 240, 255, 0.1);
+}
+
+/* Post/List Styles */
+.post-list {
+  list-style: none;
+}
+
+.post-item {
+  margin-bottom: 2rem;
+}
+
+.post-title {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.post-summary {
+  color: var(--text-muted);
+}
+
+.read-more {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1.2rem;
+  border: 1px solid var(--accent-cyan);
+  border-radius: 8px;
+  color: var(--accent-cyan);
+  font-size: 0.9rem;
+  background: transparent;
+}
+
+.read-more:hover {
+  background: rgba(0, 240, 255, 0.1);
+  color: var(--accent-cyan);
+  box-shadow: 0 0 15px rgba(0, 240, 255, 0.3);
+}
+
+/* Markdown Content Elements */
+.content {
+  font-size: 1.1rem;
+}
+
+.content p {
+  margin-bottom: 1.5rem;
+}
+
+.content code {
+  font-family: monospace;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid var(--glass-border);
+  color: var(--accent-cyan);
+}
+
+.content pre {
+  background: rgba(0, 0, 0, 0.5);
+  padding: 1.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--glass-border);
+  overflow-x: auto;
+  margin-bottom: 1.5rem;
+}
+
+.content blockquote {
+  border-left: 4px solid var(--accent-magenta);
+  padding-left: 1rem;
+  margin-left: 0;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Footer */
+.site-footer {
+  text-align: center;
+  padding: 3rem 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  border-top: 1px solid var(--glass-border);
+  margin-top: 4rem;
+}
+
+/* Tags/Taxonomy */
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 1rem 0;
+}
+
+.tag-item a {
+  display: inline-block;
+  padding: 0.3rem 0.8rem;
+  background: rgba(138, 43, 226, 0.1);
+  border: 1px solid rgba(138, 43, 226, 0.3);
+  border-radius: 20px;
+  font-size: 0.8rem;
+  color: var(--text-color);
+}
+
+.tag-item a:hover {
+  background: rgba(138, 43, 226, 0.3);
+  border-color: var(--accent-purple);
+  color: #fff;
+  box-shadow: 0 0 10px rgba(138, 43, 226, 0.4);
+}

--- a/examples/neon-synth-glass/templates/404.html
+++ b/examples/neon-synth-glass/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/neon-synth-glass/templates/footer.html
+++ b/examples/neon-synth-glass/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer">
+      <p>Powered by Hwaro</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/neon-synth-glass/templates/header.html
+++ b/examples/neon-synth-glass/templates/header.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="container">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/posts/">Blog</a>
+      </nav>
+    </header>

--- a/examples/neon-synth-glass/templates/page.html
+++ b/examples/neon-synth-glass/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="glass-panel">
+      <h1>{{ page.title | e }}</h1>
+      {% if page.date %}
+      <div class="post-meta">
+        <time datetime="{{ page.date | date("%Y-%m-%d") }}">{{ page.date | date("%B %d, %Y") }}</time>
+        {% if page.reading_time %} &middot; {{ page.reading_time }} min read{% endif %}
+      </div>
+      {% endif %}
+      <div class="content">
+        {{ content | safe }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/neon-synth-glass/templates/section.html
+++ b/examples/neon-synth-glass/templates/section.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel">
+      <h1>{{ page.title | e }}</h1>
+      {% if content %}
+      <div class="content">
+        {{ content | safe }}
+      </div>
+      {% endif %}
+
+      <ul class="post-list">
+        {% for post in section.pages %}
+        <li class="post-item glass-panel">
+          <h2 class="post-title"><a href="{{ post.url }}">{{ post.title | e }}</a></h2>
+          {% if post.date %}
+          <div class="post-meta">
+            <time datetime="{{ post.date | date("%Y-%m-%d") }}">{{ post.date | date("%B %d, %Y") }}</time>
+          </div>
+          {% endif %}
+          {% if post.summary %}
+          <p class="post-summary">{{ post.summary | safe }}</p>
+          {% endif %}
+          <a href="{{ post.url }}" class="read-more">Read More</a>
+        </li>
+        {% endfor %}
+      </ul>
+
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/neon-synth-glass/templates/shortcodes/alert.html
+++ b/examples/neon-synth-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/neon-synth-glass/templates/taxonomy.html
+++ b/examples/neon-synth-glass/templates/taxonomy.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel">
+      <h1>{{ page.title | default("Taxonomy") | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+
+      {% if terms is defined %}
+      <ul class="tag-list">
+        {% for term in terms %}
+        <li class="tag-item">
+          <a href="{{ term.url }}">{{ term.name | e }} <span class="count">({{ term.pages_count }})</span></a>
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+
+      <div class="content">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/neon-synth-glass/templates/taxonomy_term.html
+++ b/examples/neon-synth-glass/templates/taxonomy_term.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel">
+      <h1>{{ page.title | default("Term") | e }}</h1>
+      <p class="taxonomy-desc">Posts tagged with this term:</p>
+
+      <ul class="post-list">
+        {% if pages is defined %}
+        {% for post in pages %}
+        <li class="post-item glass-panel">
+          <h2 class="post-title"><a href="{{ post.url }}">{{ post.title | e }}</a></h2>
+          {% if post.date %}
+          <div class="post-meta">
+            <time datetime="{{ post.date | date("%Y-%m-%d") }}">{{ post.date | date("%B %d, %Y") }}</time>
+          </div>
+          {% endif %}
+          <a href="{{ post.url }}" class="read-more">Read More</a>
+        </li>
+        {% endfor %}
+        {% endif %}
+      </ul>
+
+      <div class="content">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9232,5 +9232,10 @@
     "dark",
     "neon",
     "elegant"
+  ],
+  "neon-synth-glass": [
+    "dark",
+    "portfolio",
+    "cyberpunk"
   ]
 }


### PR DESCRIPTION
This PR adds a new example site to the Hwaro examples collection, named `neon-synth-glass`. The site demonstrates a modern, dark-themed glassmorphism aesthetic with animated background orbs (cyan/magenta) and translucent panels. 

Key changes include:
- Initialized a new Hwaro project in `examples/neon-synth-glass`.
- Created custom CSS for the glassmorphism and animated orb effects.
- Updated Jinja2 (Crinja) templates (`header.html`, `page.html`, `section.html`, `taxonomy.html`, etc.) to apply the new aesthetic seamlessly.
- Configured the site frontmatter and `config.toml` structure.
- Appended the new example tags to `tags.json`.

---
*PR created automatically by Jules for task [4339257851603490523](https://jules.google.com/task/4339257851603490523) started by @hahwul*