### PR TITLE
Fix 404 risks and expand sparse content (batch 07)

### DIFF
--- a/examples/hardcore-pit/content/index.md
+++ b/examples/hardcore-pit/content/index.md
@@ -32,7 +32,7 @@ tags = ["event", "punk", "hardcore", "show", "chaotic"]
 <h3>RIB CAGE COLUMN</h3>
 <p class="set-time">13:15 - 13:45</p>
 <p>Local three-piece, first show. Eight songs. Please show up early; a half-empty room on band one sets the tone for the day.</p>
-<a href="/bands/rib-cage-column/">READ ZINE</a>
+<a href="{{ base_url }}/bands/rib-cage-column/">READ ZINE</a>
 </article>
 
 <article class="band-card">
@@ -46,7 +46,7 @@ tags = ["event", "punk", "hardcore", "show", "chaotic"]
 <h3>BURN PILE</h3>
 <p class="set-time">14:00 - 14:30</p>
 <p>Philly via Dayton. Four records deep. Brings their own kick pedal. Will end with the wall of death but it will be polite.</p>
-<a href="/bands/burn-pile/">READ ZINE</a>
+<a href="{{ base_url }}/bands/burn-pile/">READ ZINE</a>
 </article>
 
 <article class="band-card">
@@ -60,7 +60,7 @@ tags = ["event", "punk", "hardcore", "show", "chaotic"]
 <h3>EVEN HANDS</h3>
 <p class="set-time">14:45 - 15:20</p>
 <p>Four song split with Burn Pile last spring. Bassist is Dina who co-books this space. Please tip.</p>
-<a href="/bands/even-hands/">READ ZINE</a>
+<a href="{{ base_url }}/bands/even-hands/">READ ZINE</a>
 </article>
 
 <article class="band-card">
@@ -74,7 +74,7 @@ tags = ["event", "punk", "hardcore", "show", "chaotic"]
 <h3>GRAVEL HARVEST</h3>
 <p class="set-time">15:45 - 16:20</p>
 <p>Chicago via Gary. Saxophone over d-beat. Thirty minutes flat. Stay for the closer - it's the point.</p>
-<a href="/bands/gravel-harvest/">READ ZINE</a>
+<a href="{{ base_url }}/bands/gravel-harvest/">READ ZINE</a>
 </article>
 
 <article class="band-card">
@@ -88,7 +88,7 @@ tags = ["event", "punk", "hardcore", "show", "chaotic"]
 <h3>DOWN THE DRAIN</h3>
 <p class="set-time">16:40 - 17:20</p>
 <p>Cleveland all-womxn four-piece. Third time at this basement. New LP due in August. Merch in a suitcase, no credit cards.</p>
-<a href="/bands/down-the-drain/">READ ZINE</a>
+<a href="{{ base_url }}/bands/down-the-drain/">READ ZINE</a>
 </article>
 
 <article class="band-card">
@@ -102,7 +102,7 @@ tags = ["event", "punk", "hardcore", "show", "chaotic"]
 <h3>LAST OPEN WINDOW</h3>
 <p class="set-time">17:40 - 18:30</p>
 <p>Richmond powerviolence, reunion set. 40 minutes because they hauled twelve hours. Load-out starts the second the last note ends.</p>
-<a href="/bands/last-open-window/">READ ZINE</a>
+<a href="{{ base_url }}/bands/last-open-window/">READ ZINE</a>
 </article>
 
 </div>

--- a/examples/heavy-curtain/content/index.md
+++ b/examples/heavy-curtain/content/index.md
@@ -72,7 +72,7 @@ tags = ["event", "theater", "drama", "production", "heavy"]
 <h3>The Garden Gate</h3>
 <p class="act-setting">A walled garden at dawn. Smoke on the horizon.</p>
 <p>Helene prepares tea for a sister she has not seen in seven years. The house staff are sent away. The ash falls thicker as the act proceeds.</p>
-<a href="/acts/i-the-garden-gate/">Read the Act &rarr;</a>
+<a href="{{ base_url }}/acts/i-the-garden-gate/">Read the Act &rarr;</a>
 </article>
 
 <article class="act-card">
@@ -86,7 +86,7 @@ tags = ["event", "theater", "drama", "production", "heavy"]
 <h3>The Sealed Parlour</h3>
 <p class="act-setting">Afternoon. The front parlour, curtains drawn.</p>
 <p>The sisters speak of the will. The parlour does not contain what was promised. A third voice is heard from a room that should be empty.</p>
