### PR TITLE
Add `ethereal-horizon` example site

### DIFF
--- a/examples/ethereal-horizon/AGENTS.md
+++ b/examples/ethereal-horizon/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/ethereal-horizon/config.toml
+++ b/examples/ethereal-horizon/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Ethereal Horizon"
+description = "A structural monolith in the digital void."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/ethereal-horizon/content/_index.md
+++ b/examples/ethereal-horizon/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "The Void Architecture"
+description = "Exploring structural minimalism in the digital space."
+template = "section"
++++
+
+Welcome to Ethereal Horizon. This space serves as a testament to structural minimalism, pure colors, and functional design, stripped of unnecessary ornamentation.
+
+Here, we explore concepts of void space, architectural grid layouts, and stark typography.

--- a/examples/ethereal-horizon/content/about.md
+++ b/examples/ethereal-horizon/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About The Construct"
+description = "Purpose and origin of Ethereal Horizon."
+template = "page"
++++
+
+## Core Principles
+
+Ethereal Horizon was forged with three primary principles:
+
+1. **Structural Integrity**: A design system relying on strict grid layouts and unyielding boundaries.
+2. **Monolithic Presence**: Utilization of deep colors to simulate boundless space.
+3. **Absolute Clarity**: Typography that serves function before form, ensuring information is transmitted without interference.
+
+We are building a gallery of ideas, rendered in the starkest terms possible.

--- a/examples/ethereal-horizon/content/posts/_index.md
+++ b/examples/ethereal-horizon/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Transmissions"
+description = "Archived logs and reports from the frontier."
+template = "section"
++++
+
+A collection of thoughts, updates, and structural blueprints.

--- a/examples/ethereal-horizon/content/posts/first-post.md
+++ b/examples/ethereal-horizon/content/posts/first-post.md
@@ -1,0 +1,24 @@
++++
+title = "Initial Blueprint"
+description = "Establishing the foundation of the void."
+date = 2024-05-04
+template = "page"
+[taxonomies]
+tags = ["architecture", "foundation", "design"]
+categories = ["logs"]
++++
+
+## Foundation Protocol
+
+The structural components have been initialized. The grid is active and holding the boundaries of the layout. The primary colors - absolute black, sharp cyan, and slate grey - have been locked into the variables.
+
+### The Code
+
+```css
+:root {
+    --color-bg: #030406;
+    --color-accent: #0ea5e9;
+}
+```
+
+The system is stable.

