### PR TITLE
Fix 404 links in abecedary example template

### DIFF
--- a/examples/abecedary/templates/header.html
+++ b/examples/abecedary/templates/header.html
@@ -78,8 +78,8 @@
         <div class="container" style="display:flex; justify-content:space-between; width:100%;">
             <div class="logo">A.B.C.</div>
             <nav>
-                <a href="/">Primer</a>
-                <a href="/about">Lector</a>
+                <a href="{{ base_url }}/">Primer</a>
+                <a href="{{ base_url }}/about/">Lector</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
Fixes an issue where clicking the Primer or Lector navigation links in the `abecedary` example resulted in a 404 error due to missing `base_url` variables and missing trailing slashes.

---
*PR created automatically by Jules for task [16976675887311589352](https://jules.google.com/task/16976675887311589352) started by @hahwul*