### PR TITLE
Add quantum-obelisk example site

### DIFF
--- a/examples/quantum-obelisk/AGENTS.md
+++ b/examples/quantum-obelisk/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/quantum-obelisk/archetypes/default.md
+++ b/examples/quantum-obelisk/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/quantum-obelisk/config.toml
+++ b/examples/quantum-obelisk/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "My Hwaro Site"
+description = "Welcome to my new Hwaro site."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/quantum-obelisk/content/_index.md
+++ b/examples/quantum-obelisk/content/_index.md
@@ -1,0 +1,18 @@
++++
+title = "Quantum Obelisk"
+description = "A structural, elegant minimalist architecture without distractions."
++++
+
+# The Architecture of Information
+
+Welcome to Quantum Obelisk, an elegant, brutalist yet minimalist template designed for pure structural integrity.
+
+It strips away visual noise—eschewing gradients and emojis—to focus purely on solid colors, stark contrast, and typographic clarity.
+
+## Core Principles
+
+*   **Absolute Solid Colors:** Deep backgrounds, crisp typography, distinct accent colors. No soft gradients.
+*   **Structural Grid:** Content is organized along predictable, rigid grid systems.
+*   **Minimal Embellishments:** The design relies on spacing and typography rather than illustrations.
+
+This site serves as an example for the [Hwaro](https://github.com/hahwul/hwaro) static site generator.

--- a/examples/quantum-obelisk/content/about.md
+++ b/examples/quantum-obelisk/content/about.md
@@ -1,0 +1,18 @@
++++
+title = "About the Architecture"
+description = "Understanding the methodology behind Quantum Obelisk."
++++
+
+# About
+
+Quantum Obelisk is built for systems that require absolute clarity.
+
+In a digital landscape filled with excessive visual treatments, the return to raw structure provides a cognitive reset. This theme utilizes deep slate (`#0b0c10`) against stark cyan accents (`#66fcf1`) to create a terminal-like, highly focused reading environment.
+
+We use the Inter and IBM Plex Mono fonts to establish a rhythm that feels both contemporary and grounded in early computing aesthetics.
+
+### Specifications
+
+*   Generator: Hwaro
+*   Typography: Inter, IBM Plex Mono
+*   Theme Style: Dark, Minimal, Structural, Brutalist

--- a/examples/quantum-obelisk/content/docs/_index.md
+++ b/examples/quantum-obelisk/content/docs/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Documentation"
+description = "Technical specifications."
++++
+
+# Documentation Index
+
+Select a technical document from the grid below.

--- a/examples/quantum-obelisk/content/docs/system-layout.md
+++ b/examples/quantum-obelisk/content/docs/system-layout.md
@@ -1,0 +1,16 @@
++++
+title = "System Layout"
+description = "Grid structures and spatial organization."
++++
+
+# System Layout
+
+The layout is fundamentally a CSS Grid structure, defining rigid boundaries for all elements.
+
+```css
+.grid-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+```

--- a/examples/quantum-obelisk/templates/404.html
+++ b/examples/quantum-obelisk/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/quantum-obelisk/templates/footer.html
+++ b/examples/quantum-obelisk/templates/footer.html
@@ -1,0 +1,5 @@
+  <footer class="site-footer">
+    <p>Powered by Hwaro. Design: Quantum Obelisk.</p>
+  </footer>
+</body>
+</html>

--- a/examples/quantum-obelisk/templates/header.html
+++ b/examples/quantum-obelisk/templates/header.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  <style>
+    :root {
+      --color-bg: #0b0c10;
+      --color-fg: #c5c6c7;
+      --color-accent: #66fcf1;
+      --color-accent-dim: #45a29e;
+      --color-surface: #1f2833;
+      --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --font-mono: "IBM Plex Mono", Consolas, Monaco, monospace;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background-color: var(--color-bg);
+      color: var(--color-fg);
+      font-family: var(--font-body);
+      line-height: 1.6;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a {
+      color: var(--color-accent);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+
+    a:hover {
+      color: var(--color-accent-dim);
+    }
+
+    .site-header {
+      padding: 2rem;
+      border-bottom: 1px solid var(--color-surface);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .site-title {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--color-fg);
+    }
+
+    .site-nav {
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    .site-nav a {
+      color: var(--color-fg);
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+
+    .site-nav a:hover {
+      color: var(--color-accent);
+    }
+
+    .page-content {
+      flex: 1;
+      padding: 4rem 2rem;
+      max-width: 800px;
+      margin: 0 auto;
+      width: 100%;
+    }
+
+    .obelisk-article .title,
+    .obelisk-section .title {
+      font-size: 2.5rem;
+      font-weight: 800;
+      color: var(--color-accent);
+      margin-bottom: 1rem;
+      line-height: 1.2;
+    }
+
+    .obelisk-article .meta {
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      color: var(--color-accent-dim);
+      display: block;
+      margin-bottom: 2rem;
+    }
+
+    .content {
+      font-size: 1.1rem;
+    }
+
+    .content h1, .content h2, .content h3, .content h4, .content h5, .content h6 {
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      color: var(--color-fg);
+      font-weight: 700;
+      line-height: 1.3;
+    }
+
+    .content p {
+      margin-bottom: 1.5rem;
+    }
+
+    .content code {
+      font-family: var(--font-mono);
+      background-color: var(--color-surface);
+      padding: 0.2em 0.4em;
+      border-radius: 2px;
+      font-size: 0.9em;
+      color: var(--color-accent);
+    }
+
+    .content pre {
+      background-color: var(--color-surface);
+      padding: 1.5rem;
+      overflow-x: auto;
+      margin-bottom: 1.5rem;
+      border-left: 4px solid var(--color-accent);
+    }
+
+    .content pre code {
+      background-color: transparent;
+      padding: 0;
+      color: var(--color-fg);
+    }
+
+    .content ul, .content ol {
+      margin-bottom: 1.5rem;
+      padding-left: 2rem;
+    }
+
+    .content li {
+      margin-bottom: 0.5rem;
+    }
+
+    .grid-list {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      margin-top: 3rem;
+    }
+
+    @media (min-width: 600px) {
+      .grid-list {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+
+    .grid-item {
+      background-color: var(--color-surface);
+      padding: 2rem;
+      border-top: 4px solid var(--color-accent-dim);
+      transition: border-color 0.2s ease, transform 0.2s ease;
+    }
+
+    .grid-item:hover {
+      border-color: var(--color-accent);
+      transform: translateY(-2px);
+    }
+
+    .grid-item .item-title {
+      font-size: 1.2rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .grid-item .item-title a {
+      color: var(--color-fg);
+    }
+
+    .grid-item:hover .item-title a {
+      color: var(--color-accent);
+    }
+
+    .grid-item .item-desc {
+      font-size: 0.9rem;
+      color: #999;
+    }
+
+    .site-footer {
+      padding: 2rem;
+      text-align: center;
+      border-top: 1px solid var(--color-surface);
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      color: var(--color-accent-dim);
+      margin-top: auto;
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+    <nav class="site-nav">
+      <a href="{{ base_url }}/">Home</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </header>

--- a/examples/quantum-obelisk/templates/page.html
+++ b/examples/quantum-obelisk/templates/page.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="page-content">
+    <article class="obelisk-article">
+      <header class="article-header">
+        <h1 class="title">{{ page.title | e }}</h1>
+        {% if page.date %}
+        <time class="meta">{{ page.date | date(format="%Y-%m-%d") }}</time>
+        {% endif %}
+      </header>
+      <div class="content">
+        {{ content | safe }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/quantum-obelisk/templates/section.html
+++ b/examples/quantum-obelisk/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+  <main class="page-content">
+    <section class="obelisk-section">
+      <header class="section-header">
+        <h1 class="title">{{ page.title | e }}</h1>
+      </header>
+      <div class="content">
+        {{ content | safe }}
+      </div>
+      <div class="grid-list">
+        {% for p in section.pages %}
+        <article class="grid-item">
+          <h2 class="item-title"><a href="{{ base_url }}{{ p.permalink }}">{{ p.title | e }}</a></h2>
+          {% if p.description %}
+          <p class="item-desc">{{ p.description | e }}</p>
+          {% endif %}
+        </article>
+        {% endfor %}
+      </div>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/quantum-obelisk/templates/taxonomy.html
+++ b/examples/quantum-obelisk/templates/taxonomy.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main>
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/quantum-obelisk/templates/taxonomy_term.html
+++ b/examples/quantum-obelisk/templates/taxonomy_term.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main>
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Adds a new example site named `quantum-obelisk` to the Hwaro project examples. The site uses a unique structural, dark-themed elegant architecture relying on CSS grid and pure solid colors (slate grey and cyan accents) with Inter and IBM Plex Mono fonts. It explicitly avoids using CSS gradients and emojis per requirements.

Steps taken:
- Initialized site via `hwaro init examples/quantum-obelisk --scaffold bare`
- Configured markdown in `config.toml` to disable emojis
- Created CSS styling in `templates/header.html`
- Updated layout files `templates/page.html` and `templates/section.html` to integrate header, footer, content rendering (`safe` filter), and structural grids
- Added sample content in `content/_index.md` and `content/about.md` with appropriate markdown headings and lists.

---
*PR created automatically by Jules for task [4329544123003989133](https://jules.google.com/task/4329544123003989133) started by @hahwul*