### PR TITLE
Add crimson-forge example site

### DIFF
--- a/examples/crimson-forge/AGENTS.md
+++ b/examples/crimson-forge/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/crimson-forge/archetypes/default.md
+++ b/examples/crimson-forge/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/crimson-forge/config.toml
+++ b/examples/crimson-forge/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "My Hwaro Site"
+description = "Welcome to my new Hwaro site."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/crimson-forge/content/_index.md
+++ b/examples/crimson-forge/content/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Crimson Forge"
+description = "A haven of pure crimson elegance."
+date = "2024-05-01"
++++
+
+Welcome to Crimson Forge.
+
+This is a sanctuary of dark steel and deep crimson, forged in the depths of pure design. Here, structure meets elegance.
+
+Explore the depths of our craftsmanship.

--- a/examples/crimson-forge/content/about.md
+++ b/examples/crimson-forge/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Crimson Forge"
+description = "The history and ethos of Crimson Forge."
+date = "2024-05-01"
++++
+
+Crimson Forge is dedicated to the absolute purity of form. We reject gradients and unnecessary adornments. We embrace the raw power of pure, solid colors.
+
+Our palette is strictly limited to the deepest blacks, the sharpest whites, and the most visceral crimson.
+
+Join us in the pursuit of architectural brutalism.

