### PR TITLE
Add abyssal-architect example site

### DIFF
--- a/examples/abyssal-architect/AGENTS.md
+++ b/examples/abyssal-architect/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/abyssal-architect/config.toml
+++ b/examples/abyssal-architect/config.toml
@@ -1,0 +1,201 @@
+base_url = "http://localhost:3000"
+title = "Abyssal Architect"
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[markdown]
+safe = false
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+# [plugins]
+# processors = ["markdown"]
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+# [sitemap]
+# enabled = true
+# filename = "sitemap.xml"
+# changefreq = "weekly"
+# priority = 0.5
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/abyssal-architect/content/_index.md
+++ b/examples/abyssal-architect/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Architectural Volumes"
+template = "section"
++++
+
+Welcome to the Abyssal Architect. This space explores the interaction of pure solid colors, brutalist borders, and strict grid structures. The design intentionally lacks gradients and ornamental characters, focusing solely on layout and typography.

--- a/examples/abyssal-architect/content/about.md
+++ b/examples/abyssal-architect/content/about.md
@@ -1,0 +1,7 @@
++++
+title = "About"
++++
+
+# About
+
+This is an about page.

--- a/examples/abyssal-architect/content/project-alpha.md
+++ b/examples/abyssal-architect/content/project-alpha.md
@@ -1,0 +1,22 @@
++++
+title = "Project Alpha"
+date = "2025-05-01"
+summary = "An exploration of monolithic structures."
+[taxonomies]
+tags = ["monolith", "structure"]
++++
+
+This project demonstrates the structural integrity of the grid layout.
+
+## Concept
+
+By confining the aesthetic to solid stark contrast colors, we achieve a high level of visual hierarchy without relying on superficial depth markers.
+
+```python
+def build_structure(width, height):
+    """Generates a brutalist grid."""
+    for i in range(height):
+        print("|" + "#" * width + "|")
+```
+
+> "In the void, structure is the only truth."

