### PR TITLE
feat: add graphene-weave-ui example site

### DIFF
--- a/examples/graphene-weave-ui/AGENTS.md
+++ b/examples/graphene-weave-ui/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/graphene-weave-ui/archetypes/default.md
+++ b/examples/graphene-weave-ui/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/graphene-weave-ui/config.toml
+++ b/examples/graphene-weave-ui/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Graphene Weave UI"
+description = "A conceptual structural interface avoiding gradients and emojis."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+[markdown]
+# safe = false
+# lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/graphene-weave-ui/content/_index.md
+++ b/examples/graphene-weave-ui/content/_index.md
@@ -1,0 +1,17 @@
++++
+title = "Graphene Weave UI"
+description = "High-contrast structural monolith, intersecting grid nodes."
+date = "2024-05-18"
++++
+
+Welcome to the **Graphene Weave UI**. This interface is built upon principles of absolute contrast and rigid structure.
+
+Here we strictly utilize solid colors, precise geometric typography, and grid-based layouts. The aesthetic evokes the interconnected lattice of carbon atoms.
+
+Features of this interface paradigm:
+
+*   **Monochrome Foundation**: Deep charcoal blacks against crisp clinical whites.
+*   **Teal Accents**: Sparse injections of `var(--accent-teal)` for critical interaction points.
+*   **Grid Typology**: All elements exist within strict, unbroken cellular tracks.
+
+Explore the [About](/about) section for the design manifesto.

--- a/examples/graphene-weave-ui/content/about.md
+++ b/examples/graphene-weave-ui/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "Design Manifesto"
+description = "Principles of the Graphene Weave."
+date = "2024-05-18"
++++
+
+## The Weave Protocol
+
+The **Graphene Weave UI** represents a departure from organic softness and blurred gradients. It stands for:
+
+1.  **Clarity over Comfort:** Information is structured into distinct, high-contrast modules. Borders are sharp, backgrounds are solid.
+2.  **Absence of Illusion:** We do not pretend the screen is anything but a grid of pixels. Gradients, shadows, and rounded corners are illusions of physical space that we reject.
+3.  **Signal over Noise:** The rejection of superfluous decorative elements (like emojis) ensures that the message remains the sole focus of the user.
+
+### Typography
+
+Typography is treated as an architectural material. We use `Inter` for its neutral, machine-like legibility, structured in rigid hierarchies.
+
+Return to [System Root](/)

