### PR TITLE
Add Silicon Mirage Example

### DIFF
--- a/examples/silicon-mirage/AGENTS.md
+++ b/examples/silicon-mirage/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/silicon-mirage/config.toml
+++ b/examples/silicon-mirage/config.toml
@@ -1,0 +1,254 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Silicon Mirage"
+description = "A minimalist layout experiment focusing on spatial structure and form."
+base_url = "http://localhost:3000"
+
+[extra]
+author = "Silicon Mirage UI"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/silicon-mirage/content/_index.md
+++ b/examples/silicon-mirage/content/_index.md
@@ -1,0 +1,16 @@
++++
+title = "Silicon Mirage"
+description = "A minimalist layout experiment focusing on spatial structure and form."
+template = "page"
++++
+
+Welcome to the Silicon Mirage. This is a demonstration of elegant typography and careful spacing, utilizing deep charcoal tones and subtle cream highlights. The design rejects gradients and complex embellishments, focusing entirely on pure solid colors and functional typography.
+
+## Design Philosophy
+
+This theme emphasizes:
+- **Clean Structure**: Utilizing CSS grid and flexbox.
+- **Sophisticated Typography**: Pairing *Playfair Display* with *Inter*.
+- **Subtle Contrast**: Using muted tones to ensure readability without being overwhelming.
+
+Feel free to browse through the [Posts](/posts/) section to see more.

