### PR TITLE
feat: add starlight-echo example theme

### DIFF
--- a/examples/starlight-echo/AGENTS.md
+++ b/examples/starlight-echo/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/starlight-echo/archetypes/default.md
+++ b/examples/starlight-echo/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/starlight-echo/config.toml
+++ b/examples/starlight-echo/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Starlight Echo"
+description = "A minimalist brutalist dark theme."
+base_url = "https://examples.hwaro.hahwul.com/starlight-echo/"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/starlight-echo/content/_index.md
+++ b/examples/starlight-echo/content/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Starlight Echo"
+description = "A minimalist brutalist dark theme."
+template = "index"
++++
+
+Welcome to the Starlight Echo terminal. This space serves as a broadcast point for structural analysis and minimal transmissions.

--- a/examples/starlight-echo/content/about.md
+++ b/examples/starlight-echo/content/about.md
@@ -1,0 +1,14 @@
++++
+title = "About Protocol"
+date = 2024-05-01
++++
+
+This station monitors structural anomalies and logs them into a central database. We favor raw data over aesthetic interference.
+
+### Guidelines
+
+1.  Monitor all frequencies.
+2.  Log all deviations.
+3.  Transmit data securely.
+
+> "Structure is not just a visual choice; it is a necessity for survival."

--- a/examples/starlight-echo/content/posts/_index.md
+++ b/examples/starlight-echo/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Archive"
+description = "Historical logs and past transmissions."
++++

--- a/examples/starlight-echo/content/posts/first-post.md
+++ b/examples/starlight-echo/content/posts/first-post.md
@@ -1,0 +1,17 @@
++++
+title = "Initial Broadcast"
+date = 2024-05-01
+description = "The first transmission recorded on this network."
+[taxonomies]
+tags = ["log", "init"]
++++
+
+System online. Diagnostics show nominal performance across all sectors.
+
+The brutalist structure holds fast against the void. No gradients detected.
+
+```bash
+# System Check
+starlight-echo --status
+# Output: OK
+```

--- a/examples/starlight-echo/templates/404.html
+++ b/examples/starlight-echo/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main style="text-align: center; padding: 4rem 2rem;">
+    <h1 style="font-size: 4rem; color: var(--accent-color);">404</h1>
+    <h2 style="font-size: 2rem;">Signal Lost</h2>
+    <p style="margin-top: 1rem; font-family: var(--font-mono);">The transmission you are looking for does not exist in this sector.</p>
+    <a href="{{ site.base_url }}/" style="display: inline-block; margin-top: 2rem; border: 2px solid var(--accent-color); padding: 0.5rem 1rem; text-transform: uppercase; font-family: var(--font-mono);">Return to Origin</a>
+</main>
+{% endblock %}