--- a/examples/ethereal-horizon/templates/404.html
+++ b/examples/ethereal-horizon/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}404 - Not Found | {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="content-area" style="text-align: center; padding: 4rem 0;">
+    <h1 style="font-size: 8rem; margin-bottom: 0; color: var(--color-accent); font-family: var(--font-mono);">404</h1>
+    <h2 style="font-size: 2rem; margin-bottom: 2rem;">Structural Anomaly</h2>
+    <p>The entity you are looking for does not exist in this sector.</p>
+    <a href="/" style="font-family: var(--font-mono); text-transform: uppercase; margin-top: 2rem; display: inline-block; border: 1px solid var(--color-border); padding: 0.8rem 1.5rem;">Return to Origin</a>
+</div>
+{% endblock %}

--- a/examples/ethereal-horizon/templates/base.html
+++ b/examples/ethereal-horizon/templates/base.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <meta name="description" content="{% block description %}{{ site.description }}{% endblock %}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --color-bg: #030406;
+            --color-text: #e2e8f0;
+            --color-accent: #0ea5e9;
+            --color-border: #1e293b;
+            --color-panel: #0f172a;
+
+            --font-main: 'Inter', sans-serif;
+            --font-mono: 'Space Mono', monospace;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--color-bg);
+            color: var(--color-text);
+            font-family: var(--font-main);
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+            min-height: 100vh;
+        }
+
+        header {
+            border-bottom: 1px solid var(--color-border);
+            padding: 2rem 5%;
+            display: grid;
+            grid-template-columns: 1fr auto;
+            align-items: center;
+        }
+
+        .logo {
+            font-family: var(--font-mono);
+            font-weight: 700;
+            font-size: 1.5rem;
+            text-decoration: none;
+            color: var(--color-text);
+            text-transform: uppercase;
+            letter-spacing: -0.05em;
+        }
+
+        .logo span {
+            color: var(--color-accent);
+        }
+
+        nav {
+            display: flex;
+            gap: 2rem;
+        }
+
+        nav a {
+            color: var(--color-text);
+            text-decoration: none;
+            font-family: var(--font-mono);
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            transition: color 0.2s ease;
+        }
+
+        nav a:hover {
+            color: var(--color-accent);
+        }
+
+        main {
+            padding: 4rem 5%;
+            max-width: 1400px;
+            margin: 0 auto;
+            width: 100%;
+        }
+
+        footer {
+            border-top: 1px solid var(--color-border);
+            padding: 2rem 5%;
+            text-align: center;
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            color: #64748b;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-weight: 800;
+            line-height: 1.2;
+            margin-bottom: 1rem;
+            letter-spacing: -0.02em;
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+        }
+
+        a {
+            color: var(--color-accent);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        code, pre {
+            font-family: var(--font-mono);
+            background-color: var(--color-panel);
+            font-size: 0.9em;
+        }
+
+        code {
+            padding: 0.2em 0.4em;
+            border-radius: 2px;
+        }
+
+        pre {
+            padding: 1.5rem;
+            border: 1px solid var(--color-border);
+            overflow-x: auto;
+            margin-bottom: 1.5rem;
+        }
+
+        pre code {
+            background-color: transparent;
+            padding: 0;
+        }
+
+        .grid-layout {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 2rem;
+        }
+
+        .card {
+            background-color: var(--color-panel);
+            border: 1px solid var(--color-border);
+            padding: 2rem;
+            display: flex;
+            flex-direction: column;
+            transition: transform 0.2s ease, border-color 0.2s ease;
+        }
+
+        .card:hover {
+            transform: translateY(-4px);
+            border-color: var(--color-accent);
+        }
+
+        .card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .card .meta {
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            color: #94a3b8;
+            margin-bottom: 1rem;
+        }
+
+        .card .summary {
+            flex-grow: 1;
+            margin-bottom: 1.5rem;
+            font-size: 0.95rem;
+            color: #cbd5e1;
+        }
+
+        .card a.read-more {
+            font-family: var(--font-mono);
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            color: var(--color-accent);
+            text-decoration: none;
+            align-self: flex-start;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+
+        .card a.read-more:hover {
+            border-color: var(--color-accent);
+            text-decoration: none;
+        }
+
+        .page-header {
+            margin-bottom: 4rem;
+            border-bottom: 4px solid var(--color-accent);
+            padding-bottom: 2rem;
+            display: inline-block;
+        }
+
+        .page-header h1 {
+            font-size: 4rem;
+            margin-bottom: 0.5rem;
+        }
+
+        /* Specific styles for lists */
+        .content-area ul, .content-area ol {
+            margin-bottom: 1.5rem;
+            padding-left: 2rem;
+        }
+
+        .content-area li {
+            margin-bottom: 0.5rem;
+        }
+
+        /* Tags */
+        .tags {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .tag {
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            background-color: var(--color-bg);
+            border: 1px solid var(--color-border);
+            padding: 0.2rem 0.6rem;
+            color: #94a3b8;
+            text-transform: uppercase;
+        }
+
+    </style>
+</head>
+<body>
+
+    <header>
+        <a href="/" class="logo">Ethereal<span>Horizon</span></a>
+        <nav>
+            <a href="/posts/">Posts</a>
+            <a href="/about/">About</a>
+        </nav>
+    </header>
+
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        <p>&copy; {{ site.title }}. Built with Hwaro.</p>
+    </footer>
+
+</body>
+</html>

--- a/examples/ethereal-horizon/templates/page.html
+++ b/examples/ethereal-horizon/templates/page.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+<article class="content-area">
+    <header class="page-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="meta" style="font-family: var(--font-mono); color: #94a3b8; margin-top: 1rem;">
+            {{ page.date | date(format="%Y-%m-%d") }}
+        </div>
+        {% endif %}
+    </header>
+
+    {{ content | safe }}
+
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+    <div class="tags" style="margin-top: 3rem; border-top: 1px solid var(--color-border); padding-top: 1.5rem;">
+        <span style="font-family: var(--font-mono); font-size: 0.8rem; color: #64748b; margin-right: 1rem;">TAGGED:</span>
+        {% for tag in page.taxonomies.tags %}
+        <a href="/tags/{{ tag }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+{% endblock %}

--- a/examples/ethereal-horizon/templates/section.html
+++ b/examples/ethereal-horizon/templates/section.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}{% if section.title %}{{ section.title }}{% else %}{{ site.title }}{% endif %}{% endblock %}
+
+{% block content %}
+<div class="content-area">
+    {% if section.title %}
+    <header class="page-header">
+        <h1>{{ section.title }}</h1>
+    </header>
+    {% endif %}
+
+    {{ content | safe }}
+
+    <div class="grid-layout">
+        {% if section.pages %}
+            {% for item in section.pages %}
+            <article class="card">
+                <h2><a href="{{ item.permalink }}" style="color: inherit; text-decoration: none;">{{ item.title }}</a></h2>
+                {% if item.date %}
+                <div class="meta">{{ item.date | date(format="%Y-%m-%d") }}</div>
+                {% endif %}
+                <div class="summary">
+                    {% if item.description %}
+                        {{ item.description }}
+                    {% else %}
+                        {{ item.content | striptags | truncate(length=120) }}
+                    {% endif %}
+                </div>
+                <a href="{{ item.permalink }}" class="read-more">Read More -></a>
+            </article>
+            {% endfor %}
+        {% else %}
+            {% for page in pages %}
+            <article class="card">
+                <h2><a href="{{ page.permalink }}" style="color: inherit; text-decoration: none;">{{ page.title }}</a></h2>
+                {% if page.date %}
+                <div class="meta">{{ page.date | date(format="%Y-%m-%d") }}</div>
+                {% endif %}
+                <div class="summary">
+                    {% if page.description %}
+                        {{ page.description }}
+                    {% else %}
+                        {{ page.content | striptags | truncate(length=120) }}
+                    {% endif %}
+                </div>
+                <a href="{{ page.permalink }}" class="read-more">Read More -></a>
+            </article>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/examples/ethereal-horizon/templates/taxonomy.html
+++ b/examples/ethereal-horizon/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}{{ taxonomy_name | capitalize }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="content-area">
+    <header class="page-header">
+        <h1>{{ taxonomy_name | capitalize }}</h1>
+    </header>
+
+    <div class="tags" style="gap: 1rem;">
+        {% for term in taxonomy_terms %}
+        <a href="{{ term.permalink }}" class="tag" style="font-size: 1rem; padding: 0.5rem 1rem;">
+            {{ term.name }} <span style="color: var(--color-accent); margin-left: 0.5rem;">[{{ term.pages | length }}]</span>
+        </a>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/examples/ethereal-horizon/templates/taxonomy_term.html
+++ b/examples/ethereal-horizon/templates/taxonomy_term.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}{{ term.name }} | {{ taxonomy.name | capitalize }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="content-area">
+    <header class="page-header">
+        <h2 style="font-family: var(--font-mono); font-size: 1rem; color: var(--color-accent); font-weight: normal; margin-bottom: 0.5rem; text-transform: uppercase;">{{ taxonomy.name }}</h2>
+        <h1>{{ term.name }}</h1>
+    </header>
+
+    <div class="grid-layout">
+        {% for item in term.pages %}
+        <article class="card">
+            <h2><a href="{{ item.permalink }}" style="color: inherit; text-decoration: none;">{{ item.title }}</a></h2>
+            {% if item.date %}
+            <div class="meta">{{ item.date | date(format="%Y-%m-%d") }}</div>
+            {% endif %}
+            <div class="summary">
+                {% if item.description %}
+                    {{ item.description }}
+                {% else %}
+                    {{ item.content | striptags | truncate(length=120) }}
+                {% endif %}
+            </div>
+            <a href="{{ item.permalink }}" class="read-more">Read More -></a>
+        </article>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Adds a new example site designed to showcase a pure, minimal dark architectural UI without gradients.

---
*PR created automatically by Jules for task [15501993492127394536](https://jules.google.com/task/15501993492127394536) started by @hahwul*