### PR TITLE
feat: add obsidian-forge example

### DIFF
--- a/examples/obsidian-forge/AGENTS.md
+++ b/examples/obsidian-forge/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/obsidian-forge/archetypes/default.md
+++ b/examples/obsidian-forge/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/obsidian-forge/config.toml
+++ b/examples/obsidian-forge/config.toml
@@ -1,0 +1,247 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Obsidian Forge"
+description = "A deep dark structural minimalist example site."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+# =============================================================================
+# Markdown
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/obsidian-forge/content/_index.md
+++ b/examples/obsidian-forge/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Home"
+description = "The Obsidian Forge entry point."
++++
+
+Welcome to **Obsidian Forge**. This is a dark, structural, brutalist minimalism example site utilizing pure stark white and deep black colors, avoiding gradients and emojis entirely. It focuses purely on layout, typography (Inter and IBM Plex Mono), and solid geometry.
+
+## Latest Manifestos

--- a/examples/obsidian-forge/content/about.md
+++ b/examples/obsidian-forge/content/about.md
@@ -1,0 +1,17 @@
++++
+title = "About Obsidian Forge"
+description = "Information about the Obsidian Forge."
+date = 2024-05-01
++++
+
+Obsidian Forge is an aesthetic concept built to demonstrate structural rigor in web design.
+
+We embrace the void:
+* No gradients
+* No emojis
+* Pure solid colors
+* Distinct boundaries
+
+> "In the absence of decoration, structure becomes the art."
+
+This text is rendered from markdown, demonstrating paragraph, blockquote, and list styling.

--- a/examples/obsidian-forge/content/architecture.md
+++ b/examples/obsidian-forge/content/architecture.md
@@ -1,0 +1,18 @@
++++
+title = "Architecture of the Void"
+description = "A study in minimal structure."
+date = 2024-05-02
++++
+
+The architecture of the void relies on the absolute contrast between light and dark.
+
+By removing unnecessary visual noise, the content itself shapes the container.
+
+```css
+:root {
+    --bg-color: #0a0a0c;
+    --text-color: #ffffff;
+}
+```
+
+Code blocks are displayed with monospace fonts, highlighting structural elements.

