### PR TITLE
Fix 404 risks and expand sparse content (batch 08)

### DIFF
--- a/examples/hornbook/content/archives.md
+++ b/examples/hornbook/content/archives.md
@@ -2,4 +2,4 @@
 title = "Archives"
 +++
 
-Browse all posts by date. Check the [Posts](/posts/) section for the complete list.
+Browse all posts by date. Check the [Posts]({{ base_url }}/posts/) section for the complete list.

--- a/examples/hornbook/content/index.md
+++ b/examples/hornbook/content/index.md
@@ -20,5 +20,5 @@ We believe that the best lessons deserve a stage as focused as their contents.
 Explore our lessons of posts or read the origin story to learn about the origins of this press.
 
 <div style="margin-top: 4rem; text-align: center;">
-  <a href="/posts/" class="btn">VIEW THE LESSONS</a>
+  <a href="{{ base_url }}/posts/" class="btn">VIEW THE LESSONS</a>
 </div>

--- a/examples/hornbook/content/posts/markdown-tips.md
+++ b/examples/hornbook/content/posts/markdown-tips.md
@@ -38,7 +38,7 @@ Unordered lists:
 ## Links and Images
 
 - [Link text](https://example.com)
-- ![Alt text](/path/to/image.jpg)
+- ![Alt text]({{ base_url }}/path/to/image.jpg)
 
 ## Blockquotes
 

--- a/examples/hwaro.386/content/index.md
+++ b/examples/hwaro.386/content/index.md
@@ -9,11 +9,11 @@ Welcome to **HWARO.386**, a retro DOS-inspired blog built with [Hwaro](https://g
 
 ### Latest Articles
 
-- [Getting Started with Hwaro](posts/getting-started-with-hwaro/)
-- [The Beauty of Retro Computing](posts/the-beauty-of-retro-computing/)
-- [Static Sites in the Modern Era](posts/static-sites-in-the-modern-era/)
-- [Command Line is King](posts/command-line-is-king/)
+- [Getting Started with Hwaro]({{ base_url }}/posts/getting-started-with-hwaro/)
+- [The Beauty of Retro Computing]({{ base_url }}/posts/the-beauty-of-retro-computing/)
+- [Static Sites in the Modern Era]({{ base_url }}/posts/static-sites-in-the-modern-era/)
+- [Command Line is King]({{ base_url }}/posts/command-line-is-king/)
 
 ---
 
-Browse by [Categories](categories/) or [Tags](tags/).
+Browse by [Categories]({{ base_url }}/categories/) or [Tags]({{ base_url }}/tags/).

--- a/examples/hwaro.386/templates/404.html
+++ b/examples/hwaro.386/templates/404.html
@@ -8,8 +8,8 @@
           <h2>Bad command or file name</h2>
           <p>The file you requested could not be found on this system.</p>
           <pre>
-C:\HWARO386> type {{ page.url }}
-File not found - {{ page.url }}
+C:\HWARO386> type {{ base_url }}{{ page.url }}
+File not found - {{ base_url }}{{ page.url }}
 
 C:\HWARO386> _</pre>
           <br>

--- a/examples/hwaronight/content/index.md
+++ b/examples/hwaronight/content/index.md
@@ -27,6 +27,6 @@ hwaro serve
 
 ## Links
 
-- [Browse the blog](blog/) for sample posts
-- [Read about this theme](about/)
-- [View all tags](tags/)
+- [Browse the blog]({{ base_url }}/blog/) for sample posts
+- [Read about this theme]({{ base_url }}/about/)
+- [View all tags]({{ base_url }}/tags/)

--- a/examples/hypercube/content/docs/dimensional-theory.md
+++ b/examples/hypercube/content/docs/dimensional-theory.md
@@ -70,4 +70,4 @@ Just as a tesseract is projected from four dimensions onto a two-dimensional scr
 
 ## Implementation
 
-These theoretical principles translate into concrete implementation patterns. See the [API Reference](/docs/api-reference/) for the specific interfaces and configuration options that enable multi-dimensional documentation.
+These theoretical principles translate into concrete implementation patterns. See the [API Reference]({{ base_url }}/docs/api-reference/) for the specific interfaces and configuration options that enable multi-dimensional documentation.

--- a/examples/hypercube/content/docs/getting-started.md
+++ b/examples/hypercube/content/docs/getting-started.md
@@ -108,4 +108,4 @@ tags = ["api", "reference"]
 
 ## Next Steps
 
-With the basics in place, proceed to [Dimensional Theory](/docs/dimensional-theory/) to understand the architectural principles, or jump directly to the [API Reference](/docs/api-reference/) for interface documentation.
+With the basics in place, proceed to [Dimensional Theory]({{ base_url }}/docs/dimensional-theory/) to understand the architectural principles, or jump directly to the [API Reference]({{ base_url }}/docs/api-reference/) for interface documentation.

--- a/examples/hyperpop/content/index.md
+++ b/examples/hyperpop/content/index.md
@@ -17,4 +17,4 @@ Welcome to the **Hyperpop** example site. This design concept embraces glamorous
 
 Feel the energy of the hyperpop aesthetic in every interaction. Explore the depths of digital excess combined with elegant typography.
 
-[Learn more about our vision](/about/)
+[Learn more about our vision]({{ base_url }}/about/)

--- a/examples/ice-panel/content/archives.md
+++ b/examples/ice-panel/content/archives.md
@@ -2,4 +2,4 @@
 title = "Archives"
 +++
 
-Browse all posts by date. Check the [Posts](/posts/) section for the complete list.
+Browse all posts by date. Check the [Posts]({{ base_url }}/posts/) section for the complete list.

--- a/examples/ice-panel/content/index.md
+++ b/examples/ice-panel/content/index.md
@@ -20,5 +20,5 @@ We believe that the best content deserves a stage as clear as ice.
 Explore our logs of posts or learn about the frost philosophy.
 
 <div style="margin-top: 4rem;">
-  <a href="/posts/" class="btn">VIEW THE LOGS</a>
+  <a href="{{ base_url }}/posts/" class="btn">VIEW THE LOGS</a>
 </div>

--- a/examples/ice-panel/content/posts/markdown-tips.md
+++ b/examples/ice-panel/content/posts/markdown-tips.md
@@ -38,7 +38,7 @@ Unordered lists:
 ## Links and Images
 
 - [Link text](https://example.com)
-- ![Alt text](/path/to/image.jpg)
+- ![Alt text]({{ base_url }}/path/to/image.jpg)
 
 ## Blockquotes
 

--- a/examples/ignition-sequence/content/systems/communications.md
+++ b/examples/ignition-sequence/content/systems/communications.md
@@ -1,0 +1,34 @@
++++
+title = "Communications System"
+date = "2026-02-17"
+weight = 3
+template = "post"
+description = "Telemetry and command uplink systems documentation"
+tags = ["communications", "telemetry"]
+[extra]
+system_status = "NOMINAL"
++++
+
+## System Overview
+
+The communications system provides high-bandwidth telemetry downlink and secure command uplink capabilities. It utilizes S-band for primary vehicle telemetry and X-band for high-rate payload data transmission.
+
+## Transceiver Specifications
+
+| Specification | Value |
+|---------------|-------|
+| Primary Band | S-Band |
+| Payload Band | X-Band |
+| Telemetry Rate | 5 Mbps |
+| Payload Data Rate | 150 Mbps |
+| Encryption | AES-256 |
+| Antenna Count | 4 Omni-directional |
+| Backup Systems | UHF Secondary |
+
+## Redundancy
+
+The vehicle utilizes four flush-mounted phased array antennas positioned at 90-degree intervals to ensure continuous ground station coverage regardless of vehicle attitude. The system automatically switches between antennas based on signal strength.
+
+## Ground Station Network
+
+Coverage is maintained via a global network of ground stations, ensuring continuous contact during ascent, orbital insertion, and payload deployment. Loss of signal (LOS) periods are minimized to less than 30 seconds per orbit.

--- a/examples/ignition-sequence/templates/section.html
+++ b/examples/ignition-sequence/templates/section.html
@@ -8,7 +8,7 @@
       <div class="listing-item">
         <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
         <div>
-          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          <div class="listing-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></div>
           {% if post.description %}
           <div class="listing-desc">{{ post.description }}</div>
           {% endif %}


### PR DESCRIPTION
Fix 404 risks and expand sparse content (batch 08)

- hologram: no changes needed
- holographic-glass: no changes needed
- hornbook: prefix /posts/ link with {{ base_url }} in archives and index, prefix image in markdown-tips
- house-lights: no changes needed
- hwaro.386: prefix {{ page.url }} with {{ base_url }} in 404.html, prefix posts/links in index.md
- hwaronight: prefix blog/links in index.md
- hypercube: prefix /docs/ in dimensional-theory and getting-started
- hyperpop: prefix /about/ in index.md
- ice-panel: prefix /posts/ in index and archives, prefix image in markdown-tips
- ignition-sequence: prefix bare {{ post.url }} with {{ base_url }} in section.html, add communications system post

---
*PR created automatically by Jules for task [8972300829497494155](https://jules.google.com/task/8972300829497494155) started by @hahwul*