### PR TITLE
feat: add serene-horizon example

### DIFF
--- a/examples/serene-horizon/AGENTS.md
+++ b/examples/serene-horizon/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/serene-horizon/archetypes/default.md
+++ b/examples/serene-horizon/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/serene-horizon/config.toml
+++ b/examples/serene-horizon/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Serene Horizon"
+description = "An elegant, minimalist architectural design for Hwaro."
+base_url = "https://serene-horizon.example.com"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/serene-horizon/content/_index.md
+++ b/examples/serene-horizon/content/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Serene Horizon"
+description = "A structural void in the digital landscape."
+template = "index"
++++
+
+Welcome to Serene Horizon, a minimalist architectural exploration of structural web design built with Hwaro. This design embraces simplicity, utilizing pure solid colors, strong typography, and a stark CSS grid layout to frame content cleanly and efficiently.
+
+> "Simplicity is the ultimate sophistication."
+
+This demonstration site is a canvas for testing structure and form without relying on superficial embellishments.

--- a/examples/serene-horizon/content/about.md
+++ b/examples/serene-horizon/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About This Space"
+description = "Understanding the architectural principles of Serene Horizon."
+date = "2024-05-03"
+[taxonomies]
+tags = ["architecture", "design", "minimalism"]
++++
+
+Serene Horizon is an exercise in restraint.
+
+The aesthetic principle underlying this design is a focus on high legibility, strict structural boundaries, and pure, flat color palettes. We explicitly avoid gradients, artificial shadows, and emojis, instead prioritizing typography and geometry.
+
+### Core Principles
+
+1. **Typography as Structure**: Using *Cormorant Garamond* for elegant, structural headers, and *Inter* for highly legible, dense text.
+2. **Solid Color Palette**: Off-white (`#f7f5f0`) base to reduce eye strain, coupled with deep black (`#1a1a1a`) and a slate accent (`#3b4252`).
+3. **Rigid Grid**: A CSS Grid layout that confines content into a strict central column, establishing order and hierarchy.
+
+This approach ensures the content remains the focal point, uninterrupted by unnecessary visual noise.

--- a/examples/serene-horizon/content/posts/foundation.md
+++ b/examples/serene-horizon/content/posts/foundation.md
@@ -1,0 +1,21 @@
++++
+title = "Architectural Foundations"
+description = "Building from the ground up."
+date = "2024-05-01"
+[taxonomies]
+tags = ["foundations", "design"]
++++
+
+When constructing a digital space, the foundation is the layout system.
+
+In this template, we establish our foundation using a pure CSS Grid. It divides the viewport into three primary zones, allowing the main content column to breathe comfortably in the center while maintaining proportional margins on either side.
+
+```css
+body {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    grid-template-columns: minmax(1rem, 1fr) minmax(auto, 800px) minmax(1rem, 1fr);
+}
+```
+
+This strict adherence to a grid allows us to build complex, responsive structures with minimal effort, ensuring a consistent rhythm throughout the design.

--- a/examples/serene-horizon/templates/404.html
+++ b/examples/serene-horizon/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-box" style="text-align: center; padding: 5rem 2rem;">
+    <h1 style="font-size: 5rem; margin-bottom: 0;">404</h1>
+    <h2 style="border: none; margin-top: 1rem;">Page Not Found</h2>
+    <p>The structural element you are looking for does not exist in this domain.</p>
+    <a href="/" style="display: inline-block; margin-top: 2rem; padding: 0.75rem 1.5rem; background-color: var(--text-color); color: var(--bg-color); text-decoration: none; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;">Return Home</a>
+</div>
+{% endblock %}

