### PR TITLE
Add new ethereal-monolith example site

### DIFF
--- a/examples/ethereal-monolith/AGENTS.md
+++ b/examples/ethereal-monolith/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/ethereal-monolith/config.toml
+++ b/examples/ethereal-monolith/config.toml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Ethereal Monolith"
+description = "An ethereal monolith theme with dark slate and teal."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/ethereal-monolith/content/_index.md
+++ b/examples/ethereal-monolith/content/_index.md
@@ -1,0 +1,22 @@
++++
+title = "Ethereal Base"
++++
+
+Welcome to the Ethereal Monolith. This construct serves as a foundation for architectural explorations in static generation.
+
+## Structural Integrity
+
+The grid provides stability. The typography provides clarity. The colors provide depth.
+
+- Absolute positioning is minimized.
+- Flow remains logical.
+- The void is preserved.
+
+> "In the void, structure is the only truth."
+
+```crystal
+# Example processing sequence
+def generate_void(space : Int32)
+  Array.new(space) { " " }.join
+end
+```

--- a/examples/ethereal-monolith/content/about.md
+++ b/examples/ethereal-monolith/content/about.md
@@ -1,0 +1,7 @@
++++
+title = "About"
++++
+
+# About
+
+This is an about page.

--- a/examples/ethereal-monolith/content/projects/_index.md
+++ b/examples/ethereal-monolith/content/projects/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Projects"
+template = "section"
++++
+
+A collection of structural interventions.

--- a/examples/ethereal-monolith/content/projects/project1.md
+++ b/examples/ethereal-monolith/content/projects/project1.md
@@ -1,0 +1,16 @@
++++
+title = "Project Alpha"
+date = "2024-01-15"
+description = "The first monolithic structure."
+tags = ["monolith", "alpha"]
++++
+
+# Project Alpha
+
+Alpha represents the initial intersection of grid and plane. The structure relies heavily on implicit boundaries and stark contrasts.
+
+## Specifications
+
+- Material: Carbon Fiber / Slate
+- Height: 450m
+- State: Operational

--- a/examples/ethereal-monolith/templates/404.html
+++ b/examples/ethereal-monolith/templates/404.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>404</h1>
+  <h2>Entity Not Found</h2>
+  <p>The structural reference you requested does not exist in the current construct.</p>
+  <a href="{{ base_url }}/">&larr; Return to Base</a>
+{% endblock %}

--- a/examples/ethereal-monolith/templates/base.html
+++ b/examples/ethereal-monolith/templates/base.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site.title }}</title>
+  <meta name="description" content="{% if page_description %}{{ page_description }}{% else %}{{ site.description }}{% endif %}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg-color: #0b0f14;
+      --text-color: #e5e7eb;
+      --accent-color: #2dd4bf;
+      --border-color: #1f2937;
+
+      --font-sans: 'Inter', sans-serif;
+      --font-mono: 'Space Mono', monospace;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      font-family: var(--font-sans);
+      line-height: 1.6;
+      display: grid;
+      grid-template-columns: 1fr;
+      min-height: 100vh;
+    }
+
+    /* Architectural Layout Grid */
+    .site-wrapper {
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      grid-template-columns: minmax(0, 1fr) minmax(auto, 800px) minmax(0, 1fr);
+      min-height: 100vh;
+    }
+
+    header {
+      grid-column: 1 / -1;
+      grid-row: 1;
+      padding: 2rem;
+      border-bottom: 2px solid var(--border-color);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    header a {
+      color: var(--text-color);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-weight: 700;
+      font-size: 1.5rem;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+
+    header nav a {
+      font-size: 1rem;
+      font-weight: 400;
+      margin-left: 2rem;
+      color: var(--accent-color);
+    }
+
+    main {
+      grid-column: 2;
+      grid-row: 2;
+      padding: 4rem 2rem;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-mono);
+      margin-top: 2rem;
+      margin-bottom: 1rem;
+      color: var(--text-color);
+      font-weight: 700;
+    }
+
+    h1 {
+      font-size: 3rem;
+      line-height: 1.2;
+      border-left: 8px solid var(--accent-color);
+      padding-left: 1rem;
+      margin-top: 0;
+    }
+
+    h2 {
+      font-size: 2rem;
+    }
+
+    p {
+      margin-bottom: 1.5rem;
+      font-size: 1.1rem;
+    }
+
+    a {
+      color: var(--accent-color);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.2s;
+    }
+
+    a:hover {
+      border-color: var(--accent-color);
+    }
+
+    pre {
+      background-color: #000000;
+      padding: 1.5rem;
+      border: 1px solid var(--border-color);
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+    }
+
+    code {
+      font-family: var(--font-mono);
+      background-color: #000000;
+      padding: 0.2rem 0.4rem;
+      font-size: 0.9rem;
+    }
+
+    pre code {
+      padding: 0;
+      background-color: transparent;
+    }
+
+    blockquote {
+      margin: 2rem 0;
+      padding: 1rem 2rem;
+      border-left: 4px solid var(--accent-color);
+      background-color: #111827;
+      font-style: italic;
+    }
+
+    .meta {
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      color: #9ca3af;
+      margin-bottom: 2rem;
+      display: flex;
+      gap: 1rem;
+    }
+
+    .tags {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .tag {
+      background-color: transparent;
+      border: 1px solid var(--accent-color);
+      color: var(--accent-color);
+      padding: 0.2rem 0.5rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+    }
+
+    footer {
+      grid-column: 1 / -1;
+      grid-row: 3;
+      padding: 2rem;
+      border-top: 2px solid var(--border-color);
+      text-align: center;
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      color: #9ca3af;
+    }
+
+    .item-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+    }
+
+    .item-card {
+      border: 1px solid var(--border-color);
+      padding: 2rem;
+      background-color: #111827;
+      transition: border-color 0.2s;
+      position: relative;
+    }
+
+    .item-card::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 4px;
+      height: 100%;
+      background-color: transparent;
+      transition: background-color 0.2s;
+    }
+
+    .item-card:hover {
+      border-color: var(--accent-color);
+    }
+
+    .item-card:hover::before {
+      background-color: var(--accent-color);
+    }
+
+    .item-card h2 {
+      margin-top: 0;
+      font-size: 1.5rem;
+    }
+
+    .item-card a {
+      border: none;
+    }
+
+    .item-card a::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+
+  </style>
+</head>
+<body>
+  <div class="site-wrapper">
+    <header>
+      <a href="{{ base_url }}/">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/projects/">Projects</a>
+      </nav>
+    </header>
+
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+      <p>&copy; {{ current_year }} {{ site.title }}. Built with Hwaro.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/ethereal-monolith/templates/footer.html
+++ b/examples/ethereal-monolith/templates/footer.html
@@ -1,0 +1,5 @@
+    <footer>
+      <p>Powered by Hwaro</p>
+    </footer>
+</body>
+</html>

