### PR TITLE
Fix 404 links in iron-anvil example

### DIFF
--- a/examples/iron-anvil/templates/header.html
+++ b/examples/iron-anvil/templates/header.html
@@ -63,8 +63,8 @@
         <div class="container">
             <div class="logo">iron.anvil</div>
             <nav>
-                <a href="/">Forge</a>
-                <a href="/about">Core</a>
+                <a href="{{ base_url }}/">Forge</a>
+                <a href="{{ base_url }}/about/">Core</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
Fixes 404 broken links in the header of the iron-anvil example.

---
*PR created automatically by Jules for task [9937788687472303340](https://jules.google.com/task/9937788687472303340) started by @hahwul*