### PR TITLE
Add silent-monolith-gallery example site

### DIFF
--- a/examples/silent-monolith-gallery/AGENTS.md
+++ b/examples/silent-monolith-gallery/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/silent-monolith-gallery/archetypes/default.md
+++ b/examples/silent-monolith-gallery/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/silent-monolith-gallery/config.toml
+++ b/examples/silent-monolith-gallery/config.toml
@@ -1,0 +1,246 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Silent Monolith Gallery"
+description = "A brutalist gallery layout"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/silent-monolith-gallery/content/_index.md
+++ b/examples/silent-monolith-gallery/content/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Silent Monolith"
+description = "Welcome to the structural void."
++++
+
+The Silent Monolith Gallery is an exploration of space, structure, and contrast.
+
+We focus on the pure intersection of solid colors and stark architecture. No gradients. No unnecessary ornamentation. Just form and function laid bare.
+
+Explore our [Gallery](/gallery) to see the exhibits.

--- a/examples/silent-monolith-gallery/content/about.md
+++ b/examples/silent-monolith-gallery/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
+description = "Information about the Silent Monolith Gallery."
++++
+
+We study the absence of color and the presence of form.

--- a/examples/silent-monolith-gallery/content/gallery/_index.md
+++ b/examples/silent-monolith-gallery/content/gallery/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Gallery"
+description = "Exhibits of stark structure."
+template = "section"
++++
+
+A collection of brutalist monoliths. Each piece is a testament to solid geometry and raw architectural form.

--- a/examples/silent-monolith-gallery/content/gallery/monolith-alpha.md
+++ b/examples/silent-monolith-gallery/content/gallery/monolith-alpha.md
@@ -1,0 +1,10 @@
++++
+title = "Monolith Alpha"
+description = "The first pillar of silence."
+date = 2024-05-01
+taxonomies = { tags = ["architecture", "monolith"] }
++++
+
+**Monolith Alpha** stands as the foundational pillar of the Silent Monolith series.
+
+Its dark surface absorbs light, creating a localized void within the surrounding gallery space. The structure's sheer verticality emphasizes the starkness of its design.

--- a/examples/silent-monolith-gallery/content/gallery/monolith-beta.md
+++ b/examples/silent-monolith-gallery/content/gallery/monolith-beta.md
@@ -1,0 +1,10 @@
++++
+title = "Monolith Beta"
+description = "Intersection of planes."
+date = 2024-05-02
+taxonomies = { tags = ["geometry", "planes"] }
++++
+
+**Monolith Beta** explores the intersection of brutalist planes.
+
+Two solid slabs of deep charcoal intersect at a rigid 90-degree angle. The absence of curves forces the observer to confront the sharp reality of the edges.

--- a/examples/silent-monolith-gallery/content/gallery/monolith-gamma.md
+++ b/examples/silent-monolith-gallery/content/gallery/monolith-gamma.md
@@ -1,0 +1,10 @@
++++
+title = "Monolith Gamma"
+description = "The weight of the void."
+date = 2024-05-03
+taxonomies = { tags = ["monolith", "void"] }
++++
+
+**Monolith Gamma** is an exercise in perceived weight.
+
+A low, wide block of absolute black, Gamma grounds the room. It feels heavy, immovable, anchoring the gallery floor and defining the empty space above it.

--- a/examples/silent-monolith-gallery/templates/404.html
+++ b/examples/silent-monolith-gallery/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content" style="text-align: center; padding: 6rem 0; border-left: none;">
+    <h1 style="font-size: 4rem; color: var(--border-color);">404</h1>
+    <p style="margin: 0 auto;">The requested architecture could not be found.</p>
+    <br>
+    <a href="/">RETURN TO STRUCTURE</a>
+</div>
+{% endblock %}

