### PR TITLE
feat: add monochrome-lattice example site

### DIFF
--- a/examples/monochrome-lattice/AGENTS.md
+++ b/examples/monochrome-lattice/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/monochrome-lattice/config.toml
+++ b/examples/monochrome-lattice/config.toml
@@ -1,0 +1,161 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Monochrome Lattice"
+description = "An elegant, brutalist monochrome design focusing on structural composition."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"

--- a/examples/monochrome-lattice/content/_index.md
+++ b/examples/monochrome-lattice/content/_index.md
@@ -1,0 +1,24 @@
++++
+title = "Architecture & Form"
+description = "Monochrome Lattice focuses on the foundational elements of web structure. Stripping away the extraneous, we leave only the essential."
++++
+
+Welcome to a brutalist exploration of space, contrast, and typography. The **Monochrome Lattice** theme for Hwaro is built upon absolute truths: stark borders, precise geometric layouts via CSS Grid, and definitive solid colors. No gradients. No emojis. Just raw structure.
+
+## Structural Integrity
+
+This layout utilizes a 12-column grid system (`.lattice-grid`) that anchors the main content block within a rigid, deterministic frame.
+
+```html
+<main class="container lattice-grid">
+    <div class="lattice-main">
+        <!-- Structural Content -->
+    </div>
+</main>
+```
+
+We focus on two distinct typographic voices:
+1. `Inter` for functional reading and paragraph text.
+2. `IBM Plex Mono` for structural metadata, navigation, and code elements.
+
+Explore the [About](/about/) section to understand the philosophy, or observe the structure directly.

--- a/examples/monochrome-lattice/content/about.md
+++ b/examples/monochrome-lattice/content/about.md
@@ -1,0 +1,25 @@
++++
+title = "About the Lattice"
+description = "Understanding the rigid framework behind the design."
+date = "2023-10-24"
+[taxonomies]
+tags = ["philosophy", "design", "architecture"]
++++
+
+The **Monochrome Lattice** is not merely a visual style; it is a structural methodology for content delivery.
+
+### The Philosophy of Reduction
+
+In modern web development, there is a tendency to obfuscate structure with superficial styling. The Lattice rejects this. By reducing the palette to solid black, stark white, and specific functional grays, the actual form of the content becomes the primary visual element.
+
+> "Form follows function—that has been misunderstood. Form and function should be one, joined in a spiritual union."
+> — Frank Lloyd Wright
+
+### Core Principles
+
+1. **Absolute Contrast**: Elements must declare their presence unambiguously.
+2. **Grid Determinism**: All components must adhere strictly to the established mathematical lattice.
+3. **Typographic Hierarchy**: The scale and weight of typography must act as the primary navigational cues.
+4. **Zero Ornamentation**: Gradients, emojis, and unnecessary transitions are strictly prohibited.
+
+The result is a site that is fast, robust, and conceptually pure.

--- a/examples/monochrome-lattice/templates/404.html
+++ b/examples/monochrome-lattice/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="text-center" style="padding: var(--spacing-xl) 0;">
+    <h1 style="font-family: var(--font-mono); font-size: 8rem; margin-bottom: 0;">404</h1>
+    <h2 style="font-family: var(--font-mono); font-weight: 400; text-transform: uppercase;">Structure Not Found</h2>
+    <p class="mb-lg">The requested coordinate does not exist within the lattice.</p>
+    <a href="{{ site.base_url }}/" class="btn">Return to Origin</a>
+</div>
+{% endblock %}

