### PR TITLE
Fix 404 risks and expand sparse content (batch 10)

### DIFF
--- a/examples/iridescent-oil/templates/section.html
+++ b/examples/iridescent-oil/templates/section.html
@@ -11,7 +11,7 @@
         {% if section is defined and section.pages %}
             {% for post in section.pages %}
             <article class="post-item" style="margin-bottom: 2rem; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 1rem;">
-                <h2 style="margin-bottom: 0.5rem;"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+                <h2 style="margin-bottom: 0.5rem;"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
                 {% if post.date %}
                 <div class="meta" style="font-size: 0.9rem; opacity: 0.7; margin-bottom: 1rem;">{{ post.date | date(format="%B %d, %Y") }}</div>
                 {% endif %}

--- a/examples/isthmus/templates/index.html
+++ b/examples/isthmus/templates/index.html
@@ -8,7 +8,7 @@
           {{ west.content | safe }}
           <ul class="link-list">
             {% for link in west.extra.links %}
-              <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+              <li><a href="{{ base_url }}{{ link.url }}">{{ link.title }}</a></li>
             {% endfor %}
           </ul>
         </div>
@@ -31,7 +31,7 @@
           {{ east.content | safe }}
           <ul class="link-list">
             {% for link in east.extra.links %}
-              <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+              <li><a href="{{ base_url }}{{ link.url }}">{{ link.title }}</a></li>
             {% endfor %}
           </ul>
         </div>

--- a/examples/isthmus/templates/page.html
+++ b/examples/isthmus/templates/page.html
@@ -13,7 +13,7 @@
           {{ content | safe }}
           <ul class="link-list">
             {% for link in page.extra.links %}
-              <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+              <li><a href="{{ base_url }}{{ link.url }}">{{ link.title }}</a></li>
             {% endfor %}
           </ul>
           <a href="{{ base_url }}/" class="bridge-link">Back to Isthmus</a>
@@ -25,7 +25,7 @@
           {{ content | safe }}
           <ul class="link-list">
             {% for link in page.extra.links %}
-              <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+              <li><a href="{{ base_url }}{{ link.url }}">{{ link.title }}</a></li>
             {% endfor %}
           </ul>
           <a href="{{ base_url }}/" class="bridge-link">Back to Isthmus</a>


### PR DESCRIPTION
This PR fixes 404 risks by prepending `{{ base_url }}` to bare URL properties (e.g., `{{ post.url }}`, `{{ link.url }}`) in `iridescent-oil` and `isthmus`. The sparse content check was performed and no directories required adding additional entries (those that existed, like `posts/` in `ironworks` and `inventory/` in `inventory`, already contained 3+ items). The `permalink` properties and external scripts have been correctly omitted.

---
*PR created automatically by Jules for task [428570728363101021](https://jules.google.com/task/428570728363101021) started by @hahwul*