### PR TITLE
Add cosmic-velvet-glass example

### DIFF
--- a/examples/cosmic-velvet-glass/AGENTS.md
+++ b/examples/cosmic-velvet-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/cosmic-velvet-glass/archetypes/default.md
+++ b/examples/cosmic-velvet-glass/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/cosmic-velvet-glass/config.toml
+++ b/examples/cosmic-velvet-glass/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Cosmic Velvet Glass"
+description = "A beautiful cosmic glassmorphism theme"
+base_url = "https://cosmic-velvet-glass.examples.hwaro.hahwul.com"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/cosmic-velvet-glass/content/_index.md
+++ b/examples/cosmic-velvet-glass/content/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Cosmic Velvet Glass"
+tags = ["cosmic", "glassmorphism"]
+template = "index"
++++
+
+# Welcome to Cosmic Velvet Glass
+
+A stunning ethereal experience combining deep cosmic aesthetics with velvet glass panels.
+The theme highlights neon glows and floating elements with subtle backdrop filters.

--- a/examples/cosmic-velvet-glass/content/about.md
+++ b/examples/cosmic-velvet-glass/content/about.md
@@ -1,0 +1,13 @@
++++
+title = "About Cosmic Velvet Glass"
+tags = ["about"]
++++
+
+# The Void Awaits
+
+The **Cosmic Velvet Glass** theme is designed for those who appreciate deep space and smooth, elegant glass-like user interfaces. Floating orbs of velvet hues cast a soft neon glow over everything.
+
+## Features
+- Ethereal glass panels (`backdrop-filter`)
+- Space Grotesk & Inter typography
+- Cosmic floating orbs in magenta and cyan

