### PR TITLE
Fix 404 risks and expand sparse content (batch r3-20)

### DIFF
--- a/examples/ethereal-shimmer/templates/section.html
+++ b/examples/ethereal-shimmer/templates/section.html
@@ -13,7 +13,7 @@
     {% for post in section.pages %}
       <article class="post-preview">
         <h2 class="post-title">
-          <a href="{{ post.url }}">{{ post.title }}</a>
+          <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
         </h2>
         {% if post.date %}
           <div class="post-meta">

--- a/examples/fauvist-wild/templates/index.html
+++ b/examples/fauvist-wild/templates/index.html
@@ -16,7 +16,7 @@
         {% if s.title == "Exhibitions" %}
             {% for p in s.pages %}
             <li class="post-item">
-                <a href="{{ p.url }}">
+                <a href="{{ base_url }}{{ p.url }}">
                     <span class="post-title">{{ p.title }}</span>
                     {% if p.description %}
                     <span class="post-desc">{{ p.description }}</span>

--- a/examples/fauvist-wild/templates/section.html
+++ b/examples/fauvist-wild/templates/section.html
@@ -13,7 +13,7 @@
 <ul class="post-list">
     {% for p in section.pages %}
     <li class="post-item">
-        <a href="{{ p.url }}">
+        <a href="{{ base_url }}{{ p.url }}">
             <h2 class="post-title">{{ p.title }}</h2>
             {% if p.date %}
             <time class="post-date">{{ p.date | date(format="%B %d, %Y") }}</time>

--- a/examples/fauvist-wild/templates/taxonomy.html
+++ b/examples/fauvist-wild/templates/taxonomy.html
@@ -7,7 +7,7 @@
 <ul class="taxonomy-list">
     {% for term in taxonomy_terms %}
     <li>
-        <a href="{{ term.url }}">{{ term.name }} ({{ term.pages | length }})</a>
+        <a href="{{ base_url }}{{ term.url }}">{{ term.name }} ({{ term.pages | length }})</a>
     </li>
     {% endfor %}
 </ul>

--- a/examples/fauvist-wild/templates/taxonomy_term.html
+++ b/examples/fauvist-wild/templates/taxonomy_term.html
@@ -8,7 +8,7 @@
 <ul class="post-list">
     {% for p in taxonomy_pages %}
     <li class="post-item">
-        <a href="{{ p.url }}">
+        <a href="{{ base_url }}{{ p.url }}">
             <h2 class="post-title">{{ p.title }}</h2>
             {% if p.date %}
             <time class="post-date">{{ p.date | date(format="%B %d, %Y") }}</time>

--- a/examples/festival/templates/section.html
+++ b/examples/festival/templates/section.html
@@ -16,7 +16,7 @@
 <div class="posts-list">
     {% for post in section.pages %}
     <article class="card">
-        <h2 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <h2 class="card-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         {% if post.date %}
         <div class="card-meta">{{ post.date | date("%B %d, %Y") }}</div>
         {% endif %}
@@ -26,7 +26,7 @@
         {% endif %}
 
         <div style="margin-top: 1.5rem;">
-            <a href="{{ post.url }}" class="button">Read More</a>
+            <a href="{{ base_url }}{{ post.url }}" class="button">Read More</a>
         </div>
     </article>
     {% endfor %}

--- a/examples/festival/templates/taxonomy_term.html
+++ b/examples/festival/templates/taxonomy_term.html
@@ -10,13 +10,13 @@
 <div class="posts-list">
     {% for post in taxonomy_pages %}
     <article class="card">
-        <h2 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <h2 class="card-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         {% if post.date %}
         <div class="card-meta">{{ post.date | date("%B %d, %Y") }}</div>
         {% endif %}
 
         <div style="margin-top: 1.5rem;">
-            <a href="{{ post.url }}" class="button">Read More</a>
+            <a href="{{ base_url }}{{ post.url }}" class="button">Read More</a>
         </div>
     </article>
     {% endfor %}


### PR DESCRIPTION
Fix 404 risks and expand sparse content for batch r3-20.

Prefix bare URLs like `{{ post.url }}`, `{{ term.url }}`, and `{{ p.url }}` with `{{ base_url }}` in `ethereal-shimmer`, `fauvist-wild`, and `festival` templates.
Checked 404 links, absolute paths, missing page links, and missing content for the specified examples.
Confirmed no sparse content issues or missing sections matching the criteria.

---
*PR created automatically by Jules for task [2414493315404821263](https://jules.google.com/task/2414493315404821263) started by @chei-l*