### PR TITLE
feat(examples): add velvet-monolith example site

### DIFF
--- a/examples/velvet-monolith/AGENTS.md
+++ b/examples/velvet-monolith/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/velvet-monolith/archetypes/default.md
+++ b/examples/velvet-monolith/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/velvet-monolith/config.toml
+++ b/examples/velvet-monolith/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Velvet Monolith"
+description = "An elegant, solid-color theme emphasizing clean typography and profound stillness."
+base_url = "https://velvet-monolith.examples.hwaro.hahwul.com"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/velvet-monolith/content/about.md
+++ b/examples/velvet-monolith/content/about.md
@@ -1,0 +1,29 @@
+---
+title: "About the Monolith"
+description: "Understanding the design philosophy."
+---
+
+The Velvet Monolith design was created as a counter-movement to overly complex, gradient-heavy, and loud designs. By enforcing a strict palette of dark solids and muted, elegant accents, it ensures that the content itself becomes the focal point.
+
+### Typography
+
+The title fonts utilize **Playfair Display**, bringing an elegant and almost editorial feel. The body is set in **Inter**, providing absolute clarity and modern readability.
+
+### Code Example
+
+```python
+def monolith_philosophy():
+    """
+    Embrace simplicity.
+    Reject the unnecessary.
+    """
+    design = {
+        "gradients": False,
+        "emojis": False,
+        "typography": "Elegant",
+        "presence": "Solid"
+    }
+    return design
+```
+
+Thank you for visiting the Velvet Monolith.

--- a/examples/velvet-monolith/content/index.md
+++ b/examples/velvet-monolith/content/index.md
@@ -1,0 +1,16 @@
+---
+title: "Velvet Monolith"
+description: "A profound aesthetic grounded in solid presence."
+---
+
+Welcome to the **Velvet Monolith**. This theme strips away the superfluous. There are no gradients, no emojis, and no complex layouts. What remains is a pure, solid structure that honors typography and space.
+
+It is built on a dark, velvet-like background (`#1c1a1c`) with muted golden accents (`#b08d57`) and a subtle contrast surface (`#2b282b`).
+
+> "In the stillness of the monolith, every word carries weight."
+
+### Features of the Void
+
+*   **Pure Solids**: Relying entirely on flat colors to build structure.
+*   **Typography Focus**: Pairing *Playfair Display* for striking, elegant headers with *Inter* for legible, clean body copy.
+*   **Stark Layout**: A centered, contained design that emphasizes focus.

--- a/examples/velvet-monolith/templates/404.html
+++ b/examples/velvet-monolith/templates/404.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="hero" style="border-color: var(--vm-accent);">
+  <h1 class="hero-title" style="color: var(--vm-accent);">404</h1>
+  <p class="hero-subtitle">The page you requested dwells in the void.</p>
+</div>
+{% endblock %}

