### PR TITLE
feat: Add new example site luminara-eclipse

### DIFF
--- a/examples/luminara-eclipse/AGENTS.md
+++ b/examples/luminara-eclipse/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/luminara-eclipse/archetypes/default.md
+++ b/examples/luminara-eclipse/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/luminara-eclipse/config.toml
+++ b/examples/luminara-eclipse/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Luminara Eclipse"
+description = "A structural dark theme for Hwaro without gradients or emojis."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/luminara-eclipse/content/_index.md
+++ b/examples/luminara-eclipse/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Luminara Eclipse"
+description = "A structural dark theme for Hwaro"
+template = "section"
++++
+
+This is the Luminara Eclipse. A theme built on deep contrasts, sharp structural borders, and the explicit absence of gradients. It explores the geometric tension between pure dark backgrounds and stark light foregrounds.
+
+Welcome to the void.

--- a/examples/luminara-eclipse/content/about.md
+++ b/examples/luminara-eclipse/content/about.md
@@ -1,0 +1,13 @@
++++
+title = "About Eclipse"
+description = "Information regarding the architectural approach."
+template = "page"
++++
+
+## Concept
+
+Luminara Eclipse is a brutalist architectural template. It was designed to demonstrate that complex aesthetic experiences do not require gradients or emojis. By strictly limiting the color palette to `#050505` and `#fafafa` with a single accent color `#f43f5e`, the layout forces a reliance on typography, spacing, and strong structural borders.
+
+## Layout
+
+The design employs a rigid maximum width container framed by vertical borders. Internal components use CSS Grid and Flexbox to enforce geometric precision.

--- a/examples/luminara-eclipse/content/posts/_index.md
+++ b/examples/luminara-eclipse/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+description = "A collection of transmissions."
+template = "section"
++++
+
+Transmissions from the architectural void.

--- a/examples/luminara-eclipse/content/posts/first-transmission.md
+++ b/examples/luminara-eclipse/content/posts/first-transmission.md
@@ -1,0 +1,14 @@
++++
+title = "First Transmission"
+description = "Testing the grid."
+date = "2023-10-27"
+template = "page"
+[taxonomies]
+tags = ["test", "architecture"]
++++
+
+This is a test post to verify that the template engine properly renders markdown content inside the `page.html` wrapper, and that the typography styles defined in the global CSS block apply correctly to markdown output.
+
+- Item One
+- Item Two
+- Item Three