--- a/examples/graphene-weave-ui/static/style.css
+++ b/examples/graphene-weave-ui/static/style.css
@@ -1,0 +1,236 @@
+/* ==========================================================================
+   GRAPHENE WEAVE UI - STYLE PROTOCOL
+   Solid colors, sharp borders, absolute contrast. No gradients. No emojis.
+   ========================================================================== */
+
+   :root {
+    /* Color Palette - Absolute Solids */
+    --bg-dark: #090a0c;
+    --bg-panel: #121418;
+    --fg-main: #e2e8f0;
+    --fg-muted: #94a3b8;
+    --accent-teal: #00f0ff;
+    --border-main: #334155;
+
+    /* Typography */
+    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-mono: 'Space Mono', monospace;
+}
+
+/* Reset */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-dark);
+    color: var(--fg-main);
+    font-family: var(--font-sans);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* Site Layout Grid */
+.site-grid {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    min-height: 100vh;
+    border-left: 1px solid var(--border-main);
+    border-right: 1px solid var(--border-main);
+    max-width: 1200px;
+    margin: 0 auto;
+    background-color: var(--bg-panel);
+}
+
+/* Header */
+.site-header {
+    border-bottom: 1px solid var(--border-main);
+    padding: 1.5rem 2rem;
+    background-color: var(--bg-dark);
+}
+
+.header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.brand {
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-size: 1.2rem;
+    color: var(--fg-main);
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    letter-spacing: 0.05em;
+}
+
+.brand-node {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    background-color: var(--accent-teal);
+    border: 2px solid var(--bg-dark);
+    box-shadow: 0 0 0 1px var(--accent-teal);
+}
+
+.site-nav a {
+    color: var(--fg-muted);
+    text-decoration: none;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.5rem 1rem;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+}
+
+.site-nav a:hover {
+    color: var(--accent-teal);
+    border-color: var(--accent-teal);
+}
+
+/* Content Area */
+.site-content {
+    padding: 3rem 2rem;
+    display: grid;
+    gap: 3rem;
+}
+
+/* Hero Section */
+.hero-section {
+    padding-bottom: 2rem;
+    border-bottom: 2px solid var(--border-main);
+}
+
+.hero-title {
+    font-family: var(--font-sans);
+    font-weight: 900;
+    font-size: 4rem;
+    line-height: 1.1;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: -0.02em;
+}
+
+.hero-description {
+    font-size: 1.5rem;
+    color: var(--accent-teal);
+    font-family: var(--font-mono);
+    max-width: 800px;
+}
+
+/* Page Header */
+.page-header {
+    padding-bottom: 2rem;
+    border-bottom: 2px solid var(--border-main);
+}
+
+.page-title {
+    font-family: var(--font-sans);
+    font-weight: 900;
+    font-size: 3rem;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+}
+
+.page-meta {
+    font-family: var(--font-mono);
+    color: var(--accent-teal);
+    font-size: 0.9rem;
+}
+
+/* Content Module */
+.content-module {
+    border: 1px solid var(--border-main);
+    background-color: var(--bg-dark);
+}
+
+.module-header {
+    padding: 0.75rem 1.5rem;
+    border-bottom: 1px solid var(--border-main);
+    background-color: var(--bg-panel);
+}
+
+.module-label {
+    font-family: var(--font-mono);
+    color: var(--accent-teal);
+    font-size: 0.8rem;
+    letter-spacing: 0.1em;
+}
+
+.module-body {
+    padding: 2rem 1.5rem;
+}
+
+/* Prose (Markdown Content) */
+.prose h1, .prose h2, .prose h3 {
+    font-family: var(--font-sans);
+    font-weight: 600;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    color: var(--fg-main);
+}
+
+.prose h2 {
+    font-size: 1.75rem;
+    border-bottom: 1px dashed var(--border-main);
+    padding-bottom: 0.5rem;
+}
+
+.prose p {
+    margin-bottom: 1.5rem;
+    font-size: 1.1rem;
+    color: var(--fg-muted);
+}
+
+.prose a {
+    color: var(--accent-teal);
+    text-decoration: none;
+    border-bottom: 1px solid var(--accent-teal);
+}
+
+.prose a:hover {
+    background-color: var(--accent-teal);
+    color: var(--bg-dark);
+}
+
+.prose ul, .prose ol {
+    margin-bottom: 1.5rem;
+    padding-left: 2rem;
+    color: var(--fg-muted);
+    font-size: 1.1rem;
+}
+
+.prose li {
+    margin-bottom: 0.5rem;
+}
+
+.prose strong {
+    color: var(--fg-main);
+    font-weight: 600;
+}
+
+/* Footer */
+.site-footer {
+    border-top: 1px solid var(--border-main);
+    padding: 1.5rem 2rem;
+    background-color: var(--bg-dark);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--fg-muted);
+}
+
+.footer-inner {
+    display: flex;
+    justify-content: space-between;
+}
+
+.footer-system {
+    color: var(--accent-teal);
+}

--- a/examples/graphene-weave-ui/templates/404.html
+++ b/examples/graphene-weave-ui/templates/404.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="hero-section">
+    <h1 class="hero-title">404 - Node Not Found</h1>
+    <p class="hero-description">The requested data module does not exist in this sector.</p>
+</div>
+
+<div class="content-module">
+    <div class="module-header">
+        <span class="module-label">ERROR_STATE</span>
+    </div>
+    <div class="module-body prose">
+        <p>The path <code>{{ current_path | default(value="unknown") }}</code> leads to an empty node.</p>
+        <p><a href="{{ base_url }}/">Return to Root Node</a></p>
+    </div>
+</div>
+{% endblock content %}

