### PR TITLE
Fix 404 risks and expand sparse content (batch 21)

### DIFF
--- a/examples/tapestry/templates/404.html
+++ b/examples/tapestry/templates/404.html
@@ -5,7 +5,6 @@
       <a href="{{ base_url }}/" class="text-2xl font-bold tracking-tight text-ink hover:text-ink-light transition-colors">{{ site.title }}</a>
       <div class="flex items-center gap-6 font-sans text-sm">
         <a href="{{ base_url }}/events/" class="text-ink-muted hover:text-ink transition-colors">Timeline</a>
-        <a href="{{ base_url }}/tags/" class="text-ink-muted hover:text-ink transition-colors">Tags</a>
         <a href="{{ base_url }}/about/" class="text-ink-muted hover:text-ink transition-colors">About</a>
       </div>
     </div>

--- a/examples/tapestry/templates/home.html
+++ b/examples/tapestry/templates/home.html
@@ -5,7 +5,6 @@
       <a href="{{ base_url }}/" class="text-2xl font-bold tracking-tight text-ink hover:text-ink-light transition-colors">{{ site.title }}</a>
       <div class="flex items-center gap-6 font-sans text-sm">
         <a href="{{ base_url }}/events/" class="text-ink-muted hover:text-ink transition-colors">Timeline</a>
-        <a href="{{ base_url }}/tags/" class="text-ink-muted hover:text-ink transition-colors">Tags</a>
         <a href="{{ base_url }}/about/" class="text-ink-muted hover:text-ink transition-colors">About</a>
       </div>
     </div>

--- a/examples/tapestry/templates/page.html
+++ b/examples/tapestry/templates/page.html
@@ -5,7 +5,6 @@
       <a href="{{ base_url }}/" class="text-2xl font-bold tracking-tight text-ink hover:text-ink-light transition-colors">{{ site.title }}</a>
       <div class="flex items-center gap-6 font-sans text-sm">
         <a href="{{ base_url }}/events/" class="text-ink-muted hover:text-ink transition-colors">Timeline</a>
-        <a href="{{ base_url }}/tags/" class="text-ink-muted hover:text-ink transition-colors">Tags</a>
         <a href="{{ base_url }}/about/" class="text-ink-muted hover:text-ink transition-colors">About</a>
       </div>
     </div>

--- a/examples/tapestry/templates/post.html
+++ b/examples/tapestry/templates/post.html
@@ -5,7 +5,6 @@
       <a href="{{ base_url }}/" class="text-2xl font-bold tracking-tight text-ink hover:text-ink-light transition-colors">{{ site.title }}</a>
       <div class="flex items-center gap-6 font-sans text-sm">
         <a href="{{ base_url }}/events/" class="text-ink-muted hover:text-ink transition-colors">Timeline</a>
-        <a href="{{ base_url }}/tags/" class="text-ink-muted hover:text-ink transition-colors">Tags</a>
         <a href="{{ base_url }}/about/" class="text-ink-muted hover:text-ink transition-colors">About</a>
       </div>
     </div>

--- a/examples/tapestry/templates/section.html
+++ b/examples/tapestry/templates/section.html
@@ -5,7 +5,6 @@
       <a href="{{ base_url }}/" class="text-2xl font-bold tracking-tight text-ink hover:text-ink-light transition-colors">{{ site.title }}</a>
       <div class="flex items-center gap-6 font-sans text-sm">
         <a href="{{ base_url }}/events/" class="text-ink-muted hover:text-ink font-medium transition-colors">Timeline</a>
-        <a href="{{ base_url }}/tags/" class="text-ink-muted hover:text-ink transition-colors">Tags</a>
         <a href="{{ base_url }}/about/" class="text-ink-muted hover:text-ink transition-colors">About</a>
       </div>
     </div>

--- a/examples/tapestry/templates/taxonomy.html
+++ b/examples/tapestry/templates/taxonomy.html
@@ -5,7 +5,6 @@
       <a href="{{ base_url }}/" class="text-2xl font-bold tracking-tight text-ink hover:text-ink-light transition-colors">{{ site.title }}</a>
       <div class="flex items-center gap-6 font-sans text-sm">
         <a href="{{ base_url }}/events/" class="text-ink-muted hover:text-ink transition-colors">Timeline</a>
-        <a href="{{ base_url }}/tags/" class="text-ink-muted hover:text-ink transition-colors">Tags</a>
         <a href="{{ base_url }}/about/" class="text-ink-muted hover:text-ink transition-colors">About</a>
       </div>
     </div>

