### PR TITLE
feat: add quantum-lattice-arch example site

### DIFF
--- a/examples/quantum-lattice-arch/AGENTS.md
+++ b/examples/quantum-lattice-arch/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/quantum-lattice-arch/archetypes/default.md
+++ b/examples/quantum-lattice-arch/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/quantum-lattice-arch/config.toml
+++ b/examples/quantum-lattice-arch/config.toml
@@ -1,0 +1,225 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Quantum Lattice Arch"
+description = "A brutalist, monochrome architectural aesthetic with neon accents."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+[[taxonomies]]
+name = "tags"
+feed = false
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+[sitemap]
+enabled = false
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+[feeds]
+enabled = false
+
+# =============================================================================
+# Markdown
+# =============================================================================
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/quantum-lattice-arch/content/_index.md
+++ b/examples/quantum-lattice-arch/content/_index.md
@@ -1,0 +1,14 @@
++++
+title = "Quantum Lattice Core"
+description = "Central node of the lattice architectural grid."
++++
+
+Welcome to the **Quantum Lattice**. A structural exploration in pure contrast, brutalist layouts, and unyielding grid structures. No gradients. No softness. Pure architecture.
+
+### Primary Systems
+
+- Framework Assembly
+- Monolithic Structural Support
+- Grid Alignment Protocols
+
+Enter the lattice array to observe the structural permutations.

--- a/examples/quantum-lattice-arch/content/about.md
+++ b/examples/quantum-lattice-arch/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About the Architecture"
+description = "Specifications of the Quantum Lattice layout."
++++
+
+The **Quantum Lattice** was designed to demonstrate the power of pure grid structures and solid absolute values.
+
+It relies on absolute solid black, absolute solid white, and precise neon accents to guide the user's focus without relying on complex shadows or gradients.
+
+**Typography:**
+- Headers: Space Grotesk
+- Body text: Inter

--- a/examples/quantum-lattice-arch/content/posts/_index.md
+++ b/examples/quantum-lattice-arch/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Grid Nodes"
+description = "Active nodes within the structural lattice."
++++
+
+Explore the active data points rendered within the grid format.

--- a/examples/quantum-lattice-arch/content/posts/node-alpha.md
+++ b/examples/quantum-lattice-arch/content/posts/node-alpha.md
@@ -1,0 +1,11 @@
++++
+title = "Initialization Sequence: Alpha"
+description = "The first node initialized in the quantum grid."
+date = "2024-05-01"
++++
+
+This is the very first structural block in our grid system. It demonstrates how standard markdown text is processed and laid out within the rigid borders of the template framework.
+
+### System Diagnostics
+
+All systems nominal. Rendering pathways are perfectly aligned with zero-deviation parameters.

--- a/examples/quantum-lattice-arch/templates/404.html
+++ b/examples/quantum-lattice-arch/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+
+<article class="page-content" style="text-align: center; padding: 4rem 0;">
+    <h1 style="font-size: 6rem; color: var(--accent-alt); font-family: 'Space Grotesk', sans-serif; margin-bottom: 0;">404</h1>
+    <p style="font-size: 1.5rem; color: #a1a1aa; margin-bottom: 2rem;">System Node Not Found</p>
+    <a href="{{ site.base_url }}/" style="display: inline-block; padding: 0.75rem 1.5rem; border: 1px solid var(--accent-color); font-family: 'Space Grotesk', sans-serif; text-transform: uppercase; letter-spacing: 0.05em;">&larr; Return to Core</a>
+</article>
+
+{% include "footer.html" %}

--- a/examples/quantum-lattice-arch/templates/footer.html
+++ b/examples/quantum-lattice-arch/templates/footer.html
@@ -1,0 +1,13 @@
+        <footer class="site-footer">
+            <div class="footer-info">
+                &copy; {{ site.title }}
+            </div>
+            <div class="footer-system">
+                SYS.ARCH // QUANTUM LATTICE
+            </div>
+        </footer>
+    </main>
+</div>
+
+</body>
+</html>

