### PR TITLE
feat: add radiant-vertex example site

### DIFF
--- a/examples/radiant-vertex/AGENTS.md
+++ b/examples/radiant-vertex/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/radiant-vertex/config.toml
+++ b/examples/radiant-vertex/config.toml
@@ -1,0 +1,177 @@
+title = "Radiant Vertex"
+description = "A brutalist architectural portfolio."
+base_url = "http://localhost:3000"
+theme = ""
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/radiant-vertex/content/about.md
+++ b/examples/radiant-vertex/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "About"
+date = "2024-01-01"
++++
+
+WE ARE RADIANT VERTEX.
+
+A collective of digital architects focused on raw, uncompromising web structures. We construct experiences using pure geometry and typographic precision.
+
+CONTACT: VOID@RADIANTVERTEX.COM

--- a/examples/radiant-vertex/content/index.md
+++ b/examples/radiant-vertex/content/index.md
@@ -1,0 +1,18 @@
++++
+title = "Home"
+template = "index"
++++
+
+WE BUILD STRUCTURES IN THE DIGITAL VOID.
+
+OUR APPROACH IS FOUNDED ON MINIMALISM, RAW MATERIALS, AND UNYIELDING GEOMETRY. WE BELIEVE THAT FORM FOLLOWS FUNCTION, AND EVERY PIXEL MUST SERVE A PURPOSE.
+
+**RADIANT VERTEX** IS NOT JUST A PORTFOLIO. IT IS A DECLARATION OF ARCHITECTURAL INTENT.
+
+### PRINCIPLES
+
+1. **STRUCTURAL INTEGRITY**: Solid foundations over fragile abstractions.
+2. **HIGH CONTRAST**: Clarity through absolute light and absolute darkness.
+3. **NO DISTRACTIONS**: We reject gradients, soft shadows, and unnecessary ornaments.
+
+EXPLORE OUR [PROJECTS](/projects/) TO SEE THESE PRINCIPLES IN ACTION.

--- a/examples/radiant-vertex/content/projects/_index.md
+++ b/examples/radiant-vertex/content/projects/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Selected Works"
+sort_by = "date"
+reverse = true
++++
+
+A CATALOG OF RECENT DIGITAL CONSTRUCTIONS.

--- a/examples/radiant-vertex/content/projects/monolith-alpha.md
+++ b/examples/radiant-vertex/content/projects/monolith-alpha.md
@@ -1,0 +1,19 @@
++++
+title = "MONOLITH ALPHA"
+date = "2024-05-10"
+summary = "A highly durable, single-page application designed for absolute resilience."
++++
+
+## THE BRIEF
+
+The client required a structure that could withstand massive traffic surges without degradation in performance.
+
+## THE EXECUTION
+
+We stripped away all reactive state frameworks and built a pure HTML/CSS monolith.
+
+- Zero JavaScript dependencies.
+- Sub-millisecond TTFB.
+- Brutal efficiency.
+
+THE MONOLITH STANDS.

--- a/examples/radiant-vertex/content/projects/void-terminal.md
+++ b/examples/radiant-vertex/content/projects/void-terminal.md
@@ -1,0 +1,15 @@
++++
+title = "VOID TERMINAL"
+date = "2024-03-22"
+summary = "Command-line interface simulation with dark mode enforcement."
++++
+
+## THE BRIEF
+
+A developer tools company needed a landing page that spoke directly to system administrators.
+
+## THE EXECUTION
+
+We implemented a strictly monospaced grid system. The color palette was reduced to pure black (`#000000`), stark white (`#FFFFFF`), and a single terminal green accent (`#00FF00`).
+
+No rounded corners. Absolute precision.

--- a/examples/radiant-vertex/templates/404.html
+++ b/examples/radiant-vertex/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+    <h1 class="page-title">404</h1>
+</header>
+<div class="content">
+    <h2>ENTITY NOT FOUND</h2>
+    <p>THE REQUESTED RESOURCE HAS CEASED TO EXIST OR WAS NEVER CONSTRUCTED IN THIS DIMENSION.</p>
+    <p><a href="{{ base_url }}/" style="color: var(--accent-color); text-decoration: underline;">RETURN TO ORIGIN</a></p>
+</div>
+{% endblock %}