--- a/examples/tapestry/templates/taxonomy_term.html
+++ b/examples/tapestry/templates/taxonomy_term.html
@@ -5,7 +5,6 @@
       <a href="{{ base_url }}/" class="text-2xl font-bold tracking-tight text-ink hover:text-ink-light transition-colors">{{ site.title }}</a>
       <div class="flex items-center gap-6 font-sans text-sm">
         <a href="{{ base_url }}/events/" class="text-ink-muted hover:text-ink transition-colors">Timeline</a>
-        <a href="{{ base_url }}/tags/" class="text-ink-muted hover:text-ink transition-colors">Tags</a>
         <a href="{{ base_url }}/about/" class="text-ink-muted hover:text-ink transition-colors">About</a>
       </div>
     </div>

--- a/examples/taskboard/templates/taxonomy.html
+++ b/examples/taskboard/templates/taxonomy.html
@@ -8,7 +8,7 @@
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
     {% for term in taxonomy_terms %}
-      <a href="{{ term.permalink }}" class="block p-6 bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-shadow hover:border-blue-300 group">
+      <a href="{{ base_url }}{{ term.permalink }}" class="block p-6 bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-shadow hover:border-blue-300 group">
         <div class="flex items-center justify-between mb-2">
           <h2 class="text-xl font-semibold text-gray-800 group-hover:text-blue-600 transition-colors">{{ term.name }}</h2>
           <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-50 text-blue-700 font-bold text-sm">{{ term.pages | length }}</span>

--- a/examples/taskboard/templates/taxonomy_term.html
+++ b/examples/taskboard/templates/taxonomy_term.html
@@ -15,7 +15,7 @@
     <ul class="divide-y divide-gray-200">
       {% for post in taxonomy_pages %}
       <li class="hover:bg-gray-50 transition-colors">
-        <a href="{{ post.permalink }}" class="flex items-center justify-between p-4 block">
+        <a href="{{ base_url }}{{ post.permalink }}" class="flex items-center justify-between p-4 block">
           <div class="flex flex-col">
             <span class="text-sm font-medium text-gray-900">{{ post.title }}</span>
             <span class="text-xs text-gray-500 mt-1">{{ post.date | date(format="%B %d, %Y") }}</span>

--- a/examples/telegraph-key/content/posts/_index.md
+++ b/examples/telegraph-key/content/posts/_index.md
@@ -1,0 +1,3 @@
++++
+title = "Dispatches"
++++

--- a/examples/telegraph-key/content/posts/signal-1.md
+++ b/examples/telegraph-key/content/posts/signal-1.md
@@ -1,0 +1,5 @@
++++
+title = "The First Signal"
+date = "2025-02-10"
++++
+In the early days of telecommunication, the simple act of breaking a circuit to send a signal revolutionized how humanity connected across vast distances. The telegraph key, a humble mechanical switch, became the primary instrument for transmitting thoughts, news, and vital information. This post explores the initial adoption of the telegraph system, the standardization of Morse code, and the profound impact it had on commerce, journalism, and personal relationships. It required skilled operators who could translate complex ideas into a series of short and long pulses. The rhythmic tapping of the key was more than just noise; it was the heartbeat of a rapidly shrinking world, laying the groundwork for the digital age we live in today.

--- a/examples/telegraph-key/content/posts/signal-2.md
+++ b/examples/telegraph-key/content/posts/signal-2.md
@@ -1,0 +1,5 @@
++++
+title = "Transatlantic Cables"
+date = "2025-06-15"
++++
+The ambition to connect continents led to one of the most audacious engineering projects of the 19th century: the transatlantic telegraph cable. Overcoming immense technical and financial hurdles, pioneers successfully laid thousands of miles of insulated wire across the ocean floor. This monumental achievement reduced communication time between North America and Europe from weeks to mere minutes. The immediate economic and political ramifications were staggering, fostering international trade and diplomacy. Despite initial failures and the sheer difficulty of maintaining a cable in the harsh oceanic environment, the persistence of these early innovators proved that a globally connected network was not only possible but inevitable, setting the stage for future submarine communications.

--- a/examples/telegraph-key/content/posts/signal-3.md
+++ b/examples/telegraph-key/content/posts/signal-3.md
@@ -1,0 +1,5 @@
++++
+title = "Legacy of the Operator"
+date = "2026-01-20"
++++
+Behind every transmitted message was a telegraph operator, an often-unsung hero of the communication revolution. These individuals possessed a unique skill set, combining a deep understanding of electrical circuits with the rhythmic dexterity needed to send and receive Morse code flawlessly. Their work was demanding, requiring long hours of intense concentration in noisy environments. The telegraph office became a hub of information, and the operators were its custodians. This article delves into the daily lives, the culture, and the specialized language that developed among operators. Even as new technologies eventually rendered the telegraph obsolete, the legacy of these early communicators lives on in the protocols and practices of modern networking.

