### PR TITLE
fix(astral-lotus-nova): add missing posts index to fix 404

### DIFF
--- a/examples/astral-lotus-nova/content/posts/_index.md
+++ b/examples/astral-lotus-nova/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Writings"
+description = "Archive of cosmic journals and observations."
++++


### PR DESCRIPTION
Fixes a 404 broken link in the `astral-lotus-nova` example site. The header navigation contained a link to `{{ base_url }}/posts/`, but the corresponding `content/posts/` folder and `_index.md` file did not exist, leading to a 404 when navigating to the archive. This PR adds the missing `content/posts/_index.md` so the posts archive index correctly builds.

---
*PR created automatically by Jules for task [15245131983932760151](https://jules.google.com/task/15245131983932760151) started by @hahwul*