### PR TITLE
feat(examples): add cobalt-tesseract neo-brutalist theme example

### DIFF
--- a/examples/cobalt-tesseract/AGENTS.md
+++ b/examples/cobalt-tesseract/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/cobalt-tesseract/archetypes/default.md
+++ b/examples/cobalt-tesseract/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/cobalt-tesseract/config.toml
+++ b/examples/cobalt-tesseract/config.toml
@@ -1,0 +1,211 @@
+title = "Cobalt Tesseract"
+base_url = "https://example.com"
+description = "A structural, elegant neo-brutalist cobalt design system."
+theme = ""
+
+[markdown]
+emoji = false
+
+[[taxonomies]]
+name = "tags"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+# [plugins]
+# processors = ["markdown"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+# [sitemap]
+# enabled = true
+# filename = "sitemap.xml"
+# changefreq = "weekly"
+# priority = 0.5
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/cobalt-tesseract/content/_index.md
+++ b/examples/cobalt-tesseract/content/_index.md
@@ -1,0 +1,16 @@
++++
+title = "Cobalt Tesseract"
+description = "A structural, elegant neo-brutalist cobalt design system."
++++
+
+Welcome to the **Cobalt Tesseract** network. This framework provides an uncompromising, highly structural visual aesthetic engineered around pure absolute values: total black `#000000`, absolute white `#FFFFFF`, and pure cobalt `#0047AB`.
+
+*No gradients. No emojis.* Just pure, solid form.
+
+It emphasizes typography, solid boundaries, and structural clarity, rendering information with architectural precision.
+
+### Core Directives
+
+1.  **Structure over Decoration:** Rely on layout and spatial reasoning.
+2.  **Absolute Colors:** Gradients are strictly prohibited.
+3.  **High Contrast:** Maximize legibility through stark juxtaposition.

--- a/examples/cobalt-tesseract/content/posts/_index.md
+++ b/examples/cobalt-tesseract/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Posts"
+description = "System logs and architectural directives."
++++
+
+This sector contains documented protocols and structural logs.

--- a/examples/cobalt-tesseract/content/posts/architecture.md
+++ b/examples/cobalt-tesseract/content/posts/architecture.md
@@ -1,0 +1,31 @@
++++
+title = "Architectural Protocol Alpha"
+date = 2024-05-15
+description = "Establishing the foundation of the Cobalt Tesseract layout engine."
+[taxonomies]
+tags = ["architecture", "protocol", "css-grid"]
++++
+
+## Establishing Grid Protocols
+
+The Cobalt Tesseract framework utilizes CSS Grid to form an absolute, uncompromising structure. Every element must exist within defined geometric boundaries.
+
+The primary layout separates the navigation sector from the main data sector using a sharp, rigid axis line.
+
+```css
+/* Core Layout Matrix */
+.grid-container {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    min-height: 100vh;
+}
+```
+
+By asserting control over these absolute metrics, we eliminate ambiguity in spatial positioning.
+
+### Solid State Rules
+
+We explicitly discard soft borders and drop shadows in favor of hard demarcations.
+
+*   `--border-width: 2px`
+*   `border: var(--border-width) solid var(--c-border);`

--- a/examples/cobalt-tesseract/content/posts/design-system.md
+++ b/examples/cobalt-tesseract/content/posts/design-system.md
@@ -1,0 +1,33 @@
++++
+title = "Design System Validation"
+date = 2024-05-16
+description = "Verifying the color and typography variables within the environment."
+[taxonomies]
+tags = ["design", "validation", "variables"]
++++
+
+## Typography Matrices
+
+The system relies on a dual-font approach.
+
+1.  **Inter (Sans-Serif):** Used for primary readability and structural headers. Highly legible.
+2.  **IBM Plex Mono (Monospace):** Deployed for systemic data, tags, meta-information, and rigid tabular or code elements.
+
+## Color Axioms
+
+Three primary states exist:
+
+1.  `--c-void: #000000`
+2.  `--c-white: #FFFFFF`
+3.  `--c-cobalt: #0047AB`
+
+### Component Verification
+
+A standard Tesseract Box component isolates critical data streams:
+
+<div class="tesseract-box">
+  <h3 style="margin-top:0;">Isolated Data</h3>
+  <p style="margin-bottom:0;">This is a validated component containing essential sub-data within the primary stream.</p>
+</div>
+
+All systems nominal.

