### PR TITLE
Fix 404 risks and expand sparse content (batch 26)

### DIFF
--- a/examples/velvet-glow/templates/section.html
+++ b/examples/velvet-glow/templates/section.html
@@ -10,7 +10,7 @@
 <ul class="post-list">
   {% for subpage in section.pages %}
   <li class="post-item">
-    <h2 class="post-title"><a href="{{ subpage.permalink }}">{{ subpage.title }}</a></h2>
+    <h2 class="post-title"><a href="{{ base_url }}{{ subpage.permalink }}">{{ subpage.title }}</a></h2>
     <div class="post-meta">
       <span>
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/examples/velvet-whisper/templates/section.html
+++ b/examples/velvet-whisper/templates/section.html
@@ -5,7 +5,7 @@
 
     <ul class="section-list">
       {% for post in section.pages %}
-        <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+        <li><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></li>
       {% endfor %}
     </ul>
     {{ pagination }}

--- a/examples/velvet/templates/home.html
+++ b/examples/velvet/templates/home.html
@@ -17,7 +17,7 @@
       <div class="collections-grid">
         {% for item in site.pages %}
         {% if item.section == "collections" %}
-        <a href="{{ item.permalink }}" class="collection-card">
+        <a href="{{ base_url }}{{ item.permalink }}" class="collection-card">
           {% if item.extra.season %}
           <span class="collection-card__season">{{ item.extra.season }}</span>
           {% endif %}

--- a/examples/velvet/templates/section.html
+++ b/examples/velvet/templates/section.html
@@ -14,7 +14,7 @@
       <ul class="section-list">
         {% for page in section.pages %}
         <li class="section-list__item">
-          <a href="{{ page.permalink }}" class="section-list__link">
+          <a href="{{ base_url }}{{ page.permalink }}" class="section-list__link">
             <div class="section-list__title">{{ page.title }}</div>
             {% if page.description %}
             <div class="section-list__description">{{ page.description }}</div>


### PR DESCRIPTION
Fix 404 risks by prefixing bare absolute paths and un-prefixed template URLs in templates with `{{ base_url }}`. Verified that there were no sections with fewer than 3 entries, so skipped generating new content.

---
*PR created automatically by Jules for task [9064741735010648964](https://jules.google.com/task/9064741735010648964) started by @chei-l*