### PR TITLE
Add ethereal-neo-glass example site

### DIFF
--- a/examples/ethereal-neo-glass/AGENTS.md
+++ b/examples/ethereal-neo-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/ethereal-neo-glass/archetypes/default.md
+++ b/examples/ethereal-neo-glass/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/ethereal-neo-glass/config.toml
+++ b/examples/ethereal-neo-glass/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Ethereal Neo Glass"
+description = "A neo-glassmorphism aesthetic example for Hwaro."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/ethereal-neo-glass/content/about.md
+++ b/examples/ethereal-neo-glass/content/about.md
@@ -1,0 +1,18 @@
++++
+title = "About the Void"
+description = "Discover the origins of the Ethereal Neo Glass aesthetic."
+tags = ["design", "glassmorphism"]
+categories = ["aesthetics"]
++++
+
+## The Philosophy of Neo-Glass
+
+The Ethereal Neo Glass aesthetic is built on the interplay between light and darkness. Instead of bright, flat backgrounds, it embraces the void (`#030014`) as its primary canvas.
+
+### Core Elements
+
+1.  **Ambient Glow**: Moving, oversized orbs provide a dynamic, shifting light source that interacts with the glass elements.
+2.  **Frosted Glass**: Heavy use of `backdrop-filter: blur(16px)` combined with semi-transparent backgrounds and delicate borders creates depth.
+3.  **Typography**: *Space Grotesk* offers a geometric, futuristic feel, while *Inter* ensures maximum legibility.
+
+This design is perfect for portfolios, landing pages, or any project that demands a modern, sophisticated atmosphere.

--- a/examples/ethereal-neo-glass/content/index.md
+++ b/examples/ethereal-neo-glass/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Ethereal Neo Glass"
+description = "A deep void glassmorphism aesthetic template for Hwaro."
++++
+
+Welcome to a realm where deep voids meet glowing frosted glass. This Hwaro theme blends neo-glassmorphism with ambient, shifting light orbs to create an immersive, futuristic canvas.
+
+The aesthetic uses *Space Grotesk* for striking headlines and *Inter* for crisp, readable body text. Translucent panels float elegantly over a canvas of absolute darkness, offering a refined, atmospheric reading experience.

--- a/examples/ethereal-neo-glass/content/posts/_index.md
+++ b/examples/ethereal-neo-glass/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+description = "A collection of transmissions."
+paginate_by = 10
++++

--- a/examples/ethereal-neo-glass/content/posts/first-transmission.md
+++ b/examples/ethereal-neo-glass/content/posts/first-transmission.md
@@ -1,0 +1,7 @@
++++
+title = "First Transmission"
+description = "A signal from the void."
+date = 2024-04-27
++++
+
+We are broadcasting on all frequencies. The neo-glass aesthetics have stabilized.

