### PR TITLE
Fix 404 links in holo-neon-pulse example

### DIFF
--- a/examples/holo-neon-pulse/content/posts/_index.md
+++ b/examples/holo-neon-pulse/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Logs"
+description = "Holo neon pulse logs"
++++

--- a/examples/holo-neon-pulse/content/posts/first-post.md
+++ b/examples/holo-neon-pulse/content/posts/first-post.md
@@ -1,0 +1,5 @@
++++
+title = "First Log"
+date = "2026-05-01"
++++
+This is the first log of the holo neon pulse.


### PR DESCRIPTION
Fixes a 404 issue in the `holo-neon-pulse` example where templates point to `/posts/` but the corresponding content directory was missing. This creates `content/posts/_index.md` and a sample post to resolve the issue.

---
*PR created automatically by Jules for task [238549895994488173](https://jules.google.com/task/238549895994488173) started by @chei-l*