### PR TITLE
feat: add silent-ash example with minimalist monochrome design

### DIFF
--- a/examples/silent-ash/AGENTS.md
+++ b/examples/silent-ash/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/silent-ash/archetypes/default.md
+++ b/examples/silent-ash/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/silent-ash/config.toml
+++ b/examples/silent-ash/config.toml
@@ -1,0 +1,23 @@
+title = "Silent Ash"
+description = "A minimalist, sophisticated aesthetic inspired by silent ash."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/examples/silent-ash/content/_index.md
+++ b/examples/silent-ash/content/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Silent Ash"
+description: "A study in absence. An exploration of form through monochrome."
+---
+
+Welcome to a space defined by what it lacks. Here, color is stripped away to reveal the underlying structure of typography and layout.
+
+The aesthetic draws inspiration from the quiet remnants of combustion — a soft, unyielding spectrum of grays bridging the absolute poles of black and white.
+
+### Principles of Design
+
+*   **Monochrome Purity:** Relying solely on absolute colors within the grayscale spectrum.
+*   **Structural Depth:** Utilizing solid borders and offset box shadows rather than diffused gradients to create layers.
+*   **Typographic Hierarchy:** Employing 'Cormorant Garamond' for expressive structure and 'Inter' for functional clarity.
+
+This is a demonstration of the Hwaro static site generator.

--- a/examples/silent-ash/content/about.md
+++ b/examples/silent-ash/content/about.md
@@ -1,0 +1,23 @@
+---
+title: "About the Concept"
+description: "The philosophy behind the Silent Ash design language."
+---
+
+The concept of "Silent Ash" emerged from a desire to create a web presence that feels both permanent and ethereal.
+
+When you remove the vibrancy of color, you are left with contrast. Contrast dictates readability, draws the eye, and establishes a natural rhythm down the page.
+
+> "To see things in the seed, that is genius." — Lao Tzu
+
+By restricting the palette to stark whites, muted grays, and deep blacks, every element on the page must justify its existence through form rather than decoration.
+
+### The Palette
+
+The foundation relies on absolute colors. No transparency, no blurring, no gradients.
+
+1.  **Pure White:** The canvas.
+2.  **Ash White:** The container boundary.
+3.  **Ash Light:** The shadow and subtle division.
+4.  **Ash Medium:** The secondary text and hover states.
+5.  **Ash Dark:** The primary structural lines.
+6.  **Ash Black:** The core typographic voice.