--- a/examples/cosmic-velvet-glass/static/style.css
+++ b/examples/cosmic-velvet-glass/static/style.css
@@ -1,0 +1,291 @@
+:root {
+  --bg-color: #050110;
+  --text-color: #f0f0f0;
+  --glass-bg: rgba(20, 10, 40, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.5);
+
+  --primary-color: #e94560;
+  --secondary-color: #00f0ff;
+  --accent-color: #b026ff;
+
+  --font-heading: 'Space Grotesk', sans-serif;
+  --font-body: 'Inter', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Background Void & Orbs */
+.cosmic-void {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: radial-gradient(circle at center, #100520 0%, #050110 100%);
+  z-index: -2;
+}
+
+.orb {
+  position: fixed;
+  border-radius: 50%;
+  filter: blur(80px);
+  z-index: -1;
+  opacity: 0.6;
+  animation: float 20s infinite alternate ease-in-out;
+}
+
+.orb-magenta {
+  width: 400px;
+  height: 400px;
+  background: var(--primary-color);
+  top: 10%;
+  left: 15%;
+}
+
+.orb-cyan {
+  width: 500px;
+  height: 500px;
+  background: var(--secondary-color);
+  bottom: -10%;
+  right: 5%;
+  animation-delay: -5s;
+}
+
+.orb-purple {
+  width: 300px;
+  height: 300px;
+  background: var(--accent-color);
+  top: 40%;
+  left: 60%;
+  animation-delay: -10s;
+}
+
+@keyframes float {
+  0% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(50px, 30px) scale(1.1); }
+  100% { transform: translate(-30px, 80px) scale(0.9); }
+}
+
+/* Layout Container */
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  min-height: 100vh;
+}
+
+/* Glassmorphism Utilities */
+.glass-panel {
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 20px;
+  box-shadow: var(--glass-shadow);
+  padding: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-panel:hover {
+  box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.6);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #fff;
+  letter-spacing: -0.02em;
+}
+
+a {
+  color: var(--secondary-color);
+  text-decoration: none;
+  transition: color 0.3s, text-shadow 0.3s;
+}
+
+a:hover {
+  color: #fff;
+  text-shadow: 0 0 8px var(--secondary-color);
+}
+
+/* Header & Nav */
+.main-header {
+  padding: 1.5rem 2rem;
+}
+
+.main-header nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: linear-gradient(90deg, var(--primary-color), var(--secondary-color));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.logo:hover {
+  text-shadow: none;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  font-family: var(--font-heading);
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.8);
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+}
+
+.nav-links a:hover {
+  color: #fff;
+}
+
+/* Main Content Area */
+.site-main {
+  flex: 1;
+}
+
+.content-panel {
+  min-height: 60vh;
+}
+
+.page-title {
+  font-size: 3rem;
+  margin-bottom: 2rem;
+  background: linear-gradient(135deg, #fff, rgba(255, 255, 255, 0.6));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.page-content p {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-content ul, .page-content ol {
+  margin-bottom: 1.5rem;
+  padding-left: 2rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-content li {
+  margin-bottom: 0.5rem;
+}
+
+/* Lists and Lists Views */
+.section-list, .taxonomy-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 2rem;
+}
+
+.section-list li, .taxonomy-list li {
+  margin-bottom: 1rem;
+}
+
+.section-list a, .taxonomy-list a {
+  display: block;
+  padding: 1rem 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+  transition: all 0.3s ease;
+}
+
+.section-list a:hover, .taxonomy-list a:hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(10px);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Buttons */
+.btn {
+  display: inline-block;
+  padding: 0.8rem 1.5rem;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  font-family: var(--font-heading);
+  color: #fff;
+  transition: all 0.3s ease;
+  margin-top: 1rem;
+}
+
+.btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(0, 240, 255, 0.3);
+}
+
+/* Footer */
+.main-footer {
+  text-align: center;
+  padding: 1.5rem;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.text-center {
+  text-align: center;
+}
+
+.error-title {
+  font-size: 6rem;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .main-header nav {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .page-title {
+    font-size: 2rem;
+  }
+}

--- a/examples/cosmic-velvet-glass/templates/404.html
+++ b/examples/cosmic-velvet-glass/templates/404.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>404 Not Found - {{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ site.base_url }}/style.css">
+</head>
+<body>
+  <div class="cosmic-void"></div>
+  <div class="orb orb-magenta"></div>
+  <div class="orb orb-cyan"></div>
+  <div class="orb orb-purple"></div>
+
+  <div class="container">
+    <header class="glass-panel main-header">
+      <nav>
+        <a href="{{ site.base_url }}/" class="logo">Cosmic Velvet Glass</a>
+        <div class="nav-links">
+          <a href="{{ site.base_url }}/">Home</a>
+          <a href="{{ site.base_url }}/about/">About</a>
+          <a href="{{ site.base_url }}/tags/">Tags</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      <div class="glass-panel content-panel text-center">
+        <h1 class="page-title error-title">404</h1>
+        <p>Lost in the cosmic void. The page you're looking for does not exist.</p>
+        <a href="{{ site.base_url }}/" class="btn">Return to Safety</a>
+      </div>
+    </main>
+
+    <footer class="glass-panel main-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} Cosmic Velvet Glass.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/cosmic-velvet-glass/templates/index.html
+++ b/examples/cosmic-velvet-glass/templates/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page is defined %}{{ page.title | e }}{% else %}{{ site.title | e }}{% endif %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ site.base_url }}/style.css">
+</head>
+<body>
+  <div class="cosmic-void"></div>
+  <div class="orb orb-magenta"></div>
+  <div class="orb orb-cyan"></div>
+  <div class="orb orb-purple"></div>
+
+  <div class="container">
+    <header class="glass-panel main-header">
+      <nav>
+        <a href="{{ site.base_url }}/" class="logo">Cosmic Velvet Glass</a>
+        <div class="nav-links">
+          <a href="{{ site.base_url }}/">Home</a>
+          <a href="{{ site.base_url }}/about/">About</a>
+          <a href="{{ site.base_url }}/tags/">Tags</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      <div class="glass-panel content-panel">
+        {% if content is defined %}
+          {{ content | safe }}
+        {% endif %}
+      </div>
+    </main>
+
+    <footer class="glass-panel main-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} Cosmic Velvet Glass.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/cosmic-velvet-glass/templates/page.html
+++ b/examples/cosmic-velvet-glass/templates/page.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page is defined %}{{ page.title | e }}{% else %}{{ site.title | e }}{% endif %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ site.base_url }}/style.css">
+</head>
+<body>
+  <div class="cosmic-void"></div>
+  <div class="orb orb-magenta"></div>
+  <div class="orb orb-cyan"></div>
+  <div class="orb orb-purple"></div>
+
+  <div class="container">
+    <header class="glass-panel main-header">
+      <nav>
+        <a href="{{ site.base_url }}/" class="logo">Cosmic Velvet Glass</a>
+        <div class="nav-links">
+          <a href="{{ site.base_url }}/">Home</a>
+          <a href="{{ site.base_url }}/about/">About</a>
+          <a href="{{ site.base_url }}/tags/">Tags</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      <div class="glass-panel content-panel">
+        <article>
+          {% if page.title %}
+            <h1 class="page-title">{{ page.title | e }}</h1>
+          {% endif %}
+          <div class="page-content">
+            {% if content is defined %}
+              {{ content | safe }}
+            {% endif %}
+          </div>
+        </article>
+      </div>
+    </main>
+
+    <footer class="glass-panel main-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} Cosmic Velvet Glass.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/cosmic-velvet-glass/templates/section.html
+++ b/examples/cosmic-velvet-glass/templates/section.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page is defined %}{{ page.title | e }}{% else %}{{ site.title | e }}{% endif %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ site.base_url }}/style.css">
+</head>
+<body>
+  <div class="cosmic-void"></div>
+  <div class="orb orb-magenta"></div>
+  <div class="orb orb-cyan"></div>
+  <div class="orb orb-purple"></div>
+
+  <div class="container">
+    <header class="glass-panel main-header">
+      <nav>
+        <a href="{{ site.base_url }}/" class="logo">Cosmic Velvet Glass</a>
+        <div class="nav-links">
+          <a href="{{ site.base_url }}/">Home</a>
+          <a href="{{ site.base_url }}/about/">About</a>
+          <a href="{{ site.base_url }}/tags/">Tags</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      <div class="glass-panel content-panel">
+        <h1 class="page-title">{% if page is defined %}{{ page.title | e }}{% else %}Section{% endif %}</h1>
+        {% if content is defined %}
+          <div class="page-content">
+            {{ content | safe }}
+          </div>
+        {% endif %}
+        <ul class="section-list">
+          {% if section is defined and section.list is defined %}
+            {% for item in section.list %}
+              <li><a href="{{ site.base_url }}{{ item.path }}">{{ item.title | e }}</a></li>
+            {% endfor %}
+          {% endif %}
+        </ul>
+        {% if pagination is defined %}
+          {{ pagination | safe }}
+        {% endif %}
+      </div>
+    </main>
+
+    <footer class="glass-panel main-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} Cosmic Velvet Glass.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/cosmic-velvet-glass/templates/shortcodes/alert.html
+++ b/examples/cosmic-velvet-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/cosmic-velvet-glass/templates/taxonomy.html
+++ b/examples/cosmic-velvet-glass/templates/taxonomy.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Taxonomies - {{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ site.base_url }}/style.css">
+</head>
+<body>
+  <div class="cosmic-void"></div>
+  <div class="orb orb-magenta"></div>
+  <div class="orb orb-cyan"></div>
+  <div class="orb orb-purple"></div>
+
+  <div class="container">
+    <header class="glass-panel main-header">
+      <nav>
+        <a href="{{ site.base_url }}/" class="logo">Cosmic Velvet Glass</a>
+        <div class="nav-links">
+          <a href="{{ site.base_url }}/">Home</a>
+          <a href="{{ site.base_url }}/about/">About</a>
+          <a href="{{ site.base_url }}/tags/">Tags</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      <div class="glass-panel content-panel">
+        <h1 class="page-title">{% if taxonomy is defined %}{{ taxonomy.name | capitalize }}{% else %}Taxonomies{% endif %}</h1>
+        <ul class="taxonomy-list">
+          {% if terms is defined %}
+            {% for term in terms %}
+              <li><a href="{{ site.base_url }}{{ term.path }}">{{ term.name }} ({{ term.count }})</a></li>
+            {% endfor %}
+          {% endif %}
+        </ul>
+      </div>
+    </main>
+
+    <footer class="glass-panel main-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} Cosmic Velvet Glass.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/cosmic-velvet-glass/templates/taxonomy_term.html
+++ b/examples/cosmic-velvet-glass/templates/taxonomy_term.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if term is defined %}{{ term.name }}{% endif %} - {{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ site.base_url }}/style.css">
+</head>
+<body>
+  <div class="cosmic-void"></div>
+  <div class="orb orb-magenta"></div>
+  <div class="orb orb-cyan"></div>
+  <div class="orb orb-purple"></div>
+
+  <div class="container">
+    <header class="glass-panel main-header">
+      <nav>
+        <a href="{{ site.base_url }}/" class="logo">Cosmic Velvet Glass</a>
+        <div class="nav-links">
+          <a href="{{ site.base_url }}/">Home</a>
+          <a href="{{ site.base_url }}/about/">About</a>
+          <a href="{{ site.base_url }}/tags/">Tags</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      <div class="glass-panel content-panel">
+        <h1 class="page-title">Pages tagged with "{% if term is defined %}{{ term.name }}{% endif %}"</h1>
+        <ul class="section-list">
+          {% if term is defined and term.pages is defined %}
+            {% for page in term.pages %}
+              <li><a href="{{ site.base_url }}{{ page.path }}">{{ page.title | e }}</a></li>
+            {% endfor %}
+          {% endif %}
+        </ul>
+        {% if pagination is defined %}
+          {{ pagination | safe }}
+        {% endif %}
+      </div>
+    </main>
+
+    <footer class="glass-panel main-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} Cosmic Velvet Glass.</p>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a new, uniquely designed example project for Hwaro to demonstrate a modern, dark-themed "cosmic velvet glass" aesthetic.

Changes:
- Initialized a new Hwaro project in `examples/cosmic-velvet-glass`.
- Configured `config.toml` with appropriate metadata.
- Implemented a custom CSS design in `static/style.css` featuring animated glowing neon orbs (`#e94560`, `#00f0ff`, `#b026ff`), translucent glass panels (`backdrop-filter`), and typography using `Space Grotesk` and `Inter`.
- Added custom HTML layouts to `templates/` to support the glassmorphism aesthetic across the index, page, section, taxonomy, and 404 pages.
- Removed unused scaffold templates (`header.html`, `footer.html`).
- Added sample content (`_index.md`, `about.md`) demonstrating the styling.

---
*PR created automatically by Jules for task [1351699175798822541](https://jules.google.com/task/1351699175798822541) started by @hahwul*