--- a/examples/silent-monolith-gallery/templates/base.html
+++ b/examples/silent-monolith-gallery/templates/base.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page and page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page and page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=Inter:wght@100..900&display=swap');
+
+        :root {
+            --bg-color: #0d0d0d;
+            --text-color: #e0e0e0;
+            --accent-color: #f2f2f2;
+            --border-color: #333333;
+            --font-main: 'Inter', sans-serif;
+            --font-mono: 'IBM Plex Mono', monospace;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: var(--font-main);
+            line-height: 1.6;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+            min-height: 100vh;
+        }
+
+        header {
+            border-bottom: 2px solid var(--border-color);
+            padding: 2rem;
+            display: grid;
+            grid-template-columns: 1fr auto;
+            align-items: center;
+        }
+
+        header h1 {
+            font-family: var(--font-mono);
+            font-size: 1.5rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--accent-color);
+        }
+
+        header h1 a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        nav a {
+            color: var(--text-color);
+            text-decoration: none;
+            font-family: var(--font-mono);
+            font-size: 0.9rem;
+            margin-left: 2rem;
+            text-transform: uppercase;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s;
+        }
+
+        nav a:hover {
+            border-color: var(--accent-color);
+            color: var(--accent-color);
+        }
+
+        main {
+            padding: 4rem 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+            width: 100%;
+        }
+
+        footer {
+            border-top: 2px solid var(--border-color);
+            padding: 2rem;
+            text-align: center;
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            color: #888;
+        }
+
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-mono);
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: var(--accent-color);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+            font-size: 1.1rem;
+            max-width: 800px;
+        }
+
+        a {
+            color: var(--accent-color);
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 4px;
+        }
+
+        a:hover {
+            background-color: var(--accent-color);
+            color: var(--bg-color);
+            text-decoration: none;
+        }
+
+        /* Brutalist Grid for Gallery */
+        .gallery-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 2px;
+            background-color: var(--border-color); /* Lines between grid items */
+            border: 2px solid var(--border-color);
+        }
+
+        .gallery-item {
+            background-color: var(--bg-color);
+            padding: 2rem;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            min-height: 250px;
+            transition: background-color 0.2s;
+        }
+
+        .gallery-item:hover {
+            background-color: #1a1a1a;
+        }
+
+        .gallery-item h2 {
+            font-size: 1.2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .gallery-item h2 a {
+            text-decoration: none;
+        }
+
+        .gallery-item p {
+            font-size: 0.9rem;
+            color: #aaa;
+            margin-bottom: 0;
+        }
+
+        .meta {
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            color: #666;
+            margin-bottom: 2rem;
+            text-transform: uppercase;
+            display: block;
+        }
+
+        /* Content styling */
+        .content {
+            border-left: 2px solid var(--border-color);
+            padding-left: 2rem;
+            margin-top: 2rem;
+        }
+    </style>
+</head>
+<body>
+
+    <header>
+        <h1><a href="/">{{ site.title }}</a></h1>
+        <nav>
+            <a href="/about/">About</a>
+            <a href="/gallery/">Gallery</a>
+        </nav>
+    </header>
+
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        <p>&copy; 2024 {{ site.title }}. All rights reserved.</p>
+    </footer>
+
+</body>
+</html>

--- a/examples/silent-monolith-gallery/templates/index.html
+++ b/examples/silent-monolith-gallery/templates/index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content">
+    {{ content | safe }}
+</div>
+
+<div class="gallery-grid" style="margin-top: 4rem;">
+    {% for page in section.pages %}
+        <div class="gallery-item">
+            <div>
+                <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+                <span class="meta">{{ page.date | default("No Date") }}</span>
+            </div>
+            <p>{{ page.description | default("") }}</p>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/examples/silent-monolith-gallery/templates/page.html
+++ b/examples/silent-monolith-gallery/templates/page.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="content">
+    <h1>{{ page.title }}</h1>
+    {% if page.date %}
+        <span class="meta">{{ page.date }}</span>
+    {% endif %}
+
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+        <div style="margin-bottom: 2rem; font-family: var(--font-mono); font-size: 0.8rem;">
+            TAGS:
+            {% for tag in page.taxonomies.tags %}
+                <span style="background: var(--border-color); padding: 0.2rem 0.5rem; margin-right: 0.5rem;">{{ tag }}</span>
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    {{ content | safe }}
+</article>
+{% endblock %}

--- a/examples/silent-monolith-gallery/templates/section.html
+++ b/examples/silent-monolith-gallery/templates/section.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content" style="margin-bottom: 4rem;">
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}
+        <p>{{ section.description }}</p>
+    {% endif %}
+    {{ content | safe }}
+</div>
+
+<div class="gallery-grid">
+    {% for page in section.pages %}
+        <div class="gallery-item">
+            <div>
+                <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+                <span class="meta">{{ page.date | default("No Date") }}</span>
+            </div>
+            <p>{{ page.description | default("") }}</p>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/examples/silent-monolith-gallery/templates/taxonomy.html
+++ b/examples/silent-monolith-gallery/templates/taxonomy.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content">
+    <h1>{{ taxonomy_name | default("Taxonomy") | capitalize }}</h1>
+
+    <div style="margin-top: 2rem;">
+        {% if taxonomy_terms is defined %}
+            <ul style="list-style-type: none; padding: 0;">
+            {% for term in taxonomy_terms %}
+                <li style="margin-bottom: 1rem;">
+                    <a href="{{ term.permalink }}" style="font-family: var(--font-mono); font-size: 1.2rem;">{{ term.name }}</a>
+                    <span style="color: #666; font-size: 0.9rem;">({{ term.pages | length }})</span>
+                </li>
+            {% endfor %}
+            </ul>
+        {% else %}
+            <p>No terms found.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/examples/silent-monolith-gallery/templates/taxonomy_term.html
+++ b/examples/silent-monolith-gallery/templates/taxonomy_term.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content" style="margin-bottom: 4rem;">
+    <h1>
+        {% if term %}
+            {{ term.name }}
+        {% else %}
+            Term
+        {% endif %}
+    </h1>
+    <p>Pages tagged with this term.</p>
+</div>
+
+<div class="gallery-grid">
+    {% if term and term.pages %}
+        {% for page in term.pages %}
+            <div class="gallery-item">
+                <div>
+                    <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+                    <span class="meta">{{ page.date | default("No Date") }}</span>
+                </div>
+                <p>{{ page.description | default("") }}</p>
+            </div>
+        {% endfor %}
+    {% else %}
+        <p>No pages found for this term.</p>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR introduces a new example site called `silent-monolith-gallery`. It demonstrates a stark, brutalist aesthetic using pure solid colors, bold typography (Inter and IBM Plex Mono), and CSS Grid. The design strictly adheres to constraints prohibiting gradients and emojis. The site is fully functional within Hwaro, complete with proper TOML frontmatter and section routing.

---
*PR created automatically by Jules for task [2219292542371154432](https://jules.google.com/task/2219292542371154432) started by @hahwul*