### PR TITLE
fix(examples/mist-panel): resolve 404 errors for header navigation links

### DIFF
--- a/examples/mist-panel/templates/header.html
+++ b/examples/mist-panel/templates/header.html
@@ -79,8 +79,8 @@
         <div class="container">
             <div class="logo">mist.panel</div>
             <nav>
-                <a href="/">Vapor</a>
-                <a href="/about">Ether</a>
+                <a href="{{ base_url }}/">Vapor</a>
+                <a href="{{ base_url }}/about/">Ether</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
This PR fixes broken navigation links in the `mist-panel` example site. 

The links in `templates/header.html` were hardcoded to `/` and `/about`, which causes 404 errors when the example is deployed to a subdirectory or hosted on `https://examples.hwaro.hahwul.com/mist-panel/`. 

The links have been updated to `{{ base_url }}/` and `{{ base_url }}/about/` to properly prefix the base URL and use the trailing slash required by Hwaro's pretty URLs.

---
*PR created automatically by Jules for task [16974191759846232225](https://jules.google.com/task/16974191759846232225) started by @hahwul*