### PR TITLE
Fix 404 risks and expand sparse content (batch 05)

### DIFF
--- a/examples/pricetable/templates/taxonomy.html
+++ b/examples/pricetable/templates/taxonomy.html
@@ -8,7 +8,7 @@
     <ul class="term-list">
         {% for term in taxonomy_terms %}
         <li>
-            <a href="{{ term.permalink }}">{{ term.name }}</a>
+            <a href="{{ base_url }}{{ term.permalink }}">{{ term.name }}</a>
             <span class="count">({{ term.pages | length }})</span>
         </li>
         {% endfor %}

--- a/examples/primer/content/docs/patterns/concurrency.md
+++ b/examples/primer/content/docs/patterns/concurrency.md
@@ -1,0 +1,18 @@
++++
+title = "Concurrency Patterns"
+weight = 30
++++
+
+Concurrency is essential for writing high-performance, non-blocking applications. In this guide, we will explore core concurrency patterns to help structure robust multi-threaded systems safely and effectively.
+
+## Thread Pools
+
+Instead of instantiating a new thread for every incoming task, utilizing a thread pool allows you to recycle a fixed number of threads. This avoids the overhead of context switching and thread creation while maintaining predictable resource usage. When the pool is at capacity, tasks are queued until a thread becomes available.
+
+## Actor Model
+
+The Actor Model encapsulates state within isolated components called "actors". Actors do not share memory. Instead, they communicate exclusively by passing messages to each other asynchronously. This paradigm prevents race conditions and makes reasoning about distributed state much easier.
+
+## Promises and Futures
+
+For operations that might block, such as network requests or filesystem access, Promises and Futures offer a way to represent a value that will be available later. By chaining these objects, you can handle sequences of asynchronous tasks without deep nesting, keeping the execution flow clean and manageable.

--- a/examples/prism-docs/content/reference/templates.md
+++ b/examples/prism-docs/content/reference/templates.md
@@ -1,0 +1,37 @@
++++
+title = "Templates Reference"
++++
+
+Reference for creating and utilizing Liquid-style HTML templates in Hwaro.
+
+## Core Templates
+
+Every Hwaro project relies on a standard set of templates located in the `templates/` directory.
+
+### `base.html`
+The foundational layout for the site. Typically contains the main `<html>`, `<head>`, and `<body>` structure, including standard headers and footers. Other templates will extend this layout.
+
+### `index.html`
+The template responsible for rendering the homepage. This usually pulls in a list of recent posts or featured content.
+
+### `page.html`
+Used for rendering single content pages, such as an "About" page or a standard article. It has access to the `page` variable containing the title, content, and front matter.
+
+## Variables and Filters
+
+Hwaro templates expose several variables to display your content effectively:
+
+* `{{ site.title }}`: The global title defined in `config.toml`.
+* `{{ base_url }}`: The base URL of the site, which must be prepended to internal links.
+* `{{ page.title }}`: The title of the current page.
+* `{{ content | safe }}`: The rendered markdown content. Always pipe content through `safe` to prevent HTML escaping.
+
+## Inclusion
+
+To keep your templates modular, use the `include` tag for repeating elements like navigation bars and footers:
+
+```html
+{% include "header.html" %}
+<!-- Main page content -->
+{% include "footer.html" %}
+```

--- a/examples/prismatic-void/templates/section.html
+++ b/examples/prismatic-void/templates/section.html
@@ -10,7 +10,7 @@
 
     <div class="gallery-preview" style="margin-top: 2rem;">
         {% for page in section.pages %}
-        <a href="{{ page.url }}" style="text-decoration: none;">
+        <a href="{{ base_url }}{{ page.url }}" style="text-decoration: none;">
             <div class="glass-panel card">
                 <div class="card-inner">
                     <h3>{{ page.title }}</h3>

--- a/examples/prismatic-void/templates/taxonomy_term.html
+++ b/examples/prismatic-void/templates/taxonomy_term.html
@@ -7,7 +7,7 @@
     <div class="gallery-preview">
         {% if taxonomy_pages is defined %}
             {% for page in taxonomy_pages %}
-            <a href="{{ page.url }}" style="text-decoration: none;">
+            <a href="{{ base_url }}{{ page.url }}" style="text-decoration: none;">
                 <div class="glass-panel card">
                     <div class="card-inner">
                         <h3>{{ page.title }}</h3>


### PR DESCRIPTION
This pull request addresses 404 risks by appending `{{ base_url }}` to bare URL properties (`page.url`, `term.permalink`) in Liquid-style HTML templates for the specified batch of examples. It also expands sparse content in the `primer` and `prism-docs` documentation directories to ensure there are at least three entries in their respective sections. Plausible textual content has been generated without using emojis or CSS gradients, as per constraints.

---
*PR created automatically by Jules for task [15889823045364677453](https://jules.google.com/task/15889823045364677453) started by @hahwul*