--- a/examples/quantum-lattice-arch/templates/header.html
+++ b/examples/quantum-lattice-arch/templates/header.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% elif section.title %}{{ section.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% elif section.description %}{{ section.description }}{% else %}{{ site.description }}{% endif %}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+
+    <style>
+        /* Pure structural CSS */
+        :root {
+            --bg-color: #050505;
+            --text-color: #f4f4f5;
+            --border-color: #3f3f46;
+            --accent-color: #00ffcc; /* neon cyan accent */
+            --accent-alt: #ff0055; /* neon pink accent */
+            --grid-line: rgba(255, 255, 255, 0.05);
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: 'Inter', sans-serif;
+            line-height: 1.6;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700;
+            color: #ffffff;
+            letter-spacing: -0.02em;
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--accent-color);
+            text-decoration: none;
+            transition: color 0.2s, background-color 0.2s;
+        }
+
+        a:hover {
+            color: var(--bg-color);
+            background-color: var(--accent-color);
+        }
+
+        /* Layout Structure */
+        .site-wrapper {
+            max-width: 1200px;
+            margin: 0 auto;
+            width: 100%;
+            display: grid;
+            grid-template-columns: 250px 1fr;
+            min-height: 100vh;
+            border-left: 1px solid var(--border-color);
+            border-right: 1px solid var(--border-color);
+            background-color: var(--bg-color);
+        }
+
+        @media (max-width: 768px) {
+            .site-wrapper {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        /* Sidebar Header */
+        .sidebar {
+            border-right: 1px solid var(--border-color);
+            padding: 2rem;
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+            position: sticky;
+            top: 0;
+            height: 100vh;
+        }
+
+        @media (max-width: 768px) {
+            .sidebar {
+                height: auto;
+                position: relative;
+                border-right: none;
+                border-bottom: 1px solid var(--border-color);
+                padding: 1.5rem;
+            }
+        }
+
+        .site-brand {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1.5rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: #fff;
+            border-bottom: 2px solid var(--accent-color);
+            padding-bottom: 0.5rem;
+            display: inline-block;
+            margin-bottom: 1rem;
+        }
+
+        .site-brand a {
+            color: inherit;
+            background: none;
+        }
+
+        .site-brand a:hover {
+            color: var(--accent-color);
+            background: none;
+        }
+
+        .nav-menu {
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .nav-link {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-color);
+            padding: 0.5rem 0;
+            border-left: 2px solid transparent;
+            padding-left: 1rem;
+            margin-left: -1rem;
+            transition: all 0.2s;
+        }
+
+        .nav-link:hover, .nav-link.active {
+            color: var(--accent-color);
+            background: none;
+            border-left: 2px solid var(--accent-color);
+            background-color: rgba(0, 255, 204, 0.05);
+        }
+
+        /* Main Content Area */
+        .main-content {
+            padding: 3rem 4rem;
+            display: flex;
+            flex-direction: column;
+        }
+
+        @media (max-width: 768px) {
+            .main-content {
+                padding: 2rem 1.5rem;
+            }
+        }
+
+        .content-header {
+            margin-bottom: 3rem;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 2rem;
+        }
+
+        .page-title {
+            font-size: 3rem;
+            line-height: 1.1;
+            margin-bottom: 0.5rem;
+        }
+
+        .page-desc {
+            color: #a1a1aa;
+            font-size: 1.25rem;
+            font-family: 'Space Grotesk', sans-serif;
+        }
+
+        /* Markdown Content Styling */
+        .markdown-body {
+            font-size: 1.125rem;
+            max-width: 800px;
+        }
+
+        .markdown-body p {
+            margin-bottom: 1.5rem;
+        }
+
+        .markdown-body h2 {
+            font-size: 2rem;
+            margin-top: 3rem;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .markdown-body h3 {
+            font-size: 1.5rem;
+            margin-top: 2rem;
+        }
+
+        .markdown-body ul, .markdown-body ol {
+            margin-bottom: 1.5rem;
+            padding-left: 1.5rem;
+        }
+
+        .markdown-body li {
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-body blockquote {
+            border-left: 4px solid var(--accent-alt);
+            padding-left: 1.5rem;
+            margin-left: 0;
+            margin-bottom: 1.5rem;
+            color: #d4d4d8;
+            font-style: italic;
+            background-color: rgba(255, 0, 85, 0.05);
+            padding: 1rem 1.5rem;
+        }
+
+        .markdown-body code {
+            font-family: monospace;
+            background-color: #18181b;
+            padding: 0.2em 0.4em;
+            border: 1px solid var(--border-color);
+            font-size: 0.9em;
+            color: var(--accent-color);
+        }
+
+        .markdown-body pre {
+            background-color: #18181b;
+            padding: 1.5rem;
+            border: 1px solid var(--border-color);
+            overflow-x: auto;
+            margin-bottom: 1.5rem;
+            border-left: 2px solid var(--accent-color);
+        }
+
+        .markdown-body pre code {
+            background-color: transparent;
+            padding: 0;
+            border: none;
+            color: inherit;
+        }
+
+        /* Nodes/Posts Grid */
+        .nodes-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 2rem;
+            margin-top: 2rem;
+        }
+
+        .node-card {
+            border: 1px solid var(--border-color);
+            padding: 1.5rem;
+            background-color: #0a0a0a;
+            transition: border-color 0.2s, transform 0.2s;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .node-card:hover {
+            border-color: var(--accent-color);
+            transform: translateY(-2px);
+        }
+
+        .node-card-title {
+            font-size: 1.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .node-card-title a {
+            color: #fff;
+            background: none;
+        }
+
+        .node-card-title a:hover {
+            color: var(--accent-color);
+            background: none;
+        }
+
+        .node-card-desc {
+            color: #a1a1aa;
+            margin-bottom: 1.5rem;
+            flex-grow: 1;
+        }
+
+        .node-card-meta {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 0.875rem;
+            color: #71717a;
+            border-top: 1px dashed var(--border-color);
+            padding-top: 1rem;
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .node-action {
+            color: var(--accent-alt);
+            font-weight: 700;
+            text-transform: uppercase;
+            font-size: 0.875rem;
+        }
+
+        /* Footer */
+        .site-footer {
+            margin-top: auto;
+            padding-top: 4rem;
+            border-top: 1px solid var(--border-color);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-family: 'Space Grotesk', sans-serif;
+            color: #71717a;
+            font-size: 0.875rem;
+        }
+
+        @media (max-width: 600px) {
+            .site-footer {
+                flex-direction: column;
+                gap: 1rem;
+                text-align: center;
+            }
+        }
+    </style>
+</head>
+<body>
+
+<div class="site-wrapper">
+    <aside class="sidebar">
+        <div>
+            <div class="site-brand">
+                <a href="{{ site.base_url }}/">{{ site.title }}</a>
+            </div>
+            <p style="color: #a1a1aa; font-size: 0.875rem; margin-bottom: 2rem;">{{ site.description }}</p>
+        </div>
+
+        <nav>
+            <ul class="nav-menu">
+                <li><a href="{{ site.base_url }}/" class="nav-link">Lattice Core</a></li>
+                <li><a href="{{ site.base_url }}/about/" class="nav-link">Specifications</a></li>
+                <li><a href="{{ site.base_url }}/posts/" class="nav-link">Active Nodes</a></li>
+            </ul>
+        </nav>
+
+        <div style="margin-top: auto; padding-top: 2rem; font-family: 'Space Grotesk', sans-serif; font-size: 0.75rem; color: #52525b; text-transform: uppercase; letter-spacing: 0.1em;">
+            Status: <span style="color: var(--accent-color);">Online</span><br>
+            Mode: Strict Arch
+        </div>
+    </aside>
+
+    <main class="main-content">

--- a/examples/quantum-lattice-arch/templates/page.html
+++ b/examples/quantum-lattice-arch/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<article class="page-content">
+    <header class="content-header">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.description %}
+        <div class="page-desc">{{ page.description }}</div>
+        {% endif %}
+    </header>
+
+    <div class="markdown-body">
+        {{ page.content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/quantum-lattice-arch/templates/section.html
+++ b/examples/quantum-lattice-arch/templates/section.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+
+<div class="section-content">
+    <header class="content-header">
+        <h1 class="page-title">{{ section.title }}</h1>
+        {% if section.description %}
+        <div class="page-desc">{{ section.description }}</div>
+        {% endif %}
+    </header>
+
+    {% if section.content %}
+    <div class="markdown-body" style="margin-bottom: 3rem;">
+        {{ section.content | safe }}
+    </div>
+    {% endif %}
+
+    {% if section.pages %}
+    <div class="nodes-grid">
+        {% for page in section.pages %}
+        <article class="node-card">
+            <h2 class="node-card-title"><a href="{{ site.base_url }}{{ page.permalink }}">{{ page.title }}</a></h2>
+            {% if page.description %}
+            <p class="node-card-desc">{{ page.description }}</p>
+            {% endif %}
+
+            <div class="node-card-meta">
+                <span>{% if page.date %}{{ page.date | date(format="%Y-%m-%d") }}{% else %}NO_DATE{% endif %}</span>
+                <a href="{{ site.base_url }}{{ page.permalink }}" class="node-action">Enter Node &rarr;</a>
+            </div>
+        </article>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/quantum-lattice-arch/templates/taxonomy.html
+++ b/examples/quantum-lattice-arch/templates/taxonomy.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<div class="section-content">
+    <header class="content-header">
+        <h1 class="page-title">{{ taxonomy_name | default(value="Taxonomy") | title }}</h1>
+    </header>
+
+    <div class="nodes-grid">
+        {% if taxonomy and taxonomy.terms %}
+        {% for term, pages in taxonomy.terms %}
+        <article class="node-card">
+            <h2 class="node-card-title"><a href="{{ site.base_url }}/{{ taxonomy_name }}/{{ term | slugify }}/">{{ term }}</a></h2>
+            <p class="node-card-desc">{{ pages | length }} items</p>
+        </article>
+        {% endfor %}
+        {% endif %}
+    </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/quantum-lattice-arch/templates/taxonomy_term.html
+++ b/examples/quantum-lattice-arch/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="section-content">
+    <header class="content-header">
+        <h1 class="page-title">{{ taxonomy_name | default(value="Taxonomy") | title }}: {% if term %}{{ term.name }}{% endif %}</h1>
+    </header>
+
+    {% if term and term.pages %}
+    <div class="nodes-grid">
+        {% for page in term.pages %}
+        <article class="node-card">
+            <h2 class="node-card-title"><a href="{{ site.base_url }}{{ page.permalink }}">{{ page.title }}</a></h2>
+            {% if page.description %}
+            <p class="node-card-desc">{{ page.description }}</p>
+            {% endif %}
+        </article>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+
+{% include "footer.html" %}


### PR DESCRIPTION
Added a new `quantum-lattice-arch` example site built with Hwaro.
- Used `--scaffold bare` to generate base directories.
- Designed with strict architectural layout (CSS grids, absolute borders).
- Monochrome base (black, dark gray, white) with neon cyan and pink accents.
- Uses `Space Grotesk` and `Inter` typography.
- Emphasizes the constraint of absolutely no gradients and no emojis (disabled via `config.toml` markdown settings).

---
*PR created automatically by Jules for task [1075090747576655477](https://jules.google.com/task/1075090747576655477) started by @hahwul*