--- a/examples/starlight-echo/templates/base.html
+++ b/examples/starlight-echo/templates/base.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined and page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-color: #050505;
+            --text-color: #fafafa;
+            --accent-color: #3b82f6;
+            --border-color: #fafafa;
+            --font-sans: 'Inter', sans-serif;
+            --font-mono: 'IBM Plex Mono', monospace;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: var(--font-sans);
+            line-height: 1.6;
+            min-height: 100vh;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+        }
+
+        a {
+            color: var(--text-color);
+            text-decoration: none;
+            border-bottom: 2px solid var(--accent-color);
+            transition: background-color 0.2s, color 0.2s;
+        }
+
+        a:hover {
+            background-color: var(--accent-color);
+            color: var(--bg-color);
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-mono);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: -0.02em;
+            margin-bottom: 1rem;
+            margin-top: 2rem;
+        }
+
+        .site-header {
+            border-bottom: 4px solid var(--border-color);
+            padding: 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .site-title {
+            font-family: var(--font-mono);
+            font-size: 2rem;
+            font-weight: 800;
+            margin: 0;
+            border-bottom: none;
+            text-transform: uppercase;
+        }
+
+        .site-title:hover {
+            background-color: transparent;
+            color: var(--accent-color);
+        }
+
+        .site-nav {
+            display: flex;
+            gap: 1.5rem;
+            font-family: var(--font-mono);
+            font-size: 0.9rem;
+            text-transform: uppercase;
+        }
+
+        .site-main {
+            padding: 4rem 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+            width: 100%;
+        }
+
+        .site-footer {
+            border-top: 4px solid var(--border-color);
+            padding: 2rem;
+            text-align: center;
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            text-transform: uppercase;
+        }
+
+        /* Brutalist content elements */
+        pre {
+            background-color: var(--text-color);
+            color: var(--bg-color);
+            padding: 1.5rem;
+            font-family: var(--font-mono);
+            overflow-x: auto;
+            border: 2px solid var(--border-color);
+            margin: 2rem 0;
+        }
+
+        code {
+            font-family: var(--font-mono);
+            background-color: var(--text-color);
+            color: var(--bg-color);
+            padding: 0.2rem 0.4rem;
+        }
+
+        pre code {
+            padding: 0;
+            background-color: transparent;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 8px solid var(--accent-color);
+            padding-left: 1.5rem;
+            margin: 2rem 0;
+            font-style: italic;
+            font-size: 1.2rem;
+        }
+
+        img {
+            max-width: 100%;
+            height: auto;
+            border: 4px solid var(--border-color);
+            display: block;
+            margin: 2rem 0;
+        }
+
+        ul, ol {
+            margin: 1rem 0 1rem 2rem;
+        }
+
+        hr {
+            border: none;
+            border-top: 4px solid var(--border-color);
+            margin: 3rem 0;
+        }
+    </style>
+</head>
+<body>
+    <header class="site-header">
+        <a href="/" class="site-title">{{ site.title }}</a>
+        <nav class="site-nav">
+            <a href="/">Index</a>
+            <a href="/about/">About</a>
+            <a href="/posts/">Archive</a>
+        </nav>
+    </header>
+
+    <main class="site-main">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+        &copy; 2024 {{ site.title }}. Built with Hwaro.
+    </footer>
+</body>
+</html>

--- a/examples/starlight-echo/templates/index.html
+++ b/examples/starlight-echo/templates/index.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-content">
+    {{ content | safe }}
+</div>
+
+<div class="posts-list" style="margin-top: 4rem;">
+    <h2>Latest Transmissions</h2>
+    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 2rem; margin-top: 2rem;">
+        {% for p in pages %}
+            {% if p.permalink != "/" and p.permalink != "/about/" %}
+            <article style="border: 2px solid var(--border-color); padding: 1.5rem; display: flex; flex-direction: column; justify-content: space-between;">
+                <div>
+                    <h3 style="margin-top: 0; font-size: 1.2rem;">
+                        <a href="{{ p.permalink }}" style="border-bottom: none;">{{ p.title }}</a>
+                    </h3>
+                    {% if p.date %}
+                    <div style="font-family: var(--font-mono); font-size: 0.8rem; color: var(--accent-color); margin-bottom: 1rem;">
+                        {{ p.date | date(format="%Y-%m-%d") }}
+                    </div>
+                    {% endif %}
+                    {% if p.description %}
+                    <p style="margin-bottom: 1.5rem; font-size: 0.95rem;">{{ p.description }}</p>
+                    {% endif %}
+                </div>
+                <a href="{{ p.permalink }}" style="align-self: flex-start; font-family: var(--font-mono); font-size: 0.9rem; text-transform: uppercase;">Read More &rarr;</a>
+            </article>
+            {% endif %}
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/examples/starlight-echo/templates/page.html
+++ b/examples/starlight-echo/templates/page.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-content">
+    <header style="margin-bottom: 3rem; border-bottom: 2px solid var(--border-color); padding-bottom: 2rem;">
+        <h1 style="font-size: 3rem; margin-bottom: 0.5rem; letter-spacing: -0.05em;">{{ page.title }}</h1>
+        {% if page.date %}
+        <div style="font-family: var(--font-mono); color: var(--accent-color);">
+            {{ page.date | date(format="%Y-%m-%d") }}
+        </div>
+        {% endif %}
+    </header>
+
+    <div class="content" style="max-width: 800px;">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+    <footer style="margin-top: 4rem; padding-top: 2rem; border-top: 2px solid var(--border-color);">
+        <div style="font-family: var(--font-mono); font-size: 0.9rem; text-transform: uppercase;">
+            Tags:
+            {% for tag in page.taxonomies.tags %}
+                <a href="/tags/{{ tag | lower }}/" style="margin-right: 1rem; color: var(--accent-color); border-bottom-color: var(--text-color);">#{{ tag }}</a>
+            {% endfor %}
+        </div>
+    </footer>
+    {% endif %}
+</article>
+{% endblock %}

--- a/examples/starlight-echo/templates/section.html
+++ b/examples/starlight-echo/templates/section.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header style="margin-bottom: 3rem; border-bottom: 2px solid var(--border-color); padding-bottom: 2rem;">
+    <h1 style="font-size: 3rem; margin-bottom: 0.5rem; letter-spacing: -0.05em;">{{ section.title }}</h1>
+    {% if content %}
+    <div style="font-size: 1.2rem; max-width: 800px;">
+        {{ content | safe }}
+    </div>
+    {% endif %}
+</header>
+
+<div class="posts-list">
+    {% for item in section.pages %}
+    <article style="border: 2px solid var(--border-color); padding: 2rem; margin-bottom: 2rem; display: flex; flex-direction: column; gap: 1rem; max-width: 800px;">
+        <header>
+            <h2 style="margin: 0; font-size: 1.5rem;">
+                <a href="{{ item.permalink }}" style="border-bottom: none;">{{ item.title }}</a>
+            </h2>
+            {% if item.date %}
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--accent-color); margin-top: 0.5rem;">
+                {{ item.date | date(format="%Y-%m-%d") }}
+            </div>
+            {% endif %}
+        </header>
+
+        {% if item.description %}
+        <p>{{ item.description }}</p>
+        {% endif %}
+
+        <a href="{{ item.permalink }}" style="align-self: flex-start; font-family: var(--font-mono); text-transform: uppercase;">Read More &rarr;</a>
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/examples/starlight-echo/templates/taxonomy.html
+++ b/examples/starlight-echo/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main>
+    <header style="margin-bottom: 3rem; border-bottom: 2px solid var(--border-color); padding-bottom: 2rem;">
+        <h1 style="font-size: 3rem; margin-bottom: 0.5rem; letter-spacing: -0.05em; text-transform: capitalize;">{{ taxonomy_name }}</h1>
+    </header>
+
+    <div style="display: flex; flex-wrap: wrap; gap: 1rem;">
+        {% if taxonomy_terms is defined %}
+            {% for term in taxonomy_terms %}
+            <a href="/{{ taxonomy_name }}/{{ term | lower }}/" style="border: 2px solid var(--border-color); padding: 0.5rem 1rem; font-family: var(--font-mono); text-transform: uppercase;">
+                {{ term }}
+            </a>
+            {% endfor %}
+        {% endif %}
+    </div>
+</main>
+{% endblock %}