--- a/examples/abyssal-architect/static/css/style.css
+++ b/examples/abyssal-architect/static/css/style.css
@@ -1,0 +1,281 @@
+/* ==========================================================================
+   Variables & Reset
+   ========================================================================== */
+:root {
+    --bg-color: #050505;
+    --text-color: #fafafa;
+    --accent-color: #f43f5e;
+    --border-color: #fafafa;
+    --muted-color: #888888;
+
+    --font-body: 'Inter', sans-serif;
+    --font-mono: 'IBM Plex Mono', monospace;
+
+    --border-width: 2px;
+    --spacing-sm: 1rem;
+    --spacing-md: 2rem;
+    --spacing-lg: 4rem;
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: var(--font-body);
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    margin: 0 0 var(--spacing-sm) 0;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    line-height: 1.2;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+a {
+    color: var(--text-color);
+    text-decoration: none;
+    transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+a:hover {
+    color: var(--bg-color);
+    background-color: var(--accent-color);
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    border: var(--border-width) solid var(--border-color);
+}
+
+/* ==========================================================================
+   Layout Structure
+   ========================================================================== */
+.site-container {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    min-height: 100vh;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: var(--spacing-md);
+    gap: var(--spacing-lg);
+}
+
+/* Header */
+.site-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: var(--spacing-md);
+    border-bottom: var(--border-width) solid var(--border-color);
+}
+
+.logo a {
+    font-family: var(--font-mono);
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.logo a:hover {
+    background-color: transparent;
+    color: var(--accent-color);
+}
+
+.main-nav {
+    display: flex;
+    gap: var(--spacing-md);
+}
+
+.main-nav a {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding: 0.25rem 0.5rem;
+    border: var(--border-width) solid transparent;
+}
+
+.main-nav a:hover {
+    border-color: var(--border-color);
+    background-color: var(--text-color);
+    color: var(--bg-color);
+}
+
+/* ==========================================================================
+   Grid System (Index / Sections)
+   ========================================================================== */
+.section-header {
+    margin-bottom: var(--spacing-lg);
+}
+
+.section-title {
+    font-size: 3rem;
+    color: var(--accent-color);
+    border-left: calc(var(--border-width) * 4) solid var(--text-color);
+    padding-left: var(--spacing-sm);
+}
+
+.grid-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: var(--spacing-md);
+    border-top: var(--border-width) solid var(--border-color);
+    border-left: var(--border-width) solid var(--border-color);
+}
+
+.grid-item {
+    border-right: var(--border-width) solid var(--border-color);
+    border-bottom: var(--border-width) solid var(--border-color);
+    padding: var(--spacing-md);
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.2s ease;
+}
+
+.grid-item:hover {
+    transform: translate(-4px, -4px);
+    box-shadow: 4px 4px 0 0 var(--accent-color);
+}
+
+.item-meta {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--muted-color);
+    margin-bottom: var(--spacing-sm);
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--muted-color);
+}
+
+.item-title {
+    font-size: 1.5rem;
+    margin-bottom: var(--spacing-sm);
+}
+
+.item-title a {
+    display: block;
+}
+
+.item-title a:hover {
+    background-color: transparent;
+    color: var(--accent-color);
+}
+
+.item-summary {
+    font-size: 0.95rem;
+    color: var(--muted-color);
+    flex-grow: 1;
+}
+
+/* ==========================================================================
+   Page Content
+   ========================================================================== */
+.page-header {
+    margin-bottom: var(--spacing-lg);
+    border-bottom: var(--border-width) solid var(--border-color);
+    padding-bottom: var(--spacing-md);
+}
+
+.page-title {
+    font-size: 4rem;
+    margin-bottom: 0.5rem;
+}
+
+.page-meta {
+    font-family: var(--font-mono);
+    color: var(--accent-color);
+    font-weight: 700;
+}
+
+.content-body {
+    max-width: 800px;
+    font-size: 1.1rem;
+}
+
+.content-body p {
+    margin-bottom: var(--spacing-md);
+}
+
+.content-body blockquote {
+    margin: var(--spacing-md) 0;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-left: calc(var(--border-width) * 2) solid var(--accent-color);
+    background-color: rgba(250, 250, 250, 0.05);
+    font-style: italic;
+}
+
+.content-body code {
+    font-family: var(--font-mono);
+    background-color: rgba(250, 250, 250, 0.1);
+    padding: 0.1rem 0.3rem;
+    border: 1px solid var(--muted-color);
+}
+
+.content-body pre {
+    background-color: #111;
+    padding: var(--spacing-md);
+    border: var(--border-width) solid var(--border-color);
+    overflow-x: auto;
+    margin-bottom: var(--spacing-md);
+}
+
+.content-body pre code {
+    background-color: transparent;
+    border: none;
+    padding: 0;
+}
+
+.page-tags {
+    margin-top: var(--spacing-lg);
+    padding-top: var(--spacing-md);
+    border-top: 1px dashed var(--muted-color);
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+}
+
+.tag-label {
+    color: var(--muted-color);
+    margin-right: 0.5rem;
+}
+
+.tag {
+    display: inline-block;
+    padding: 0.2rem 0.5rem;
+    border: 1px solid var(--accent-color);
+    color: var(--accent-color);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+}
+
+.tag:hover {
+    background-color: var(--accent-color);
+    color: var(--bg-color);
+}
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+.site-footer {
+    border-top: var(--border-width) solid var(--border-color);
+    padding-top: var(--spacing-md);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--muted-color);
+    text-align: center;
+    text-transform: uppercase;
+}

--- a/examples/abyssal-architect/templates/404.html
+++ b/examples/abyssal-architect/templates/404.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-content">
+    <header class="page-header">
+        <h1 class="page-title">404</h1>
+    </header>
+    <div class="content-body">
+        <p>The structural node you requested does not exist in this volume.</p>
+        <p><a href="{{ base_url }}/">Return to Index</a></p>
+    </div>
+</div>
+{% endblock %}

