### PR TITLE
feat(examples): add aether-monolith example site

### DIFF
--- a/examples/aether-monolith/AGENTS.md
+++ b/examples/aether-monolith/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/aether-monolith/archetypes/default.md
+++ b/examples/aether-monolith/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/aether-monolith/config.toml
+++ b/examples/aether-monolith/config.toml
@@ -1,0 +1,10 @@
+base_url = "https://aether-monolith.example.com"
+title = "Aether Monolith"
+description = "A structural, elegant monolith in the aether."
+
+[markdown]
+highlight_code = true
+emoji = false
+
+[extra]
+author = "Aether Architect"

--- a/examples/aether-monolith/content/_index.md
+++ b/examples/aether-monolith/content/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Aether Monolith"
+description = "A structural, elegant monolith in the aether."
+template = "section.html"
++++
+
+Welcome to the Aether Monolith.
+
+A place of structural integrity, deep contrast, and pure architectural beauty without the noise.
+
+This site is built with strong typographic principles and stark, geometric layouts.

--- a/examples/aether-monolith/content/about.md
+++ b/examples/aether-monolith/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "About the Monolith"
+description = "The architecture behind the Aether Monolith."
++++
+
+The Aether Monolith is an exercise in restraint.
+
+We eschew gradients and visual clutter in favor of stark contrast, solid forms, and unyielding structure. The design language speaks in off-whites and deep blacks, creating a digital space that feels monumental and permanent.
+
+Constructed for clarity and presence.

