### PR TITLE
fix(aurora-drift-glass): resolve 404 error by adding missing about page

### DIFF
--- a/examples/aurora-drift-glass/content/about.md
+++ b/examples/aurora-drift-glass/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About"
+description = "About Aurora Drift Glass"
++++
+
+This is the about page for the **Aurora Drift Glass** theme.
+
+The Aurora Drift Glass theme features an elegant glassmorphism and aurora gradient aesthetic, utilizing a deep void background with animated glowing aurora orbs, translucent frosted glass elements, and modern typography.


### PR DESCRIPTION
This commit adds a missing `about.md` page to the `aurora-drift-glass` example site. The header template contains a link to `/about` but the content file was missing, resulting in a 404 error. The new markdown file provides basic information about the theme and uses appropriate frontmatter.

---
*PR created automatically by Jules for task [3705578199267315594](https://jules.google.com/task/3705578199267315594) started by @hahwul*