### PR TITLE
Fix broken links in rubber-hose example

### DIFF
--- a/examples/rubber-hose/templates/header.html
+++ b/examples/rubber-hose/templates/header.html
@@ -63,8 +63,8 @@
         <div class="container">
             <div class="logo">rubber.hose</div>
             <nav>
-                <a href="/">Bounce</a>
-                <a href="/about">Stretch</a>
+                <a href="{{ base_url }}/">Bounce</a>
+                <a href="{{ base_url }}/about/">Stretch</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
This PR updates the `rubber-hose` example templates by prepending `{{ base_url }}` to internal links, preventing 404 errors when deployed on subdirectory environments (like `examples.hwaro.hahwul.com`).

---
*PR created automatically by Jules for task [11973119879540059816](https://jules.google.com/task/11973119879540059816) started by @chei-l*