### PR TITLE
feat: add aether-aperture example

### DIFF
--- a/examples/aether-aperture/AGENTS.md
+++ b/examples/aether-aperture/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/aether-aperture/config.toml
+++ b/examples/aether-aperture/config.toml
@@ -1,0 +1,199 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Aether Aperture"
+description = "A sophisticated minimalist and architectural layout."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+# =============================================================================
+# Markdown
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/aether-aperture/content/about.md
+++ b/examples/aether-aperture/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "About Structure"
+description = "Understanding the absolute architecture."
+date = "2025-05-05"
+template = "page"
++++
+
+This page demonstrates the structural content layout. The Aether Aperture maintains strict architectural grids, separating concepts into visual rooms using borders and backgrounds.
+
+### Section One
+
+A section showcasing text elements within the structural constraints.
+
+### Section Two
+
+Another section ensuring headers, lists, and elements align with the grid.

--- a/examples/aether-aperture/content/index.md
+++ b/examples/aether-aperture/content/index.md
@@ -1,0 +1,29 @@
++++
+title = "Aether Aperture"
+description = "A sophisticated minimalist architectural documentation and blog layout."
+date = "2025-05-05"
+template = "index"
++++
+
+Welcome to the Aether Aperture. This is an architectural study in negative space and structure. Built using pure solid colors and stark contrasting borders, it avoids the artificial depth of gradients.
+
+## Philosophy
+
+The design philosophy revolves around absolute structure:
+
+- Pure Solid Colors
+- Stark Borders and Framing
+- Absolute Positioning
+- No Emoticons or Gradients
+
+## Elements
+
+We focus on raw layout primitives. The design reveals the structural boundaries of the content, highlighting the structure rather than masking it.
+
+```css
+.aperture-structure {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  box-shadow: 10px 10px 0 var(--accent-color);
+}
+```

--- a/examples/aether-aperture/templates/404.html
+++ b/examples/aether-aperture/templates/404.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block title %}404 Not Found | {{ site.title }}{% endblock %}
+
+{% block content %}
+<header class="page-header">
+  <h1 class="page-title">404 Not Found</h1>
+</header>
+
+<article class="content-area">
+  <p>The page you are looking for does not exist.</p>
+  <p><a href="{{ site.base_url }}/">Return to Home</a></p>
+</article>
+{% endblock %}