--- a/examples/ethereal-monolith/templates/header.html
+++ b/examples/ethereal-monolith/templates/header.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+</head>
+<body>
+  <header>
+    <a href="{{ base_url }}/">{{ site.title }}</a>
+    <nav>
+      <a href="{{ base_url }}/">Home</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </header>

--- a/examples/ethereal-monolith/templates/index.html
+++ b/examples/ethereal-monolith/templates/index.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ page.title | default(site.title) }}</h1>
+
+  <div class="content">
+    {{ content | safe }}
+  </div>
+{% endblock %}

--- a/examples/ethereal-monolith/templates/page.html
+++ b/examples/ethereal-monolith/templates/page.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ page.title }}</h1>
+
+  <div class="meta">
+    {% if page.date %}
+      <span>{{ page.date | date("%Y-%m-%d") }}</span>
+    {% endif %}
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+      <div class="tags">
+        {% for tag in page.taxonomies.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+
+  <div class="content">
+    {{ content | safe }}
+  </div>
+{% endblock %}

--- a/examples/ethereal-monolith/templates/section.html
+++ b/examples/ethereal-monolith/templates/section.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ section.title }}</h1>
+
+  {% if section.description %}
+    <p>{{ section.description }}</p>
+  {% endif %}
+
+  {% if content %}
+    <div class="content">
+      {{ content | safe }}
+    </div>
+  {% endif %}
+
+  <ul class="item-list">
+    {% for item in section.pages %}
+      <li class="item-card">
+        <h2><a href="{{ item.permalink }}">{{ item.title }}</a></h2>
+        {% if item.date %}
+          <div class="meta">{{ item.date | date("%Y-%m-%d") }}</div>
+        {% endif %}
+        {% if item.summary %}
+          <p>{{ item.summary | strip_html }}</p>
+        {% elif item.description %}
+          <p>{{ item.description }}</p>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/examples/ethereal-monolith/templates/taxonomy.html
+++ b/examples/ethereal-monolith/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ taxonomy_name | default("Taxonomy") | title }}</h1>
+
+  <ul class="item-list">
+    {% if taxonomy_terms is defined %}
+      {% for term in taxonomy_terms %}
+        <li class="item-card">
+          <h2><a href="{{ base_url }}/{{ taxonomy_name }}/{{ term.name | slugify }}/">{{ term.name }}</a></h2>
+          <p>{{ term.pages | length }} Items</p>
+        </li>
+      {% endfor %}
+    {% endif %}
+  </ul>
+{% endblock %}

--- a/examples/ethereal-monolith/templates/taxonomy_term.html
+++ b/examples/ethereal-monolith/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ taxonomy_name | default("Taxonomy") | title }}: {% if taxonomy_term is defined %}{{ taxonomy_term.name }}{% else %}Unknown{% endif %}</h1>
+
+  <ul class="item-list">
+    {% if taxonomy_term is defined %}
+      {% for item in taxonomy_term.pages %}
+        <li class="item-card">
+          <h2><a href="{{ item.permalink }}">{{ item.title }}</a></h2>
+          {% if item.date %}
+            <div class="meta">{{ item.date | date("%Y-%m-%d") }}</div>
+          {% endif %}
+          {% if item.summary %}
+            <p>{{ item.summary | strip_html }}</p>
+          {% elif item.description %}
+            <p>{{ item.description }}</p>
+          {% endif %}
+        </li>
+      {% endfor %}
+    {% endif %}
+  </ul>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -9409,5 +9409,11 @@
     "dark",
     "portfolio",
     "minimal"
+  ],
+  "ethereal-monolith": [
+    "dark",
+    "minimal",
+    "portfolio",
+    "architectural"
   ]
 }


### PR DESCRIPTION
Adds a new example site to `examples/ethereal-monolith` using a "Ethereal Monolith" architectural aesthetic. The design relies on CSS Grid layout, solid colors (dark slate/black backgrounds, off-white texts, muted teal and vermilion accents), and avoids gradients and emojis. Google Fonts "Inter" and "Space Mono" are utilized. `tags.json` is also updated.

---
*PR created automatically by Jules for task [1368849756297048829](https://jules.google.com/task/1368849756297048829) started by @hahwul*