--- a/examples/telegraph/templates/section.html
+++ b/examples/telegraph/templates/section.html
@@ -24,9 +24,9 @@
   </ul>
   {% if paginator %}
   <div class="pagination">
-    {% if paginator.previous %}<a href="{{ paginator.previous }}">Previous</a>{% endif %}
+    {% if paginator.previous %}<a href="{{ base_url }}{{ paginator.previous }}">Previous</a>{% endif %}
     <span class="current">Page {{ paginator.current_index }} of {{ paginator.number_pagers }}</span>
-    {% if paginator.next %}<a href="{{ paginator.next }}">Next</a>{% endif %}
+    {% if paginator.next %}<a href="{{ base_url }}{{ paginator.next }}">Next</a>{% endif %}
   </div>
   {% endif %}
 {% include "footer.html" %}

--- a/examples/tension-wire/content/posts/_index.md
+++ b/examples/tension-wire/content/posts/_index.md
@@ -1,0 +1,3 @@
++++
+title = "Updates"
++++

--- a/examples/tension-wire/content/posts/update-1.md
+++ b/examples/tension-wire/content/posts/update-1.md
@@ -1,0 +1,5 @@
++++
+title = "Balancing the Load"
+date = "2025-03-12"
++++
+Structural integrity often relies on the delicate balance of opposing forces. The concept of a tension wire perfectly encapsulates this principle. By applying a controlled pulling force, these wires counteract compression and bending stresses, allowing for lighter and more elegant architectural designs. This update examines the mathematical models used to calculate the necessary tension and the material science behind the high-strength steel cables employed in modern construction. Understanding how these elements work in harmony is crucial for creating structures that are not only aesthetically pleasing but also robust and capable of withstanding significant environmental loads, such as wind and seismic activity.

--- a/examples/tension-wire/content/posts/update-2.md
+++ b/examples/tension-wire/content/posts/update-2.md
@@ -1,0 +1,5 @@
++++
+title = "Suspension Bridges"
+date = "2025-08-05"
++++
+The suspension bridge remains one of the iconic applications of tension wire technology. Spanning immense distances, these structures rely on massive main cables and countless vertical suspender ropes to support the bridge deck. This post breaks down the anatomy of a suspension bridge, from the deep-rooted anchorages to the towering pylons. We explore the engineering challenges involved in designing a system where tension is the primary means of support. The graceful curves of the cables are a testament to the elegant solutions engineers have devised to conquer formidable geographical obstacles, proving that strength can be achieved through flexibility and carefully managed tension.

--- a/examples/tension-wire/content/posts/update-3.md
+++ b/examples/tension-wire/content/posts/update-3.md
@@ -1,0 +1,5 @@
++++
+title = "Architectural Applications"
+date = "2026-02-28"
++++
+Beyond grand bridges, tension wires have found their way into a myriad of architectural applications. From striking fabric roofs and tensile structures to the stabilizing elements of glass facades, cables offer a versatile solution for modern designers. This article highlights several contemporary projects that utilize tension elements to achieve dramatic visual effects and functional efficiency. The ability to span large areas with minimal material makes tensile architecture an attractive option for stadiums, exhibition halls, and transportation hubs. As materials continue to improve, we can expect to see even more innovative uses of tension wires, pushing the boundaries of what is structurally possible.


### PR DESCRIPTION
Fixes 404 risks in `templates/*.html` and expands sparse content for batch 21 of the Hwaro examples repository.

- Removes dead link to `/tags/` in all `tapestry` templates.
- Prefixes `{{ base_url }}` to `{{ term.permalink }}` and `{{ post.permalink }}` in `taskboard` templates.
- Prefixes `{{ base_url }}` to `{{ paginator.previous }}` and `{{ paginator.next }}` in `telegraph` section template.
- Expands sparse content for `telegraph-key` by creating `content/posts/` with `_index.md` and 3 realistic posts.
- Expands sparse content for `tension-wire` by creating `content/posts/` with `_index.md` and 3 realistic posts.

---
*PR created automatically by Jules for task [10048922497946153638](https://jules.google.com/task/10048922497946153638) started by @chei-l*