### PR TITLE
Fix 404 links in obsidian-abyss-forge example

### DIFF
--- a/examples/obsidian-abyss-forge/content/archives.md
+++ b/examples/obsidian-abyss-forge/content/archives.md
@@ -1,0 +1,4 @@
++++
+title = "Archives"
+description = "Archives"
++++

--- a/examples/obsidian-abyss-forge/templates/header.html
+++ b/examples/obsidian-abyss-forge/templates/header.html
@@ -11,8 +11,8 @@
     <header>
         <a href="{{ base_url }}/" class="logo">{% if site is defined %}{{ site.title }}{% else %}Obsidian{% endif %}</a>
         <nav>
-            <a href="{{ base_url }}/about.html">About</a>
-            <a href="{{ base_url }}/archives.html">Archives</a>
+            <a href="{{ base_url }}/about/">About</a>
+            <a href="{{ base_url }}/archives/">Archives</a>
         </nav>
     </header>
     <main>


### PR DESCRIPTION
Updates hardcoded `.html` links (`about.html`, `archives.html`) in the `obsidian-abyss-forge` header template to point to proper pretty-url directories (`/about/`, `/archives/`) to prevent 404 errors. Also creates the missing `archives.md` file in the content directory to ensure the `/archives/` link has a valid target.

---
*PR created automatically by Jules for task [7410374094875253862](https://jules.google.com/task/7410374094875253862) started by @hahwul*