### PR TITLE
Fix 404 risks and expand sparse content (batch r3-05)

### DIFF
--- a/examples/bismuth/templates/section.html
+++ b/examples/bismuth/templates/section.html
@@ -14,7 +14,7 @@
     <div class="specimen-card">
       <div style="position: absolute; top: 0; left: 0; width: 4px; height: 100%; background: var(--gold);"></div>
       <p class="date">{{ page.date | date("%Y-%m-%d") }}</p>
-      <h3><a href="{{ page.url }}">{{ page.title }}</a></h3>
+      <h3><a href="{{ base_url }}{{ page.url }}">{{ page.title }}</a></h3>
       {% if page.summary %}
         <p>{{ page.summary | truncate_words(20) | strip_html }}</p>
       {% endif %}


### PR DESCRIPTION
Fixes 404 risks by adding base_url to un-prefixed URLs in the 10 target examples. The only site requiring this fix was bismuth. Sparse content requirements were also assessed: there were no sparse directories in the specified targets.

---
*PR created automatically by Jules for task [18152682653333708891](https://jules.google.com/task/18152682653333708891) started by @hahwul*