### PR TITLE
Fix 404 links in kinetic-typography example

### DIFF
--- a/examples/kinetic-typography/content/_index.md
+++ b/examples/kinetic-typography/content/_index.md
@@ -1,5 +1,6 @@
 +++
 title = "Home"
+description = "Home page"
 sort_by = "date"
 template = "index.html"
 +++

--- a/examples/kinetic-typography/content/about.md
+++ b/examples/kinetic-typography/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
+description = "About us"
++++
+# About Us
+Welcome to the Kinetic Typography demo.

--- a/examples/kinetic-typography/content/contact.md
+++ b/examples/kinetic-typography/content/contact.md
@@ -1,0 +1,6 @@
++++
+title = "Contact"
+description = "Contact us"
++++
+# Contact Us
+Reach out for kinetic typography inquiries.

--- a/examples/kinetic-typography/content/work.md
+++ b/examples/kinetic-typography/content/work.md
@@ -1,0 +1,6 @@
++++
+title = "Work"
+description = "Our work"
++++
+# Our Work
+Check out our kinetic typography projects.


### PR DESCRIPTION
Fixes 404 broken links in the `kinetic-typography` example by providing the missing content files for `/about`, `/contact`, and `/work` which were linked in the template. Also added missing description to `_index.md`.

---
*PR created automatically by Jules for task [17745164020042800043](https://jules.google.com/task/17745164020042800043) started by @chei-l*