### PR TITLE
Fix 404 risks and expand sparse content (batch 04)

### DIFF
--- a/examples/geodesic/templates/header.html
+++ b/examples/geodesic/templates/header.html
@@ -36,7 +36,7 @@
         <nav>
             <ul>
                 <li><a href="{{ base_url }}">System</a></li>
-                <li><a href="{{ base_url }}/about">Biosphere</a></li>
+                <li><a href="{{ base_url }}/about/">Biosphere</a></li>
             </ul>
         </nav>
     </header>

--- a/examples/gilded/templates/header.html
+++ b/examples/gilded/templates/header.html
@@ -21,7 +21,7 @@
       <nav class="site-nav">
         <a href="{{ base_url }}/">Home</a>
         <a href="{{ base_url }}/posts/">Archive</a>
-        <a href="{{ base_url }}/tags/">Tags</a>
+
         <a href="{{ base_url }}/about/">About</a>
       </nav>
     </div>

--- a/examples/gilt-edge/templates/section.html
+++ b/examples/gilt-edge/templates/section.html
@@ -11,7 +11,7 @@
     <ol class="plate-table">
       {% for pl in section.pages %}
       <li class="plate-row">
-        <a href="{{ pl.url }}" class="plate-link">
+        <a href="{{ base_url }}{{ pl.url }}" class="plate-link">
           <span class="plate-no">{% if pl.extra.plate_no %}{{ pl.extra.plate_no | e }}{% else %}{{ loop.index }}{% endif %}</span>
           <span class="plate-title-wrap">
             <span class="plate-title-bl">{{ pl.title | e }}</span>

--- a/examples/glacier/templates/header.html
+++ b/examples/glacier/templates/header.html
@@ -21,7 +21,7 @@
       <a href="{{ base_url }}/" class="site-logo">Glacier</a>
       <nav class="site-nav">
         <a href="{{ base_url }}/posts/">Posts</a>
-        <a href="{{ base_url }}/tags/">Tags</a>
+
         <a href="{{ base_url }}/about/">About</a>
       </nav>
       <button class="mobile-menu-toggle" aria-label="Toggle menu" onclick="document.body.classList.toggle('menu-open')">
@@ -33,6 +33,6 @@
 
   <nav class="mobile-nav">
     <a href="{{ base_url }}/posts/">Posts</a>
-    <a href="{{ base_url }}/tags/">Tags</a>
+
     <a href="{{ base_url }}/about/">About</a>
   </nav>

--- a/examples/glam-rock/templates/footer.html
+++ b/examples/glam-rock/templates/footer.html
@@ -1,6 +1,6 @@
     <footer class="site-footer">
       <div class="footer-content">
-        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a></p>
         <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
       </div>
     </footer>

--- a/examples/glam-rock/templates/header.html
+++ b/examples/glam-rock/templates/header.html
@@ -20,7 +20,7 @@
       <nav class="site-nav">
         <a href="{{ base_url }}/">Home</a>
         <a href="{{ base_url }}/posts/">Posts</a>
-        <a href="{{ base_url }}/tags/">Tags</a>
+
         <a href="{{ base_url }}/about/">About</a>
       </nav>
       <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>

--- a/examples/glass-tower/content/reference/api.md
+++ b/examples/glass-tower/content/reference/api.md
@@ -1,0 +1,77 @@
++++
+title = "API Reference"
++++
+
+Reference for the Glass Tower API endpoints and integration patterns.
+
+## Overview
+
+The Glass Tower API allows you to programmatically access your content and metadata. It is built around standard REST principles and returns JSON responses. The endpoints are designed to be fast, reliable, and easy to use.
+
+## Authentication
+
+All API requests require an API key to be passed in the `Authorization` header.
+
+```bash
+curl -H "Authorization: Bearer YOUR_API_KEY" https://api.example.com/v1/content
+```
+
+## Endpoints
+
+### Get Content
+
+Retrieve a list of content items from your Glass Tower project.
+
+```http
+GET /v1/content
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `limit` | integer | Number of items to return (default: 10, max: 100) |
+| `offset` | integer | Number of items to skip |
+| `type` | string | Filter by content type (e.g., "article", "page") |
+
+**Response:**
+
+```json
+{
+  "data": [
+    {
+      "id": "123",
+      "title": "Getting Started",
+      "slug": "getting-started",
+      "type": "article",
+      "created_at": "2025-02-15T10:00:00Z"
+    }
+  ],
+  "meta": {
+    "total": 42,
+    "limit": 10,
+    "offset": 0
+  }
+}
+```
+
+### Get Single Content Item
+
+Retrieve detailed information about a specific content item.
+
+```http
+GET /v1/content/:id
+```
+
+## Error Handling
+
+When an error occurs, the API returns standard HTTP status codes along with a JSON response containing an error message.
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Invalid API key provided"
+  }
+}
+```

--- a/examples/glass-tower/templates/header.html
+++ b/examples/glass-tower/templates/header.html
@@ -29,7 +29,7 @@
         {% for s in site.sections | sort_by("weight") %}
         <li style="margin-top: 1.5rem; font-weight: 800; font-size: 0.7rem; color: var(--text); text-transform: uppercase; letter-spacing: 0.1em;">{{ s.title }}</li>
         {% for p in s.pages | sort_by("weight") %}
-        <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+        <li><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></li>
         {% endfor %}
         {% endfor %}
       </ul>

--- a/examples/glassmorphism/templates/footer.html
+++ b/examples/glassmorphism/templates/footer.html
@@ -2,8 +2,8 @@
       <p>&copy; 2026 {{ site.title }}. All rights reserved.</p>
       <p>
         Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a>
-        &middot;
-        <a href="{{ base_url }}/rss.xml">RSS</a>
+
+
       </p>
     </footer>
   </div>


### PR DESCRIPTION
Fix 404 risks and expand sparse content (batch 04)

- geodesic: prefix `/about/` with `{{ base_url }}` and add trailing slash
- gilded: remove dead link to `/tags/` in header
- gilded-mirage: no changes needed
- gilt-edge: prefix bare `{{ pl.url }}` with `{{ base_url }}` in `section.html`
- glacier: remove dead link to `/tags/` in header
- glam-rock: remove dead link to `/tags/` in header and `/rss.xml` in footer
- glass-lotus: no changes needed
- glass-tower: prefix bare `{{ p.url }}` with `{{ base_url }}` in `header.html`; add `api.md` to `content/reference`
- glassmorphism: remove dead link to `/rss.xml` in footer
- glitch: no changes needed

---
*PR created automatically by Jules for task [17732377603401419899](https://jules.google.com/task/17732377603401419899) started by @hahwul*