### PR TITLE
feat: add celestial-monolith example

### DIFF
--- a/examples/celestial-monolith/AGENTS.md
+++ b/examples/celestial-monolith/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/celestial-monolith/archetypes/default.md
+++ b/examples/celestial-monolith/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/celestial-monolith/config.toml
+++ b/examples/celestial-monolith/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Celestial Monolith"
+description = "A brutalist solid-color architectural aesthetic"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/celestial-monolith/content/_index.md
+++ b/examples/celestial-monolith/content/_index.md
@@ -1,0 +1,14 @@
++++
+title = "Celestial Monolith"
+description = "Architecture of the Void"
++++
+
+Welcome to the Celestial Monolith. A structure built upon pure mathematical principles, devoid of distraction, gradients, or ornamentation.
+
+## Core Directives
+
+1. **Absolute Structure:** The layout must be purely structural.
+2. **Solid Form:** Only solid colors are permitted. Deep space blacks and stark stellar whites.
+3. **No Distraction:** Gradients and frivolous symbols are explicitly avoided.
+
+We find clarity in the abyss.

--- a/examples/celestial-monolith/content/about.md
+++ b/examples/celestial-monolith/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About the Monolith"
+description = "Purpose of the structure"
+date = "2024-05-01"
++++
+
+# The Architecture
+
+The monolith was designed to withstand the harsh environment of the cosmos. Its walls are constructed of pure geometric forms, intersecting at absolute right angles.
+
+There is no room for compromise here. Every pixel serves a structural purpose. The text is the interface. The contrast is the guide.
+
+> In the void, structure is the only truth.
+
+Return to the [nexus](/) when you are ready.

--- a/examples/celestial-monolith/templates/404.html
+++ b/examples/celestial-monolith/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>404</h1>
+    <div class="page-content">
+        <p>The requested structural element could not be found in the monolith.</p>
+        <p><a href="{{ base_url }}/">Return to coordinates</a></p>
+    </div>
+{% endblock %}