--- a/examples/silent-ash/templates/404.html
+++ b/examples/silent-ash/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/silent-ash/templates/footer.html
+++ b/examples/silent-ash/templates/footer.html
@@ -1,0 +1,7 @@
+        </main>
+        <footer class="site-footer">
+            <p>&copy; {{ now() | date(format="%Y") }} {{ site.title }}. A study in monochrome.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/silent-ash/templates/header.html
+++ b/examples/silent-ash/templates/header.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            /* Silent Ash Color Palette - Absolute Monochrome / No Gradients */
+            --ash-black: #1a1a1a;
+            --ash-dark: #333333;
+            --ash-medium: #7f7f7f;
+            --ash-light: #e0e0e0;
+            --ash-white: #f8f8f8;
+            --pure-white: #ffffff;
+
+            --font-serif: 'Cormorant Garamond', serif;
+            --font-sans: 'Inter', sans-serif;
+
+            --border-thin: 1px solid var(--ash-light);
+            --border-thick: 2px solid var(--ash-dark);
+
+            --spacing-xs: 0.5rem;
+            --spacing-sm: 1rem;
+            --spacing-md: 2rem;
+            --spacing-lg: 4rem;
+            --spacing-xl: 8rem;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: var(--font-serif);
+            background-color: var(--pure-white);
+            color: var(--ash-black);
+            line-height: 1.6;
+            font-size: 18px;
+            font-weight: 400;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        /* Layout */
+        .wrapper {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 0 var(--spacing-md);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            border-left: var(--border-thin);
+            border-right: var(--border-thin);
+            background-color: var(--ash-white);
+        }
+
+        .site-header {
+            padding: var(--spacing-lg) 0 var(--spacing-md);
+            border-bottom: var(--border-thin);
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+
+        .site-title {
+            font-size: 2.5rem;
+            font-weight: 300;
+            letter-spacing: -0.02em;
+        }
+
+        .site-title a {
+            color: var(--ash-black);
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        .site-title a:hover {
+            color: var(--ash-medium);
+        }
+
+        .site-nav {
+            font-family: var(--font-sans);
+            font-size: 0.85rem;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+
+        .site-nav ul {
+            list-style: none;
+            display: flex;
+            gap: var(--spacing-md);
+        }
+
+        .site-nav a {
+            color: var(--ash-dark);
+            text-decoration: none;
+            padding-bottom: 4px;
+            border-bottom: 1px solid transparent;
+            transition: all 0.3s ease;
+        }
+
+        .site-nav a:hover {
+            color: var(--ash-black);
+            border-bottom-color: var(--ash-black);
+        }
+
+        .main-content {
+            flex-grow: 1;
+            padding: var(--spacing-lg) 0;
+        }
+
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-weight: 400;
+            margin-bottom: var(--spacing-sm);
+            color: var(--ash-black);
+        }
+
+        h1 {
+            font-size: 3rem;
+            line-height: 1.1;
+            margin-bottom: var(--spacing-md);
+            letter-spacing: -0.01em;
+        }
+
+        h2 {
+            font-size: 2rem;
+            margin-top: var(--spacing-md);
+            border-bottom: var(--border-thin);
+            padding-bottom: var(--spacing-xs);
+        }
+
+        p {
+            margin-bottom: var(--spacing-md);
+            color: var(--ash-dark);
+        }
+
+        a {
+            color: var(--ash-black);
+            text-decoration-thickness: 1px;
+            text-underline-offset: 4px;
+        }
+
+        a:hover {
+            color: var(--ash-medium);
+        }
+
+        /* Components */
+        .page-header {
+            margin-bottom: var(--spacing-xl);
+            text-align: center;
+        }
+
+        .page-description {
+            font-family: var(--font-sans);
+            font-size: 1rem;
+            color: var(--ash-medium);
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        .content-box {
+            background-color: var(--pure-white);
+            padding: var(--spacing-lg);
+            border: var(--border-thin);
+            box-shadow: 4px 4px 0 var(--ash-light); /* Solid shadow, no blur/gradient */
+        }
+
+        hr {
+            border: none;
+            border-top: var(--border-thin);
+            margin: var(--spacing-lg) 0;
+        }
+
+        blockquote {
+            font-style: italic;
+            font-size: 1.25rem;
+            color: var(--ash-dark);
+            padding-left: var(--spacing-md);
+            border-left: var(--border-thick);
+            margin: var(--spacing-md) 0;
+        }
+
+        code {
+            font-family: monospace;
+            background-color: var(--ash-light);
+            padding: 0.2em 0.4em;
+            font-size: 0.85em;
+        }
+
+        pre {
+            background-color: var(--ash-black);
+            color: var(--ash-white);
+            padding: var(--spacing-md);
+            overflow-x: auto;
+            margin: var(--spacing-md) 0;
+            border: 1px solid var(--ash-dark);
+        }
+
+        pre code {
+            background-color: transparent;
+            color: inherit;
+            padding: 0;
+        }
+
+        /* Lists */
+        ul, ol {
+            margin-bottom: var(--spacing-md);
+            padding-left: var(--spacing-md);
+            color: var(--ash-dark);
+        }
+
+        li {
+            margin-bottom: var(--spacing-xs);
+        }
+
+        /* Footer */
+        .site-footer {
+            padding: var(--spacing-md) 0;
+            border-top: var(--border-thin);
+            text-align: center;
+            font-family: var(--font-sans);
+            font-size: 0.85rem;
+            color: var(--ash-medium);
+            margin-top: auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="wrapper">
+        <header class="site-header">
+            <div class="site-title"><a href="{{ base_url }}/">{{ site.title }}</a></div>
+            <nav class="site-nav">
+                <ul>
+                    <li><a href="{{ base_url }}/">Home</a></li>
+                    <li><a href="{{ base_url }}/about/">About</a></li>
+                </ul>
+            </nav>
+        </header>
+        <main class="main-content">

--- a/examples/silent-ash/templates/index.html
+++ b/examples/silent-ash/templates/index.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+
+<div class="page-header">
+    <h1>{{ page.title | default(value=site.title) }}</h1>
+    <p class="page-description">{{ page.description | default(value=site.description) }}</p>
+</div>
+
+<div class="content-box">
+    {% if content %}
+        {{ content | safe }}
+    {% endif %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/silent-ash/templates/page.html
+++ b/examples/silent-ash/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<article class="content-box">
+    <header class="page-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.description %}
+            <p class="page-description">{{ page.description }}</p>
+        {% endif %}
+    </header>
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/silent-ash/templates/section.html
+++ b/examples/silent-ash/templates/section.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+
+<div class="page-header">
+    <h1>{{ page.title | default(value=site.title) }}</h1>
+    <p class="page-description">{{ page.description | default(value=site.description) }}</p>
+</div>
+
+<div class="content-box">
+    {% if content %}
+        {{ content | safe }}
+    {% endif %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/silent-ash/templates/shortcodes/alert.html
+++ b/examples/silent-ash/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/silent-ash/templates/taxonomy.html
+++ b/examples/silent-ash/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/silent-ash/templates/taxonomy_term.html
+++ b/examples/silent-ash/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR introduces a new example called `silent-ash` to the repository. 

Key features:
- A sophisticated, minimalist monochrome design language.
- Explicitly avoids gradients, using solid borders and un-blurred offset shadows for depth.
- Explicitly disables emoji parsing in `config.toml`.
- Focuses on strong typographic hierarchy utilizing Cormorant Garamond and Inter fonts.

This example was generated cleanly via `hwaro init` and customized according to the requested constraints.

---
*PR created automatically by Jules for task [9371720980296573140](https://jules.google.com/task/9371720980296573140) started by @hahwul*