--- a/examples/serene-horizon/templates/base.html
+++ b/examples/serene-horizon/templates/base.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,400&family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-color: #f7f5f0;
+            --text-color: #1a1a1a;
+            --accent-color: #3b4252;
+            --border-color: #d8d3c8;
+            --muted-color: #7b7f87;
+
+            --font-sans: 'Inter', sans-serif;
+            --font-serif: 'Cormorant Garamond', serif;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: var(--font-sans);
+            line-height: 1.6;
+            min-height: 100vh;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+            grid-template-columns: minmax(1rem, 1fr) minmax(auto, 800px) minmax(1rem, 1fr);
+            gap: 2rem;
+            padding-top: 2rem;
+            padding-bottom: 2rem;
+        }
+
+        header, main, footer {
+            grid-column: 2;
+        }
+
+        header {
+            border-bottom: 2px solid var(--text-color);
+            padding-bottom: 1.5rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            flex-wrap: wrap;
+        }
+
+        .site-title {
+            font-family: var(--font-serif);
+            font-size: 2.5rem;
+            font-weight: 600;
+            color: var(--text-color);
+            text-decoration: none;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        nav {
+            display: flex;
+            gap: 1.5rem;
+        }
+
+        nav a {
+            color: var(--accent-color);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            transition: color 0.2s ease;
+        }
+
+        nav a:hover {
+            color: var(--text-color);
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-serif);
+            font-weight: 400;
+            color: var(--text-color);
+            margin-bottom: 1rem;
+            line-height: 1.2;
+        }
+
+        h1 {
+            font-size: 3rem;
+            margin-top: 1rem;
+            margin-bottom: 1.5rem;
+        }
+
+        h2 {
+            font-size: 2rem;
+            margin-top: 2.5rem;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+            color: var(--text-color);
+        }
+
+        a {
+            color: var(--text-color);
+            text-decoration-thickness: 1px;
+            text-underline-offset: 4px;
+        }
+
+        a:hover {
+            text-decoration-thickness: 2px;
+        }
+
+        .meta {
+            font-size: 0.85rem;
+            color: var(--muted-color);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 2rem;
+            display: block;
+        }
+
+        .content-box {
+            background-color: #ffffff;
+            border: 1px solid var(--border-color);
+            padding: 2.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .item-list {
+            list-style: none;
+        }
+
+        .item-list li {
+            padding: 1.5rem 0;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .item-list li:last-child {
+            border-bottom: none;
+        }
+
+        .item-title {
+            font-size: 1.5rem;
+            font-family: var(--font-serif);
+            margin-bottom: 0.5rem;
+        }
+
+        .item-title a {
+            text-decoration: none;
+        }
+
+        .item-title a:hover {
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 4px;
+        }
+
+        footer {
+            border-top: 1px solid var(--border-color);
+            padding-top: 1.5rem;
+            font-size: 0.85rem;
+            color: var(--muted-color);
+            text-align: center;
+        }
+
+        /* Blocks for specialized content */
+        blockquote {
+            font-family: var(--font-serif);
+            font-style: italic;
+            font-size: 1.25rem;
+            border-left: 3px solid var(--accent-color);
+            padding-left: 1.5rem;
+            margin: 2rem 0;
+            color: var(--accent-color);
+        }
+
+        code {
+            font-family: 'Inter', monospace;
+            background-color: #eae7df;
+            padding: 0.2em 0.4em;
+            font-size: 0.9em;
+        }
+
+        pre code {
+            display: block;
+            padding: 1.5rem;
+            background-color: var(--text-color);
+            color: var(--bg-color);
+            overflow-x: auto;
+            border-radius: 0;
+            margin: 1.5rem 0;
+        }
+
+        hr {
+            border: none;
+            border-top: 1px solid var(--border-color);
+            margin: 3rem 0;
+        }
+
+    </style>
+</head>
+<body>
+
+    <header>
+        <a href="/" class="site-title">{{ site.title }}</a>
+        <nav>
+            <a href="/">Home</a>
+            <a href="/about/">About</a>
+        </nav>
+    </header>
+
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        &copy; {{ now() | date("%Y") }} {{ site.title }}. Built with Hwaro.
+    </footer>
+
+</body>
+</html>

--- a/examples/serene-horizon/templates/index.html
+++ b/examples/serene-horizon/templates/index.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-box">
+    <h1>{{ page.title }}</h1>
+
+    <div class="page-content" style="margin-bottom: 3rem;">
+        {{ content | safe }}
+    </div>
+
+    <h2 style="margin-bottom: 1.5rem;">Recent Updates</h2>
+    <ul class="item-list">
+        {% for item in pages %}
+        <li>
+            <h3 class="item-title"><a href="{{ item.permalink }}">{{ item.title }}</a></h3>
+            {% if item.date %}
+            <span class="meta">{{ item.date | date("%B %d, %Y") }}</span>
+            {% endif %}
+            {% if item.description %}
+            <p>{{ item.description }}</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/examples/serene-horizon/templates/page.html
+++ b/examples/serene-horizon/templates/page.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="content-box">
+    <h1>{{ page.title }}</h1>
+
+    {% if page.date %}
+    <span class="meta">{{ page.date | date("%B %d, %Y") }}</span>
+    {% endif %}
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+    <div style="margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+        <span class="meta" style="display:inline; margin-right: 1rem;">Tags:</span>
+        {% for tag in page.taxonomies.tags %}
+        <a href="/tags/{{ tag | urlencode }}/" style="margin-right: 1rem; text-transform: uppercase; font-size: 0.85rem; font-weight: 600; color: var(--accent-color);">{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+{% endblock %}

--- a/examples/serene-horizon/templates/section.html
+++ b/examples/serene-horizon/templates/section.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-box">
+    <h1>{{ section.title }}</h1>
+
+    <div class="page-content" style="margin-bottom: 2rem;">
+        {{ content | safe }}
+    </div>
+
+    <ul class="item-list">
+        {% for item in section.pages %}
+        <li>
+            <h2 class="item-title"><a href="{{ item.permalink }}">{{ item.title }}</a></h2>
+            {% if item.date %}
+            <span class="meta">{{ item.date | date("%B %d, %Y") }}</span>
+            {% endif %}
+            {% if item.description %}
+            <p>{{ item.description }}</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/examples/serene-horizon/templates/taxonomy.html
+++ b/examples/serene-horizon/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-box">
+    <h1>{{ taxonomy_name | capitalize }}</h1>
+
+    <ul class="item-list">
+        {% for term in taxonomy_terms %}
+        <li>
+            <h2 class="item-title"><a href="{{ term.permalink }}">{{ term.name }}</a></h2>
+            <span class="meta">{{ term.pages | length }} items</span>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/examples/serene-horizon/templates/taxonomy_term.html
+++ b/examples/serene-horizon/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-box">
+    <h1>Term: {{ term.name }}</h1>
+
+    <ul class="item-list">
+        {% for item in term.pages %}
+        <li>
+            <h2 class="item-title"><a href="{{ item.permalink }}">{{ item.title }}</a></h2>
+            {% if item.date %}
+            <span class="meta">{{ item.date | date("%B %d, %Y") }}</span>
+            {% endif %}
+            {% if item.description %}
+            <p>{{ item.description }}</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
Added a new example website `serene-horizon` built to demonstrate structural minimal web design for the Hwaro SSG. Includes working sample templates, basic content, and site configuration.

---
*PR created automatically by Jules for task [3414278814999894887](https://jules.google.com/task/3414278814999894887) started by @hahwul*