### PR TITLE
Fix missing 404 links in realty example

### DIFF
--- a/examples/realty/content/contact.md
+++ b/examples/realty/content/contact.md
@@ -1,0 +1,23 @@
++++
+title = "Contact Us"
+description = "Get in touch with Aura Real Estate."
+template = "page"
++++
+
+# Contact Aura Real Estate
+
+We are here to assist you with all your luxury real estate needs. Whether you are looking to buy, sell, or simply have a question about the market, our team of experts is ready to help.
+
+## Contact Information
+
+**Address:**
+123 Luxury Avenue
+Beverly Hills, CA 90210
+
+**Email:**
+[inquiries@aurarealty.com](mailto:inquiries@aurarealty.com)
+
+**Phone:**
++1 (555) 123-4567
+
+Please feel free to reach out to us at any time. We look forward to hearing from you.

--- a/examples/realty/content/journal/_index.md
+++ b/examples/realty/content/journal/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Journal"
+description = "Insights, news, and features from the world of luxury real estate."
+template = "section"
+paginate = 10
++++
+
+Welcome to the Aura Real Estate Journal. Here you will find our latest insights, news, and features from the world of luxury real estate.


### PR DESCRIPTION
Created `contact.md` and `journal/_index.md` in the `realty` example to fix 404 broken links pointing from `header.html` and `footer.html`.

---
*PR created automatically by Jules for task [10536278750910315895](https://jules.google.com/task/10536278750910315895) started by @hahwul*