### PR TITLE
feat: add Cyber Hanok Neon example site

### DIFF
--- a/examples/cyber-hanok-neon/AGENTS.md
+++ b/examples/cyber-hanok-neon/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/cyber-hanok-neon/archetypes/default.md
+++ b/examples/cyber-hanok-neon/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/cyber-hanok-neon/config.toml
+++ b/examples/cyber-hanok-neon/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Cyber Hanok Neon"
+description = "A fusion of traditional Korean architecture and cyberpunk aesthetics."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/cyber-hanok-neon/content/about.md
+++ b/examples/cyber-hanok-neon/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "About System"
+description = "Information about the Cyber Hanok Neon project."
+tags = ["system"]
+categories = ["info"]
++++
+
+# About the Construct
+
+This is a demonstration of Hwaro's capabilities, combining the aesthetic of a traditional Korean Hanok with Cyberpunk neon styling.

--- a/examples/cyber-hanok-neon/content/index.md
+++ b/examples/cyber-hanok-neon/content/index.md
@@ -1,0 +1,12 @@
++++
+title = "Neo-Seoul: Cyber Hanok"
+description = "Welcome to the neon-lit alleys of traditional Neo-Seoul."
+tags = ["neon", "seoul"]
+categories = ["exploration"]
++++
+
+# The Convergence
+
+Welcome to the digital frontier where ancient wooden beams meet pulsating neon lights. Explore the streets of Neo-Seoul below.
+
+[Enter the Grid](/posts/)

--- a/examples/cyber-hanok-neon/content/posts/_index.md
+++ b/examples/cyber-hanok-neon/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Data Logs"
+description = "Archived transmissions from the neon hanok sector."
++++

--- a/examples/cyber-hanok-neon/content/posts/cyber-giwa.md
+++ b/examples/cyber-hanok-neon/content/posts/cyber-giwa.md
@@ -1,0 +1,9 @@
++++
+title = "Cyber Giwa Roofs"
+description = "Solar-absorbent tiles powering the local grid."
+date = "2024-04-23"
+tags = ["power", "giwa"]
+categories = ["infrastructure"]
++++
+
+The traditional curved giwa tiles have been replaced by hyper-efficient solar collectors that emit a soft blue glow at night, illuminating the narrow alleyways.

--- a/examples/cyber-hanok-neon/content/posts/neon-dancheong.md
+++ b/examples/cyber-hanok-neon/content/posts/neon-dancheong.md
@@ -1,0 +1,9 @@
++++
+title = "Neon Dancheong"
+description = "Traditional painting replaced with holographic emitters."
+date = "2024-04-24"
+tags = ["hologram", "dancheong"]
+categories = ["architecture"]
++++
+
+The eaves of the grand hanok no longer use paint. Instead, micro-projectors paint the air with brilliant cyan and magenta fractals that shift with the wind.

--- a/examples/cyber-hanok-neon/templates/404.html
+++ b/examples/cyber-hanok-neon/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main class="site-main" style="text-align: center;">
+  <h1 style="font-size: 4rem; margin-bottom: 0;">404</h1>
+  <p>SYSTEM ERROR: Page Not Found.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 10px 20px; border: 1px solid var(--neon-cyan); text-transform: uppercase;">Return to Base</a>
+</main>
+{% include "footer.html" %}

--- a/examples/cyber-hanok-neon/templates/footer.html
+++ b/examples/cyber-hanok-neon/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer">
+      <p>&copy; 2024 {{ site.title | e }}. All systems online.</p>
+      <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank">Hwaro</a></p>
+    </footer>
+  </div>
+  <div class="roof-border" style="border-top: 2px solid var(--neon-cyan); border-bottom: none; transform: scaleY(-1);"></div>
+</body>
+</html>