--- a/examples/aether-monolith/templates/404.html
+++ b/examples/aether-monolith/templates/404.html
@@ -1,0 +1,50 @@
+{% include "header.html" %}
+
+<div class="error-container">
+    <h1 class="error-code">404</h1>
+    <p class="error-message">The structure you are looking for does not exist in this space.</p>
+    <a href="/" class="home-link">Return to Base</a>
+</div>
+
+<style>
+    .error-container {
+        text-align: center;
+        padding: 6rem 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .error-code {
+        font-size: 8rem;
+        line-height: 1;
+        margin-bottom: 1rem;
+        letter-spacing: -0.05em;
+    }
+
+    .error-message {
+        font-family: 'Cormorant Garamond', serif;
+        font-size: 1.5rem;
+        font-style: italic;
+        color: #555;
+        margin-bottom: 3rem;
+    }
+
+    .home-link {
+        display: inline-block;
+        border: 1px solid var(--border-color);
+        padding: 0.75rem 1.5rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 0.9rem;
+        transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
+    .home-link:hover {
+        background-color: var(--border-color);
+        color: var(--bg-color);
+    }
+</style>
+
+{% include "footer.html" %}

--- a/examples/aether-monolith/templates/footer.html
+++ b/examples/aether-monolith/templates/footer.html
@@ -1,0 +1,34 @@
+        </div>
+    </main>
+    <footer class="site-footer">
+        <div class="monolith-container footer-content">
+            <p>&copy; 2024 Aether Monolith. All rights reserved.</p>
+            <p>Architected by Aether Architect</p>
+        </div>
+    </footer>
+    <style>
+        .site-footer {
+            border-top: 2px solid var(--border-color);
+            padding: 2.5rem 0;
+            margin-top: auto;
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .footer-content {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        @media (max-width: 600px) {
+            .footer-content {
+                flex-direction: column;
+                gap: 1rem;
+                text-align: center;
+            }
+        }
+    </style>
+</body>
+</html>

--- a/examples/aether-monolith/templates/header.html
+++ b/examples/aether-monolith/templates/header.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% elif section.title %}{{ section.title }} | {% endif %}Aether Monolith</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;600&display=swap');
+
+        :root {
+            --bg-color: #f7f7f5;
+            --text-color: #0f0f0f;
+            --border-color: #0f0f0f;
+            --accent-color: #e5e5e5;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: 'Inter', sans-serif;
+            font-weight: 300;
+            line-height: 1.6;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Cormorant Garamond', serif;
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: 1rem;
+            color: var(--text-color);
+        }
+
+        a {
+            color: var(--text-color);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-bottom-color 0.2s ease;
+        }
+
+        a:hover {
+            border-bottom-color: var(--text-color);
+        }
+
+        .monolith-container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            width: 100%;
+        }
+
+        .site-header {
+            border-bottom: 2px solid var(--border-color);
+            padding: 2.5rem 0;
+            margin-bottom: 4rem;
+        }
+
+        .header-content {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+
+        .site-title {
+            font-size: 2.5rem;
+            letter-spacing: -0.02em;
+            text-transform: uppercase;
+        }
+
+        .site-nav {
+            display: flex;
+            gap: 2rem;
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            font-weight: 400;
+        }
+
+        .main-content {
+            flex: 1;
+            padding-bottom: 6rem;
+        }
+    </style>
+</head>
+<body>
+    <header class="site-header">
+        <div class="monolith-container header-content">
+            <h1 class="site-title"><a href="/">Aether Monolith</a></h1>
+            <nav class="site-nav">
+                <a href="/">Home</a>
+                <a href="/about/">About</a>
+            </nav>
+        </div>
+    </header>
+    <main class="main-content">
+        <div class="monolith-container">

--- a/examples/aether-monolith/templates/page.html
+++ b/examples/aether-monolith/templates/page.html
@@ -1,0 +1,45 @@
+{% include "header.html" %}
+
+<article class="page-content">
+    <header class="page-header">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.description %}
+        <p class="page-description">{{ page.description }}</p>
+        {% endif %}
+    </header>
+
+    <div class="prose">
+        {{ page.content | safe }}
+    </div>
+</article>
+
+<style>
+    .page-header {
+        margin-bottom: 3rem;
+        padding-bottom: 2rem;
+        border-bottom: 1px solid var(--accent-color);
+    }
+
+    .page-title {
+        font-size: 3.5rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .page-description {
+        font-size: 1.2rem;
+        color: #555;
+        font-family: 'Cormorant Garamond', serif;
+        font-style: italic;
+    }
+
+    .prose {
+        font-size: 1.1rem;
+        max-width: 65ch;
+    }
+
+    .prose p {
+        margin-bottom: 1.5rem;
+    }
+</style>
+
+{% include "footer.html" %}

--- a/examples/aether-monolith/templates/section.html
+++ b/examples/aether-monolith/templates/section.html
@@ -1,0 +1,96 @@
+{% include "header.html" %}
+
+<article class="section-content">
+    <header class="section-header">
+        <h1 class="section-title">{{ section.title }}</h1>
+        {% if section.description %}
+        <p class="section-description">{{ section.description }}</p>
+        {% endif %}
+    </header>
+
+    <div class="prose">
+        {{ section.content | safe }}
+    </div>
+
+    {% if section.pages | length > 0 %}
+    <div class="section-pages">
+        <h2>Readings</h2>
+        <ul class="page-list">
+            {% for page in section.pages %}
+            <li class="page-item">
+                <a href="{{ page.permalink }}" class="page-link">{{ page.title }}</a>
+                {% if page.description %}
+                <span class="page-meta">{{ page.description }}</span>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+</article>
+
+<style>
+    .section-header {
+        margin-bottom: 3rem;
+    }
+
+    .section-title {
+        font-size: 4rem;
+        margin-bottom: 0.5rem;
+        letter-spacing: -0.03em;
+    }
+
+    .section-description {
+        font-size: 1.5rem;
+        color: #555;
+        font-family: 'Cormorant Garamond', serif;
+        font-style: italic;
+    }
+
+    .prose {
+        font-size: 1.25rem;
+        max-width: 65ch;
+        margin-bottom: 4rem;
+    }
+
+    .prose p {
+        margin-bottom: 1.5rem;
+    }
+
+    .section-pages {
+        border-top: 2px solid var(--border-color);
+        padding-top: 2rem;
+    }
+
+    .section-pages h2 {
+        font-size: 1.5rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        margin-bottom: 2rem;
+    }
+
+    .page-list {
+        list-style: none;
+    }
+
+    .page-item {
+        margin-bottom: 1.5rem;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .page-link {
+        font-family: 'Cormorant Garamond', serif;
+        font-size: 2rem;
+        font-weight: 600;
+        line-height: 1.2;
+    }
+
+    .page-meta {
+        font-size: 0.9rem;
+        color: #666;
+        margin-top: 0.25rem;
+    }
+</style>
+
+{% include "footer.html" %}

--- a/examples/aether-monolith/templates/shortcodes/alert.html
+++ b/examples/aether-monolith/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/aether-monolith/templates/taxonomy.html
+++ b/examples/aether-monolith/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/aether-monolith/templates/taxonomy_term.html
+++ b/examples/aether-monolith/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Added a new example site called `aether-monolith`. 
This example demonstrates a structural, elegant minimalist design focusing on solid colors (off-whites and stark blacks) and high-contrast typography. It explicitly avoids the use of gradients and emojis, creating a clean architectural feel.

Key elements:
- Built with Hwaro template defaults.
- Configured with `emoji = false`.
- High contrast typography with Cormorant Garamond and Inter.
- Clean structural layout matching the theme requirements.

---
*PR created automatically by Jules for task [2113975761585811045](https://jules.google.com/task/2113975761585811045) started by @hahwul*