### PR TITLE
Fix 404 risks and expand sparse content (batch 16)

### DIFF
--- a/examples/solarflare/content/tags/_index.md
+++ b/examples/solarflare/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+template = "taxonomy"
++++

--- a/examples/solaris-glass-forge/templates/section.html
+++ b/examples/solaris-glass-forge/templates/section.html
@@ -10,7 +10,7 @@
   <div class="grid-layout mt-4">
     {% for post in section.pages %}
       <article class="glass-card">
-        <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+        <h3><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
         {% if post.date %}
           <div class="meta">{{ post.date | date("%Y-%m-%d") }}</div>
         {% endif %}

--- a/examples/solaris-glass-forge/templates/taxonomy_term.html
+++ b/examples/solaris-glass-forge/templates/taxonomy_term.html
@@ -7,7 +7,7 @@
   <div class="grid-layout mt-4">
     {% for post in taxonomy_pages %}
       <article class="glass-card">
-        <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+        <h3><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
         {% if post.date %}
           <div class="meta">{{ post.date | date("%Y-%m-%d") }}</div>
         {% endif %}

--- a/examples/solarium/templates/section.html
+++ b/examples/solarium/templates/section.html
@@ -10,12 +10,12 @@
   <article class="post-card">
     <span class="post-card-meta">{{ p.date | date("%B %d, %Y") }}</span>
     <h2 class="post-card-title">
-      <a href="{{ p.url }}">{{ p.title | e }}</a>
+      <a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a>
     </h2>
     <div class="post-card-excerpt">
       {{ p.summary | default("") | strip_html | truncate_words(30) }}
     </div>
-    <a href="{{ p.url }}" class="read-more">Read Entry &rarr;</a>
+    <a href="{{ base_url }}{{ p.url }}" class="read-more">Read Entry &rarr;</a>
   </article>
   {% endfor %}
 </div>
@@ -24,13 +24,13 @@
 <nav class="pagination">
   <div class="pagination-list">
     {% if paginator.previous %}
-    <a href="{{ paginator.previous }}" class="pagination-prev">&larr; Newer</a>
+    <a href="{{ base_url }}{{ paginator.previous }}" class="pagination-prev">&larr; Newer</a>
     {% endif %}
 
     <span class="pagination-info">Page {{ paginator.current_index }} of {{ paginator.total_pages }}</span>
 
     {% if paginator.next %}
-    <a href="{{ paginator.next }}" class="pagination-next">Older &rarr;</a>
+    <a href="{{ base_url }}{{ paginator.next }}" class="pagination-next">Older &rarr;</a>
     {% endif %}
   </div>
 </nav>

--- a/examples/solarium/templates/taxonomy_term.html
+++ b/examples/solarium/templates/taxonomy_term.html
@@ -11,12 +11,12 @@
   <article class="post-card">
     <span class="post-card-meta">{{ p.date | date("%B %d, %Y") }}</span>
     <h2 class="post-card-title">
-      <a href="{{ p.url }}">{{ p.title | e }}</a>
+      <a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a>
     </h2>
     <div class="post-card-excerpt">
       {{ p.summary | default("") | strip_html | truncate_words(30) }}
     </div>
-    <a href="{{ p.url }}" class="read-more">Read Entry &rarr;</a>
+    <a href="{{ base_url }}{{ p.url }}" class="read-more">Read Entry &rarr;</a>
   </article>
   {% endfor %}
 </div>

--- a/examples/soliloquy-glass/templates/section.html
+++ b/examples/soliloquy-glass/templates/section.html
@@ -7,7 +7,7 @@
 
     <div class="post-list">
       {% for child in section.pages %}
-        <a href="{{ child.permalink }}" class="post-item">
+        <a href="{{ base_url }}{{ child.permalink }}" class="post-item">
           <article class="post-card glass-container">
             <h2>{{ child.title | e }}</h2>
             {% if child.description %}

--- a/examples/soundcheck/templates/section.html
+++ b/examples/soundcheck/templates/section.html
@@ -6,7 +6,7 @@
   <div style="display: grid; grid-template-columns: 1fr; gap: 1rem; margin-top: 2rem;">
     {% for page in section.pages %}
     <div style="border: 1px dashed var(--dim-green); padding: 1rem;">
-      <a href="{{ page.permalink }}" style="color: var(--phosphor-green); font-family: 'Fira Mono'; text-decoration: none;">[{{ loop.index }}] {{ page.title }}</a>
+      <a href="{{ base_url }}{{ page.permalink }}" style="color: var(--phosphor-green); font-family: 'Fira Mono'; text-decoration: none;">[{{ loop.index }}] {{ page.title }}</a>
       <p style="font-size: 14px; margin: 0.5rem 0 0;">{{ page.description }}</p>
     </div>
     {% endfor %}


### PR DESCRIPTION
Fix 404 risks by adding base_url prefixes where required across multiple examples. Expanded one missing tags link in solarflare. Verified other templates did not contain bare link variables or require expansion.

---
*PR created automatically by Jules for task [12566884374490176217](https://jules.google.com/task/12566884374490176217) started by @chei-l*