--- a/examples/graphene-weave-ui/templates/base.html
+++ b/examples/graphene-weave-ui/templates/base.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ base_url }}/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;900&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="site-grid">
+        <header class="site-header">
+            <div class="header-inner">
+                <a href="{{ base_url }}/" class="brand">
+                    <span class="brand-node"></span>
+                    GRAPHENE // WEAVE
+                </a>
+                <nav class="site-nav">
+                    <a href="{{ base_url }}/about">About</a>
+                </nav>
+            </div>
+        </header>
+
+        <main class="site-content">
+            {% block content %}{% endblock content %}
+        </main>
+
+        <footer class="site-footer">
+            <div class="footer-inner">
+                <div class="footer-system">SYS.OP.OK</div>
+                <div class="footer-copy">&copy; 2024 {{ site.title }}</div>
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/graphene-weave-ui/templates/index.html
+++ b/examples/graphene-weave-ui/templates/index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="hero-section">
+    <h1 class="hero-title">{{ page.title }}</h1>
+    {% if page.description %}
+    <p class="hero-description">{{ page.description }}</p>
+    {% endif %}
+</div>
+
+<div class="content-module">
+    <div class="module-header">
+        <span class="module-label">DOC_ROOT</span>
+    </div>
+    <div class="module-body prose">
+        {{ content | safe }}
+    </div>
+</div>
+{% endblock content %}

--- a/examples/graphene-weave-ui/templates/page.html
+++ b/examples/graphene-weave-ui/templates/page.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+    <h1 class="page-title">{{ page.title }}</h1>
+    {% if page.date %}
+    <div class="page-meta">INIT: {{ page.date }}</div>
+    {% endif %}
+</div>
+
+<div class="content-module">
+    <div class="module-header">
+        <span class="module-label">DATA_STREAM</span>
+    </div>
+    <div class="module-body prose">
+        {{ content | safe }}
+    </div>
+</div>
+{% endblock content %}

--- a/examples/graphene-weave-ui/templates/section.html
+++ b/examples/graphene-weave-ui/templates/section.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+    <h1 class="page-title">{{ section.title | default(value="Section Index") }}</h1>
+</div>
+
+<div class="content-module">
+    <div class="module-header">
+        <span class="module-label">SECTION_NODES</span>
+    </div>
+    <div class="module-body prose">
+        {% if section.pages %}
+        <ul>
+            {% for page in section.pages %}
+            <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p>No active nodes in this sector.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock content %}

--- a/examples/graphene-weave-ui/templates/taxonomy.html
+++ b/examples/graphene-weave-ui/templates/taxonomy.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+    <h1 class="page-title">{{ taxonomy.name | title | default(value="Taxonomy") }}</h1>
+</div>
+
+<div class="content-module">
+    <div class="module-header">
+        <span class="module-label">TAXONOMY_TERMS</span>
+    </div>
+    <div class="module-body prose">
+        {% if terms %}
+        <ul>
+            {% for term in terms %}
+            <li><a href="{{ term.permalink }}">{{ term.name }} ({{ term.pages | length }})</a></li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p>No taxonomy terms found.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock content %}

--- a/examples/graphene-weave-ui/templates/taxonomy_term.html
+++ b/examples/graphene-weave-ui/templates/taxonomy_term.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+    <h1 class="page-title">{{ term.name | default(value="Term") }}</h1>
+</div>
+
+<div class="content-module">
+    <div class="module-header">
+        <span class="module-label">PAGES_WITH_TERM</span>
+    </div>
+    <div class="module-body prose">
+        {% if term and term.pages %}
+        <ul>
+            {% for page in term.pages %}
+            <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p>No pages found with this term.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Adds a new Hwaro example site named `graphene-weave-ui`.

This example addresses the requirement for a unique, elegantly designed webpage that strictly avoids emojis and gradients. It features:
* A `base.html` template extending an architecture that all internal pages (`index.html`, `page.html`, `404.html`, etc.) inherit from.
* A `style.css` utilizing pure solid colors (high contrast monochrome with `#00f0ff` teal accents) and CSS Grid.
* Simple content detailing the UI's design manifesto (`_index.md`, `about.md`).
* Configurations in `config.toml` that explicitly disable markdown emoji support.

---
*PR created automatically by Jules for task [8010822283732412485](https://jules.google.com/task/8010822283732412485) started by @hahwul*