### PR TITLE
Fix broken about link in glacial-ice example

### DIFF
--- a/examples/glacial-ice/content/about.md
+++ b/examples/glacial-ice/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
+description = "About Glacial Ice theme"
++++
+
+This is the about page for the Glacial Ice theme.


### PR DESCRIPTION
Found that the `glacial-ice` example theme had a broken link in the header pointing to `/about`. I created a simple `about.md` page in `examples/glacial-ice/content/about.md` to resolve the 404 error.

---
*PR created automatically by Jules for task [12776644179680822239](https://jules.google.com/task/12776644179680822239) started by @chei-l*