-<a href="/acts/ii-the-sealed-parlour/">Read the Act &rarr;</a>
+<a href="{{ base_url }}/acts/ii-the-sealed-parlour/">Read the Act &rarr;</a>
 </article>
 
 <article class="act-card">
@@ -100,7 +100,7 @@ tags = ["event", "theater", "drama", "production", "heavy"]
 <h3>The Last Door</h3>
 <p class="act-setting">Midnight. The hallway, the door at the far end.</p>
 <p>The caldera crests the hill. The door that has been closed for a generation must now be opened. The tragedy is not in what leaves but in what stays.</p>
-<a href="/acts/iii-the-last-door/">Read the Act &rarr;</a>
+<a href="{{ base_url }}/acts/iii-the-last-door/">Read the Act &rarr;</a>
 </article>
 
 </div>

--- a/examples/helix-docs/content/reference/api.md
+++ b/examples/helix-docs/content/reference/api.md
@@ -1,0 +1,54 @@
++++
+title = "API Reference"
++++
+
+Complete reference for the Helix Node API.
+
+## Node Creation
+
+```javascript
+import { createNode } from '@helix/core';
+
+const node = createNode({
+  id: 'node-1',
+  type: 'processor',
+  options: {
+    timeout: 5000,
+    retry: 3
+  }
+});
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `id` | string | Unique identifier for the node |
+| `type` | string | Node functional classification |
+| `options` | object | Node-specific configuration |
+
+## Event Handling
+
+```javascript
+node.on('process', (data) => {
+  console.log(`Processing payload: ${data.id}`);
+});
+
+node.emit('ready', { status: 'online' });
+```
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `on` | `event`, `callback` | Registers an event listener |
+| `emit` | `event`, `payload` | Dispatches an event to listeners |
+
+## State Management
+
+Nodes maintain internal state that can be queried and modified during execution.
+
+```javascript
+const currentState = node.getState();
+node.setState({ active: true });
+```
+
+State changes trigger the `stateChange` event automatically. Always ensure that complex state transitions are handled through the defined action reducers rather than direct assignment.
+
+For distributed node operations, consider the asynchronous state lock mechanism to prevent race conditions during cluster scale-out events.

--- a/examples/herald/content/index.md
+++ b/examples/herald/content/index.md
@@ -8,11 +8,11 @@ template = "page"
     <div class="main-column">
         <article class="main-story">
             <div class="main-story-image">
-                <a href="/posts/post1/">
+                <a href="{{ base_url }}/posts/post1/">
                     <img src="https://images.unsplash.com/photo-1541872516559-251cd612cd20?ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&q=80" alt="Capitol Building" loading="lazy">
                 </a>
             </div>
-            <h2 class="main-story-title"><a href="/posts/post1/">Landmark Legislation Passes Senate in Midnight Vote</a></h2>
+            <h2 class="main-story-title"><a href="{{ base_url }}/posts/post1/">Landmark Legislation Passes Senate in Midnight Vote</a></h2>
             <p class="main-story-excerpt">After months of gridlock and intense negotiation, lawmakers reached a bipartisan consensus early this morning. The historic bill aims to overhaul national infrastructure and digital privacy standards...</p>
             <div class="meta">
                 <span class="byline">By <strong>Eleanor Rigby</strong></span> &middot; <span class="pubdate">Oct 24, 2023</span>
@@ -23,12 +23,12 @@ template = "page"
 
         <div class="articles-grid">
             <article class="grid-item">
-                <a href="/posts/post2/" class="grid-image-link">
+                <a href="{{ base_url }}/posts/post2/" class="grid-image-link">
                     <img src="https://images.unsplash.com/photo-1611974789855-9c2a0a7236a3?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80" alt="Stock Market Display" class="grid-image" loading="lazy">
                 </a>
                 <div class="grid-content">
-                    <span class="grid-category"><a href="/categories/business/">Business</a></span>
-                    <h3 class="grid-title"><a href="/posts/post2/">Markets Rally as Tech Sector Reports Record Earnings</a></h3>
+                    <span class="grid-category"><a href="{{ base_url }}/categories/business/">Business</a></span>
+                    <h3 class="grid-title"><a href="{{ base_url }}/posts/post2/">Markets Rally as Tech Sector Reports Record Earnings</a></h3>
                     <p class="grid-excerpt">Major indices hit new all-time highs as the largest technology firms blew past analyst expectations for the third quarter.</p>
                     <div class="grid-meta">
                         <span class="grid-author">James Miller</span>
@@ -38,12 +38,12 @@ template = "page"
             </article>
 
             <article class="grid-item">
-                <a href="/posts/post3/" class="grid-image-link">
+                <a href="{{ base_url }}/posts/post3/" class="grid-image-link">
                     <img src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80" alt="Team collaborating" class="grid-image" loading="lazy">
                 </a>
                 <div class="grid-content">
-                    <span class="grid-category"><a href="/categories/technology/">Technology</a></span>
-                    <h3 class="grid-title"><a href="/posts/post3/">The Future of Remote Work is Hybrid</a></h3>
+                    <span class="grid-category"><a href="{{ base_url }}/categories/technology/">Technology</a></span>
+                    <h3 class="grid-title"><a href="{{ base_url }}/posts/post3/">The Future of Remote Work is Hybrid</a></h3>
                     <p class="grid-excerpt">New data suggests that the permanent return to office is a myth, with the majority of enterprises adopting a flexible hybrid model.</p>
                     <div class="grid-meta">
                         <span class="grid-author">Sarah Jenkins</span>
@@ -57,7 +57,7 @@ template = "page"
     <aside class="sidebar-column">
         <div class="sidebar-stories">
             <article class="secondary-story">
-                <h3 class="secondary-story-title"><a href="/posts/post4/">Global Summit Concludes with Bold Climate Commitments</a></h3>
+                <h3 class="secondary-story-title"><a href="{{ base_url }}/posts/post4/">Global Summit Concludes with Bold Climate Commitments</a></h3>
                 <p class="secondary-story-excerpt">World leaders agreed to accelerate the phase-out of fossil fuels, committing billions in new funding for developing nations transitioning to green energy.</p>
                 <div class="meta">
                     <span class="byline">By <strong>David Chen</strong></span> &middot; <span class="pubdate">Oct 24, 2023</span>

--- a/examples/herald/templates/section.html
+++ b/examples/herald/templates/section.html
@@ -38,11 +38,11 @@
     {% if paginator %}
     <nav class="pagination">
         {% if paginator.previous %}
-        <a href="{{ paginator.previous }}" class="prev">Previous</a>
+        <a href="{{ base_url }}{{ paginator.previous }}" class="prev">Previous</a>
         {% endif %}
         <span class="page-number">Page {{ paginator.current_index }} of {{ paginator.total_pages }}</span>
         {% if paginator.next %}
-        <a href="{{ paginator.next }}" class="next">Next</a>
+        <a href="{{ base_url }}{{ paginator.next }}" class="next">Next</a>
         {% endif %}
     </nav>
     {% endif %}

--- a/examples/herald/templates/taxonomy_term.html
+++ b/examples/herald/templates/taxonomy_term.html
@@ -36,11 +36,11 @@
     {% if paginator %}
     <nav class="pagination">
         {% if paginator.previous %}
-        <a href="{{ paginator.previous }}" class="prev">Previous</a>
+        <a href="{{ base_url }}{{ paginator.previous }}" class="prev">Previous</a>
         {% endif %}
         <span class="page-number">Page {{ paginator.current_index }} of {{ paginator.total_pages }}</span>
         {% if paginator.next %}
-        <a href="{{ paginator.next }}" class="next">Next</a>
+        <a href="{{ base_url }}{{ paginator.next }}" class="next">Next</a>
         {% endif %}
     </nav>
     {% endif %}


### PR DESCRIPTION
Fix 404 risks and expand sparse content (batch 07)

- hangar: no changes needed
- hanji-paper: no changes needed
- hardcore-pit: prefix bare /bands/ links with {{ base_url }} in index.md
- headliner-bold: no changes needed
- hearth: no changes needed
- heavy-curtain: prefix bare /acts/ links with {{ base_url }} in index.md
- heliograph: no changes needed
- helix-docs: add 1 post so reference has 3
- herald: prefix bare paginator links and /posts/, /categories/ links with {{ base_url }}
- hermit: no changes needed

---
*PR created automatically by Jules for task [9843024009915692884](https://jules.google.com/task/9843024009915692884) started by @hahwul*