--- a/examples/cyber-hanok-neon/templates/header.html
+++ b/examples/cyber-hanok-neon/templates/header.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page is defined and page.description is defined %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page is defined and page.title is defined %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Noto+Serif+KR:wght@400;700&display=swap');
+    :root {
+      --bg: #050505;
+      --text: #e0e0e0;
+      --neon-cyan: #0ff;
+      --neon-magenta: #f0f;
+      --hanok-wood: #4a2e15;
+      --hanok-wood-light: #6e4b2d;
+      --hanok-red: #8b0000;
+      --bg-subtle: #111;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: 'Noto Serif KR', serif; line-height: 1.6; margin: 0; color: var(--text); background: var(--bg); overflow-x: hidden; }
+
+    /* Hanok Roof Pattern */
+    .roof-border {
+      height: 15px;
+      background: linear-gradient(135deg, var(--hanok-red) 25%, transparent 25%) -25px 0,
+                  linear-gradient(225deg, var(--hanok-red) 25%, transparent 25%) -25px 0,
+                  linear-gradient(315deg, var(--hanok-red) 25%, transparent 25%),
+                  linear-gradient(45deg, var(--hanok-red) 25%, transparent 25%);
+      background-size: 50px 50px;
+      background-color: var(--hanok-wood);
+      box-shadow: 0 0 10px var(--neon-cyan), inset 0 0 10px var(--neon-magenta);
+      border-bottom: 2px solid var(--neon-cyan);
+    }
+
+    .site-wrapper { max-width: 900px; margin: 0 auto; padding: 0 1.5rem; }
+
+    /* Header */
+    .site-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 1.5rem 0; margin-bottom: 2rem;
+      border-bottom: 2px solid var(--neon-magenta);
+      box-shadow: 0 5px 15px rgba(255, 0, 255, 0.2);
+    }
+    .site-logo {
+      font-family: 'Orbitron', sans-serif; font-weight: 700; font-size: 1.8rem;
+      color: var(--neon-cyan); text-decoration: none; text-shadow: 0 0 8px var(--neon-cyan);
+    }
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a {
+      font-family: 'Orbitron', sans-serif; color: var(--text);
+      text-decoration: none; font-size: 1rem; text-transform: uppercase; letter-spacing: 2px;
+      transition: color 0.3s, text-shadow 0.3s;
+    }
+    .site-header nav a:hover { color: var(--neon-magenta); text-shadow: 0 0 8px var(--neon-magenta); }
+
+    /* Main layout */
+    .site-main { min-height: calc(100vh - 250px); padding: 2rem; background: rgba(17, 17, 17, 0.8); border: 1px solid var(--hanok-wood-light); border-radius: 8px; box-shadow: inset 0 0 20px rgba(0, 255, 255, 0.1); }
+
+    /* Footer */
+    .site-footer {
+      margin-top: 3rem; padding: 2rem 0; text-align: center;
+      border-top: 2px solid var(--neon-cyan); box-shadow: 0 -5px 15px rgba(0, 255, 255, 0.2);
+      font-family: 'Orbitron', sans-serif; font-size: 0.9rem; color: #888;
+    }
+
+    /* Typography */
+    h1, h2, h3 { font-family: 'Orbitron', sans-serif; font-weight: 700; color: var(--neon-magenta); text-shadow: 0 0 5px rgba(255, 0, 255, 0.5); }
+    a { color: var(--neon-cyan); text-decoration: none; }
+    a:hover { text-shadow: 0 0 5px var(--neon-cyan); }
+
+    /* Grids & Cards */
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1.5rem; margin-top: 2rem; }
+    .card { background: #1a1a1a; padding: 1.5rem; border: 1px solid var(--hanok-wood); border-left: 4px solid var(--neon-cyan); transition: transform 0.3s, box-shadow 0.3s; }
+    .card:hover { transform: translateY(-5px); box-shadow: 0 5px 15px rgba(0, 255, 255, 0.3); border-color: var(--neon-cyan); }
+    .card-title { margin-top: 0; font-size: 1.2rem; }
+    .card-meta { font-size: 0.8rem; color: #aaa; margin-bottom: 1rem; }
+
+    /* Lists */
+    ul.item-list { list-style: none; padding: 0; }
+    ul.item-list li { margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px dashed #333; }
+    ul.item-list li::before { content: '>'; color: var(--neon-magenta); margin-right: 10px; font-weight: bold; }
+  </style>
+  {{ highlight_tags | safe }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="roof-border"></div>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title | e }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/examples/cyber-hanok-neon/templates/page.html
+++ b/examples/cyber-hanok-neon/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main class="site-main">
+  {% if page is defined and page.title is defined %}
+    <h1>{{ page.title | e }}</h1>
+  {% endif %}
+  <div class="content-body">
+    {{ content | safe }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/cyber-hanok-neon/templates/section.html
+++ b/examples/cyber-hanok-neon/templates/section.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<main class="site-main">
+  {% if page is defined and page.title is defined %}
+    <h1>{{ page.title | e }}</h1>
+  {% endif %}
+  <div class="content-body">
+    {{ content | safe }}
+  </div>
+  {% if section.pages is defined %}
+    <div class="grid">
+      {% for p in section.pages %}
+        <div class="card">
+          <h3 class="card-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></h3>
+          {% if p.date is defined %}
+            <div class="card-meta">{{ p.date }}</div>
+          {% endif %}
+          <p>{% if p.description is defined %}{{ p.description | e }}{% endif %}</p>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+</main>
+{% include "footer.html" %}

--- a/examples/cyber-hanok-neon/templates/shortcodes/alert.html
+++ b/examples/cyber-hanok-neon/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/cyber-hanok-neon/templates/taxonomy.html
+++ b/examples/cyber-hanok-neon/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main class="site-main">
+  <h1>All {{ taxonomy | capitalize }}</h1>
+  <ul class="item-list">
+    {% for term in terms %}
+      <li><a href="{{ base_url }}/{{ taxonomy }}/{{ term | urlencode }}/">{{ term | e }}</a></li>
+    {% endfor %}
+  </ul>
+</main>
+{% include "footer.html" %}

--- a/examples/cyber-hanok-neon/templates/taxonomy_term.html
+++ b/examples/cyber-hanok-neon/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+<main class="site-main">
+  <h1>{{ term | e }}</h1>
+  <div class="grid">
+    {% for page in pages %}
+      <div class="card">
+        <h3 class="card-title"><a href="{{ base_url }}{{ page.url }}">{{ page.title | e }}</a></h3>
+        <p>{% if page.description is defined %}{{ page.description | e }}{% endif %}</p>
+      </div>
+    {% endfor %}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9316,5 +9316,11 @@
     "dark",
     "glow",
     "glassmorphism"
+  ],
+  "cyber-hanok-neon": [
+    "dark",
+    "cyberpunk",
+    "hanok",
+    "neon"
   ]
 }


### PR DESCRIPTION
Adds a new Hwaro example site named 'cyber-hanok-neon' featuring a unique design blending traditional Korean architecture aesthetics with cyberpunk neon styling. Configured with custom templates, sample thematic posts, and registered in tags.json.

---
*PR created automatically by Jules for task [5672537811069831507](https://jules.google.com/task/5672537811069831507) started by @chei-l*