--- a/examples/cobalt-tesseract/templates/404.html
+++ b/examples/cobalt-tesseract/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}404 - Not Found | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <div style="text-align: center; padding: 5rem 0;">
+        <h1 style="border-bottom: none; font-size: 8rem; margin-bottom: 0; color: var(--c-cobalt);">404</h1>
+        <h2 style="border-left: none; padding-left: 0; margin-top: 0; margin-bottom: 2rem;">ENTITY NOT FOUND</h2>
+        <p>The requested protocol or data sector could not be located in the current spatial dimension.</p>
+        <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 1rem 2rem; background-color: var(--c-white); color: var(--c-void); font-family: var(--f-mono); font-weight: 600; text-decoration: none;">&larr; RETURN TO BASE</a>
+    </div>
+{% endblock %}

--- a/examples/cobalt-tesseract/templates/base.html
+++ b/examples/cobalt-tesseract/templates/base.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Inter:wght@400;600;800&display=swap');
+
+        :root {
+            --c-void: #000000;
+            --c-white: #FFFFFF;
+            --c-cobalt: #0047AB;
+            --c-cobalt-light: #3366CC;
+            --c-border: var(--c-white);
+
+            --f-sans: 'Inter', sans-serif;
+            --f-mono: 'IBM Plex Mono', monospace;
+
+            --border-width: 2px;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--c-void);
+            color: var(--c-white);
+            font-family: var(--f-sans);
+            line-height: 1.6;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        /* Layout Grid */
+        .grid-container {
+            display: grid;
+            grid-template-columns: 280px 1fr;
+            min-height: 100vh;
+        }
+
+        @media (max-width: 768px) {
+            .grid-container {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        /* Sidebar Structure */
+        .sidebar {
+            background-color: var(--c-cobalt);
+            border-right: var(--border-width) solid var(--c-border);
+            padding: 2rem;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+        }
+
+        .sidebar-brand {
+            font-family: var(--f-mono);
+            font-size: 1.5rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: -0.05em;
+            color: var(--c-white);
+            text-decoration: none;
+            display: block;
+            margin-bottom: 2rem;
+        }
+
+        .sidebar-nav {
+            list-style: none;
+            margin-top: 2rem;
+        }
+
+        .sidebar-nav li {
+            margin-bottom: 1rem;
+        }
+
+        .sidebar-nav a {
+            color: var(--c-white);
+            text-decoration: none;
+            font-size: 1rem;
+            font-weight: 600;
+            transition: color 0.2s;
+            display: inline-block;
+            position: relative;
+        }
+
+        .sidebar-nav a::after {
+            content: '';
+            position: absolute;
+            width: 100%;
+            height: var(--border-width);
+            bottom: -2px;
+            left: 0;
+            background-color: var(--c-white);
+            transform: scaleX(0);
+            transform-origin: bottom right;
+            transition: transform 0.25s ease-out;
+        }
+
+        .sidebar-nav a:hover::after {
+            transform: scaleX(1);
+            transform-origin: bottom left;
+        }
+
+        /* Main Content Structure */
+        .main-content {
+            padding: 4rem;
+            max-width: 1000px;
+        }
+
+        @media (max-width: 768px) {
+            .main-content {
+                padding: 2rem;
+            }
+            .sidebar {
+                border-right: none;
+                border-bottom: var(--border-width) solid var(--c-border);
+            }
+        }
+
+        /* Typography */
+        h1, h2, h3, h4 {
+            font-family: var(--f-sans);
+            font-weight: 800;
+            letter-spacing: -0.02em;
+            margin-bottom: 1.5rem;
+            color: var(--c-white);
+        }
+
+        h1 {
+            font-size: 3.5rem;
+            text-transform: uppercase;
+            border-bottom: var(--border-width) solid var(--c-white);
+            padding-bottom: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        h2 {
+            font-size: 2rem;
+            margin-top: 3rem;
+            border-left: calc(var(--border-width) * 2) solid var(--c-cobalt);
+            padding-left: 1rem;
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+            font-size: 1.1rem;
+            color: #CCCCCC;
+        }
+
+        a {
+            color: var(--c-cobalt-light);
+            text-decoration: none;
+            border-bottom: 1px solid var(--c-cobalt-light);
+        }
+
+        a:hover {
+            color: var(--c-white);
+            border-bottom-color: var(--c-white);
+        }
+
+        /* Code Blocks */
+        pre {
+            background-color: #111111;
+            border: var(--border-width) solid #333333;
+            padding: 1.5rem;
+            overflow-x: auto;
+            margin-bottom: 2rem;
+        }
+
+        code {
+            font-family: var(--f-mono);
+            font-size: 0.9rem;
+            color: #EEEEEE;
+        }
+
+        /* Component Showcase */
+        .tesseract-box {
+            border: var(--border-width) solid var(--c-border);
+            padding: 2rem;
+            margin: 2rem 0;
+            position: relative;
+            background-color: var(--c-void);
+        }
+
+        .tesseract-box::before {
+            content: '';
+            position: absolute;
+            top: -6px;
+            left: -6px;
+            right: -6px;
+            bottom: -6px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            pointer-events: none;
+        }
+
+        .tesseract-box::after {
+            content: 'TESSERACT';
+            position: absolute;
+            top: -0.8rem;
+            right: 1rem;
+            background-color: var(--c-void);
+            padding: 0 0.5rem;
+            font-family: var(--f-mono);
+            font-size: 0.8rem;
+            color: var(--c-cobalt-light);
+            font-weight: 600;
+        }
+
+        /* Taxonomy Tags */
+        .tag-list {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 2rem;
+            flex-wrap: wrap;
+        }
+
+        .tag {
+            background-color: var(--c-white);
+            color: var(--c-void);
+            font-family: var(--f-mono);
+            font-size: 0.8rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+            text-transform: uppercase;
+            text-decoration: none;
+            border: none;
+        }
+
+        .tag:hover {
+            background-color: var(--c-cobalt);
+            color: var(--c-white);
+        }
+
+        hr {
+            border: 0;
+            border-top: var(--border-width) dashed #333;
+            margin: 3rem 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="grid-container">
+        <aside class="sidebar">
+            <div>
+                <a href="{{ base_url }}/" class="sidebar-brand">{{ site.title }}</a>
+                <p style="font-size: 0.9rem; color: rgba(255,255,255,0.7); font-family: var(--f-mono);">System Version 1.0</p>
+                <ul class="sidebar-nav">
+                    <li><a href="{{ base_url }}/posts/">Posts</a></li>
+                    <li><a href="{{ base_url }}/tags/">Tags</a></li>
+                </ul>
+            </div>
+            <div style="font-family: var(--f-mono); font-size: 0.8rem; color: rgba(255,255,255,0.5);">
+                &copy; {{ site.title }}
+            </div>
+        </aside>
+
+        <main class="main-content">
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+</body>
+</html>

--- a/examples/cobalt-tesseract/templates/index.html
+++ b/examples/cobalt-tesseract/templates/index.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title | default(value=site.title) }}</h1>
+    <div class="tesseract-box">
+        <p>{{ site.description }}</p>
+    </div>
+
+    <div>
+        {{ content | safe }}
+    </div>
+
+    {% if section and section.pages %}
+        <h2>Latest Directives</h2>
+        {% for post in section.pages | slice(end=3) %}
+            <div style="margin-bottom: 2rem; border-left: var(--border-width) solid var(--c-white); padding-left: 1.5rem;">
+                <div style="font-family: var(--f-mono); font-size: 0.9rem; color: var(--c-cobalt-light); margin-bottom: 0.5rem;">{{ post.date | date(format="%Y-%m-%d") }}</div>
+                <h3 style="margin-bottom: 0.5rem;"><a href="{{ post.permalink }}" style="color: var(--c-white); text-decoration: none; border-bottom: none;">{{ post.title }}</a></h3>
+                <p style="font-size: 1rem;">{{ post.description }}</p>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endblock %}

--- a/examples/cobalt-tesseract/templates/page.html
+++ b/examples/cobalt-tesseract/templates/page.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <article>
+        <h1>{{ page.title }}</h1>
+
+        <div style="font-family: var(--f-mono); font-size: 0.9rem; color: var(--c-cobalt-light); margin-bottom: 2rem; border-bottom: 1px solid #333; padding-bottom: 1rem;">
+            INITIALIZED: {{ page.date | date(format="%Y-%m-%d") }}
+        </div>
+
+        {% if page.taxonomies and page.taxonomies.tags %}
+            <div class="tag-list">
+                {% for tag in page.taxonomies.tags %}
+                    <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+                {% endfor %}
+            </div>
+        {% endif %}
+
+        <div class="page-content">
+            {{ content | safe }}
+        </div>
+    </article>
+{% endblock %}

--- a/examples/cobalt-tesseract/templates/section.html
+++ b/examples/cobalt-tesseract/templates/section.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}{{ section.title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <h1>{{ section.title }}</h1>
+
+    {% if section.content %}
+    <div style="margin-bottom: 3rem;">
+        {{ section.content | safe }}
+    </div>
+    {% endif %}
+
+    <div class="posts-grid" style="display: grid; gap: 2rem;">
+        {% for post in section.pages %}
+            <div class="tesseract-box" style="margin: 0;">
+                <div style="font-family: var(--f-mono); font-size: 0.9rem; color: var(--c-cobalt-light); margin-bottom: 0.5rem;">{{ post.date | date(format="%Y-%m-%d") }}</div>
+                <h2 style="margin-top: 0; margin-bottom: 1rem; border-left: none; padding-left: 0; font-size: 1.5rem;">
+                    <a href="{{ post.permalink }}" style="color: var(--c-white); text-decoration: none; border-bottom: none;">{{ post.title }}</a>
+                </h2>
+                <p style="font-size: 1rem; margin-bottom: 1.5rem;">{{ post.description }}</p>
+                <a href="{{ post.permalink }}" style="font-family: var(--f-mono); font-size: 0.9rem; text-transform: uppercase; font-weight: 600;">ACCESS PROTOCOL &rarr;</a>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/examples/cobalt-tesseract/templates/shortcodes/alert.html
+++ b/examples/cobalt-tesseract/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/cobalt-tesseract/templates/taxonomy.html
+++ b/examples/cobalt-tesseract/templates/taxonomy.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}{{ taxonomy.name | default(value="Tags") | title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <h1>{{ taxonomy.name | default(value="Tags") | title }}</h1>
+
+    <div class="tag-list" style="margin-top: 3rem;">
+        {% if taxonomy and taxonomy.terms %}
+            {% for term in taxonomy.terms %}
+                <a href="{{ term.permalink }}" class="tag" style="font-size: 1rem; padding: 0.5rem 1rem;">{{ term.name }} ({{ term.pages | length }})</a>
+            {% endfor %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/examples/cobalt-tesseract/templates/taxonomy_term.html
+++ b/examples/cobalt-tesseract/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}{% if term %}{{ term.name }}{% else %}Tag{% endif %} | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <h1>{% if term %}{{ term.name }}{% else %}Tag{% endif %}</h1>
+
+    <div class="posts-grid" style="display: grid; gap: 2rem; margin-top: 3rem;">
+        {% if term %}
+            {% for post in term.pages %}
+                <div class="tesseract-box" style="margin: 0;">
+                    <div style="font-family: var(--f-mono); font-size: 0.9rem; color: var(--c-cobalt-light); margin-bottom: 0.5rem;">{{ post.date | date(format="%Y-%m-%d") }}</div>
+                    <h2 style="margin-top: 0; margin-bottom: 1rem; border-left: none; padding-left: 0; font-size: 1.5rem;">
+                        <a href="{{ post.permalink }}" style="color: var(--c-white); text-decoration: none; border-bottom: none;">{{ post.title }}</a>
+                    </h2>
+                    <a href="{{ post.permalink }}" style="font-family: var(--f-mono); font-size: 0.9rem; text-transform: uppercase; font-weight: 600;">ACCESS PROTOCOL &rarr;</a>
+                </div>
+            {% endfor %}
+        {% endif %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
This PR introduces a new example site for Hwaro: `cobalt-tesseract`. 

It fulfills the following requirements:
*   Initializes a new `hwaro` project in the `examples/` directory with a highly unique name.
*   Implements a custom "neo-brutalist" theme with a focus on solid structural layouts, utilizing absolute color values (void black, pure white, and cobalt blue).
*   Strictly prohibits the use of gradients in CSS and emojis in content/settings (`emoji = false`).
*   Provides fully customized template pages (`base.html`, `index.html`, `section.html`, `page.html`, `taxonomy.html`, `taxonomy_term.html`, `404.html`) showcasing a robust structural methodology relying on CSS Grid.
*   Includes sample markdown content demonstrating component and layout behaviors.

---
*PR created automatically by Jules for task [15681401957360328707](https://jules.google.com/task/15681401957360328707) started by @hahwul*