--- a/examples/silicon-mirage/content/about.md
+++ b/examples/silicon-mirage/content/about.md
@@ -1,0 +1,13 @@
++++
+title = "About Silicon Mirage"
+description = "Information about the Silicon Mirage theme."
++++
+
+The **Silicon Mirage** theme was crafted to provide an elegant, reading-focused experience.
+
+It intentionally avoids distractions, relying instead on solid architectural principles of web design:
+1.  Clear visual hierarchy.
+2.  Ample whitespace.
+3.  Carefully chosen typographic pairings.
+
+This project was built as an example for the [Hwaro](https://hwaro.hahwul.com) static site generator.

--- a/examples/silicon-mirage/content/posts/_index.md
+++ b/examples/silicon-mirage/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Posts"
+description = "A collection of thoughts and reflections."
++++
+
+Here are the latest updates from the Silicon Mirage.

--- a/examples/silicon-mirage/content/posts/hello-world.md
+++ b/examples/silicon-mirage/content/posts/hello-world.md
@@ -1,0 +1,16 @@
++++
+title = "Hello, World"
+date = 2024-05-04
+description = "The first transmission."
+taxonomies = { tags = ["announcement", "first-post"] }
++++
+
+This is the very first post on the Silicon Mirage.
+
+> "Simplicity is the ultimate sophistication." - Leonardo da Vinci
+
+We are testing the layout, typography, and spacing. Notice how the tags appear at the bottom and the blockquote is styled with an accent border.
+
+### Sub-heading
+
+Here is some more text to demonstrate the hierarchy. The solid colors provide a sturdy foundation for the content to shine.

--- a/examples/silicon-mirage/static/style.css
+++ b/examples/silicon-mirage/static/style.css
@@ -1,0 +1,251 @@
+/*
+  Silicon Mirage Theme
+  Fonts: Playfair Display (headings), Inter (body)
+  Colors: Deep Charcoal, Soft Cream, Muted Sand
+  Design: Clean, elegant, no gradients, no emojis
+*/
+
+:root {
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-text: #F9F9F9;
+  --color-text-muted: #A0A0A0;
+  --color-accent: #E0A96D;
+  --color-border: #333333;
+
+  --font-sans: 'Inter', sans-serif;
+  --font-serif: 'Playfair Display', serif;
+
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1.5rem;
+  --spacing-lg: 3rem;
+  --spacing-xl: 6rem;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  color: var(--color-text);
+  margin-bottom: var(--spacing-md);
+  line-height: 1.2;
+}
+
+h1 { font-size: 3.5rem; }
+h2 { font-size: 2.5rem; }
+h3 { font-size: 1.75rem; }
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: var(--color-text);
+}
+
+p {
+  margin-bottom: var(--spacing-md);
+}
+
+/* Layout */
+.layout-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.header-inner,
+.site-main,
+.footer-inner {
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 var(--spacing-md);
+}
+
+/* Header */
+.site-header {
+  padding: var(--spacing-lg) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.header-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.site-title {
+  font-family: var(--font-serif);
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: 0.05em;
+}
+
+.site-nav {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.site-nav a {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+}
+
+.site-nav a:hover {
+  color: var(--color-accent);
+}
+
+/* Main */
+.site-main {
+  flex: 1;
+  padding-top: var(--spacing-xl);
+  padding-bottom: var(--spacing-xl);
+}
+
+/* Typography styles for content */
+.content-area h2 {
+  margin-top: var(--spacing-lg);
+}
+
+.content-area ul, .content-area ol {
+  margin-bottom: var(--spacing-md);
+  padding-left: var(--spacing-lg);
+}
+
+.content-area li {
+  margin-bottom: var(--spacing-sm);
+}
+
+.content-area hr {
+  border: 0;
+  height: 1px;
+  background-color: var(--color-border);
+  margin: var(--spacing-lg) 0;
+}
+
+.content-area blockquote {
+  border-left: 4px solid var(--color-accent);
+  padding-left: var(--spacing-md);
+  margin-left: 0;
+  font-style: italic;
+  color: var(--color-text-muted);
+}
+
+/* Post Lists */
+.post-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.post-item {
+  margin-bottom: var(--spacing-lg);
+  padding-bottom: var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.post-item:last-child {
+  border-bottom: none;
+}
+
+.post-title {
+  margin-bottom: var(--spacing-sm);
+}
+
+.post-title a {
+  color: var(--color-text);
+}
+
+.post-title a:hover {
+  color: var(--color-accent);
+}
+
+.post-meta {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--spacing-sm);
+}
+
+.post-summary {
+  color: var(--color-text-muted);
+}
+
+.read-more {
+  display: inline-block;
+  margin-top: var(--spacing-md);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+.tag {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.6rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  border-radius: 2px;
+}
+
+.tag:hover {
+  background-color: var(--color-accent);
+  color: var(--color-bg);
+  border-color: var(--color-accent);
+}
+
+/* Footer */
+.site-footer {
+  padding: var(--spacing-lg) 0;
+  border-top: 1px solid var(--color-border);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.author-credits {
+  margin-top: var(--spacing-sm);
+  font-style: italic;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .header-inner {
+    flex-direction: column;
+    gap: var(--spacing-md);
+    align-items: center;
+  }
+
+  h1 { font-size: 2.5rem; }
+  h2 { font-size: 2rem; }
+}

--- a/examples/silicon-mirage/templates/404.html
+++ b/examples/silicon-mirage/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}404 - Not Found{% endblock %}
+
+{% block content %}
+<div class="content-area" style="text-align: center; padding-top: var(--spacing-xl);">
+    <h1 style="font-size: 5rem; margin-bottom: 0; color: var(--color-accent);">404</h1>
+    <h2>Page Not Found</h2>
+    <p>The page you are looking for does not exist.</p>
+    <a href="/" class="read-more">Return Home</a>
+</div>
+{% endblock %}

--- a/examples/silicon-mirage/templates/base.html
+++ b/examples/silicon-mirage/templates/base.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <link rel="stylesheet" href="/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="site-header">
+            <div class="header-inner">
+                <a href="/" class="site-title">{{ site.title }}</a>
+                <nav class="site-nav">
+                    <a href="/">Home</a>
+                    <a href="/about/">About</a>
+                    <a href="/posts/">Posts</a>
+                </nav>
+            </div>
+        </header>
+
+        <main class="site-main">
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer class="site-footer">
+            <div class="footer-inner">
+                <p>&copy; {{ site.title }}</p>
+                {% if site.extra is defined and site.extra.author %}
+                    <p class="author-credits">Designed by {{ site.extra.author }}</p>
+                {% endif %}
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/silicon-mirage/templates/page.html
+++ b/examples/silicon-mirage/templates/page.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="content-area">
+    <header class="page-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+            <div class="post-meta">
+                <time datetime="{{ page.date | date('%Y-%m-%d') }}">{{ page.date | date("%B %d, %Y") }}</time>
+            </div>
+        {% endif %}
+    </header>
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+        <div class="tag-list">
+            {% for tag in page.taxonomies.tags %}
+                <a href="/tags/{{ tag }}/" class="tag">{{ tag }}</a>
+            {% endfor %}
+        </div>
+    {% endif %}
+</article>
+{% endblock %}

--- a/examples/silicon-mirage/templates/section.html
+++ b/examples/silicon-mirage/templates/section.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-area">
+    <header class="section-header">
+        <h1>{{ section.title }}</h1>
+        {% if content %}
+            <div class="section-description">
+                {{ content | safe }}
+            </div>
+        {% endif %}
+    </header>
+
+    {% if section.pages %}
+        <div class="post-list">
+            {% for item in section.pages %}
+                <article class="post-item">
+                    <h2 class="post-title"><a href="{{ item.permalink }}">{{ item.title }}</a></h2>
+                    {% if item.date %}
+                        <div class="post-meta">
+                            <time datetime="{{ item.date | date('%Y-%m-%d') }}">{{ item.date | date("%B %d, %Y") }}</time>
+                        </div>
+                    {% endif %}
+                    {% if item.description %}
+                        <p class="post-summary">{{ item.description }}</p>
+                    {% endif %}
+                    <a href="{{ item.permalink }}" class="read-more">Read Article</a>
+                </article>
+            {% endfor %}
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/examples/silicon-mirage/templates/taxonomy.html
+++ b/examples/silicon-mirage/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-area">
+    <header class="section-header">
+        <h1>{{ taxonomy_name | capitalize }}</h1>
+    </header>
+
+    {% if taxonomy_terms %}
+        <div class="tag-list" style="margin-top: var(--spacing-lg);">
+            {% for term in taxonomy_terms %}
+                <a href="{{ term.permalink }}" class="tag" style="font-size: 1rem; padding: 0.5rem 1rem;">{{ term.name }} ({{ term.pages | length }})</a>
+            {% endfor %}
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/examples/silicon-mirage/templates/taxonomy_term.html
+++ b/examples/silicon-mirage/templates/taxonomy_term.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-area">
+    <header class="section-header">
+        <h1>Articles tagged: {{ term.name }}</h1>
+    </header>
+
+    {% if term.pages %}
+        <div class="post-list">
+            {% for item in term.pages %}
+                <article class="post-item">
+                    <h2 class="post-title"><a href="{{ item.permalink }}">{{ item.title }}</a></h2>
+                    {% if item.date %}
+                        <div class="post-meta">
+                            <time datetime="{{ item.date | date('%Y-%m-%d') }}">{{ item.date | date("%B %d, %Y") }}</time>
+                        </div>
+                    {% endif %}
+                    {% if item.description %}
+                        <p class="post-summary">{{ item.description }}</p>
+                    {% endif %}
+                    <a href="{{ item.permalink }}" class="read-more">Read Article</a>
+                </article>
+            {% endfor %}
+        </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds a new example site named `silicon-mirage` built with Hwaro. It features an elegant, minimalist dark theme utilizing pure solid colors (deep charcoal, soft cream, muted sand accent) and relies entirely on typography (Playfair Display and Inter) and CSS spacing, strictly avoiding gradients and emojis as requested. The site is initialized using the `bare` scaffold and fully customized using Jinja2/Crinja-compatible templates extending from a base layout.

---
*PR created automatically by Jules for task [9961179916961442311](https://jules.google.com/task/9961179916961442311) started by @hahwul*