### PR TITLE
feat: add yggdrasil-nexus example site

### DIFF
--- a/examples/yggdrasil-nexus/AGENTS.md
+++ b/examples/yggdrasil-nexus/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/yggdrasil-nexus/archetypes/default.md
+++ b/examples/yggdrasil-nexus/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/yggdrasil-nexus/config.toml
+++ b/examples/yggdrasil-nexus/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Yggdrasil Nexus"
+description = "An elegant, architectural exploration of deep green solid colors and stark white structural design. Pure CSS Grid without gradients."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/yggdrasil-nexus/content/_index.md
+++ b/examples/yggdrasil-nexus/content/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Yggdrasil Nexus"
+description = "A conceptual structure in deep green and white."
+template = "section"
++++
+
+Welcome to the Yggdrasil Nexus. This is an exploration of solid color block brutalism paired with elegant typography.
+
+This design avoids gradients, shadows, and unnecessary visual noise. Instead, it relies on strict CSS Grid alignment, pure architectural lines, and stark contrasts to deliver content clearly.
+
+### Structural Integrity
+
+The architecture of this site is built upon semantic HTML and the raw speed of Hwaro. No client-side frameworks, only the essential structure needed to convey information.

--- a/examples/yggdrasil-nexus/content/about.md
+++ b/examples/yggdrasil-nexus/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "About the Nexus"
+description = "Understanding the architectural principles."
++++
+
+The Yggdrasil Nexus is conceived as a digital arbor, a branching structure of information rooted in fundamental design principles.
+
+### Principles
+
+1.  **Solidity**: Colors are absolute. No gradients, no transparency effects, no shadows.
+2.  **Structure**: Layout is dictated by the grid. Every element occupies a defined space.
+3.  **Clarity**: Typography is the primary medium of communication. Cormorant Garamond for the voice, Inter for the data.
+
+> "A house is a machine for living in." - Le Corbusier
+
+In this digital space, the site is a machine for reading in.

--- a/examples/yggdrasil-nexus/content/posts/_index.md
+++ b/examples/yggdrasil-nexus/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Journal"
+description = "Logs of structural changes."
+template = "section"
++++
+
+This section details the ongoing iterations and thoughts behind the development of the Nexus.

--- a/examples/yggdrasil-nexus/content/posts/initial-structuring.md
+++ b/examples/yggdrasil-nexus/content/posts/initial-structuring.md
@@ -1,0 +1,18 @@
++++
+title = "Initial Structuring"
+date = "2024-05-01"
+description = "Laying down the foundational grid and color palette."
+[taxonomies]
+tags = ["design", "architecture"]
++++
+
+The first step in constructing the Nexus was establishing the grid. We opted for a simple two-column layout that collapses into a single column on smaller viewports. This ensures that the primary content area always has enough room to breathe.
+
+The color palette is deliberately constrained:
+
+*   **Deep Verdant Black**: `#03120f`
+*   **Off-white**: `#f0f5f3`
+*   **Solid Dark Green**: `#1f4a3e`
+*   **Pale Green**: `#d1e8df`
+
+This palette provides high contrast while remaining easy on the eyes for long reading sessions.

