### PR TITLE
Fix 404 risks and expand sparse content (batch 00)

### DIFF
--- a/examples/overdrive/templates/header.html
+++ b/examples/overdrive/templates/header.html
@@ -87,8 +87,8 @@
         <div class="container" style="display:flex; justify-content:space-between; align-items:center; width:100%;">
             <div class="logo">OVER//DRIVE</div>
             <nav>
-                <a href="/">Boost</a>
-                <a href="/about">Thrust</a>
+                <a href="{{ base_url }}/">Boost</a>
+                <a href="{{ base_url }}/about/">Thrust</a>
             </nav>
         </div>
     </header>

--- a/examples/overture/templates/section.html
+++ b/examples/overture/templates/section.html
@@ -8,7 +8,7 @@
       <div class="listing-item">
         <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
         <div>
-          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          <div class="listing-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></div>
           {% if post.description %}
           <div class="listing-desc">{{ post.description }}</div>
           {% endif %}

--- a/examples/oxide/templates/section.html
+++ b/examples/oxide/templates/section.html
@@ -8,7 +8,7 @@
     <ul class="section-list">
       {% for page in section.pages %}
         <li>
-          <a href="{{ page.url }}">
+          <a href="{{ base_url }}{{ page.url }}">
             {{ page.title }}
             {% if page.date is present %}
               <span style="display:block; font-size:0.75rem; font-weight:400; margin-top:0.5rem; color:var(--text-dim);">

--- a/examples/oxide/templates/taxonomy.html
+++ b/examples/oxide/templates/taxonomy.html
@@ -6,7 +6,7 @@
     <ul class="section-list">
       {% for term in taxonomy_terms %}
         <li>
-          <a href="{{ term.url }}">
+          <a href="{{ base_url }}{{ term.url }}">
             {{ term.name }}
             <span style="display:block; font-size:0.75rem; font-weight:400; margin-top:0.5rem; color:var(--text-dim);">
               {{ term.pages | length }} items

--- a/examples/oxide/templates/taxonomy_term.html
+++ b/examples/oxide/templates/taxonomy_term.html
@@ -6,7 +6,7 @@
     <ul class="section-list">
       {% for page in taxonomy_pages %}
         <li>
-          <a href="{{ page.url }}">
+          <a href="{{ base_url }}{{ page.url }}">
             {{ page.title }}
             {% if page.date is present %}
               <span style="display:block; font-size:0.75rem; font-weight:400; margin-top:0.5rem; color:var(--text-dim);">

--- a/examples/palette/content/colors/neutrals.md
+++ b/examples/palette/content/colors/neutrals.md
@@ -1,0 +1,10 @@
++++
+title = "Neutral Colors"
+date = 2025-05-17
++++
+
+Neutral colors—the expansive spectrum spanning stark white to the deepest charcoal—are the unsung heroes of our design system. They are the negative space, the canvas, and the structural delineators that allow the more vibrant primary and secondary palettes to shine effectively. Without a rigorous and well-defined neutral scale, our interfaces would lack balance, contrast, and basic readability.
+
+Our neutral palette is extensively utilized for typography, borders, subtle shadows, disabled states, and the vast majority of background surfaces. We have carefully selected specific shades of gray to avoid the starkness of pure black, utilizing softer charcoals and slate tones that reduce eye strain during prolonged use. This subtle warming or cooling of grays provides a more organic feel to the digital environment.
+
+Consistent application of neutral tones is vital for establishing a clear visual hierarchy. Lighter grays are perfect for defining subtle card boundaries or alternative table row backgrounds, while darker shades ensure body text remains legible across various devices. The deliberate pacing between each step of our neutral scale guarantees that designers have enough options to create depth and structure without muddying the overall composition. Always respect the contrast ratios defined within the system when applying neutral text to neutral backgrounds.

