### PR TITLE
Fix 404 risks and expand sparse content (batch 08)

### DIFF
--- a/examples/quire-fold/templates/page.html
+++ b/examples/quire-fold/templates/page.html
@@ -48,7 +48,7 @@
       {% for post in site.pages | sort_by(attribute="date", reverse=true) %}
       {% if post.section == "signatures" and post.url != page.url %}
       <li>
-        <a href="{{ post.url }}">{{ post.title }}</a>
+        <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
         <span>{{ post.extra.signature | default(value="-") }}</span>
       </li>
       {% endif %}

--- a/examples/quire-fold/templates/section.html
+++ b/examples/quire-fold/templates/section.html
@@ -9,7 +9,7 @@
         <span>Sig. {{ post.extra.signature | default(value="&#8212;") | safe }}</span>
         <span>Fol. {{ post.extra.folio | default(value="&#8212;") | safe }}</span>
       </div>
-      <div class="folio-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+      <div class="folio-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></div>
       {% if post.description %}<div class="folio-summary">{{ post.description }}</div>{% endif %}
       <div class="folio-meta">
         <span>{% if post.date %}{{ post.date | date(format="%d %b %Y") }}{% endif %}</span>

--- a/examples/radiant-cosmos/templates/section.html
+++ b/examples/radiant-cosmos/templates/section.html
@@ -39,7 +39,7 @@
 
     <div class="post-list">
       {% for post in section.pages %}
-        <a href="{{ post.url }}" class="post-item glass-panel">
+        <a href="{{ base_url }}{{ post.url }}" class="post-item glass-panel">
           <h2 class="post-title">{{ post.title }}</h2>
           <div class="post-meta">{{ post.date | date("%B %d, %Y") }}</div>
           {% if post.description %}
@@ -54,13 +54,13 @@
     {% if pagination is defined and pagination.total_pages is defined and pagination.total_pages > 1 %}
     <div class="pagination">
         {% if pagination.prev %}
-            <a href="{{ pagination.prev }}">&laquo; Prev</a>
+            <a href="{{ base_url }}{{ pagination.prev }}">&laquo; Prev</a>
         {% endif %}
 
         <span class="active">{{ pagination.current_page }} / {{ pagination.total_pages }}</span>
 
         {% if pagination.next %}
-            <a href="{{ pagination.next }}">Next &raquo;</a>
+            <a href="{{ base_url }}{{ pagination.next }}">Next &raquo;</a>
         {% endif %}
     </div>
     {% endif %}

--- a/examples/radiant-cosmos/templates/taxonomy_term.html
+++ b/examples/radiant-cosmos/templates/taxonomy_term.html
@@ -35,7 +35,7 @@
 
     <div class="post-list">
       {% for post in taxonomy_pages %}
-        <a href="{{ post.url }}" class="post-item glass-panel">
+        <a href="{{ base_url }}{{ post.url }}" class="post-item glass-panel">
           <h2 class="post-title">{{ post.title }}</h2>
           <div class="post-meta">{{ post.date | date("%B %d, %Y") }}</div>
           {% if post.description %}
@@ -50,13 +50,13 @@
     {% if pagination is defined and pagination.total_pages is defined and pagination.total_pages > 1 %}
     <div class="pagination">
         {% if pagination.prev %}
-            <a href="{{ pagination.prev }}">&laquo; Prev</a>
+            <a href="{{ base_url }}{{ pagination.prev }}">&laquo; Prev</a>
         {% endif %}
 
         <span class="active">{{ pagination.current_page }} / {{ pagination.total_pages }}</span>
 
         {% if pagination.next %}
-            <a href="{{ pagination.next }}">Next &raquo;</a>
+            <a href="{{ base_url }}{{ pagination.next }}">Next &raquo;</a>
         {% endif %}
     </div>
     {% endif %}

--- a/examples/rally-cry/templates/section.html
+++ b/examples/rally-cry/templates/section.html
@@ -4,7 +4,7 @@
 <div style="display: grid; grid-template-columns: 1fr; gap: 2rem; margin-top: 2rem;">
   {% for page in section.pages %}
   <div style="border: 4px solid var(--black); padding: 2rem; background-color: var(--white);">
-    <h2 style="font-family: 'Bebas Neue'; font-size: 32px; margin: 0;"><a href="{{ page.permalink }}" style="color: var(--black); text-decoration: none;">{{ page.title }}</a></h2>
+    <h2 style="font-family: 'Bebas Neue'; font-size: 32px; margin: 0;"><a href="{{ base_url }}{{ page.url }}" style="color: var(--black); text-decoration: none;">{{ page.title }}</a></h2>
     <p style="font-family: 'Source Code Pro'; font-size: 14px; margin-top: 1rem;">{{ page.description }}</p>
   </div>
   {% endfor %}


### PR DESCRIPTION
Fixes 404 risks by adding `{{ base_url }}` prefixes to bare URLs in `quire-fold`, `radiant-cosmos`, and `rally-cry` template files. Verified sparse content rules (none of these 10 examples required new content as they already met the 3 post minimum or lacked a posts directory). Cleaned up testing scripts.

---
*PR created automatically by Jules for task [7518316894406084042](https://jules.google.com/task/7518316894406084042) started by @hahwul*