### PR TITLE
docs(install): correct Homebrew tap shorthand to hahwul/hwaro/hwaro

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To work with these examples or for AI agents acting on your behalf, you need to 
 
 ### macOS / Linux (Homebrew)
 ```bash
-brew install hahwul/tap/hwaro
+brew install hahwul/hwaro/hwaro
 ```
 
 ### Linux (Arch)


### PR DESCRIPTION
## Summary
- `brew install hahwul/tap/hwaro` resolves to a non-existent `hahwul/homebrew-tap`. The actual tap is `hahwul/homebrew-hwaro`, so the shorthand should be `hahwul/hwaro/hwaro`.
- Aligns with the official install docs after hahwul/hwaro#517.

## Test plan
- [ ] `brew install hahwul/hwaro/hwaro` works against the real tap