--- a/examples/celestial-monolith/templates/base.html
+++ b/examples/celestial-monolith/templates/base.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <style>
+        :root {
+            --bg-void: #050505;
+            --text-stark: #f8f9fa;
+            --accent-monolith: #e9ecef;
+            --border-strict: #343a40;
+            --grid-line: #212529;
+            --font-mono: 'Space Mono', 'IBM Plex Mono', 'Courier New', Courier, monospace;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-void);
+            color: var(--text-stark);
+            font-family: var(--font-sans);
+            line-height: 1.6;
+            min-height: 100vh;
+            display: grid;
+            grid-template-columns: 1fr;
+            grid-template-rows: auto 1fr auto;
+            /* Grid background pattern using pure solid lines, no gradients */
+            background-image: linear-gradient(var(--grid-line) 1px, transparent 1px),
+                              linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+            background-size: 40px 40px;
+            background-position: center center;
+        }
+
+        /* Override the gradient background to be pure solid lines by using repeating-linear-gradient with solid stops */
+        body {
+            background-image: repeating-linear-gradient(var(--grid-line) 0, var(--grid-line) 1px, transparent 1px, transparent 40px),
+                              repeating-linear-gradient(90deg, var(--grid-line) 0, var(--grid-line) 1px, transparent 1px, transparent 40px);
+        }
+
+        .monolith-container {
+            max-width: 900px;
+            margin: 0 auto;
+            width: 100%;
+            padding: 2rem;
+            display: grid;
+            gap: 2rem;
+        }
+
+        header {
+            border-bottom: 2px solid var(--text-stark);
+            padding-bottom: 2rem;
+            margin-top: 4rem;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            background-color: var(--bg-void);
+        }
+
+        .site-title {
+            font-family: var(--font-mono);
+            font-size: 2.5rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: -0.05em;
+            color: var(--text-stark);
+            text-decoration: none;
+            display: inline-block;
+            background-color: var(--text-stark);
+            color: var(--bg-void);
+            padding: 0.2em 0.4em;
+        }
+
+        .site-desc {
+            font-family: var(--font-mono);
+            font-size: 1rem;
+            margin-top: 1rem;
+            color: var(--accent-monolith);
+            border-left: 4px solid var(--border-strict);
+            padding-left: 1rem;
+        }
+
+        nav {
+            margin-top: 2rem;
+            width: 100%;
+            display: flex;
+            gap: 1.5rem;
+            border-top: 1px solid var(--border-strict);
+            padding-top: 1rem;
+        }
+
+        nav a {
+            color: var(--text-stark);
+            text-decoration: none;
+            font-family: var(--font-mono);
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            transition: background-color 0.2s, color 0.2s;
+            padding: 0.2rem 0.5rem;
+            border: 1px solid transparent;
+        }
+
+        nav a:hover {
+            background-color: var(--text-stark);
+            color: var(--bg-void);
+            border-color: var(--text-stark);
+        }
+
+        main {
+            background-color: var(--bg-void);
+            border: 1px solid var(--border-strict);
+            padding: 3rem;
+            position: relative;
+        }
+
+        main::before {
+            content: '';
+            position: absolute;
+            top: -5px;
+            left: -5px;
+            width: 20px;
+            height: 20px;
+            border-top: 2px solid var(--text-stark);
+            border-left: 2px solid var(--text-stark);
+        }
+
+        main::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            right: -5px;
+            width: 20px;
+            height: 20px;
+            border-bottom: 2px solid var(--text-stark);
+            border-right: 2px solid var(--text-stark);
+        }
+
+        h1, h2, h3 {
+            font-family: var(--font-sans);
+            font-weight: 800;
+            margin-bottom: 1.5rem;
+            margin-top: 2.5rem;
+            letter-spacing: -0.02em;
+        }
+
+        h1 {
+            font-size: 3rem;
+            line-height: 1.1;
+            border-bottom: 4px solid var(--border-strict);
+            padding-bottom: 0.5rem;
+            margin-top: 0;
+        }
+
+        h2 {
+            font-size: 2rem;
+            border-bottom: 1px solid var(--border-strict);
+            padding-bottom: 0.5rem;
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+            font-size: 1.1rem;
+            color: var(--accent-monolith);
+        }
+
+        a {
+            color: var(--text-stark);
+            text-decoration: underline;
+            text-decoration-thickness: 2px;
+            text-underline-offset: 4px;
+        }
+
+        a:hover {
+            background-color: var(--text-stark);
+            color: var(--bg-void);
+            text-decoration: none;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--text-stark);
+            margin: 2rem 0;
+            padding: 1rem 2rem;
+            background-color: rgba(255, 255, 255, 0.03); /* Extremely subtle solid fill */
+            font-style: italic;
+            font-family: var(--font-mono);
+            color: var(--text-stark);
+        }
+
+        ul, ol {
+            margin-bottom: 1.5rem;
+            padding-left: 2rem;
+            color: var(--accent-monolith);
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
+        code {
+            font-family: var(--font-mono);
+            background-color: var(--border-strict);
+            padding: 0.2em 0.4em;
+            font-size: 0.9em;
+            color: var(--text-stark);
+        }
+
+        pre {
+            background-color: var(--border-strict);
+            padding: 1.5rem;
+            overflow-x: auto;
+            margin-bottom: 1.5rem;
+            border: 1px solid var(--grid-line);
+        }
+
+        pre code {
+            background-color: transparent;
+            padding: 0;
+            color: var(--text-stark);
+        }
+
+        .post-meta {
+            font-family: var(--font-mono);
+            font-size: 0.85rem;
+            color: var(--border-strict);
+            margin-bottom: 2rem;
+            text-transform: uppercase;
+            display: flex;
+            gap: 1rem;
+        }
+
+        .post-meta span {
+            color: var(--text-stark);
+            background-color: var(--grid-line);
+            padding: 0.2rem 0.5rem;
+        }
+
+        .content-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 2rem;
+            margin-top: 3rem;
+        }
+
+        .card {
+            border: 1px solid var(--border-strict);
+            padding: 1.5rem;
+            background-color: var(--bg-void);
+            transition: transform 0.2s, border-color 0.2s;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .card:hover {
+            transform: translateY(-4px);
+            border-color: var(--text-stark);
+        }
+
+        .card-title {
+            font-family: var(--font-mono);
+            font-size: 1.25rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+            margin-top: 0;
+            border-bottom: none;
+        }
+
+        .card-title a {
+            text-decoration: none;
+            color: var(--text-stark);
+        }
+
+        .card-title a:hover {
+            background-color: transparent;
+            color: var(--text-stark);
+            text-decoration: underline;
+        }
+
+        .card-desc {
+            font-size: 0.95rem;
+            color: var(--accent-monolith);
+            flex-grow: 1;
+        }
+
+        footer {
+            border-top: 2px solid var(--text-stark);
+            padding-top: 2rem;
+            margin-bottom: 4rem;
+            text-align: center;
+            font-family: var(--font-mono);
+            font-size: 0.85rem;
+            color: var(--accent-monolith);
+            background-color: var(--bg-void);
+            width: 100%;
+        }
+
+        @media (max-width: 768px) {
+            .monolith-container {
+                padding: 1rem;
+            }
+            main {
+                padding: 1.5rem;
+            }
+            h1 {
+                font-size: 2.2rem;
+            }
+        }
+    </style>
+</head>
+<body>
+
+<div class="monolith-container">
+    <header>
+        <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+        <div class="site-desc">{{ site.description }}</div>
+        <nav>
+            <a href="{{ base_url }}/">Home</a>
+            <a href="{{ base_url }}/about/">About</a>
+        </nav>
+    </header>
+
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        &copy; {{ now() | date(format="%Y") }} {{ site.title }}. ZERO GRADIENTS.
+    </footer>
+</div>
+
+</body>
+</html>

--- a/examples/celestial-monolith/templates/index.html
+++ b/examples/celestial-monolith/templates/index.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title | default(value=site.title) }}</h1>
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+
+    {% if pages %}
+        <div class="content-grid">
+            {% for p in pages %}
+                <article class="card">
+                    <h3 class="card-title"><a href="{{ base_url }}{{ p.path }}">{{ p.title }}</a></h3>
+                    {% if p.description %}
+                        <p class="card-desc">{{ p.description }}</p>
+                    {% endif %}
+                </article>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/examples/celestial-monolith/templates/page.html
+++ b/examples/celestial-monolith/templates/page.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+
+    {% if page.date or page.taxonomies is defined %}
+        <div class="post-meta">
+            {% if page.date %}
+                <span>DATE: {{ page.date | date(format="%Y-%m-%d") }}</span>
+            {% endif %}
+            {% if page.taxonomies is defined and page.taxonomies.tags %}
+                <span>TAGS: {% for tag in page.taxonomies.tags %}{{ tag }}{% if not loop.last %}, {% endif %}{% endfor %}</span>
+            {% endif %}
+        </div>
+    {% endif %}
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+{% endblock %}

