### PR TITLE
Fix 404 risks and expand sparse content (batch 14)

### DIFF
--- a/examples/lucid-glass/templates/index.html
+++ b/examples/lucid-glass/templates/index.html
@@ -17,11 +17,11 @@
   {% for p in site.pages %}
     {% if p.url != page.url %}
     <div class="portfolio-card glass-container" style="padding: 1.5rem; transition: transform 0.3s ease;">
-      <h3 style="margin-top: 0;"><a href="{{ p.url }}" style="color: inherit;">{{ p.title | e }}</a></h3>
+      <h3 style="margin-top: 0;"><a href="{{ base_url }}{{ p.url }}" style="color: inherit;">{{ p.title | e }}</a></h3>
       {% if p.description %}
       <p style="font-size: 0.95rem; color: var(--text-muted);">{{ p.description | e }}</p>
       {% endif %}
-      <a href="{{ p.url }}" style="font-size: 0.9rem; font-weight: 500;">View Details &rarr;</a>
+      <a href="{{ base_url }}{{ p.url }}" style="font-size: 0.9rem; font-weight: 500;">View Details &rarr;</a>
     </div>
     {% endif %}
   {% endfor %}

--- a/examples/lumina-architect/content/contact.md
+++ b/examples/lumina-architect/content/contact.md
@@ -1,0 +1,10 @@
++++
+title = "Contact"
+date = "2025-01-01"
++++
+
+We'd love to hear from you. Please reach out to Lumina Architect to create beautiful things together.
+
+Our office is open from Monday to Friday, 9:00 AM to 5:00 PM.
+
+You can contact us at info@lumina-architect.example.com or visit us at our headquarters to discuss your next project.

--- a/examples/lumina-architect/content/studio.md
+++ b/examples/lumina-architect/content/studio.md
@@ -1,0 +1,10 @@
++++
+title = "Studio"
+date = "2025-01-01"
++++
+
+Welcome to our Studio. At Lumina Architect, we believe in crafting spaces that transcend mere functionality.
+
+Our multidisciplinary team of designers and architects works closely to create holistic environments that foster well-being, productivity, and connection.
+
+We specialize in modern architectural masterworks that balance striking aesthetics with quiet, intentional functionality, bringing light into every corner of your life.

--- a/examples/lumina-architect/templates/header.html
+++ b/examples/lumina-architect/templates/header.html
@@ -152,10 +152,10 @@
 <body>
   <div class="container">
     <header class="site-header">
-      <a href="{{ base_url }}" class="site-logo">Lumina</a>
+      <a href="{{ base_url }}/" class="site-logo">Lumina</a>
       <nav class="site-nav">
-        <a href="{{ base_url }}">Portfolio</a>
-        <a href="{{ base_url }}">Studio</a>
-        <a href="{{ base_url }}">Contact</a>
+        <a href="{{ base_url }}/">Portfolio</a>
+        <a href="{{ base_url }}/studio/">Studio</a>
+        <a href="{{ base_url }}/contact/">Contact</a>
       </nav>
     </header>

--- a/examples/luminance-stream/templates/header.html
+++ b/examples/luminance-stream/templates/header.html
@@ -12,11 +12,11 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a href="{{ base_url }}" class="site-logo">Luminance Stream</a>
+            <a href="{{ base_url }}/" class="site-logo">Luminance Stream</a>
             <nav class="site-nav">
-                <a href="{{ base_url }}">Home</a>
-                <a href="{{ base_url }}about/">About</a>
-                <a href="{{ base_url }}tags/">Tags</a>
+                <a href="{{ base_url }}/">Home</a>
+                <a href="{{ base_url }}/about/">About</a>
+                <a href="{{ base_url }}/tags/">Tags</a>
             </nav>
         </div>
     </header>

--- a/examples/luminescent-glass-prism/templates/section.html
+++ b/examples/luminescent-glass-prism/templates/section.html
@@ -8,7 +8,7 @@
 
       <ul class="section-list">
       {% for p in pages %}
-        <li><a href="{{ p.url }}">{{ p.title | e }}</a> <span style="font-size: 0.85em; color: var(--text-muted); float: right;">{{ p.date | date("%Y-%m-%d") }}</span></li>
+        <li><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a> <span style="font-size: 0.85em; color: var(--text-muted); float: right;">{{ p.date | date("%Y-%m-%d") }}</span></li>
       {% endfor %}
       </ul>
 

--- a/examples/luminescent-glass-prism/templates/taxonomy.html
+++ b/examples/luminescent-glass-prism/templates/taxonomy.html
@@ -4,7 +4,7 @@
       <h1>{{ page.title | e }}</h1>
       <ul class="section-list">
       {% for term in taxonomy_terms %}
-        <li><a href="{{ term.url }}">{{ term.name | e }}</a> ({{ term.pages_count }})</li>
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term.name | e }}</a> ({{ term.pages_count }})</li>
       {% endfor %}
       </ul>
     </div>

--- a/examples/luminescent-glass-prism/templates/taxonomy_term.html
+++ b/examples/luminescent-glass-prism/templates/taxonomy_term.html
@@ -6,7 +6,7 @@
 
       <ul class="section-list">
       {% for p in taxonomy_pages %}
-        <li><a href="{{ p.url }}">{{ p.title | e }}</a></li>
+        <li><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></li>
       {% endfor %}
       </ul>
 


### PR DESCRIPTION
This PR addresses 404 risks and sparse content across a specific batch of Hwaro static-site examples.

Changes made:
- **lucid-glass**: Prefixed bare URL variables with `{{ base_url }}` in `index.html`.
- **lumina-architect**: Corrected absolute paths missing trailing slashes in `header.html` and added missing stub pages `contact.md` and `studio.md` to resolve dead links.
- **luminance-stream**: Added trailing slashes to absolute paths in `header.html`.
- **luminescent-glass-prism**: Prefixed bare URL variables with `{{ base_url }}` in `section.html`, `taxonomy.html`, and `taxonomy_term.html`.
- Verified no sparse sections (with fewer than 3 entries) existed in the target examples.
- Kept inline styles intact and avoided adding unnecessary documentation per constraints.

---
*PR created automatically by Jules for task [10172338781635975081](https://jules.google.com/task/10172338781635975081) started by @hahwul*