### PR TITLE
feat: add obsidian-lattice example

### DIFF
--- a/examples/obsidian-lattice/AGENTS.md
+++ b/examples/obsidian-lattice/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/obsidian-lattice/archetypes/default.md
+++ b/examples/obsidian-lattice/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/obsidian-lattice/config.toml
+++ b/examples/obsidian-lattice/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Obsidian Lattice"
+description = "A structural dark themed site"
+base_url = "https://examples.hwaro.hahwul.com/obsidian-lattice"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/obsidian-lattice/content/_index.md
+++ b/examples/obsidian-lattice/content/_index.md
@@ -1,0 +1,25 @@
++++
+title = "The Obsidian Lattice"
+tags = ["structure", "darkness"]
++++
+
+# Core Node
+
+Welcome to the Obsidian Lattice. A highly structured, absolute zero environment designed for clarity and absolute structural integrity.
+
+## Architecture
+
+The system operates on strict grid principles, completely avoiding arbitrary color gradients or irregular spacing. Every element has its designated sector.
+
+1. **Monochrome Base:** `#000000` void background.
+2. **Structural Lines:** `#333333` borders defining lattice cells.
+3. **Contrast:** `#ffffff` accents for critical data points.
+
+```yaml
+system:
+  status: "ONLINE"
+  integrity: "100%"
+  theme: "OBSIDIAN"
+```
+
+Explore the [system tags](/tags/) to traverse the nodes.

--- a/examples/obsidian-lattice/content/about.md
+++ b/examples/obsidian-lattice/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "System Specifications"
+tags = ["info", "about"]
++++
+
+# About the Lattice
+
+The Obsidian Lattice is a brutalist, strictly structured framework meant to display information with maximum contrast and minimal decoration.
+
+## Principles
+
+*   **Zero Gradients:** Solid colors only. No fading or transitioning light sources.
+*   **Absolute Contrast:** White text on pure black backgrounds.
+*   **Grid Enforcement:** Information must be constrained within defined boundaries.
+
+> "Structure is not just a visual choice. It is the fundamental reality of the lattice."
+
+### Node Allocation
+
+All nodes are registered within the `content/` directory and compiled by the Hwaro engine into static, immutable outputs.

--- a/examples/obsidian-lattice/templates/404.html
+++ b/examples/obsidian-lattice/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/obsidian-lattice/templates/footer.html
+++ b/examples/obsidian-lattice/templates/footer.html
@@ -1,0 +1,9 @@
+      <footer class="site-footer" style="margin-top: 4rem; padding-top: 2rem; border-top: 1px solid var(--lattice-border); font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; text-align: center;">
+        <p>System Online // Powered by Hwaro</p>
+      </footer>
+    </div><!-- .main-content -->
+  </div><!-- .lattice-layout -->
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/obsidian-lattice/templates/header.html
+++ b/examples/obsidian-lattice/templates/header.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,600;1,400&family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
+  <style>
+  :root {
+    --bg-void: #000000;
+    --lattice-border: #333333;
+    --lattice-bg: #111111;
+    --text-primary: #e0e0e0;
+    --text-muted: #888888;
+    --accent: #ffffff;
+    --font-sans: 'Inter', -apple-system, sans-serif;
+    --font-mono: 'IBM Plex Mono', monospace;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; }
+
+  body {
+    font-family: var(--font-sans);
+    line-height: 1.6;
+    margin: 0;
+    color: var(--text-primary);
+    background: var(--bg-void);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Structural Grid - The Lattice */
+  .lattice-layout {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    min-height: 100vh;
+    border-right: 1px solid var(--lattice-border);
+    border-left: 1px solid var(--lattice-border);
+    max-width: 1400px;
+    margin: 0 auto;
+    position: relative;
+  }
+
+
+  .sidebar {
+    background: var(--bg-void);
+    border-right: 1px solid var(--lattice-border);
+    padding: 3rem 2rem;
+    display: flex;
+    flex-direction: column;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    z-index: 10;
+  }
+
+  .main-content {
+    background: var(--bg-void);
+    padding: 3rem 4rem;
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Header & Navigation */
+  .site-logo {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    font-size: 1.25rem;
+    color: var(--accent);
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 3rem;
+    display: block;
+    border: 1px solid var(--lattice-border);
+    padding: 1rem;
+    text-align: center;
+    background: var(--lattice-bg);
+  }
+
+  .site-logo:hover {
+    background: var(--accent);
+    color: var(--bg-void);
+  }
+
+  .nav-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: auto;
+  }
+
+  .nav-menu a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.95rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid transparent;
+    transition: all 0.2s;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+  }
+
+  .nav-menu a:hover {
+    color: var(--accent);
+    border-color: var(--lattice-border);
+    background: var(--lattice-bg);
+  }
+
+  /* Typography */
+  h1, h2, h3, h4 {
+    font-family: var(--font-sans);
+    line-height: 1.2;
+    margin-top: 2em;
+    margin-bottom: 1em;
+    font-weight: 800;
+    color: var(--accent);
+    letter-spacing: -0.02em;
+  }
+
+  h1 { font-size: 3rem; margin-top: 0; border-bottom: 2px solid var(--accent); padding-bottom: 0.5rem; display: inline-block; }
+  h2 { font-size: 2rem; border-bottom: 1px solid var(--lattice-border); padding-bottom: 0.5rem; }
+  h3 { font-size: 1.5rem; }
+
+  p { margin: 1.5em 0; font-weight: 300; font-size: 1.05rem; }
+
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px solid var(--lattice-border); padding-bottom: 1px; }
+  a:hover { border-bottom-color: var(--accent); }
+
+  code {
+    background: var(--lattice-bg);
+    color: var(--accent);
+    padding: 0.2em 0.4em;
+    border: 1px solid var(--lattice-border);
+    font-size: 0.85em;
+    font-family: var(--font-mono);
+  }
+
+  pre {
+    background: var(--lattice-bg);
+    padding: 1.5rem;
+    border: 1px solid var(--lattice-border);
+    overflow-x: auto;
+    margin: 2rem 0;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    border: none;
+    color: var(--text-primary);
+  }
+
+  blockquote {
+    margin: 2rem 0;
+    padding: 1rem 2rem;
+    border-left: 4px solid var(--accent);
+    background: var(--lattice-bg);
+    color: var(--text-muted);
+    font-style: italic;
+  }
+
+  /* Components */
+  ul.section-list { list-style: none; padding: 0; margin: 2rem 0; display: grid; gap: 1rem; }
+  ul.section-list li { padding: 1.5rem; background: var(--lattice-bg); border: 1px solid var(--lattice-border); transition: border-color 0.2s; }
+  ul.section-list li:hover { border-color: var(--text-muted); }
+  ul.section-list li a { font-weight: 600; font-size: 1.25rem; border: none; display: block; margin-bottom: 0.5rem; }
+
+  .taxonomy-desc { color: var(--text-muted); margin-bottom: 2rem; font-family: var(--font-mono); text-transform: uppercase; font-size: 0.85rem; letter-spacing: 0.05em; }
+
+  nav.pagination { margin: 3rem 0; border-top: 1px solid var(--lattice-border); padding-top: 2rem; }
+  nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+  nav.pagination a { display: inline-block; padding: 0.5rem 1rem; border: 1px solid var(--lattice-border); color: var(--text-muted); text-decoration: none; font-family: var(--font-mono); }
+  nav.pagination a:hover { color: var(--accent); border-color: var(--accent); background: var(--lattice-bg); }
+  .pagination-current span { display: inline-block; padding: 0.5rem 1rem; border: 1px solid var(--accent); background: var(--accent); color: var(--bg-void); font-family: var(--font-mono); font-weight: 600; }
+  .pagination-disabled span { display: inline-block; padding: 0.5rem 1rem; border: 1px solid var(--lattice-border); color: var(--lattice-border); font-family: var(--font-mono); }
+
+  hr { border: none; border-top: 1px solid var(--lattice-border); margin: 3rem 0; }
+
+  /* Responsive */
+  @media (max-width: 900px) {
+    .lattice-layout { grid-template-columns: 1fr; border: none; }
+    .sidebar { height: auto; position: relative; padding: 2rem; border-right: none; border-bottom: 1px solid var(--lattice-border); }
+    .main-content { padding: 2rem; }
+    .nav-menu { flex-direction: row; flex-wrap: wrap; justify-content: center; margin-top: 1rem; }
+    h1 { font-size: 2.25rem; }
+  }
+</style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="lattice-layout">
+    <aside class="sidebar">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="nav-menu">
+        <a href="{{ base_url }}/">Node_00 // Home</a>
+        <a href="{{ base_url }}/about/">Node_01 // About</a>
+        <a href="{{ base_url }}/tags/">Index // Tags</a>
+      </nav>
+    </aside>
+    <div class="main-content">

