### PR TITLE
Fix 404 links in marble-slab example

### DIFF
--- a/examples/marble-slab/config.toml
+++ b/examples/marble-slab/config.toml
@@ -1,7 +1,7 @@
 title = "MARBLE-SLAB"
 description = "A sophisticated, marble-inspired design for high-value and permanent content."
 default_language = "en"
-base_url = "https://example.com"
+base_url = "https://examples.hwaro.hahwul.com/marble-slab"
 
 [taxonomies]
 tags = "tags"

--- a/examples/marble-slab/templates/header.html
+++ b/examples/marble-slab/templates/header.html
@@ -68,8 +68,8 @@
         <div class="container">
             <div class="logo">marble.slab</div>
             <nav>
-                <a href="/">Vein</a>
-                <a href="/about">Surface</a>
+                <a href="{{ base_url }}/">Vein</a>
+                <a href="{{ base_url }}/about/">Surface</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
In the marble-slab example, the internal navigation links for the site didn't use the configured `base_url`. This caused 404 errors when navigating to the internal `/` and `/about/` pages in some deployment scenarios. 

This commit fixes this by updating the `href` attribute on these links to include the `base_url` variable. It also updates the configured `base_url` to accurately point to the published example (`https://examples.hwaro.hahwul.com/marble-slab`).

---
*PR created automatically by Jules for task [8013771396832236591](https://jules.google.com/task/8013771396832236591) started by @chei-l*