--- a/examples/crimson-forge/templates/404.html
+++ b/examples/crimson-forge/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/crimson-forge/templates/footer.html
+++ b/examples/crimson-forge/templates/footer.html
@@ -1,0 +1,10 @@
+    </main>
+
+    <footer class="site-footer">
+        <div class="container">
+            <p>&copy; {{ site.title }}. Forged in pure CSS and HTML.</p>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/examples/crimson-forge/templates/header.html
+++ b/examples/crimson-forge/templates/header.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page and page.title %}{{ page.title }} | {% elif section and section.title %}{{ section.title }} | {% endif %}{{ site.title }}</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --bg-color: #0a0303;
+            --text-color: #f0f0f0;
+            --accent-color: #d11a2a;
+            --border-color: #330b0f;
+            --font-heading: 'Cinzel', serif;
+            --font-body: 'Inter', sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: var(--font-body);
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        a {
+            color: var(--accent-color);
+            text-decoration: none;
+            transition: color 0.2s ease, border-bottom-color 0.2s ease;
+            border-bottom: 1px solid transparent;
+        }
+
+        a:hover {
+            color: #ff3344;
+            border-bottom-color: #ff3344;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 700;
+            margin-bottom: 1rem;
+            color: var(--text-color);
+            text-transform: uppercase;
+            letter-spacing: 2px;
+        }
+
+        .site-header {
+            border-bottom: 2px solid var(--border-color);
+            padding: 2rem 0;
+            margin-bottom: 3rem;
+            text-align: center;
+        }
+
+        .site-title {
+            font-size: 2.5rem;
+            font-family: var(--font-heading);
+            color: var(--accent-color);
+            text-decoration: none;
+            border-bottom: none;
+            display: inline-block;
+        }
+
+        .site-title:hover {
+            color: var(--accent-color);
+            border-bottom: none;
+        }
+
+        .site-nav {
+            margin-top: 1.5rem;
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+        }
+
+        .site-nav a {
+            font-family: var(--font-heading);
+            font-size: 0.9rem;
+            letter-spacing: 1px;
+            color: var(--text-color);
+            padding-bottom: 4px;
+        }
+
+        .site-nav a:hover {
+            color: var(--accent-color);
+            border-bottom-color: var(--accent-color);
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 2rem;
+        }
+
+        .content {
+            font-size: 1.1rem;
+        }
+
+        .content p {
+            margin-bottom: 1.5rem;
+        }
+
+        .content h2 {
+            margin-top: 3rem;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .page-header {
+            margin-bottom: 2rem;
+            text-align: center;
+        }
+
+        .page-title {
+            font-size: 2rem;
+            color: var(--text-color);
+            margin-bottom: 0.5rem;
+        }
+
+        .page-meta {
+            font-family: var(--font-body);
+            font-size: 0.85rem;
+            color: #888;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .post-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .post-item {
+            margin-bottom: 2.5rem;
+            padding-bottom: 2.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .post-item:last-child {
+            border-bottom: none;
+        }
+
+        .post-title {
+            font-size: 1.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .post-title a {
+            color: var(--text-color);
+            border-bottom: none;
+        }
+
+        .post-title a:hover {
+            color: var(--accent-color);
+        }
+
+        .post-summary {
+            color: #ccc;
+            margin-bottom: 1rem;
+        }
+
+        .read-more {
+            font-family: var(--font-heading);
+            font-size: 0.85rem;
+            color: var(--accent-color);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            border-bottom: 1px solid var(--accent-color);
+            padding-bottom: 2px;
+        }
+
+        .read-more:hover {
+            color: #ff3344;
+            border-bottom-color: #ff3344;
+        }
+
+        hr {
+            border: 0;
+            height: 1px;
+            background-color: var(--border-color);
+            margin: 3rem 0;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--accent-color);
+            padding-left: 1.5rem;
+            margin-left: 0;
+            font-style: italic;
+            color: #ccc;
+            background-color: rgba(209, 26, 42, 0.05);
+            padding: 1rem 1.5rem;
+        }
+
+        code {
+            font-family: monospace;
+            background-color: #1a0808;
+            padding: 0.2rem 0.4rem;
+            border-radius: 2px;
+            color: #ff9999;
+        }
+
+        pre {
+            background-color: #1a0808;
+            padding: 1.5rem;
+            overflow-x: auto;
+            border-left: 2px solid var(--accent-color);
+        }
+
+        pre code {
+            background-color: transparent;
+            padding: 0;
+            color: #f0f0f0;
+        }
+
+        .site-footer {
+            margin-top: 5rem;
+            padding: 3rem 0;
+            border-top: 2px solid var(--border-color);
+            text-align: center;
+            font-size: 0.85rem;
+            color: #666;
+            font-family: var(--font-heading);
+            letter-spacing: 1px;
+            text-transform: uppercase;
+        }
+    </style>
+</head>
+<body>
+
+    <header class="site-header">
+        <div class="container">
+            <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+            <nav class="site-nav">
+                <a href="{{ base_url }}/">Home</a>
+                <a href="{{ base_url }}/about/">About</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container">

--- a/examples/crimson-forge/templates/page.html
+++ b/examples/crimson-forge/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<article class="page">
+    <header class="page-header">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="page-meta">{{ page.date | date(format="%B %d, %Y") }}</div>
+        {% endif %}
+    </header>
+
+    <div class="content">
+        {{ page.content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/crimson-forge/templates/section.html
+++ b/examples/crimson-forge/templates/section.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+
+<div class="section">
+    {% if section.title %}
+    <header class="page-header">
+        <h1 class="page-title">{{ section.title }}</h1>
+        {% if section.description %}
+        <p class="page-meta">{{ section.description }}</p>
+        {% endif %}
+    </header>
+    {% endif %}
+
+    {% if section.content %}
+    <div class="content" style="margin-bottom: 3rem;">
+        {{ section.content | safe }}
+    </div>
+    {% endif %}
+
+    <div class="post-list">
+        {% for page in pages %}
+        <div class="post-item">
+            <h2 class="post-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+            {% if page.date %}
+            <div class="page-meta" style="margin-bottom: 1rem;">{{ page.date | date(format="%Y-%m-%d") }}</div>
+            {% endif %}
+            {% if page.description %}
+            <div class="post-summary">{{ page.description }}</div>
+            {% endif %}
+            <a href="{{ page.permalink }}" class="read-more">Read More</a>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/crimson-forge/templates/shortcodes/alert.html
+++ b/examples/crimson-forge/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/crimson-forge/templates/taxonomy.html
+++ b/examples/crimson-forge/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/crimson-forge/templates/taxonomy_term.html
+++ b/examples/crimson-forge/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Added a new Hwaro example site named `crimson-forge`. It features a pure dark theme utilizing solid black backgrounds and deep crimson accents, strictly adhering to the constraint of avoiding gradients and emojis. Sample minimal content and custom structural templates (header, footer, page, section) were provided to showcase the styling.

---
*PR created automatically by Jules for task [11252765250263945975](https://jules.google.com/task/11252765250263945975) started by @hahwul*