### PR TITLE
Fix 404 links in abecedary theme header

### DIFF
--- a/examples/abecedary/templates/header.html
+++ b/examples/abecedary/templates/header.html
@@ -78,8 +78,8 @@
         <div class="container" style="display:flex; justify-content:space-between; width:100%;">
             <div class="logo">A.B.C.</div>
             <nav>
-                <a href="/">Primer</a>
-                <a href="/about">Lector</a>
+                <a href="{{ base_url }}/">Primer</a>
+                <a href="{{ base_url }}/about/">Lector</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
This PR fixes the navigation links in the `abecedary` theme header to properly resolve when deployed to a subpath. 

It updates `href="/"` to `href="{{ base_url }}/"` and `href="/about"` to `href="{{ base_url }}/about/"` in `examples/abecedary/templates/header.html`. This ensures that absolute URL resolution defaults to the configured base URL instead of the domain root, preventing 404s on environments like `https://examples.hwaro.hahwul.com/abecedary/`.

---
*PR created automatically by Jules for task [2788719787354693874](https://jules.google.com/task/2788719787354693874) started by @chei-l*