--- a/examples/aether-aperture/templates/base.html
+++ b/examples/aether-aperture/templates/base.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}{{ site.title }}{% endblock %}</title>
+  <meta name="description" content="{% block description %}{{ site.description }}{% endblock %}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg-primary: #0a0a0c;
+      --bg-secondary: #121215;
+      --text-primary: #ededef;
+      --text-secondary: #a1a1aa;
+      --accent: #00ffcc;
+      --border: #27272a;
+
+      --font-sans: 'Inter', sans-serif;
+      --font-mono: 'IBM Plex Mono', monospace;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: var(--font-sans);
+      background-color: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      display: grid;
+      grid-template-columns: 280px 1fr;
+      grid-template-rows: 100vh;
+      overflow: hidden;
+    }
+
+    a {
+      color: var(--accent);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+
+    a:hover {
+      color: var(--text-primary);
+    }
+
+    .sidebar {
+      background-color: var(--bg-secondary);
+      border-right: 1px solid var(--border);
+      padding: 2rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      overflow-y: auto;
+    }
+
+    .logo {
+      font-family: var(--font-mono);
+      font-size: 1.5rem;
+      font-weight: 600;
+      letter-spacing: -0.05em;
+      color: var(--text-primary);
+      margin-bottom: 3rem;
+      display: block;
+      text-transform: uppercase;
+    }
+
+    .logo::after {
+      content: '';
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      background-color: var(--accent);
+      margin-left: 8px;
+    }
+
+    .nav-links {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .nav-links a {
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .nav-links a:hover, .nav-links a.active {
+      color: var(--text-primary);
+    }
+
+    .nav-links a::before {
+      content: '';
+      display: inline-block;
+      width: 0;
+      height: 1px;
+      background-color: var(--accent);
+      transition: width 0.3s ease;
+      margin-right: 0;
+    }
+
+    .nav-links a:hover::before, .nav-links a.active::before {
+      width: 20px;
+      margin-right: 10px;
+    }
+
+    .footer-meta {
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      border-top: 1px solid var(--border);
+      padding-top: 1rem;
+    }
+
+    .main-content {
+      padding: 4rem 6rem;
+      overflow-y: auto;
+      max-width: 1000px;
+    }
+
+    .page-header {
+      margin-bottom: 4rem;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 2rem;
+    }
+
+    .page-title {
+      font-size: 3rem;
+      font-weight: 300;
+      letter-spacing: -0.02em;
+      margin-bottom: 1rem;
+    }
+
+    .page-description {
+      font-family: var(--font-mono);
+      font-size: 1rem;
+      color: var(--text-secondary);
+    }
+
+    .content-area {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+    }
+
+    .content-area h1, .content-area h2, .content-area h3 {
+      color: var(--text-primary);
+      font-weight: 400;
+      margin-top: 3rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .content-area h2 {
+      font-size: 2rem;
+      border-left: 4px solid var(--accent);
+      padding-left: 1rem;
+    }
+
+    .content-area p {
+      margin-bottom: 1.5rem;
+    }
+
+    .content-area ul, .content-area ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+
+    .content-area li {
+      margin-bottom: 0.5rem;
+    }
+
+    .content-area blockquote {
+      border-left: 1px solid var(--accent);
+      padding-left: 1.5rem;
+      margin: 2rem 0;
+      color: var(--text-primary);
+      font-style: italic;
+    }
+
+    .content-area pre {
+      background-color: var(--bg-secondary);
+      border: 1px solid var(--border);
+      padding: 1.5rem;
+      overflow-x: auto;
+      margin-bottom: 2rem;
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+    }
+
+    .content-area code {
+      font-family: var(--font-mono);
+      background-color: var(--bg-secondary);
+      padding: 0.2rem 0.4rem;
+      border: 1px solid var(--border);
+      font-size: 0.9em;
+      color: var(--accent);
+    }
+
+    .content-area pre code {
+      background-color: transparent;
+      padding: 0;
+      border: none;
+      color: inherit;
+    }
+
+    @media (max-width: 900px) {
+      body {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr;
+        overflow: auto;
+      }
+
+      .sidebar {
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+        padding: 1.5rem;
+        flex-direction: row;
+        align-items: center;
+      }
+
+      .logo {
+        margin-bottom: 0;
+      }
+
+      .nav-links {
+        flex-direction: row;
+      }
+
+      .nav-links a::before {
+        display: none;
+      }
+
+      .footer-meta {
+        display: none;
+      }
+
+      .main-content {
+        padding: 2rem;
+        overflow-y: visible;
+      }
+
+      .page-title {
+        font-size: 2rem;
+      }
+    }
+  </style>
+  {% block head %}{% endblock %}
+</head>
+<body>
+  <aside class="sidebar">
+    <div>
+      <a href="{{ site.base_url }}/" class="logo">{{ site.title }}</a>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="{{ site.base_url }}/">Home</a></li>
+          <li><a href="{{ site.base_url }}/about/">About</a></li>
+        </ul>
+      </nav>
+    </div>
+    <div class="footer-meta">
+      &copy; {{ current_year }} {{ site.title }}<br>
+      Built with Hwaro
+    </div>
+  </aside>
+
+  <main class="main-content">
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/examples/aether-aperture/templates/index.html
+++ b/examples/aether-aperture/templates/index.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+  <h1 class="page-title">{{ page.title }}</h1>
+  {% if page.description %}
+  <p class="page-description">{{ page.description }}</p>
+  {% endif %}
+</header>
+
+<article class="content-area">
+  {{ content | safe }}
+</article>
+{% endblock %}

--- a/examples/aether-aperture/templates/page.html
+++ b/examples/aether-aperture/templates/page.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ site.title }}{% endblock %}
+{% block description %}{{ page.description | default(site.description) }}{% endblock %}
+
+{% block content %}
+<header class="page-header">
+  <h1 class="page-title">{{ page.title }}</h1>
+  {% if page.description %}
+  <p class="page-description">{{ page.description }}</p>
+  {% endif %}
+</header>
+
+<article class="content-area">
+  {{ content | safe }}
+</article>
+{% endblock %}

--- a/examples/aether-aperture/templates/section.html
+++ b/examples/aether-aperture/templates/section.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}{{ section.title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+<header class="page-header">
+  <h1 class="page-title">{{ section.title }}</h1>
+  {% if section.description %}
+  <p class="page-description">{{ section.description }}</p>
+  {% endif %}
+</header>
+
+<article class="content-area">
+  {% if content %}
+    {{ content | safe }}
+  {% endif %}
+  <ul>
+  {% for page in section.pages %}
+    <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+  {% endfor %}
+  </ul>
+</article>
+{% endblock %}

--- a/examples/aether-aperture/templates/taxonomy.html
+++ b/examples/aether-aperture/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Taxonomies | {{ site.title }}{% endblock %}
+
+{% block content %}
+<header class="page-header">
+  <h1 class="page-title">{{ taxonomy_name | capitalize }}</h1>
+</header>
+
+<article class="content-area">
+  <ul>
+  {% for term in taxonomy_terms %}
+    <li><a href="{{ term.permalink }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
+  {% endfor %}
+  </ul>
+</article>
+{% endblock %}

--- a/examples/aether-aperture/templates/taxonomy_term.html
+++ b/examples/aether-aperture/templates/taxonomy_term.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}{{ term.name }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+<header class="page-header">
+  <h1 class="page-title">{{ term.name }}</h1>
+</header>
+
+<article class="content-area">
+  <ul>
+  {% for page in term.pages %}
+    <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+  {% endfor %}
+  </ul>
+</article>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1,4 +1,9 @@
 {
+  "aether-aperture": [
+    "dark",
+    "minimal",
+    "sidebar"
+  ],
   "cement-type": [
     "light",
     "blog",


### PR DESCRIPTION
This PR introduces a new example site called `aether-aperture`.
It satisfies the requirement for a uniquely named, non-conflicting example that demonstrates an original, elegant design without the use of gradients or emojis.
It features:
- A stark architectural dark theme with solid colors (`#0a0a0c`, `#121215`) and a cyan accent (`#00ffcc`).
- Usage of CSS grid for strict structural alignment.
- Clean TOML configuration aligned with Hwaro CLI standards.
- Tag setup and updated `base.html` + templates.

---
*PR created automatically by Jules for task [6191632889168391638](https://jules.google.com/task/6191632889168391638) started by @hahwul*