### PR TITLE
Fix 404 in aurelia example

### DIFF
--- a/examples/aurelia/content/posts/_index.md
+++ b/examples/aurelia/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Writing"
+template = "section"
++++
+
+Posts go here.

--- a/examples/aurelia/templates/section.html
+++ b/examples/aurelia/templates/section.html
@@ -7,16 +7,16 @@
 
     {% if content %}
     <div class="content" style="margin-bottom: 3rem;">
-        {{ content }}
+        {{ content | safe }}
     </div>
     {% endif %}
 
-    {% if section.list %}
+    {% if section.pages %}
     <div class="posts">
         <ul class="post-list">
-        {% for post in section.list %}
+        {% for post in section.pages %}
             <li class="post-item">
-                <a href="{{ post.permalink }}">
+                <a href="{{ post.path }}">
                     <h2>{{ post.title }}</h2>
                 </a>
                 {% if post.date %}


### PR DESCRIPTION
- Added `examples/aurelia/content/posts/_index.md` to resolve the 404 issue when navigating to `/posts/`.
- Updated `examples/aurelia/templates/section.html` to correctly use `section.pages` instead of `section.list` and `post.path` instead of `post.permalink`.
- Added `| safe` filter to `{{ content }}` rendering.

---
*PR created automatically by Jules for task [14417063858363801033](https://jules.google.com/task/14417063858363801033) started by @chei-l*