### PR TITLE
Fix 404 link in liquid example by creating missing about.md

### DIFF
--- a/examples/liquid/content/about.md
+++ b/examples/liquid/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
+description = "About this liquid template"
++++
+
+This is a fluid template using SVG filters for gooey effects.


### PR DESCRIPTION
This PR fixes a 404 link found in the `liquid` example theme. Specifically, `templates/base.html` linked to `/about`, but the corresponding `about.md` content file was missing, causing a 404 error when navigating to the About page.

Fixes included:
- Created `examples/liquid/content/about.md` with appropriate frontmatter and basic content.
- Verified build succeeds using `hwaro build` inside `examples/liquid`.

---
*PR created automatically by Jules for task [11010962976505305903](https://jules.google.com/task/11010962976505305903) started by @chei-l*