### PR TITLE
Fix 404 error on VintageTV about page

### DIFF
--- a/examples/vintagetv/content/about.md
+++ b/examples/vintagetv/content/about.md
@@ -1,0 +1,13 @@
++++
+title = "SYSTEM INFO"
+description = "Broadcast system details and logs."
++++
+
+## SYSTEM DIAGNOSTICS
+
+VintageTV Broadcast System v2.0
+Operating normally.
+
+This channel transmits retro signals into the modern web. Expect scanlines, chromatic aberration, and occasional signal loss.
+
+> "We control the horizontal. We control the vertical."


### PR DESCRIPTION
Fix 404 error on VintageTV about page

Added the missing `about.md` file to the `vintagetv` example's content
directory. This resolves a 404 error caused by a dead link in the
site's header navigation. The new page includes frontmatter and
content matching the retro TV broadcast aesthetic.

---
*PR created automatically by Jules for task [14780146418197308242](https://jules.google.com/task/14780146418197308242) started by @hahwul*