--- a/examples/ethereal-neo-glass/static/style.css
+++ b/examples/ethereal-neo-glass/static/style.css
@@ -1,0 +1,427 @@
+:root {
+  --bg: #030014;
+  --bg-subtle: #080424;
+  --text: #f8fafc;
+  --text-muted: #94a3b8;
+  --accent-cyan: #00f2fe;
+  --accent-purple: #4facfe;
+  --accent-pink: #ff0844;
+  --glass-bg: rgba(15, 10, 40, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-highlight: rgba(255, 255, 255, 0.15);
+  --glow-cyan: 0 0 20px rgba(0, 242, 254, 0.5);
+  --glow-purple: 0 0 30px rgba(79, 172, 254, 0.4);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Space Grotesk', sans-serif;
+  margin-top: 0;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+a {
+  color: var(--accent-cyan);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  color: var(--accent-purple);
+  text-shadow: var(--glow-cyan);
+}
+
+/* Background Animation */
+.ambient-orbs {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.5;
+  animation: float 20s infinite alternate ease-in-out;
+}
+
+.orb-1 {
+  top: -10%;
+  left: -10%;
+  width: 50vw;
+  height: 50vw;
+  background: radial-gradient(circle, var(--accent-purple), transparent 70%);
+  animation-duration: 25s;
+}
+
+.orb-2 {
+  bottom: -20%;
+  right: -10%;
+  width: 60vw;
+  height: 60vw;
+  background: radial-gradient(circle, var(--accent-cyan), transparent 70%);
+  animation-duration: 30s;
+  animation-delay: -5s;
+}
+
+.orb-3 {
+  top: 40%;
+  left: 60%;
+  width: 40vw;
+  height: 40vw;
+  background: radial-gradient(circle, var(--accent-pink), transparent 70%);
+  animation-duration: 22s;
+  animation-delay: -10s;
+  opacity: 0.3;
+}
+
+@keyframes float {
+  0% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(5%, 5%) scale(1.1); }
+  66% { transform: translate(-5%, 10%) scale(0.9); }
+  100% { transform: translate(0, 0) scale(1); }
+}
+
+/* Layout */
+.site-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* Glassmorphism Classes */
+.glass-panel, .glass-header, .glass-footer {
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+}
+
+/* Header */
+.glass-header {
+  margin-top: 2rem;
+  padding: 1.25rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 100px; /* Pill shape */
+}
+
+.site-logo {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.site-logo:hover {
+  color: var(--accent-cyan);
+}
+
+.main-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.main-nav a {
+  color: var(--text);
+  font-weight: 500;
+  font-size: 0.95rem;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  border: 1px solid transparent;
+}
+
+.main-nav a:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--glass-highlight);
+  color: var(--accent-cyan);
+}
+
+/* Main Content */
+.site-main {
+  flex-grow: 1;
+  padding: 3rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.page-content {
+  padding: 3rem;
+}
+
+.page-title {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #fff, var(--accent-cyan));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.page-desc, .taxonomy-desc {
+  font-size: 1.25rem;
+  color: var(--text-muted);
+  margin-bottom: 2rem;
+}
+
+.content-body p {
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Hero Section */
+.hero-glass {
+  padding: 5rem 3rem;
+  border-radius: 24px;
+}
+
+.hero-title {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  line-height: 1.1;
+  background: linear-gradient(to right, var(--accent-cyan), var(--accent-purple));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 10px rgba(0, 242, 254, 0.3));
+}
+
+.hero-desc {
+  font-size: 1.5rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto 2rem auto;
+}
+
+.hero-content {
+  font-size: 1.1rem;
+  margin-bottom: 2.5rem;
+}
+
+/* Buttons */
+.btn {
+  display: inline-block;
+  padding: 0.8rem 2rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  border-radius: 30px;
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.btn-glass {
+  background: rgba(0, 242, 254, 0.1);
+  border: 1px solid var(--accent-cyan);
+  color: var(--accent-cyan);
+  box-shadow: 0 0 15px rgba(0, 242, 254, 0.2);
+}
+
+.btn-glass:hover {
+  background: var(--accent-cyan);
+  color: #000;
+  box-shadow: 0 0 25px rgba(0, 242, 254, 0.6);
+  transform: translateY(-2px);
+  text-shadow: none;
+}
+
+/* Lists and Sections */
+.section-title {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.section-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.section-header {
+  padding: 2rem 3rem;
+}
+
+.latest-posts {
+  padding: 2.5rem;
+}
+
+ul.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+ul.section-list li {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  transition: all 0.3s ease;
+}
+
+ul.section-list li:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--accent-cyan);
+  transform: translateX(5px);
+  box-shadow: -5px 0 15px rgba(0, 242, 254, 0.1);
+}
+
+ul.section-list li a {
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: var(--text);
+  font-family: 'Space Grotesk', sans-serif;
+}
+
+ul.section-list li:hover a {
+  color: var(--accent-cyan);
+}
+
+ul.section-list time {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  margin-top: 0.3rem;
+}
+
+/* Code Blocks */
+pre {
+  background: rgba(0, 0, 0, 0.4) !important;
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  overflow-x: auto;
+}
+
+code {
+  font-family: 'ui-monospace', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.9em;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+/* Pagination */
+nav.pagination-wrapper {
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: center;
+}
+
+.pagination-list {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.pagination-list a, .pagination-list span {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-weight: 500;
+}
+
+.pagination-list a {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--glass-border);
+  color: var(--text);
+}
+
+.pagination-list a:hover {
+  background: rgba(0, 242, 254, 0.1);
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+
+.pagination-current span {
+  background: var(--accent-cyan);
+  color: #000;
+  border: 1px solid var(--accent-cyan);
+  box-shadow: 0 0 10px rgba(0, 242, 254, 0.4);
+}
+
+.pagination-disabled span {
+  opacity: 0.3;
+  background: transparent;
+  border: 1px solid var(--glass-border);
+}
+
+/* Footer */
+.glass-footer {
+  padding: 2rem;
+  text-align: center;
+  margin-bottom: 2rem;
+  border-radius: 100px;
+}
+
+.glass-footer p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* Utils */
+.text-center {
+  text-align: center;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero-title {
+    font-size: 2.5rem;
+  }
+  .page-title {
+    font-size: 2.2rem;
+  }
+  .glass-header {
+    flex-direction: column;
+    border-radius: 20px;
+    padding: 1.5rem;
+    gap: 1rem;
+  }
+  .page-content, .hero-glass, .latest-posts {
+    padding: 2rem 1.5rem;
+  }
+}

--- a/examples/ethereal-neo-glass/templates/404.html
+++ b/examples/ethereal-neo-glass/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel text-center page-404">
+  <h1 class="page-title text-glow">404</h1>
+  <p class="page-desc">The ethereal link you followed has vanished into the void.</p>
+  <a href="{{ base_url }}/" class="btn btn-glass">Return to Reality</a>
+</div>
+{% endblock content %}

--- a/examples/ethereal-neo-glass/templates/base.html
+++ b/examples/ethereal-neo-glass/templates/base.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page is defined %}{{ page.description | default(value='') | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page is defined and page.title != site.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="{{ base_url }}/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{% if page is defined %}{{ page.section }}{% endif %}">
+  <div class="ambient-orbs">
+    <div class="orb orb-1"></div>
+    <div class="orb orb-2"></div>
+    <div class="orb orb-3"></div>
+  </div>
+
+  <div class="site-wrapper">
+    <header class="glass-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="main-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="glass-footer">
+      <p>&copy; 2024 {{ site.title }}. Designed with Hwaro.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/ethereal-neo-glass/templates/index.html
+++ b/examples/ethereal-neo-glass/templates/index.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero-section text-center">
+  <div class="glass-panel hero-glass">
+    <h1 class="hero-title text-glow">{{ page.title | default(value=site.title) | e }}</h1>
+
+    {% if page.description is present %}
+      <p class="hero-desc">{{ page.description | e }}</p>
+    {% endif %}
+
+    <div class="hero-content">
+      {{ content | safe }}
+    </div>
+
+    <div class="hero-actions">
+      <a href="{{ base_url }}/about/" class="btn btn-glass">Explore the Void</a>
+    </div>
+  </div>
+</section>
+
+{% if section is defined and section.list is defined %}
+<section class="latest-posts glass-panel">
+  <h2 class="section-title">Ethereal Transmissions</h2>
+  <ul class="section-list neon-list">
+    {{ section.list }}
+  </ul>
+</section>
+{% endif %}
+{% endblock content %}

--- a/examples/ethereal-neo-glass/templates/page.html
+++ b/examples/ethereal-neo-glass/templates/page.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-panel page-content">
+  <header class="page-header">
+    <h1 class="page-title">{{ page.title }}</h1>
+    {% if page.description is present %}
+      <p class="page-desc">{{ page.description }}</p>
+    {% endif %}
+  </header>
+
+  <div class="content-body">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock content %}

--- a/examples/ethereal-neo-glass/templates/section.html
+++ b/examples/ethereal-neo-glass/templates/section.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-container">
+  <header class="glass-panel section-header">
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    {{ content | safe }}
+  </header>
+
+  <ul class="section-list">
+    {{ section.list }}
+  </ul>
+
+  {% if pagination is defined %}
+  <nav class="pagination-wrapper glass-panel">
+    {{ pagination }}
+  </nav>
+  {% endif %}
+</div>
+{% endblock content %}

--- a/examples/ethereal-neo-glass/templates/shortcodes/alert.html
+++ b/examples/ethereal-neo-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/ethereal-neo-glass/templates/taxonomy.html
+++ b/examples/ethereal-neo-glass/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel page-content">
+  <h1 class="page-title">{{ page.title | e }}</h1>
+  {% if taxonomy is defined %}
+  <p class="taxonomy-desc">Browse all terms in {{ taxonomy.name }}:</p>
+  {% else %}
+  <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+  {% endif %}
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/ethereal-neo-glass/templates/taxonomy_term.html
+++ b/examples/ethereal-neo-glass/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel page-content">
+  <h1 class="page-title">{{ page.title | e }}</h1>
+  {% if term is defined %}
+  <p class="taxonomy-desc">Posts tagged with <strong>{{ term.name }}</strong>:</p>
+  {% else %}
+  <p class="taxonomy-desc">Posts tagged with this term:</p>
+  {% endif %}
+  {{ content | safe }}
+</div>
+{% endblock content %}


### PR DESCRIPTION
This PR introduces a new example template to the Hwaro examples repository called `ethereal-neo-glass`. The theme is a dark-mode neo-glassmorphism aesthetic built on a deep void background with animated glowing light orbs, translucent frosted glass panels, and typography powered by the Space Grotesk and Inter fonts.

The site is fully responsive and leverages native Hwaro features like blocks and layout inheritance. Unused default scaffold files were successfully cleaned up.

---
*PR created automatically by Jules for task [16822239508278938717](https://jules.google.com/task/16822239508278938717) started by @hahwul*