--- a/examples/obsidian-forge/templates/base.html
+++ b/examples/obsidian-forge/templates/base.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-color: #0a0a0c;
+            --text-color: #ffffff;
+            --accent-color: #d1d1d1;
+            --border-color: #333333;
+            --font-main: 'Inter', sans-serif;
+            --font-mono: 'IBM Plex Mono', monospace;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: var(--font-main);
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 2rem;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1rem;
+            margin-bottom: 3rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+
+        .site-title {
+            font-size: 1.5rem;
+            font-weight: 800;
+            letter-spacing: -0.05em;
+            text-transform: uppercase;
+        }
+
+        .site-title a {
+            color: var(--text-color);
+            text-decoration: none;
+        }
+
+        nav a {
+            color: var(--accent-color);
+            text-decoration: none;
+            margin-left: 1.5rem;
+            font-family: var(--font-mono);
+            font-size: 0.9rem;
+            text-transform: lowercase;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s;
+        }
+
+        nav a:hover {
+            color: var(--text-color);
+            border-bottom-color: var(--text-color);
+        }
+
+        main {
+            flex: 1;
+        }
+
+        footer {
+            border-top: 2px solid var(--border-color);
+            padding-top: 1rem;
+            margin-top: 4rem;
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            color: var(--accent-color);
+            text-align: right;
+            text-transform: uppercase;
+        }
+
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-weight: 800;
+            margin-bottom: 1rem;
+            letter-spacing: -0.02em;
+        }
+
+        h1 { font-size: 3rem; line-height: 1.1; margin-bottom: 1.5rem; }
+        h2 { font-size: 2rem; margin-top: 2rem; }
+        h3 { font-size: 1.5rem; margin-top: 1.5rem; }
+
+        p {
+            margin-bottom: 1.5rem;
+            font-size: 1.1rem;
+            color: #e0e0e0;
+        }
+
+        a {
+            color: var(--text-color);
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 4px;
+        }
+
+        a:hover {
+            text-decoration-thickness: 2px;
+        }
+
+        code {
+            font-family: var(--font-mono);
+            background-color: #1a1a1d;
+            padding: 0.2em 0.4em;
+            font-size: 0.9em;
+            border: 1px solid var(--border-color);
+        }
+
+        pre {
+            background-color: #111114;
+            padding: 1.5rem;
+            overflow-x: auto;
+            border: 1px solid var(--border-color);
+            margin-bottom: 1.5rem;
+        }
+
+        pre code {
+            background-color: transparent;
+            padding: 0;
+            border: none;
+            color: #d1d1d1;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--text-color);
+            padding-left: 1rem;
+            margin-left: 0;
+            margin-bottom: 1.5rem;
+            font-style: italic;
+            color: var(--accent-color);
+        }
+
+        hr {
+            border: 0;
+            border-top: 1px dashed var(--border-color);
+            margin: 2rem 0;
+        }
+
+        ul, ol {
+            margin-bottom: 1.5rem;
+            padding-left: 1.5rem;
+            color: #e0e0e0;
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
+        .meta {
+            font-family: var(--font-mono);
+            font-size: 0.85rem;
+            color: var(--accent-color);
+            margin-bottom: 2rem;
+            text-transform: uppercase;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+            display: inline-block;
+        }
+
+        .post-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .post-list li {
+            margin-bottom: 2rem;
+            border: 1px solid var(--border-color);
+            padding: 1.5rem;
+            transition: border-color 0.2s;
+        }
+
+        .post-list li:hover {
+            border-color: var(--text-color);
+        }
+
+        .post-list h2 {
+            margin: 0 0 0.5rem 0;
+            font-size: 1.5rem;
+        }
+
+        .post-list h2 a {
+            text-decoration: none;
+        }
+
+        .post-list .meta {
+            margin-bottom: 1rem;
+            border: none;
+            padding: 0;
+        }
+
+        .post-list p {
+            margin-bottom: 0;
+            font-size: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <div class="site-title"><a href="{{ base_url }}/">{{ site.title }}</a></div>
+            <nav>
+                <a href="{{ base_url }}/about/">About</a>
+            </nav>
+        </header>
+
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer>
+            {{ site.title }} &copy; 2024
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/obsidian-forge/templates/index.html
+++ b/examples/obsidian-forge/templates/index.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+    {{ content | safe }}
+
+    <ul class="post-list">
+    {% for page in pages %}
+        <li>
+            <div class="meta">{{ page.date | date(format="%Y-%m-%d") }}</div>
+            <h2><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></h2>
+            {% if page.description %}
+            <p>{{ page.description }}</p>
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+{% endblock %}

--- a/examples/obsidian-forge/templates/page.html
+++ b/examples/obsidian-forge/templates/page.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} - {{ site.title }}{% endblock %}
+
+{% block content %}
+    <article>
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="meta">{{ page.date | date(format="%Y-%m-%d") }}</div>
+        {% endif %}
+
+        <div class="content">
+            {{ content | safe }}
+        </div>
+    </article>
+{% endblock %}


### PR DESCRIPTION
Creates a new Hwaro example site named `obsidian-forge` featuring a dark, brutalist structural minimalist aesthetic. It strictly utilizes solid colors (deep black background, pure white text) and avoids any emojis or CSS gradients. Uses Inter and IBM Plex Mono for typography.

- Scaffolds a new bare site.
- Implements custom `base.html`, `index.html`, and `page.html` focusing on structural CSS without gradients.
- Includes sample content showcasing the visual style.
- Fixes config via `hwaro doctor --fix`.
- Removes unused bare templates (`header.html`, `footer.html`, `section.html`, etc.) to resolve build errors and keep the example clean.

---
*PR created automatically by Jules for task [18061515021554064126](https://jules.google.com/task/18061515021554064126) started by @hahwul*