--- a/examples/velvet-monolith/templates/base.html
+++ b/examples/velvet-monolith/templates/base.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page and page.description %}{{ page.description | e }}{% elif section and section.description %}{{ section.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page and page.title %}{{ page.title | e }} - {% elif section and section.title %}{{ section.title | e }} - {% endif %}{{ site.title | e }}</title>
+
+  {{ og_all_tags | default(value="") }}
+  {{ hreflang_tags | default(value="") }}
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+
+  <style>
+    /* Velvet Monolith Aesthetic */
+    :root {
+      /* Absolutely NO gradients. Only pure solid colors. */
+      --vm-bg: #1c1a1c;
+      --vm-surface: #2b282b;
+      --vm-text-primary: #f0ebe1;
+      --vm-text-secondary: #a39c94;
+      --vm-accent: #b08d57;
+      --vm-accent-hover: #cfab76;
+      --vm-border: #403b40;
+
+      --font-serif: 'Playfair Display', serif;
+      --font-sans: 'Inter', sans-serif;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: var(--vm-bg);
+      color: var(--vm-text-primary);
+      font-family: var(--font-sans);
+      line-height: 1.7;
+      font-weight: 300;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    a {
+      color: var(--vm-accent);
+      text-decoration: none;
+      transition: color 0.3s ease;
+    }
+
+    a:hover {
+      color: var(--vm-accent-hover);
+    }
+
+    /* Layout */
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 0 2rem;
+    }
+
+    .site-header {
+      padding: 4rem 0 2rem;
+      border-bottom: 1px solid var(--vm-border);
+      margin-bottom: 4rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+
+    .site-title {
+      font-family: var(--font-serif);
+      font-size: 2.5rem;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      margin: 0;
+    }
+
+    .site-title a {
+      color: var(--vm-text-primary);
+    }
+
+    .site-nav {
+      font-family: var(--font-sans);
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    .site-nav a {
+      margin-left: 2rem;
+      color: var(--vm-text-secondary);
+    }
+
+    .site-nav a:hover {
+      color: var(--vm-accent);
+    }
+
+    .site-main {
+      min-height: 60vh;
+    }
+
+    .site-footer {
+      margin-top: 6rem;
+      padding: 3rem 0;
+      border-top: 1px solid var(--vm-border);
+      text-align: center;
+      font-size: 0.85rem;
+      color: var(--vm-text-secondary);
+      font-family: var(--font-sans);
+    }
+
+    /* Content Styling */
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-serif);
+      color: var(--vm-text-primary);
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      font-weight: 400;
+    }
+
+    h1 {
+      font-size: 3rem;
+      line-height: 1.2;
+      margin-top: 0;
+    }
+
+    h2 {
+      font-size: 2rem;
+      border-bottom: 1px solid var(--vm-surface);
+      padding-bottom: 0.5rem;
+    }
+
+    p {
+      margin-bottom: 1.5rem;
+      font-size: 1.1rem;
+    }
+
+    blockquote {
+      margin: 2rem 0;
+      padding: 1.5rem 2rem;
+      border-left: 4px solid var(--vm-accent);
+      background-color: var(--vm-surface);
+      font-family: var(--font-serif);
+      font-style: italic;
+      font-size: 1.2rem;
+      color: var(--vm-text-primary);
+    }
+
+    code {
+      font-family: monospace;
+      background-color: var(--vm-surface);
+      padding: 0.2rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.9em;
+      color: var(--vm-accent);
+    }
+
+    pre {
+      background-color: var(--vm-surface);
+      padding: 1.5rem;
+      border-radius: 4px;
+      overflow-x: auto;
+      border: 1px solid var(--vm-border);
+    }
+
+    pre code {
+      background-color: transparent;
+      padding: 0;
+      color: inherit;
+    }
+
+    ul, ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+
+    li {
+      margin-bottom: 0.5rem;
+    }
+
+    /* Monolithic Hero */
+    .hero {
+      text-align: center;
+      padding: 6rem 0;
+      background-color: var(--vm-surface);
+      border: 1px solid var(--vm-border);
+      margin-bottom: 4rem;
+    }
+
+    .hero-title {
+      font-family: var(--font-serif);
+      font-size: 4rem;
+      margin-bottom: 1rem;
+      margin-top: 0;
+      font-weight: 700;
+      color: var(--vm-text-primary);
+    }
+
+    .hero-subtitle {
+      font-size: 1.2rem;
+      color: var(--vm-text-secondary);
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    /* Pages list */
+    .pages-list {
+      list-style: none;
+      padding: 0;
+      margin: 2rem 0;
+    }
+
+    .page-item {
+      margin-bottom: 2rem;
+      padding-bottom: 2rem;
+      border-bottom: 1px solid var(--vm-surface);
+    }
+
+    .page-item-title {
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+      font-size: 1.8rem;
+    }
+
+    .page-item-desc {
+      color: var(--vm-text-secondary);
+      margin-bottom: 0;
+    }
+  </style>
+
+  {{ highlight_css | default(value="") }}
+  {{ auto_includes_css | default(value="") }}
+</head>
+<body>
+  <div class="container">
+    <header class="site-header">
+      <h1 class="site-title"><a href="{{ base_url }}/">{{ site.title }}</a></h1>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; {{ site.title }}. Styled with profound stillness.</p>
+    </footer>
+  </div>
+
+  {{ auto_includes_js | default(value="") }}
+</body>
+</html>

--- a/examples/velvet-monolith/templates/index.html
+++ b/examples/velvet-monolith/templates/index.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="hero">
+  <h1 class="hero-title">{{ page.title | default(value=site.title) }}</h1>
+  <p class="hero-subtitle">{{ page.description | default(value=site.description) }}</p>
+</div>
+
+<div class="content">
+  {{ content | safe }}
+</div>
+
+{% if section and section.pages %}
+  <ul class="pages-list">
+  {% for p in section.pages %}
+    <li class="page-item">
+      <h2 class="page-item-title"><a href="{{ p.permalink }}">{{ p.title }}</a></h2>
+      {% if p.description %}
+      <p class="page-item-desc">{{ p.description }}</p>
+      {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
+{% endif %}
+{% endblock %}

--- a/examples/velvet-monolith/templates/page.html
+++ b/examples/velvet-monolith/templates/page.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="post">
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title }}</h1>
+    {% if page.description %}
+    <p class="post-description" style="color: var(--vm-text-secondary); font-size: 1.2rem; font-family: var(--font-serif); font-style: italic;">{{ page.description }}</p>
+    {% endif %}
+  </header>
+
+  <div class="post-content content">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/examples/velvet-monolith/templates/section.html
+++ b/examples/velvet-monolith/templates/section.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1 class="section-title">{{ section.title }}</h1>
+  {% if section.description %}
+  <p class="section-description">{{ section.description }}</p>
+  {% endif %}
+</header>
+
+<div class="content">
+  {{ content | safe }}
+</div>
+
+{% if section.pages %}
+<ul class="pages-list">
+  {% for p in section.pages %}
+  <li class="page-item">
+    <h2 class="page-item-title"><a href="{{ p.permalink }}">{{ p.title }}</a></h2>
+    {% if p.description %}
+    <p class="page-item-desc">{{ p.description }}</p>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/examples/velvet-monolith/templates/shortcodes/alert.html
+++ b/examples/velvet-monolith/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/velvet-monolith/templates/taxonomy.html
+++ b/examples/velvet-monolith/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1 class="section-title">Taxonomies</h1>
+</header>
+<div class="content">
+  <p class="taxonomy-desc">Explore the various classifications across the monolith.</p>
+  <ul class="section-list taxonomy-list">
+    {% for tax in taxonomies %}
+    <li>
+      <a href="{{ tax.permalink }}">{{ tax.name | title }}</a> ({{ tax.term_count }} terms)
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/examples/velvet-monolith/templates/taxonomy_term.html
+++ b/examples/velvet-monolith/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1 class="section-title">{{ term.name }}</h1>
+</header>
+<div class="content">
+  <p class="taxonomy-desc">Pages related to this term within the monolith.</p>
+  <ul class="section-list">
+    {% for p in term.pages %}
+    <li>
+      <a href="{{ p.permalink }}">{{ p.title }}</a>
+      <div class="taxonomy-date" style="color: var(--vm-text-secondary); font-size: 0.9em;">
+        {% if p.date %}{{ p.date | date(format="%B %d, %Y") }}{% endif %}
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds a new Hwaro example site named `velvet-monolith`.

The goal of this example is to demonstrate a strictly minimal and elegant aesthetic using:
* Pure, solid colors with zero gradients.
* No emojis.
* Beautiful, distinct typography combining Playfair Display (for headings) and Inter (for body text).

It includes a fully functional layout via `base.html`, updated `index.html`, content pages, and fixed taxonomy templates to match the single-base layout model.

---
*PR created automatically by Jules for task [2700068311113355953](https://jules.google.com/task/2700068311113355953) started by @hahwul*