### PR TITLE
fix(examples): resolve 404 links in rooftop example templates

### DIFF
--- a/examples/rooftop/templates/home.html
+++ b/examples/rooftop/templates/home.html
@@ -16,7 +16,7 @@
       {% for post in pages %}
       <article class="post-card">
         <h3 class="post-card__title">
-          <a href="{{ base_url }}{{ post.permalink }}">{{ post.title }}</a>
+          <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
         </h3>
         <div class="post-card__meta">{{ post.date | date(format="%B %d, %Y") }}</div>
         {% if post.description %}

--- a/examples/rooftop/templates/page.html
+++ b/examples/rooftop/templates/page.html
@@ -27,7 +27,7 @@
 
     <nav class="post-nav">
       {% if page.earlier %}
-      <a href="{{ base_url }}{{ page.earlier.permalink }}" class="post-nav__link">
+      <a href="{{ base_url }}{{ page.earlier.url }}" class="post-nav__link">
         <div class="post-nav__label">Previous</div>
         <div class="post-nav__title">{{ page.earlier.title }}</div>
       </a>
@@ -35,7 +35,7 @@
       <div></div>
       {% endif %}
       {% if page.later %}
-      <a href="{{ base_url }}{{ page.later.permalink }}" class="post-nav__link post-nav__link--next">
+      <a href="{{ base_url }}{{ page.later.url }}" class="post-nav__link post-nav__link--next">
         <div class="post-nav__label">Next</div>
         <div class="post-nav__title">{{ page.later.title }}</div>
       </a>

--- a/examples/rooftop/templates/section.html
+++ b/examples/rooftop/templates/section.html
@@ -9,7 +9,7 @@
       {% for post in paginator.pages %}
       <article class="post-card">
         <h3 class="post-card__title">
-          <a href="{{ base_url }}{{ post.permalink }}">{{ post.title }}</a>
+          <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
         </h3>
         <div class="post-card__meta">{{ post.date | date(format="%B %d, %Y") }}</div>
         {% if post.description %}

--- a/examples/rooftop/templates/taxonomy_term.html
+++ b/examples/rooftop/templates/taxonomy_term.html
@@ -9,7 +9,7 @@
       {% for post in term.pages %}
       <article class="post-card">
         <h3 class="post-card__title">
-          <a href="{{ base_url }}{{ post.permalink }}">{{ post.title }}</a>
+          <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
         </h3>
         <div class="post-card__meta">{{ post.date | date(format="%B %d, %Y") }}</div>
         {% if post.description %}


### PR DESCRIPTION
Resolves broken 404 links within the `rooftop` example templates by fixing the usage of undefined context variable `.permalink` to `.url` when generating article links in loops or next/prev navigation paths.

---
*PR created automatically by Jules for task [13353835862113549416](https://jules.google.com/task/13353835862113549416) started by @hahwul*