--- a/examples/radiant-vertex/templates/base.html
+++ b/examples/radiant-vertex/templates/base.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined and page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{{ site.description }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-color: #0d0d0d;
+            --text-color: #f4f4f4;
+            --accent-color: #d83b01;
+            --border-color: #333333;
+            --sub-text: #a0a0a0;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: 'Inter', sans-serif;
+            line-height: 1.6;
+            display: grid;
+            grid-template-columns: 250px 1fr;
+            min-height: 100vh;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Space Mono', monospace;
+            text-transform: uppercase;
+            font-weight: 900;
+            letter-spacing: -0.05em;
+        }
+
+        a {
+            color: var(--text-color);
+            text-decoration: none;
+            transition: color 0.2s ease;
+        }
+
+        a:hover {
+            color: var(--accent-color);
+        }
+
+        /* Sidebar Sidebar */
+        aside {
+            border-right: 2px solid var(--border-color);
+            padding: 3rem 2rem;
+            display: flex;
+            flex-direction: column;
+            position: sticky;
+            top: 0;
+            height: 100vh;
+        }
+
+        .site-title {
+            font-size: 1.5rem;
+            margin-bottom: 0.5rem;
+            color: var(--accent-color);
+            word-wrap: break-word;
+        }
+
+        .site-desc {
+            font-size: 0.85rem;
+            color: var(--sub-text);
+            margin-bottom: 3rem;
+            font-family: 'Space Mono', monospace;
+        }
+
+        nav ul {
+            list-style: none;
+        }
+
+        nav ul li {
+            margin-bottom: 1rem;
+        }
+
+        nav ul li a {
+            font-family: 'Space Mono', monospace;
+            font-size: 1.1rem;
+            text-transform: uppercase;
+            font-weight: 700;
+            display: block;
+            padding-bottom: 0.2rem;
+            border-bottom: 2px solid transparent;
+            width: fit-content;
+        }
+
+        nav ul li a:hover {
+            border-bottom-color: var(--accent-color);
+        }
+
+        .footer-info {
+            margin-top: auto;
+            font-size: 0.75rem;
+            color: var(--sub-text);
+            font-family: 'Space Mono', monospace;
+        }
+
+        /* Main Content */
+        main {
+            padding: 4rem;
+            max-width: 1200px;
+        }
+
+        .page-header {
+            margin-bottom: 4rem;
+            padding-bottom: 2rem;
+            border-bottom: 4px solid var(--accent-color);
+        }
+
+        .page-title {
+            font-size: 4rem;
+            line-height: 1;
+        }
+
+        .content {
+            font-size: 1.125rem;
+        }
+
+        .content h2 {
+            font-size: 2.5rem;
+            margin: 3rem 0 1.5rem;
+            color: var(--accent-color);
+        }
+
+        .content p {
+            margin-bottom: 1.5rem;
+            max-width: 80ch;
+        }
+
+        .grid-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 2rem;
+            margin-top: 3rem;
+        }
+
+        .card {
+            border: 2px solid var(--border-color);
+            padding: 2rem;
+            background-color: #151515;
+            transition: border-color 0.2s, transform 0.2s;
+        }
+
+        .card:hover {
+            border-color: var(--accent-color);
+            transform: translateY(-5px);
+        }
+
+        .card-title {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .card-title a {
+            color: var(--text-color);
+        }
+
+        .card-title a:hover {
+            color: var(--accent-color);
+        }
+
+        .card-date {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.85rem;
+            color: var(--sub-text);
+            margin-bottom: 1.5rem;
+            display: block;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            body {
+                grid-template-columns: 1fr;
+            }
+
+            aside {
+                position: relative;
+                height: auto;
+                border-right: none;
+                border-bottom: 2px solid var(--border-color);
+                padding: 2rem;
+            }
+
+            main {
+                padding: 2rem;
+            }
+
+            .page-title {
+                font-size: 2.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <aside>
+        <div>
+            <h1 class="site-title"><a href="{{ base_url }}/">{{ site.title }}</a></h1>
+            <p class="site-desc">{{ site.description }}</p>
+        </div>
+        <nav>
+            <ul>
+                <li><a href="{{ base_url }}/">Home</a></li>
+                <li><a href="{{ base_url }}/projects/">Projects</a></li>
+                <li><a href="{{ base_url }}/about/">About</a></li>
+            </ul>
+        </nav>
+        <div class="footer-info">
+            &copy; {{ current_year }} RADIANT VERTEX.<br>
+            BUILT WITH HWARO.
+        </div>
+    </aside>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/examples/radiant-vertex/templates/index.html
+++ b/examples/radiant-vertex/templates/index.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+    <h1 class="page-title">MANIFESTO</h1>
+</header>
+<div class="content">
+    {{ content | safe }}
+</div>
+{% endblock %}

--- a/examples/radiant-vertex/templates/page.html
+++ b/examples/radiant-vertex/templates/page.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+    <h1 class="page-title">{{ page.title }}</h1>
+    {% if page.date %}
+    <span class="card-date" style="margin-top: 1rem;">{{ page.date | date("%Y.%m.%d") }}</span>
+    {% endif %}
+</header>
+<div class="content">
+    {{ content | safe }}
+</div>
+{% endblock %}

--- a/examples/radiant-vertex/templates/section.html
+++ b/examples/radiant-vertex/templates/section.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+    <h1 class="page-title">{{ section.title }}</h1>
+</header>
+<div class="content">
+    {{ content | safe }}
+</div>
+
+<div class="grid-container">
+    {% for post in section.pages %}
+    <article class="card">
+        <h2 class="card-title"><a href="{{ base_url }}{{ post.permalink }}">{{ post.title }}</a></h2>
+        {% if post.date %}
+        <span class="card-date">{{ post.date | date("%Y.%m.%d") }}</span>
+        {% endif %}
+        {% if post.summary %}
+        <p>{{ post.summary | strip_html }}</p>
+        {% endif %}
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/examples/radiant-vertex/templates/shortcodes/alert.html
+++ b/examples/radiant-vertex/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/radiant-vertex/templates/taxonomy.html
+++ b/examples/radiant-vertex/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+    <h1 class="page-title">{{ taxonomy_name | upper }}</h1>
+</header>
+<div class="content">
+    <ul>
+        {% for term_name, term_data in taxonomy_terms %}
+            <li>
+                <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term_name | slugify }}/">{{ term_name }} ({{ term_data.pages | length }})</a>
+            </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/examples/radiant-vertex/templates/taxonomy_term.html
+++ b/examples/radiant-vertex/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+    <h1 class="page-title">{{ term.name | upper }}</h1>
+</header>
+<div class="grid-container">
+    {% for post in term.pages %}
+    <article class="card">
+        <h2 class="card-title"><a href="{{ base_url }}{{ post.permalink }}">{{ post.title }}</a></h2>
+        {% if post.date %}
+        <span class="card-date">{{ post.date | date("%Y.%m.%d") }}</span>
+        {% endif %}
+        {% if post.summary %}
+        <p>{{ post.summary | strip_html }}</p>
+        {% endif %}
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -9409,5 +9409,11 @@
     "dark",
     "portfolio",
     "minimal"
+  ],
+  "radiant-vertex": [
+    "dark",
+    "portfolio",
+    "minimal",
+    "architecture"
   ]
 }


### PR DESCRIPTION
This PR introduces `radiant-vertex`, a new example site.

- Themed as a "brutalist architectural portfolio".
- Strictly uses solid colors.
- Explicitly avoids gradients and emojis.
- Relies on CSS Grid and typography (`Inter` and `Space Mono`).
- Registers `radiant-vertex` into `tags.json` as `["dark", "portfolio", "minimal", "architecture"]`.
- Built cleanly via `hwaro build`.

---
*PR created automatically by Jules for task [14434370046867372834](https://jules.google.com/task/14434370046867372834) started by @hahwul*