### PR TITLE
Fix 404 link for /atelier in luxury-horology example

### DIFF
--- a/examples/luxury-horology/content/atelier/_index.md
+++ b/examples/luxury-horology/content/atelier/_index.md
@@ -1,0 +1,3 @@
++++
+title = "Atelier"
++++


### PR DESCRIPTION
Fixes a 404 error in the luxury-horology example where the "/atelier" link did not have a corresponding content page. The fix creates a basic `_index.md` file for the atelier section.

---
*PR created automatically by Jules for task [913228966603652102](https://jules.google.com/task/913228966603652102) started by @chei-l*