--- a/examples/celestial-monolith/templates/section.html
+++ b/examples/celestial-monolith/templates/section.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title | default(value="Section") }}</h1>
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+
+    {% if section.pages %}
+        <div class="content-grid">
+            {% for p in section.pages %}
+                <article class="card">
+                    <h3 class="card-title"><a href="{{ base_url }}{{ p.path }}">{{ p.title }}</a></h3>
+                    {% if p.description %}
+                        <p class="card-desc">{{ p.description }}</p>
+                    {% endif %}
+                </article>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/examples/celestial-monolith/templates/taxonomy.html
+++ b/examples/celestial-monolith/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ taxonomy_name | default(value="Taxonomy") | title }}</h1>
+
+    <div class="content-grid">
+        {% if taxonomy and taxonomy.terms %}
+            {% for t in taxonomy.terms %}
+                <article class="card">
+                    <h3 class="card-title"><a href="{{ base_url }}{{ t.path }}">{{ t.name }}</a></h3>
+                    <p class="card-desc">{{ t.pages | length }} items</p>
+                </article>
+            {% endfor %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/examples/celestial-monolith/templates/taxonomy_term.html
+++ b/examples/celestial-monolith/templates/taxonomy_term.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{% if term %}{{ term.name }}{% else %}Term{% endif %}</h1>
+
+    {% if term and term.pages %}
+        <div class="content-grid">
+            {% for p in term.pages %}
+                <article class="card">
+                    <h3 class="card-title"><a href="{{ base_url }}{{ p.path }}">{{ p.title }}</a></h3>
+                    {% if p.description %}
+                        <p class="card-desc">{{ p.description }}</p>
+                    {% endif %}
+                </article>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Adds a new example site named `celestial-monolith`. It uses the bare scaffold and implements an elegant, brutalist solid-color architectural aesthetic using CSS Grid. It strictly follows the requirements of avoiding emojis and gradients.

---
*PR created automatically by Jules for task [5830716952757039136](https://jules.google.com/task/5830716952757039136) started by @hahwul*