--- a/examples/yggdrasil-nexus/templates/404.html
+++ b/examples/yggdrasil-nexus/templates/404.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}404 - Not Found | {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="meta-header">
+    <h1>404.</h1>
+</div>
+<div class="content-body">
+    <p>The structural node you are looking for does not exist in the nexus.</p>
+    <a href="/">Return to origin</a>
+</div>
+{% endblock %}

--- a/examples/yggdrasil-nexus/templates/base.html
+++ b/examples/yggdrasil-nexus/templates/base.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <meta name="description" content="{{ site.description }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --color-bg: #03120f; /* Deep verdant black */
+            --color-text: #f0f5f3; /* Off-white / light green tint */
+            --color-accent: #1f4a3e; /* Solid dark green accent */
+            --color-highlight: #d1e8df; /* Pale green highlight */
+            --color-border: rgba(209, 232, 223, 0.15); /* Faint stark border */
+
+            --font-display: 'Cormorant Garamond', serif;
+            --font-body: 'Inter', sans-serif;
+
+            --grid-gap: 2rem;
+            --container-width: 1200px;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--color-bg);
+            color: var(--color-text);
+            font-family: var(--font-body);
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        .layout {
+            display: grid;
+            grid-template-columns: 250px 1fr;
+            grid-template-rows: 100vh;
+            max-width: var(--container-width);
+            margin: 0 auto;
+            border-left: 1px solid var(--color-border);
+            border-right: 1px solid var(--color-border);
+        }
+
+        @media (max-width: 900px) {
+            .layout {
+                grid-template-columns: 1fr;
+                grid-template-rows: auto 1fr;
+            }
+        }
+
+        header {
+            border-right: 1px solid var(--color-border);
+            padding: 3rem 2rem;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            background-color: var(--color-bg);
+            position: sticky;
+            top: 0;
+            height: 100vh;
+        }
+
+        @media (max-width: 900px) {
+            header {
+                border-right: none;
+                border-bottom: 1px solid var(--color-border);
+                height: auto;
+                position: relative;
+                padding: 2rem;
+            }
+        }
+
+        .brand-title {
+            font-family: var(--font-display);
+            font-size: 2.5rem;
+            font-weight: 700;
+            line-height: 1.1;
+            color: var(--color-highlight);
+            text-decoration: none;
+            display: block;
+            margin-bottom: 1rem;
+            letter-spacing: -0.02em;
+        }
+
+        .brand-desc {
+            font-size: 0.85rem;
+            color: var(--color-text);
+            opacity: 0.7;
+            margin-bottom: 3rem;
+            max-width: 200px;
+        }
+
+        nav {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        nav a {
+            color: var(--color-text);
+            text-decoration: none;
+            font-family: var(--font-body);
+            font-size: 0.9rem;
+            font-weight: 500;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            padding: 0.5rem 0;
+            border-bottom: 1px solid transparent;
+            transition: color 0.2s, border-color 0.2s;
+            display: inline-block;
+            width: max-content;
+        }
+
+        nav a:hover {
+            color: var(--color-highlight);
+            border-bottom: 1px solid var(--color-highlight);
+        }
+
+        .nav-section-title {
+            font-family: var(--font-display);
+            font-style: italic;
+            font-size: 1.2rem;
+            color: var(--color-accent);
+            margin-bottom: 0.5rem;
+            margin-top: 2rem;
+        }
+
+        .footer-meta {
+            margin-top: auto;
+            font-size: 0.75rem;
+            opacity: 0.5;
+        }
+
+        main {
+            padding: 4rem;
+            overflow-y: auto;
+            height: 100vh;
+            background-color: var(--color-bg);
+        }
+
+        @media (max-width: 900px) {
+            main {
+                padding: 2rem;
+                height: auto;
+                overflow-y: visible;
+            }
+        }
+
+        /* Content Typography */
+        h1, h2, h3, h4 {
+            font-family: var(--font-display);
+            color: var(--color-highlight);
+            margin-top: 2.5rem;
+            margin-bottom: 1rem;
+            line-height: 1.2;
+            font-weight: 600;
+        }
+
+        h1 {
+            font-size: 3.5rem;
+            margin-top: 0;
+            margin-bottom: 2rem;
+            border-bottom: 1px solid var(--color-border);
+            padding-bottom: 1rem;
+        }
+
+        h2 { font-size: 2.5rem; }
+        h3 { font-size: 1.8rem; }
+
+        p {
+            margin-bottom: 1.5rem;
+            font-size: 1.1rem;
+            max-width: 75ch;
+            color: rgba(240, 245, 243, 0.85);
+        }
+
+        a {
+            color: var(--color-highlight);
+            text-decoration: none;
+            border-bottom: 1px solid var(--color-accent);
+            transition: all 0.2s ease;
+        }
+
+        a:hover {
+            background-color: var(--color-accent);
+            color: var(--color-text);
+            border-bottom-color: var(--color-highlight);
+        }
+
+        ul, ol {
+            margin-bottom: 1.5rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-accent);
+            padding-left: 1.5rem;
+            margin-left: 0;
+            margin-bottom: 2rem;
+            font-family: var(--font-display);
+            font-size: 1.5rem;
+            font-style: italic;
+            color: var(--color-highlight);
+        }
+
+        code {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            background-color: var(--color-accent);
+            padding: 0.2em 0.4em;
+            font-size: 0.85em;
+            border-radius: 2px;
+            color: var(--color-text);
+        }
+
+        pre {
+            background-color: #010807;
+            padding: 1.5rem;
+            overflow-x: auto;
+            margin-bottom: 2rem;
+            border: 1px solid var(--color-border);
+        }
+
+        pre code {
+            background-color: transparent;
+            padding: 0;
+            font-size: 0.9rem;
+            color: var(--color-highlight);
+        }
+
+        hr {
+            border: 0;
+            height: 1px;
+            background-color: var(--color-border);
+            margin: 3rem 0;
+        }
+
+        /* Post lists */
+        .post-list {
+            list-style: none;
+            padding: 0;
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 2rem;
+        }
+
+        .post-card {
+            border: 1px solid var(--color-border);
+            padding: 2rem;
+            transition: border-color 0.3s;
+            background-color: rgba(31, 74, 62, 0.05);
+        }
+
+        .post-card:hover {
+            border-color: var(--color-highlight);
+        }
+
+        .post-card-title {
+            font-family: var(--font-display);
+            font-size: 1.8rem;
+            margin-bottom: 0.5rem;
+            margin-top: 0;
+        }
+
+        .post-card-title a {
+            border: none;
+            color: var(--color-highlight);
+        }
+
+        .post-card-title a:hover {
+            background: transparent;
+        }
+
+        .post-card-date {
+            font-size: 0.85rem;
+            color: var(--color-accent);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin-bottom: 1rem;
+            display: block;
+        }
+
+        .post-card-summary {
+            font-size: 1rem;
+            margin-bottom: 0;
+            color: rgba(240, 245, 243, 0.7);
+        }
+
+        /* Taxonomies */
+        .taxonomy-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            list-style: none;
+            padding: 0;
+            margin-top: 1rem;
+        }
+
+        .taxonomy-tag {
+            background-color: var(--color-accent);
+            color: var(--color-text);
+            padding: 0.2rem 0.6rem;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .taxonomy-tag a {
+            border: none;
+            color: inherit;
+        }
+
+        .taxonomy-tag a:hover {
+            background: transparent;
+            color: var(--color-highlight);
+        }
+
+        .meta-header {
+            margin-bottom: 3rem;
+        }
+
+    </style>
+</head>
+<body>
+    <div class="layout">
+        <header>
+            <div>
+                <a href="/" class="brand-title">{{ site.title }}</a>
+                <div class="brand-desc">{{ site.description }}</div>
+
+                <nav>
+                    <div class="nav-section-title">Directory</div>
+                    <a href="/">Index</a>
+                    <a href="/about/">About</a>
+                    <a href="/posts/">Journal</a>
+                </nav>
+            </div>
+            <div class="footer-meta">
+                &copy; {{ current_year | default(2024) }} {{ site.title }}.<br>
+                Powered by Hwaro.
+            </div>
+        </header>
+
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+</body>
+</html>

--- a/examples/yggdrasil-nexus/templates/page.html
+++ b/examples/yggdrasil-nexus/templates/page.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+<article>
+    <div class="meta-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="post-card-date">{{ page.date | date("%B %d, %Y") }}</div>
+        {% endif %}
+
+        {% if page.taxonomies is defined and page.taxonomies.tags %}
+        <ul class="taxonomy-list">
+            {% for tag in page.taxonomies.tags %}
+            <li class="taxonomy-tag"><a href="/tags/{{ tag }}/">{{ tag }}</a></li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+
+    <div class="content-body">
+        {{ content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/examples/yggdrasil-nexus/templates/section.html
+++ b/examples/yggdrasil-nexus/templates/section.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}{% if section.title %}{{ section.title }}{% else %}{{ site.title }}{% endif %}{% endblock %}
+
+{% block content %}
+<div class="meta-header">
+    <h1>{% if section.title %}{{ section.title }}{% else %}Index{% endif %}</h1>
+    {% if section.description %}
+    <p class="section-desc">{{ section.description }}</p>
+    {% endif %}
+</div>
+
+<div class="content-body">
+    {{ content | safe }}
+</div>
+
+{% if section.pages %}
+<ul class="post-list">
+    {% for page in section.pages %}
+    <li class="post-card">
+        {% if page.date %}
+        <span class="post-card-date">{{ page.date | date("%Y.%m.%d") }}</span>
+        {% endif %}
+        <h2 class="post-card-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+        {% if page.description %}
+        <p class="post-card-summary">{{ page.description }}</p>
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/examples/yggdrasil-nexus/templates/taxonomy.html
+++ b/examples/yggdrasil-nexus/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Taxonomy: {{ taxonomy_name }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="meta-header">
+    <h1>{{ taxonomy_name | capitalize }}</h1>
+</div>
+
+<ul class="taxonomy-list" style="margin-top: 2rem;">
+    {% for term in taxonomy_terms %}
+    <li class="taxonomy-tag" style="font-size: 1rem; padding: 0.5rem 1rem;">
+        <a href="/{{ taxonomy_name }}/{{ term.name }}/">{{ term.name }} ({{ term.pages | size }})</a>
+    </li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/examples/yggdrasil-nexus/templates/taxonomy_term.html
+++ b/examples/yggdrasil-nexus/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}{% if term %}{{ term.name }}{% endif %} | {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="meta-header">
+    <h1>{% if term %}{{ term.name }}{% endif %}</h1>
+    <p>Items tagged with this term.</p>
+</div>
+
+{% if term and term.pages %}
+<ul class="post-list">
+    {% for page in term.pages %}
+    <li class="post-card">
+        {% if page.date %}
+        <span class="post-card-date">{{ page.date | date("%Y.%m.%d") }}</span>
+        {% endif %}
+        <h2 class="post-card-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Adds a new example Hwaro site named `yggdrasil-nexus`.

This site demonstrates:
* An elegant, structural aesthetic using a pure CSS Grid layout.
* A strict color palette consisting of solid deep greens (`#03120f`, `#1f4a3e`, `#d1e8df`) and stark white (`#f0f5f3`).
* Strict avoidance of gradients and emojis to create a brutalist, architectural feel.
* Elegant typography leveraging the 'Cormorant Garamond' and 'Inter' fonts.
* Customized core templates (`base.html`, `page.html`, `section.html`, `taxonomy.html`) overriding the default bare scaffold.

---
*PR created automatically by Jules for task [7878593694506779155](https://jules.google.com/task/7878593694506779155) started by @hahwul*