### PR TITLE
Fix 404 risks and expand sparse content (batch 17)

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,12 @@
+Fix 404 risks and expand sparse content (batch 17)
+
+- spire: no changes needed
+- split-tone: no changes needed
+- spotlight-hour: prefix absolute URLs with {{ base_url }} in templates
+- stagelight: prefix absolute URLs with {{ base_url }} in templates
+- stained-glass: no changes needed
+- standing-ovation: prefix absolute URLs with {{ base_url }} in templates
+- stardust-voyage: no changes needed
+- stargate: no changes needed
+- starlight-synth-glass: prefix absolute URLs with {{ base_url }} in templates
+- starlight-veil-nexus: prefix absolute URLs with {{ base_url }} in templates

--- a/examples/spotlight-hour/templates/section.html
+++ b/examples/spotlight-hour/templates/section.html
@@ -9,7 +9,7 @@
         <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
       </svg>
     </div>
-    <h2 class="speaker-name"><a href="{{ page.permalink }}" style="color: var(--gold); text-decoration: none;">{{ page.title }}</a></h2>
+    <h2 class="speaker-name"><a href="{{ base_url }}{{ page.permalink }}" style="color: var(--gold); text-decoration: none;">{{ page.title }}</a></h2>
     <p class="talk-abstract">{{ page.description }}</p>
   </div>
   {% endfor %}

--- a/examples/stagelight/templates/section.html
+++ b/examples/stagelight/templates/section.html
@@ -4,7 +4,7 @@
 <div style="display: grid; grid-template-columns: 1fr; gap: 4rem; text-align: center;">
   {% for page in section.pages %}
   <div style="border-bottom: 1px solid var(--gray); padding-bottom: 2rem;">
-    <h2 style="font-family: 'DM Serif Display'; font-size: 40px;"><a href="{{ page.permalink }}" style="color: var(--white); text-decoration: none;">{{ page.title }}</a></h2>
+    <h2 style="font-family: 'DM Serif Display'; font-size: 40px;"><a href="{{ base_url }}{{ page.permalink }}" style="color: var(--white); text-decoration: none;">{{ page.title }}</a></h2>
     <p>{{ page.description }}</p>
   </div>
   {% endfor %}

--- a/examples/standing-ovation/templates/section.html
+++ b/examples/standing-ovation/templates/section.html
@@ -4,7 +4,7 @@
 <div style="display: grid; grid-template-columns: 1fr; gap: 4rem;">
   {% for page in section.pages %}
   <div style="border-bottom: 1px solid var(--gold); padding-bottom: 2rem;">
-    <h2 class="winner-name" style="font-size: 40px;"><a href="{{ page.permalink }}" style="color: var(--gold); text-decoration: none;">{{ page.title }}</a></h2>
+    <h2 class="winner-name" style="font-size: 40px;"><a href="{{ base_url }}{{ page.permalink }}" style="color: var(--gold); text-decoration: none;">{{ page.title }}</a></h2>
     <p>{{ page.description }}</p>
   </div>
   {% endfor %}

--- a/examples/starlight-synth-glass/templates/section.html
+++ b/examples/starlight-synth-glass/templates/section.html
@@ -12,7 +12,7 @@
             <div class="page-list">
                 {% for page in section.pages %}
                 <article class="list-item" style="margin-top: 2rem; padding-top: 2rem; border-top: 1px solid rgba(255,255,255,0.1);">
-                    <h3><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+                    <h3><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></h3>
                     {% if page.description %}
                     <p>{{ page.description }}</p>
                     {% endif %}

--- a/examples/starlight-veil-nexus/templates/section.html
+++ b/examples/starlight-veil-nexus/templates/section.html
@@ -4,7 +4,7 @@
 
     <ul class="section-list">
       {% for p in section.pages %}
-      <li><a href="{{ p.url }}">{{ p.title | e }}</a></li>
+      <li><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></li>
       {% endfor %}
     </ul>
 {% include "footer.html" %}


### PR DESCRIPTION
Fixes 404 risks by prefixing bare template URLs (like `{{ page.permalink }}` and `{{ p.url }}`) with `{{ base_url }}` in templates. Verified that taxonomy `_index.md` files are automatically handled by the engine config. No sparse content additions were necessary.

---
*PR created automatically by Jules for task [17625853741364484467](https://jules.google.com/task/17625853741364484467) started by @chei-l*