### PR TITLE
fix: resolve 404 link in lumina-flare example

### DIFF
--- a/examples/lumina-flare/templates/header.html
+++ b/examples/lumina-flare/templates/header.html
@@ -2,6 +2,6 @@
     <a href="/" class="site-title">{{ site.title }}</a>
     <nav>
         <a href="/">Home</a>
-        <a href="/about.html">About</a>
+        <a href="/about/">About</a>
     </nav>
 </header>


### PR DESCRIPTION
Found and fixed a 404 link in the `lumina-flare` example project by updating a hardcoded reference to `about.html` in the header to point to `about/`, matching Hwaro's default output structure.

---
*PR created automatically by Jules for task [5777235918453685535](https://jules.google.com/task/5777235918453685535) started by @chei-l*