--- a/examples/palette/content/colors/primary.md
+++ b/examples/palette/content/colors/primary.md
@@ -1,0 +1,10 @@
++++
+title = "Primary Colors"
+date = 2025-05-15
++++
+
+The primary color palette forms the fundamental visual anchor of our entire design system identity. When interacting with any of our digital products, users should immediately recognize these core hues, as they dictate the emotional resonance and overarching structural presence of our brand.
+
+By applying these primary colors systematically, we ensure consistency across varied contexts—from marketing materials to the most complex internal dashboards. They are carefully calibrated to maintain high contrast, ensuring accessibility and legibility under all standard lighting conditions. The primary accent, specifically, is reserved exclusively for the most critical user actions. Think of standard "Call to Action" buttons, primary navigation highlights, and crucial alert thresholds where immediate visual distinction is necessary.
+
+We encourage designers and developers alike to resist the urge to deviate from these predefined foundational colors. While the temptation to introduce subtle shades often arises during exploratory design phases, strictly adhering to this core set simplifies the cognitive load for our users and fortifies our brand's visual muscle. Remember, restraint is the hallmark of a mature design system. When in doubt regarding color application, always fall back to these primary values to maintain structural integrity and brand cohesion.

--- a/examples/palette/content/colors/secondary.md
+++ b/examples/palette/content/colors/secondary.md
@@ -1,0 +1,10 @@
++++
+title = "Secondary Colors"
+date = 2025-05-16
++++
+
+While our primary palette provides the dominant structural foundation, our secondary colors are the supporting cast that adds depth, nuance, and contextual richness to the user interface. Secondary colors should never overpower the primary identity; instead, they exist to guide the eye, provide subtle state changes, and demarcate less critical informational hierarchies.
+
+You will typically find secondary colors deployed in areas like subtle background fills, secondary button states, tag highlights, and complex data visualizations where distinct categorization is required without demanding the user's full attention. They are intentionally designed to harmonize with the primary set, providing a visually pleasing transition between disparate elements on the screen.
+
+When utilizing secondary colors, careful consideration must be given to their proximity to primary actions. A common pitfall is the overuse of secondary accents, which can clutter the visual field and confuse the user regarding what action they should take next. Therefore, secondary colors should be applied sparingly, almost as a whisper compared to the shout of a primary action color. Use them to create visual rhythm and a sophisticated layering of information that enhances the overall user experience without causing visual fatigue.

--- a/examples/palette/content/components/buttons.md
+++ b/examples/palette/content/components/buttons.md
@@ -1,0 +1,10 @@
++++
+title = "Buttons"
+date = 2025-06-01
++++
+
+Buttons are the quintessential interactive components within our design system, serving as the primary conduit for user action and task completion. Their design, placement, and state management directly dictate the flow and overall usability of our applications. Because they are the gateway to action, they require meticulous attention to detail regarding their visual presence and interactive feedback.
+
+Our button system is categorized into primary, secondary, tertiary, and destructive variants. Primary buttons command the highest visual weight and should be used sparingly—ideally, only once per view—to guide the user toward the intended "happy path." Secondary buttons offer alternative actions of lesser importance, often sitting alongside primary actions to provide necessary, but not critical, options. Tertiary variants, usually styled as text links or minimal outlines, are reserved for the lowest priority actions.
+
+State management is crucial for a responsive user experience. Every button must possess clearly defined default, hover, active (pressed), disabled, and focus states. The focus state, in particular, is an absolute necessity for keyboard accessibility, ensuring that all users can confidently navigate our interfaces. Consistent padding, clear typography, and predictable state changes build trust with the user, reassuring them that the system is stable, responsive, and predictable.

