### PR TITLE
Add Velvet Slate example template

### DIFF
--- a/examples/velvet-slate/AGENTS.md
+++ b/examples/velvet-slate/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/velvet-slate/config.toml
+++ b/examples/velvet-slate/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Velvet Slate"
+description = "An elegant, dark-themed Hwaro example."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/velvet-slate/content/_index.md
+++ b/examples/velvet-slate/content/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Velvet Slate"
+template = "section"
++++
+Welcome to Velvet Slate, an exhibition of deep contrasts and subtle typography. This space explores the quiet resonance of dark tones.

--- a/examples/velvet-slate/content/about.md
+++ b/examples/velvet-slate/content/about.md
@@ -1,0 +1,4 @@
++++
+title = "About the Slate"
++++
+Velvet Slate is a design concept for Hwaro. It aims for high readability without the harshness of pure white text on black. It uses subtle borders and elegant typography to bring content to the forefront.

--- a/examples/velvet-slate/content/posts/first-entry.md
+++ b/examples/velvet-slate/content/posts/first-entry.md
@@ -1,0 +1,4 @@
++++
+title = "The First Entry"
++++
+A whisper in the dark, the first stroke on the canvas. Finding clarity in negative space.

--- a/examples/velvet-slate/content/posts/silent-echo.md
+++ b/examples/velvet-slate/content/posts/silent-echo.md
@@ -1,0 +1,4 @@
++++
+title = "A Silent Echo"
++++
+Shadows define the light. In this post, we discuss the aesthetics of minimal design.

--- a/examples/velvet-slate/templates/404.html
+++ b/examples/velvet-slate/templates/404.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main style="text-align: center; padding: 4rem 0;">
+    <h1 style="font-size: 5rem; margin-bottom: 1rem;">404</h1>
+    <p>The requested page could not be found.</p>
+  </main>
+{% include "footer.html" %}

--- a/examples/velvet-slate/templates/footer.html
+++ b/examples/velvet-slate/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="footer">
+      &copy; {{ site.title }}
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/velvet-slate/templates/header.html
+++ b/examples/velvet-slate/templates/header.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --bg: #111216;
+      --text: #c8c9ce;
+      --heading: #e9ecef;
+      --primary: #a8b2c1;
+      --border: #2c2e33;
+    }
+    body {
+      font-family: "Georgia", serif;
+      background-color: var(--bg);
+      color: var(--text);
+      line-height: 1.8;
+      margin: 0;
+    }
+    a {
+      color: var(--primary);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.3s ease, color 0.3s ease;
+    }
+    a:hover {
+      border-bottom-color: var(--primary);
+      color: #fff;
+    }
+    .container {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 4rem 2rem;
+    }
+    .header {
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 3rem;
+      margin-bottom: 4rem;
+      text-align: center;
+    }
+    .site-title {
+      font-size: 2.2rem;
+      color: var(--heading);
+      margin: 0 0 1.5rem 0;
+      font-weight: normal;
+      letter-spacing: 3px;
+      text-transform: uppercase;
+    }
+    .nav {
+      display: flex;
+      justify-content: center;
+      gap: 2.5rem;
+    }
+    .nav a {
+      font-family: "Helvetica Neue", Arial, sans-serif;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 1.5px;
+      color: var(--text);
+    }
+    .nav a:hover {
+      color: #fff;
+      border-bottom-color: transparent;
+    }
+    h1, h2, h3 {
+      color: var(--heading);
+      font-weight: normal;
+      margin-top: 3rem;
+      margin-bottom: 1.5rem;
+    }
+    h1 { font-size: 2.4rem; }
+    h2 { font-size: 1.8rem; }
+    h3 { font-size: 1.4rem; }
+    p { margin-bottom: 1.5rem; }
+    .post-list {
+      list-style: none;
+      padding: 0;
+    }
+    .post-item {
+      margin-bottom: 3rem;
+    }
+    .post-title {
+      font-size: 1.6rem;
+      margin: 0 0 0.5rem 0;
+    }
+    .post-title a {
+      color: var(--heading);
+      border-bottom: none;
+    }
+    .post-title a:hover {
+      color: var(--primary);
+    }
+    .footer {
+      border-top: 1px solid var(--border);
+      padding-top: 3rem;
+      margin-top: 5rem;
+      text-align: center;
+      font-family: "Helvetica Neue", Arial, sans-serif;
+      font-size: 0.8rem;
+      color: #666;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="container">
+    <header class="header">
+      <div class="site-title"><a href="{{ base_url }}/" style="border:none; color:inherit;">{{ site.title }}</a></div>
+      <nav class="nav">
+        <a href="{{ base_url }}/">Exhibition</a>
+        <a href="{{ base_url }}/about/">Concept</a>
+      </nav>
+    </header>

--- a/examples/velvet-slate/templates/page.html
+++ b/examples/velvet-slate/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main>
+    <article>
+      <h1>{{ page.title | e }}</h1>
+      <div class="content">
+        {{ content | safe }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/velvet-slate/templates/section.html
+++ b/examples/velvet-slate/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main>
+    <div class="content" style="margin-bottom: 4rem; text-align: center; font-style: italic; font-size: 1.2rem; color: #888;">
+      {{ content | safe }}
+    </div>
+    <ul class="post-list">
+      {% for post in section.pages %}
+      <li class="post-item">
+        <h2 class="post-title"><a href="{{ post.path }}">{{ post.title | e }}</a></h2>
+      </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/velvet-slate/templates/shortcodes/alert.html
+++ b/examples/velvet-slate/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/velvet-slate/templates/taxonomy.html
+++ b/examples/velvet-slate/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main>
+    <h1>{{ taxonomy }}</h1>
+    <ul class="post-list">
+      {% for term in terms %}
+      <li class="post-item">
+        <h2 class="post-title"><a href="{{ term.path }}">{{ term.name | e }}</a></h2>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/examples/velvet-slate/templates/taxonomy_term.html
+++ b/examples/velvet-slate/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main>
+    <h1>{{ term }}</h1>
+    <ul class="post-list">
+      {% for post in pages %}
+      <li class="post-item">
+        <h2 class="post-title"><a href="{{ post.path }}">{{ post.title | e }}</a></h2>
+      </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Adds a new Hwaro example template named `velvet-slate`. The design focuses on elegant typography and minimalist dark-themed aesthetics, satisfying constraints to not use gradients or emojis.

Changes:
- Initialized Hwaro project in `examples/velvet-slate`
- Configured title and description in `config.toml`
- Implemented elegant dark theme custom templates (`header.html`, `footer.html`, `page.html`, `section.html`, `404.html`, `taxonomy.html`, `taxonomy_term.html`)
- Replaced the default `index.md` with a custom `_index.md` to properly render the homepage using the `section` template.
- Added sample content: `about.md`, `first-entry.md`, and `silent-echo.md`.

---
*PR created automatically by Jules for task [5431393823182439926](https://jules.google.com/task/5431393823182439926) started by @chei-l*