--- a/examples/luminara-eclipse/templates/404.html
+++ b/examples/luminara-eclipse/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="eclipse-main">
+    <div class="content-block">
+      <h1 style="color: #f43f5e; font-size: 4rem;">404</h1>
+      <p style="font-size: 1.5rem; text-transform: uppercase;">Signal Lost in the Eclipse</p>
+      <p>The requested coordinate does not exist.</p>
+      <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; border: 1px solid #f43f5e; padding: 1rem 2rem; color: #f43f5e; text-decoration: none; text-transform: uppercase; letter-spacing: 0.1em; transition: all 0.2s;">Return to Base</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/luminara-eclipse/templates/footer.html
+++ b/examples/luminara-eclipse/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer style="padding: 2rem; border-top: 1px solid #333; margin-top: auto; text-align: center; font-size: 0.875rem; color: #666; background-color: #0f0f0f;">
+      <p>Powered by Hwaro. Luminara Eclipse Architecture.</p>
+      <div class="motif-container"></div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/luminara-eclipse/templates/header.html
+++ b/examples/luminara-eclipse/templates/header.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  <style>
+    /* Reset and Base */
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+    body, h1, h2, h3, p, ul, li {
+      margin: 0;
+      padding: 0;
+    }
+    html {
+      font-size: 16px;
+      line-height: 1.6;
+    }
+    body {
+      background-color: #050505;
+      color: #fafafa;
+      font-family: "Space Mono", monospace, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+    ul {
+      list-style: none;
+    }
+
+    /* Typography */
+    h1, h2, h3 {
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-weight: 700;
+      color: #ffffff;
+    }
+
+    /* Layout Components */
+    .eclipse-wrapper {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      width: 100%;
+      max-width: 1200px;
+      margin: 0 auto;
+      border-left: 1px solid #333;
+      border-right: 1px solid #333;
+    }
+
+    .eclipse-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 2rem;
+      border-bottom: 2px solid #fafafa;
+      background-color: #0f0f0f;
+    }
+
+    .eclipse-title {
+      font-size: 1.5rem;
+      font-weight: 900;
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+    }
+
+    .eclipse-title a {
+      color: #fafafa;
+    }
+
+    .eclipse-title a:hover {
+      color: #f43f5e;
+    }
+
+    .eclipse-nav {
+      display: flex;
+      gap: 2rem;
+    }
+
+    .eclipse-nav a {
+      font-size: 0.875rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-weight: bold;
+      border: 1px solid transparent;
+      padding: 0.5rem 1rem;
+      transition: all 0.2s ease;
+    }
+
+    .eclipse-nav a:hover {
+      border-color: #fafafa;
+      color: #050505;
+      background-color: #fafafa;
+    }
+
+    .eclipse-main {
+      flex: 1;
+      padding: 4rem 2rem;
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 3rem;
+    }
+
+    /* Specific elements inside main */
+    .content-block {
+      background-color: #0f0f0f;
+      padding: 3rem;
+      border: 1px solid #333;
+    }
+
+    .content-block h1 {
+      font-size: 2.5rem;
+      margin-bottom: 2rem;
+      border-bottom: 1px solid #333;
+      padding-bottom: 1rem;
+    }
+
+    .content-block p {
+      margin-bottom: 1.5rem;
+      color: #cccccc;
+    }
+
+    .content-block p:last-child {
+      margin-bottom: 0;
+    }
+
+    .content-block a {
+      color: #f43f5e;
+      border-bottom: 1px solid #f43f5e;
+    }
+
+    /* Eclipse graphic motif */
+    .motif-container {
+      width: 100%;
+      height: 10px;
+      background-color: #f43f5e;
+      margin-top: 2rem;
+    }
+
+  </style>
+</head>
+<body>
+  <div class="eclipse-wrapper">
+    <header class="eclipse-header">
+      <div class="eclipse-title">
+        <a href="{{ base_url }}/">{{ site.title }}</a>
+      </div>
+      <nav class="eclipse-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/examples/luminara-eclipse/templates/page.html
+++ b/examples/luminara-eclipse/templates/page.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="eclipse-main">
+    <article class="content-block">
+      <h1>{{ page.title | e }}</h1>
+      {{ content | safe }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/luminara-eclipse/templates/section.html
+++ b/examples/luminara-eclipse/templates/section.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="eclipse-main">
+    <div class="content-block">
+      <h1>{{ page.title | e }}</h1>
+      {{ content | safe }}
+    </div>
+
+    <div class="section-list-container" style="border: 1px solid #333; padding: 2rem;">
+      <h2 style="margin-bottom: 1.5rem; font-size: 1.25rem; color: #f43f5e;">INDEX</h2>
+      <ul style="display: grid; gap: 1rem;">
+        {% for p in section.pages %}
+        <li style="border-bottom: 1px dashed #333; padding-bottom: 0.5rem;">
+          <a href="{{ base_url }}{{ p.path }}" style="display: flex; justify-content: space-between; font-weight: bold; transition: color 0.2s;">
+            <span>{{ p.title | e }}</span>
+            <span style="color: #666; font-size: 0.875rem;">READ</span>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+
+    {% if pagination %}
+    <div class="pagination-block" style="margin-top: 2rem; border: 1px solid #333; padding: 1rem; text-align: center;">
+      {{ pagination }}
+    </div>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/examples/luminara-eclipse/templates/taxonomy.html
+++ b/examples/luminara-eclipse/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+  <main class="eclipse-main">
+    <div class="content-block">
+      <h1>{{ taxonomy_name | default(value="Taxonomy") | title | e }}</h1>
+      <p>Classification index.</p>
+    </div>
+    <div class="section-list-container" style="border: 1px solid #333; padding: 2rem;">
+      <ul style="display: flex; flex-wrap: wrap; gap: 1rem;">
+        {% for term in terms %}
+        <li>
+          <a href="{{ base_url }}{{ term.path }}" style="display: inline-block; border: 1px solid #666; padding: 0.5rem 1rem; text-transform: uppercase; font-size: 0.875rem;">
+            {{ term.name | e }} ({{ term.pages | length }})
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/luminara-eclipse/templates/taxonomy_term.html
+++ b/examples/luminara-eclipse/templates/taxonomy_term.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+  <main class="eclipse-main">
+    <div class="content-block">
+      {% if term %}
+      <h1>{{ term.name | e }}</h1>
+      <p>Items classified under {{ term.name | e }}.</p>
+      {% else %}
+      <h1>Term</h1>
+      {% endif %}
+    </div>
+
+    <div class="section-list-container" style="border: 1px solid #333; padding: 2rem;">
+      <ul style="display: grid; gap: 1rem;">
+        {% if term %}
+        {% for p in term.pages %}
+        <li style="border-bottom: 1px dashed #333; padding-bottom: 0.5rem;">
+          <a href="{{ base_url }}{{ p.path }}" style="display: flex; justify-content: space-between; font-weight: bold;">
+            <span>{{ p.title | e }}</span>
+          </a>
+        </li>
+        {% endfor %}
+        {% endif %}
+      </ul>
+    </div>
+
+    {% if pagination %}
+    <div class="pagination-block" style="margin-top: 2rem; border: 1px solid #333; padding: 1rem; text-align: center;">
+      {{ pagination }}
+    </div>
+    {% endif %}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR adds a brand new unique Hwaro example site named `luminara-eclipse`. It explores a high-contrast brutalist architectural style using pure CSS with rigid structural borders, built using `Space Mono`.

It strictly avoids gradients and emojis across the design and config logic. The example includes structural templates and some base sample posts to demonstrate the functionality.

---
*PR created automatically by Jules for task [11241219773698902025](https://jules.google.com/task/11241219773698902025) started by @hahwul*