--- a/examples/palette/content/components/cards.md
+++ b/examples/palette/content/components/cards.md
@@ -1,0 +1,10 @@
++++
+title = "Cards"
+date = 2025-06-02
++++
+
+Cards operate as highly versatile, self-contained units of information, designed to aggregate disparate content types into a unified, digestible block. They are essential for presenting collections of related data, such as user profiles, product summaries, or recent activity feeds, allowing users to scan complex information quickly and efficiently.
+
+The structural integrity of a card relies heavily on consistent internal padding and a clear separation from the background surface, typically achieved through subtle border definitions or soft drop shadows. A standard card architecture includes a header, a distinct body area for primary content, and an optional footer for secondary actions or metadata. This predictable layout pattern helps users quickly understand the relationship between the enclosed elements.
+
+Flexibility is a defining characteristic of our card component. While they must adhere to standard grid systems and responsive behaviors, their internal layout can adapt to house imagery, typography, lists, and interactive elements like buttons or toggles. However, this flexibility must be managed carefully. Overloading a card with too many disparate actions or excessive text defeats its purpose as a quick summary element. When a card becomes too complex, it is often a signal that the content should be broken down into simpler units or elevated to a dedicated page view.

--- a/examples/palette/content/components/modals.md
+++ b/examples/palette/content/components/modals.md
@@ -1,0 +1,10 @@
++++
+title = "Modals"
+date = 2025-06-03
++++
+
+Modals, or dialog boxes, are high-friction components designed to interrupt the standard user flow to demand immediate attention or facilitate a critical, contextual task. Because they explicitly block interaction with the underlying page, they must be deployed with extreme caution and only when absolutely necessary for the user's success or system stability.
+
+When a modal is invoked, the background is typically obscured with a semi-transparent overlay to focus the user's attention entirely on the dialog. The architecture of a modal usually consists of a clear, descriptive title, a concise body explaining the necessary action or information, and explicit action buttons—typically confirming or canceling the interruption. A clear and easily accessible close mechanism, such as an "X" icon in the upper corner or a definitive "Cancel" button, is mandatory to prevent user frustration.
+
+Modals are best utilized for tasks like critical confirmations (e.g., "Are you sure you want to delete this?"), complex data entry that requires focus, or displaying important alerts that cannot be ignored. They should never be used for casual notifications or complex, multi-step processes that would be better served by a dedicated page route. Respect the user's context; unnecessary interruptions via poorly timed or overly complex modals are one of the fastest ways to degrade the overall user experience.

--- a/examples/palette/content/typography/body-text.md
+++ b/examples/palette/content/typography/body-text.md
@@ -1,0 +1,10 @@
++++
+title = "Body Text"
+date = 2025-07-02
++++
+
+Body text is the workhorse of our typographic system, carrying the vast majority of our written content and requiring the highest degree of legibility. While headings capture attention and provide structure, the body text is where deep engagement occurs. If the body text is difficult to read, the user experience rapidly degrades, regardless of how elegant the surrounding design might be.
+
+Our approach to body typography prioritizes reading comfort above all else. We utilize a clean, highly legible sans-serif typeface specifically chosen for its excellent rendering across various screen resolutions and operating systems. Crucial to this legibility is the careful calibration of line height (leading) and paragraph spacing. A line height that is too tight causes the eye to lose its place during vertical tracking, while excessive line height disconnects related sentences. Our standard body copy employs a balanced ratio that guides the reader effortlessly from one line to the next.
+
+Furthermore, we impose strict limitations on line length (measure). Lines that extend too far across the screen cause reader fatigue as the eye struggles to return to the beginning of the next line. We aim for an optimal line length of roughly 60 to 80 characters, ensuring a comfortable reading rhythm. We also define clear styles for standard body text, secondary descriptors, and subtle captions, allowing designers to establish a nuanced hierarchy within the text blocks themselves without compromising readability.