--- a/examples/monochrome-lattice/templates/base.html
+++ b/examples/monochrome-lattice/templates/base.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Inter:wght@400;600;900&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --color-bg: #fdfdfd;
+            --color-text: #1a1a1a;
+            --color-accent: #000000;
+            --color-border: #e0e0e0;
+            --color-muted: #666666;
+
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+            --spacing-xs: 0.5rem;
+            --spacing-sm: 1rem;
+            --spacing-md: 2rem;
+            --spacing-lg: 4rem;
+            --spacing-xl: 8rem;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --color-bg: #0a0a0a;
+                --color-text: #f0f0f0;
+                --color-accent: #ffffff;
+                --color-border: #333333;
+                --color-muted: #999999;
+            }
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: var(--font-sans);
+            background-color: var(--color-bg);
+            color: var(--color-text);
+            line-height: 1.6;
+            min-height: 100vh;
+            display: grid;
+            grid-template-columns: 1fr;
+            grid-template-rows: auto 1fr auto;
+        }
+
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-weight: 900;
+            line-height: 1.2;
+            letter-spacing: -0.02em;
+            margin-bottom: var(--spacing-sm);
+        }
+
+        h1 { font-size: clamp(2.5rem, 5vw, 5rem); }
+        h2 { font-size: clamp(2rem, 4vw, 3.5rem); }
+        h3 { font-size: clamp(1.5rem, 3vw, 2.5rem); }
+
+        p { margin-bottom: var(--spacing-md); }
+
+        a {
+            color: var(--color-text);
+            text-decoration: none;
+            border-bottom: 1px solid var(--color-border);
+            transition: all 0.2s ease;
+        }
+
+        a:hover {
+            color: var(--color-bg);
+            background-color: var(--color-text);
+            border-color: var(--color-text);
+        }
+
+        code, pre {
+            font-family: var(--font-mono);
+            font-size: 0.9em;
+        }
+
+        code {
+            background-color: var(--color-border);
+            padding: 0.2em 0.4em;
+        }
+
+        pre {
+            background-color: var(--color-border);
+            padding: var(--spacing-sm);
+            overflow-x: auto;
+            margin-bottom: var(--spacing-md);
+        }
+
+        pre code {
+            background-color: transparent;
+            padding: 0;
+        }
+
+        /* Layout */
+        .site-header {
+            padding: var(--spacing-md);
+            border-bottom: 2px solid var(--color-accent);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .site-title {
+            font-family: var(--font-mono);
+            font-weight: 600;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+
+        .site-title a {
+            border: none;
+        }
+        .site-title a:hover {
+            background-color: transparent;
+            color: var(--color-text);
+        }
+
+        .site-nav ul {
+            list-style: none;
+            display: flex;
+            gap: var(--spacing-md);
+        }
+
+        .site-nav a {
+            font-family: var(--font-mono);
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            border: none;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: var(--spacing-lg) var(--spacing-md);
+            width: 100%;
+        }
+
+        .site-footer {
+            padding: var(--spacing-md);
+            border-top: 1px solid var(--color-border);
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            text-align: center;
+            color: var(--color-muted);
+        }
+
+        /* Lattice Grid Specific */
+        .lattice-grid {
+            display: grid;
+            grid-template-columns: repeat(12, 1fr);
+            gap: var(--spacing-md);
+        }
+
+        .lattice-main {
+            grid-column: 1 / -1;
+        }
+
+        @media (min-width: 768px) {
+            .lattice-main {
+                grid-column: 2 / 12;
+            }
+        }
+
+        @media (min-width: 1024px) {
+            .lattice-main {
+                grid-column: 3 / 11;
+            }
+        }
+
+        .post-meta {
+            font-family: var(--font-mono);
+            color: var(--color-muted);
+            font-size: 0.9rem;
+            margin-bottom: var(--spacing-md);
+            border-bottom: 1px solid var(--color-border);
+            padding-bottom: var(--spacing-xs);
+        }
+
+        .article-list {
+            list-style: none;
+        }
+
+        .article-item {
+            margin-bottom: var(--spacing-lg);
+            padding-bottom: var(--spacing-md);
+            border-bottom: 1px solid var(--color-border);
+        }
+
+        .article-item:last-child {
+            border-bottom: none;
+        }
+
+        .article-title {
+            margin-bottom: var(--spacing-xs);
+        }
+
+        .article-summary {
+            color: var(--color-muted);
+        }
+
+        .btn {
+            display: inline-block;
+            font-family: var(--font-mono);
+            font-weight: 600;
+            text-transform: uppercase;
+            padding: var(--spacing-sm) var(--spacing-md);
+            border: 2px solid var(--color-text);
+            background-color: transparent;
+            color: var(--color-text);
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .btn:hover {
+            background-color: var(--color-text);
+            color: var(--color-bg);
+        }
+
+        /* Utility */
+        .text-center { text-align: center; }
+        .mb-sm { margin-bottom: var(--spacing-sm); }
+        .mb-md { margin-bottom: var(--spacing-md); }
+        .mb-lg { margin-bottom: var(--spacing-lg); }
+
+    </style>
+</head>
+<body>
+    <header class="site-header">
+        <div class="site-title">
+            <a href="{{ site.base_url }}/">{{ site.title }}</a>
+        </div>
+        <nav class="site-nav">
+            <ul>
+                <li><a href="{{ site.base_url }}/about/">About</a></li>
+                <li><a href="{{ site.base_url }}/tags/">Tags</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main class="container lattice-grid">
+        <div class="lattice-main">
+            {% block content %}{% endblock %}
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; {{ site.title }}. Built with Hwaro.</p>
+    </footer>
+</body>
+</html>

--- a/examples/monochrome-lattice/templates/page.html
+++ b/examples/monochrome-lattice/templates/page.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article>
+    <header>
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="post-meta">
+            <time datetime="{{ page.date }}">{{ page.date }}</time>
+        </div>
+        {% endif %}
+    </header>
+
+    <div class="content">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+    <div class="post-meta" style="margin-top: var(--spacing-lg);">
+        <span>TAGS: </span>
+        {% for tag in page.taxonomies.tags %}
+            <a href="{{ site.base_url }}/tags/{{ tag | urlencode }}/">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+{% endblock %}

--- a/examples/monochrome-lattice/templates/section.html
+++ b/examples/monochrome-lattice/templates/section.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="mb-lg">
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}
+        <p class="article-summary">{{ section.description }}</p>
+    {% endif %}
+</header>
+
+<div class="content mb-lg">
+    {{ content | safe }}
+</div>
+
+<ul class="article-list">
+    {% for page in section.pages %}
+    <li class="article-item">
+        <h2 class="article-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+        {% if page.date %}
+        <div class="post-meta">
+            <time datetime="{{ page.date }}">{{ page.date }}</time>
+        </div>
+        {% endif %}
+        {% if page.description %}
+        <p class="article-summary">{{ page.description }}</p>
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/examples/monochrome-lattice/templates/taxonomy.html
+++ b/examples/monochrome-lattice/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="mb-lg">
+    <h1 style="text-transform: capitalize;">{{ taxonomy_name }}</h1>
+</header>
+
+<ul class="article-list">
+    {% for term in taxonomy_terms %}
+    <li class="article-item" style="border: none; padding: 0; margin-bottom: var(--spacing-sm);">
+        <h2><a href="{{ site.base_url }}/{{ taxonomy_name }}/{{ term.name | urlencode }}/">{{ term.name }}</a></h2>
+        <span class="post-meta">({{ term.pages | length }} items)</span>
+    </li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/examples/monochrome-lattice/templates/taxonomy_term.html
+++ b/examples/monochrome-lattice/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="mb-lg">
+    <h1>Tag: {{ term.name }}</h1>
+</header>
+
+<ul class="article-list">
+    {% for page in term.pages %}
+    <li class="article-item">
+        <h2 class="article-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+        {% if page.date %}
+        <div class="post-meta">
+            <time datetime="{{ page.date }}">{{ page.date }}</time>
+        </div>
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
This PR introduces a new example Hwaro theme named `monochrome-lattice`. It features a highly structural, brutalist aesthetic leveraging CSS Grid, pure solid monochrome colors, and robust typography (Inter and IBM Plex Mono). The design explicitly avoids gradients and emojis, delivering an essential, stark, and architectural experience suitable for documentation, portfolios, or content-heavy sites.

Changes:
- Added the `monochrome-lattice` project initialized under `examples/`.
- Created a robust `base.html` template.
- Updated supporting scaffolding templates to inherit from the unified layout.
- Added sample content illustrating the lattice concept.

---
*PR created automatically by Jules for task [1867473493502082624](https://jules.google.com/task/1867473493502082624) started by @hahwul*