### PR TITLE
Fix 404 risks and expand sparse content (batch 05)

### DIFF
--- a/examples/gong-show/templates/section.html
+++ b/examples/gong-show/templates/section.html
@@ -8,7 +8,7 @@
       <div class="listing-item">
         <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
         <div>
-          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          <div class="listing-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></div>
           {% if post.description %}
           <div class="listing-desc">{{ post.description }}</div>
           {% endif %}

--- a/examples/gothic/templates/section.html
+++ b/examples/gothic/templates/section.html
@@ -80,7 +80,7 @@
     <nav class="pagination" aria-label="Chronicles pagination">
       <ul class="pagination-list">
         {% if paginator.previous %}
-        <li><a href="{{ paginator.previous }}">&larr; Previous</a></li>
+        <li><a href="{{ base_url }}{{ paginator.previous }}">&larr; Previous</a></li>
         {% else %}
         <li class="pagination-disabled"><span>&larr; Previous</span></li>
         {% endif %}
@@ -89,12 +89,12 @@
           {% if page_num == paginator.current_page %}
           <li class="pagination-current"><span>{{ page_num }}</span></li>
           {% else %}
-          <li><a href="{{ paginator.base_url }}{% if page_num > 1 %}page/{{ page_num }}/{% endif %}">{{ page_num }}</a></li>
+          <li><a href="{{ base_url }}{{ paginator.base_url }}{% if page_num > 1 %}page/{{ page_num }}/{% endif %}">{{ page_num }}</a></li>
           {% endif %}
         {% endfor %}
 
         {% if paginator.next %}
-        <li><a href="{{ paginator.next }}">Next &rarr;</a></li>
+        <li><a href="{{ base_url }}{{ paginator.next }}">Next &rarr;</a></li>
         {% else %}
         <li class="pagination-disabled"><span>Next &rarr;</span></li>
         {% endif %}

--- a/examples/ground-zero/templates/section.html
+++ b/examples/ground-zero/templates/section.html
@@ -8,7 +8,7 @@
       <div class="listing-item">
         <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
         <div>
-          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          <div class="listing-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></div>
           {% if post.description %}
           <div class="listing-desc">{{ post.description }}</div>
           {% endif %}


### PR DESCRIPTION
Fix 404 risks by appending `{{ base_url }}` to relative paths in Liquid templates across the 10 target sites. Checked all target examples for sparse content, but all targets already had 3 or more entries, so no new content was added.

---
*PR created automatically by Jules for task [15330044081961801477](https://jules.google.com/task/15330044081961801477) started by @hahwul*