--- a/examples/palette/content/typography/headings.md
+++ b/examples/palette/content/typography/headings.md
@@ -1,0 +1,10 @@
++++
+title = "Headings"
+date = 2025-07-01
++++
+
+Headings are the structural backbone of our content architecture, serving as essential wayfinding markers that guide the user's eye and establish a clear, scannable hierarchy. Effective use of typography in headings is not merely an aesthetic choice; it is a fundamental requirement for usability and accessibility. They organize complex information into digestible sections, allowing readers to quickly comprehend the outline and flow of a page before committing to deep reading.
+
+Our design system utilizes a strict semantic scale, ranging from H1 to H6. The H1 is reserved exclusively for the primary title of the page, acting as the loudest typographical voice and setting the immediate context. Subsequent heading levels (H2 through H6) must be used sequentially to define nested sections, ensuring that the structural logic remains intact for both visual readers and assistive technologies like screen readers. Skipping heading levels (e.g., jumping from an H2 directly to an H4) fragments the logical outline and introduces unnecessary confusion.
+
+Visually, our headings are distinguished by specific weight, size, and line-height combinations designed to create immediate contrast with the surrounding body text. We rely on heavier weights and tighter tracking for larger headings to maintain a solid, impactful presence, while smaller headings adapt to softer weights to ensure legibility. Consistent application of these typographical rules across the entire ecosystem ensures that our brand voice remains clear, structured, and authoritative.

--- a/examples/palette/content/typography/monospace.md
+++ b/examples/palette/content/typography/monospace.md
@@ -1,0 +1,10 @@
++++
+title = "Monospace Typography"
+date = 2025-07-03
++++
+
+Within our broader typographic ecosystem, monospace fonts serve a highly specialized, utilitarian purpose. Unlike proportional fonts where character widths vary (an 'i' takes up less horizontal space than an 'm'), monospace fonts assign exactly the same width to every single character. This rigid structure is inherently technical, evoking the aesthetics of code editors, terminal interfaces, and raw data environments.
+
+We deploy monospace typography exclusively in contexts where structural alignment and distinct character recognition are paramount. Its most common application is for displaying code snippets, inline variables, and technical documentation, where the precise alignment of brackets, operators, and indentation is critical for comprehension. When a user sees a monospace string, it acts as an immediate visual cue indicating technical or systemic information, separating it from the narrative flow of standard body text.
+
+Beyond code, monospace fonts are occasionally utilized for the display of sensitive numerical data, such as serial numbers, specific identification hashes, or tabular data where strict vertical alignment of digits aids in quick comparison. We deliberately select monospace typefaces that feature distinct characteristics for easily confused glyphs (such as distinguishing between a capital 'O' and a zero '0', or a lowercase 'l' and a number '1'). While it should never be used for extended paragraphs or general reading, the judicious use of monospace typography adds an essential layer of precision and clarity to our technical interfaces.

--- a/examples/panopticon/templates/home.html
+++ b/examples/panopticon/templates/home.html
@@ -24,7 +24,7 @@
 
     {% for post in posts | slice(count=8) %}
       <div class="radial-item" style="transform: rotate({{ loop.index0 * step }}deg) translate(350px) rotate(-{{ loop.index0 * step }}deg);">
-        <a href="{{ post.permalink }}">{{ post.title }}</a>
+        <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
       </div>
     {% endfor %}
   </div>

--- a/examples/panopticon/templates/section.html
+++ b/examples/panopticon/templates/section.html
@@ -8,7 +8,7 @@
       {% for page in section.pages %}
         <article class="post-card">
           <div class="date">{{ page.date | date("%Y.%m.%d") }}</div>
-          <h3><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+          <h3><a href="{{ base_url }}{{ page.url }}">{{ page.title }}</a></h3>
           <p>{{ page.summary | strip_html | truncate_words(value=20) }}</p>
         </article>
       {% endfor %}


### PR DESCRIPTION
Fixed 404 risks by correctly using `{{ base_url }}` for absolute URLs and bare variables like `page.url` across target example sites (`overdrive`, `overture`, `oxide`, `panopticon`). Also filled sparse content sections in `palette` with at least 3 entries per folder of ~150-300 word design system content without using emojis or modifying other constraints.

---
*PR created automatically by Jules for task [15998425136513618924](https://jules.google.com/task/15998425136513618924) started by @hahwul*