--- a/examples/starlight-echo/templates/taxonomy_term.html
+++ b/examples/starlight-echo/templates/taxonomy_term.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main>
+    <header style="margin-bottom: 3rem; border-bottom: 2px solid var(--border-color); padding-bottom: 2rem;">
+        <h1 style="font-size: 3rem; margin-bottom: 0.5rem; letter-spacing: -0.05em;">
+            Tagged: <span style="color: var(--accent-color);">{% if term is defined %}{{ term }}{% endif %}</span>
+        </h1>
+    </header>
+
+    <div class="posts-list">
+        {% if pages is defined %}
+            {% for item in pages %}
+            <article style="border: 2px solid var(--border-color); padding: 2rem; margin-bottom: 2rem; display: flex; flex-direction: column; gap: 1rem; max-width: 800px;">
+                <header>
+                    <h2 style="margin: 0; font-size: 1.5rem;">
+                        <a href="{{ item.permalink }}" style="border-bottom: none;">{{ item.title }}</a>
+                    </h2>
+                    {% if item.date %}
+                    <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--accent-color); margin-top: 0.5rem;">
+                        {{ item.date | date(format="%Y-%m-%d") }}
+                    </div>
+                    {% endif %}
+                </header>
+
+                {% if item.description %}
+                <p>{{ item.description }}</p>
+                {% endif %}
+
+                <a href="{{ item.permalink }}" style="align-self: flex-start; font-family: var(--font-mono); text-transform: uppercase;">Read More &rarr;</a>
+            </article>
+            {% endfor %}
+        {% endif %}
+    </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
This PR introduces a new example site named `starlight-echo`.

The design is a custom "minimalist brutalist dark theme" utilizing solid colors (`#050505` background, `#fafafa` text, `#3b82f6` accent). It leverages a CSS Grid layout, raw structural elements (exposed borders, solid blocky sections), and typography based on `Inter` and `IBM Plex Mono`.

The code has been verified with `hwaro build` and correctly outputs the expected HTML files without errors, ensuring the variables map properly to `{{ content | safe }}`.

All constraints requested by the user have been met, specifically the strict avoidance of gradients and emojis.

---
*PR created automatically by Jules for task [14037014783919384637](https://jules.google.com/task/14037014783919384637) started by @hahwul*