### PR TITLE
Fix 404 links in prism-glass theme

### DIFF
--- a/examples/prism-glass/templates/header.html
+++ b/examples/prism-glass/templates/header.html
@@ -82,7 +82,7 @@
     <header>
         <div class="logo">prism.glass</div>
         <nav>
-            <a href="/">Angle</a>
-            <a href="/about">Light</a>
+            <a href="{{ base_url }}/">Angle</a>
+            <a href="{{ base_url }}/about">Light</a>
         </nav>
     </header>


### PR DESCRIPTION
Updated the hardcoded paths `/` and `/about` in `examples/prism-glass/templates/header.html` to use `{{ base_url }}` so that they resolve correctly when deployed to subdirectories, fixing the 404 errors.

---
*PR created automatically by Jules for task [10429010212417135289](https://jules.google.com/task/10429010212417135289) started by @hahwul*