--- a/examples/abyssal-architect/templates/base.html
+++ b/examples/abyssal-architect/templates/base.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site.title }}</title>
+    <meta name="description" content="A brutalist architectural void constructed of pure black, stark white, and deep crimson.">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,700;1,400&family=Inter:wght@400;600;900&display=swap" rel="stylesheet">
+
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+    <div class="site-container">
+        <header class="site-header">
+            <div class="logo">
+                <a href="{{ base_url }}/">{{ site.title }}</a>
+            </div>
+            <nav class="main-nav">
+                <a href="{{ base_url }}/">Index</a>
+                <a href="{{ base_url }}/about/">About</a>
+            </nav>
+        </header>
+
+        <main class="site-content">
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer class="site-footer">
+            <div class="footer-inner">
+                <p>&copy; {{ current_year }} Abyssal Architect. Structural Minimal.</p>
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/abyssal-architect/templates/page.html
+++ b/examples/abyssal-architect/templates/page.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-content">
+    <header class="page-header">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="page-meta">
+            <time datetime="{{ page.date | date("%Y-%m-%d") }}">{{ page.date | date("%Y.%m.%d") }}</time>
+        </div>
+        {% endif %}
+    </header>
+
+    <div class="content-body">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+    <div class="page-tags">
+        <span class="tag-label">Tags:</span>
+        {% for tag in page.taxonomies.tags %}
+        <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+{% endblock %}

--- a/examples/abyssal-architect/templates/section.html
+++ b/examples/abyssal-architect/templates/section.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% if section.title %}
+<header class="section-header">
+    <h1 class="section-title">{{ section.title }}</h1>
+</header>
+{% endif %}
+
+{% if content %}
+<div class="section-content">
+    {{ content | safe }}
+</div>
+{% endif %}
+
+<div class="grid-container">
+    {% for page in section.pages %}
+    <article class="grid-item">
+        <div class="item-meta">
+            <span class="item-id">No.{{ loop.index }}</span>
+            {% if page.date %}
+            <time class="item-date" datetime="{{ page.date | date("%Y-%m-%d") }}">{{ page.date | date("%Y.%m.%d") }}</time>
+            {% endif %}
+        </div>
+        <h2 class="item-title"><a href="{{ page.url }}">{{ page.title }}</a></h2>
+        {% if page.summary %}
+        <div class="item-summary">{{ page.summary | strip_html | truncate_words(20) }}</div>
+        {% endif %}
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/examples/abyssal-architect/templates/taxonomy.html
+++ b/examples/abyssal-architect/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+    <h1 class="page-title">{{ taxonomy_name }}</h1>
+</header>
+<div class="page-tags">
+    {% for term in taxonomy_terms %}
+    <a href="{{ base_url }}/{{ taxonomy_name | slugify }}/{{ term | slugify }}/" class="tag">{{ term }}</a>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/examples/abyssal-architect/templates/taxonomy_term.html
+++ b/examples/abyssal-architect/templates/taxonomy_term.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-header">
+    <h1 class="page-title">Items tagged with "{{ term.name }}"</h1>
+</header>
+
+<div class="grid-container">
+    {% for page in term.pages %}
+    <article class="grid-item">
+        <h2 class="item-title"><a href="{{ page.url }}">{{ page.title }}</a></h2>
+        {% if page.summary %}
+        <div class="item-summary">{{ page.summary | strip_html | truncate_words(20) }}</div>
+        {% endif %}
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -8656,5 +8656,11 @@
     "dark",
     "portfolio",
     "minimal"
+  ],
+  "abyssal-architect": [
+    "dark",
+    "minimal",
+    "brutalist",
+    "portfolio"
   ]
 }


### PR DESCRIPTION
Adds the `abyssal-architect` example site. This site demonstrates a brutalist, dark-themed architectural aesthetic. It explicitly avoids using gradients and emojis, utilizing pure CSS Grid layouts and solid colors for a stark, structured look. The site is fully functional, builds cleanly with Hwaro 0.10.0, and includes an `AGENTS.md` and updated `tags.json` configuration.

---
*PR created automatically by Jules for task [9817673511668108125](https://jules.google.com/task/9817673511668108125) started by @hahwul*