--- a/examples/obsidian-lattice/templates/page.html
+++ b/examples/obsidian-lattice/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article>
+      {{ content | safe }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/obsidian-lattice/templates/section.html
+++ b/examples/obsidian-lattice/templates/section.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <header class="section-header">
+      <h1>{{ page.title | e }}</h1>
+      {% if page.description %}
+      <p class="section-desc">{{ page.description | e }}</p>
+      {% endif %}
+    </header>
+    {{ content | safe }}
+    <ul class="section-list">
+      {% for item in pages %}
+        <li><a href="{{ item.permalink }}">{{ item.title | e }}</a></li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/obsidian-lattice/templates/shortcodes/alert.html
+++ b/examples/obsidian-lattice/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/obsidian-lattice/templates/taxonomy.html
+++ b/examples/obsidian-lattice/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <header class="section-header">
+      <h1>{{ taxonomy_name | default(value="Taxonomy") | title }}</h1>
+    </header>
+    <p class="taxonomy-desc">Index // Browse all entities in this class:</p>
+    {{ content | safe }}
+    <ul class="section-list">
+      {% for term in terms %}
+      <li><a href="{{ term.permalink }}">{{ term.name | e }} ({{ term.pages | length }})</a></li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/examples/obsidian-lattice/templates/taxonomy_term.html
+++ b/examples/obsidian-lattice/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <header class="section-header">
+      <h1>{{ page.title | e }}</h1>
+    </header>
+    <p class="taxonomy-desc">Index // Entities classified under this term:</p>
+    {{ content | safe }}
+    <ul class="section-list">
+      {% for item in pages %}
+      <li><a href="{{ item.permalink }}">{{ item.title | e }}</a></li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR adds a new example called `obsidian-lattice`.

It is a dark-themed, structural framework using pure black and monochrome styling without any gradients or emojis, fulfilling the user's constraints. It utilizes CSS Grid for layout and pairs `Inter` with `IBM Plex Mono` for a highly structural aesthetic.

The codebase incorporates best practices such as ensuring Markdown `content` is piped through the `safe` filter in Crinja templates and correctly iterating through generated pages in listing sections.

---
*PR created automatically by Jules for task [5560180022135022092](https://jules.google.com/task/5560180022135022092) started by @hahwul*