### PR TITLE
Fix broken links in zenith-monolith example

### DIFF
--- a/examples/zenith-monolith/templates/index.html
+++ b/examples/zenith-monolith/templates/index.html
@@ -11,7 +11,7 @@
 <ul class="post-list">
     {% for page in pages %}
     <li class="post-item">
-        <h3 class="post-title"><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></h3>
+        <h3 class="post-title"><a href="{{ base_url }}{{ page.url }}">{{ page.title }}</a></h3>
         <div class="post-meta">
             {% if page.date %}{{ page.date | date(format="%Y-%m-%d") }}{% endif %}
         </div>

--- a/examples/zenith-monolith/templates/section.html
+++ b/examples/zenith-monolith/templates/section.html
@@ -15,7 +15,7 @@
 <ul class="post-list">
     {% for page in section.pages %}
     <li class="post-item">
-        <h3 class="post-title"><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></h3>
+        <h3 class="post-title"><a href="{{ base_url }}{{ page.url }}">{{ page.title }}</a></h3>
         <div class="post-meta">
             {% if page.date %}{{ page.date | date(format="%Y-%m-%d") }}{% endif %}
         </div>

--- a/examples/zenith-monolith/templates/taxonomy.html
+++ b/examples/zenith-monolith/templates/taxonomy.html
@@ -2,12 +2,12 @@
 
 {% block content %}
 <article>
-    <h1>{{ taxonomy.name | default(value="Tags") | title }}</h1>
+    <h1>{{ taxonomy_name | default(value="Tags") | title }}</h1>
 
     <ul style="list-style: none; padding: 0;">
-    {% for term in terms %}
+    {% for term in taxonomy_terms %}
         <li style="margin-bottom: 1rem; border-bottom: 1px solid var(--border-color); padding-bottom: 1rem;">
-            <a href="{{ base_url }}{{ term.permalink }}" style="font-size: 1.5rem; font-family: 'IBM Plex Mono', monospace;">{{ term.name }}</a>
+            <a href="{{ base_url }}{{ term.url }}" style="font-size: 1.5rem; font-family: 'IBM Plex Mono', monospace;">{{ term.name }}</a>
             <span class="post-meta" style="margin-left: 1rem;">({{ term.pages | length }} pages)</span>
         </li>
     {% endfor %}

--- a/examples/zenith-monolith/templates/taxonomy_term.html
+++ b/examples/zenith-monolith/templates/taxonomy_term.html
@@ -8,7 +8,7 @@
     <ul class="post-list">
         {% for page in term.pages %}
         <li class="post-item">
-            <h3 class="post-title"><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></h3>
+            <h3 class="post-title"><a href="{{ base_url }}{{ page.url }}">{{ page.title }}</a></h3>
             <div class="post-meta">
                 {% if page.date %}{{ page.date | date(format="%Y-%m-%d") }}{% endif %}
             </div>


### PR DESCRIPTION
Replaced deprecated `page.permalink` and `term.permalink` variables with `page.url` and `term.url` respectively in `zenith-monolith` templates to resolve 404 broken links. Also updated `taxonomy.html` to use the correct `taxonomy_name` and `taxonomy_terms` variables to avoid template rendering errors.

---
*PR created automatically by Jules for task [886616347267055991](https://jules.google.com/task/886616347267055991) started by @hahwul*