### PR TITLE
Fix 404 risks and expand sparse content (batch 23)

### DIFF
--- a/examples/thermal/templates/section.html
+++ b/examples/thermal/templates/section.html
@@ -4,7 +4,7 @@
     {{ content | safe }}
     <ul class="section-list">
       {% for page in section.pages %}
-        <li><a href="{{ page.url }}">{{ page.title }}</a></li>
+        <li><a href="{{ base_url }}{{ page.url }}">{{ page.title }}</a></li>
       {% endfor %}
     </ul>
   </div>

--- a/examples/thesis/templates/home.html
+++ b/examples/thesis/templates/home.html
@@ -8,7 +8,7 @@
       {% for p in site.pages %}
       {% if p.section == "papers" %}
         <li class="paper-list-item">
-          <div class="paper-list-title"><a href="{{ p.url }}">{{ p.title }}</a></div>
+          <div class="paper-list-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></div>
           <div class="paper-list-meta">
             {% if p.extra.authors %}{{ p.extra.authors }} &middot; {% endif %}{{ p.date | date("%B %d, %Y") }}
           </div>

--- a/examples/thunderclap/templates/section.html
+++ b/examples/thunderclap/templates/section.html
@@ -4,7 +4,7 @@
 <div style="margin-top: 4rem;">
   {% for page in section.pages %}
   <div class="act-listing">
-    <h2 style="font-size: 48px; margin: 0;"><a href="{{ page.permalink }}" style="color: var(--white); text-decoration: none;">{{ page.title }}</a></h2>
+    <h2 style="font-size: 48px; margin: 0;"><a href="{{ base_url }}{{ page.permalink }}" style="color: var(--white); text-decoration: none;">{{ page.title }}</a></h2>
     <p style="font-family: 'IBM Plex Mono'; font-size: 14px; margin-top: 1rem;">{{ page.description }}</p>
   </div>
   {% endfor %}

--- a/examples/thunderdome/templates/section.html
+++ b/examples/thunderdome/templates/section.html
@@ -8,7 +8,7 @@
       <div class="listing-item">
         <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
         <div>
-          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          <div class="listing-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></div>
           {% if post.description %}
           <div class="listing-desc">{{ post.description }}</div>
           {% endif %}

--- a/examples/ticker-board/templates/section.html
+++ b/examples/ticker-board/templates/section.html
@@ -8,7 +8,7 @@
       <div class="listing-item">
         <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
         <div>
-          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          <div class="listing-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></div>
           {% if post.description %}
           <div class="listing-desc">{{ post.description }}</div>
           {% endif %}


### PR DESCRIPTION
This PR fixes 404 risks in `templates/*.html` for the second batch of 10 examples (thermal through timber) by making sure that template variables resolving to URL paths are prefixed with `{{ base_url }}`.

Checks:
- Prepended `{{ base_url }}` to template variables containing `.url` or `.permalink`.
- No absolute hardcoded path vulnerabilities (`href="/..."` without `base_url`) remained to be updated.
- No sparse content needed to be expanded because all targeted section directories that have content already contained 3 or more entries.
- Ran `hwaro build` on modified examples to assure no build errors occurred.

---
*PR created automatically by Jules for task [17545273988178462483](https://jules.google.com/task/17545273988178462483) started by @chei-l*