### PR TITLE
Fix 404 risks and expand sparse content (batch r3-28)

### DIFF
--- a/examples/holo-glass-forge/templates/section.html
+++ b/examples/holo-glass-forge/templates/section.html
@@ -15,7 +15,7 @@
     <div class="grid-container">
       {% for p in section.pages %}
       <article class="glass-panel grid-item">
-        <h2><a href="{{ p.permalink }}">{{ p.title }}</a></h2>
+        <h2><a href="{{ base_url }}{{ p.permalink }}">{{ p.title }}</a></h2>
         {% if p.description %}
           <p>{{ p.description }}</p>
         {% endif %}

--- a/examples/holo-neon-pulse/content/posts/second-post.md
+++ b/examples/holo-neon-pulse/content/posts/second-post.md
@@ -1,0 +1,7 @@
++++
+title = "Second Log: Calibration"
+date = "2026-06-15"
++++
+The neon calibration sequences have completed successfully. The pulse generator is functioning at peak efficiency. We've managed to stabilize the core temperature while pushing the matrix deeper into the overclocked zone.
+
+System diagnostics show nominal parameters across the board, with minimal resonance interference from the secondary coil. We are preparing to initiate the next phase of the Holo Neon sequence, which should yield significantly higher light density output.

--- a/examples/holo-neon-pulse/content/posts/third-post.md
+++ b/examples/holo-neon-pulse/content/posts/third-post.md
@@ -1,0 +1,7 @@
++++
+title = "Third Log: Final Initialization"
+date = "2026-07-22"
++++
+Final initialization phase has been reached. The pulse synchronicity is perfectly aligned with the main network grid. The holographic emitters are displaying pristine clarity, a vast improvement over the previous iteration.
+
+We've observed a 20% increase in power retention, meaning the pulse frequency can be maintained for extended periods without risking core degradation. Overall, the Holo Neon project is exceeding expectations. Monitoring will continue for the next 48 hours to ensure stability.

--- a/examples/holo-neon-pulse/templates/section.html
+++ b/examples/holo-neon-pulse/templates/section.html
@@ -23,7 +23,7 @@
   {% for p in pages %}
     <li>
       {% if p.date is present %}<div class="post-meta">{{ p.date | date(format="%Y-%m-%d") }}</div>{% endif %}
-      <a href="{{ p.url }}">{{ p.title | e }}</a>
+      <a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a>
       {% if p.description is present %}<p style="color:var(--muted);margin:0.5rem 0 0;font-family:'Bricolage Grotesque',sans-serif;text-transform:none;font-weight:400;font-size:0.95rem;">{{ p.description | e }}</p>{% endif %}
     </li>
   {% endfor %}
@@ -33,12 +33,12 @@
 <nav class="pagination">
   <ul class="pagination-list">
     {% if pagination.previous %}
-      <li><a href="{{ pagination.previous }}">&larr; Previous</a></li>
+      <li><a href="{{ base_url }}{{ pagination.previous }}">&larr; Previous</a></li>
     {% else %}
       <li class="pagination-disabled"><span>&larr; Previous</span></li>
     {% endif %}
     {% if pagination.next %}
-      <li><a href="{{ pagination.next }}">Next &rarr;</a></li>
+      <li><a href="{{ base_url }}{{ pagination.next }}">Next &rarr;</a></li>
     {% else %}
       <li class="pagination-disabled"><span>Next &rarr;</span></li>
     {% endif %}

--- a/examples/hyper-loom/templates/section.html
+++ b/examples/hyper-loom/templates/section.html
@@ -15,7 +15,7 @@
   <ul class="section-list">
   {% for p in pages %}
     <li>
-      <a href="{{ p.permalink }}">{{ p.title | e }}</a>
+      <a href="{{ base_url }}{{ p.permalink }}">{{ p.title | e }}</a>
       {% if p.date is defined and p.date %}
       <time datetime="{{ p.date }}">{{ p.date }}</time>
       {% endif %}
@@ -30,7 +30,7 @@
   <nav class="pagination">
     <ul class="pagination-list">
       {% if pagination.prev_page %}
-      <li><a href="{{ pagination.prev_page_link }}">&laquo; Prev</a></li>
+      <li><a href="{{ base_url }}{{ pagination.prev_page_link }}">&laquo; Prev</a></li>
       {% else %}
       <li class="pagination-disabled"><span>&laquo; Prev</span></li>
       {% endif %}
@@ -39,12 +39,12 @@
         {% if i == pagination.current_page %}
         <li class="pagination-current"><span>{{ i }}</span></li>
         {% else %}
-        <li><a href="{{ pagination.page_link_prefix }}{{ i }}/">{{ i }}</a></li>
+        <li><a href="{{ base_url }}{{ pagination.page_link_prefix }}{{ i }}/">{{ i }}</a></li>
         {% endif %}
       {% endfor %}
 
       {% if pagination.next_page %}
-      <li><a href="{{ pagination.next_page_link }}">Next &raquo;</a></li>
+      <li><a href="{{ base_url }}{{ pagination.next_page_link }}">Next &raquo;</a></li>
       {% else %}
       <li class="pagination-disabled"><span>Next &raquo;</span></li>
       {% endif %}

--- a/examples/hyper-monolith/templates/index.html
+++ b/examples/hyper-monolith/templates/index.html
@@ -4,7 +4,7 @@
       {{ content | safe }}
       <ul class="section-list" style="list-style-type: none; padding-left: 0;">
         {% for page in pages %}
-          <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+          <li><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></li>
         {% endfor %}
       </ul>
     </article>

--- a/examples/hyper-monolith/templates/section.html
+++ b/examples/hyper-monolith/templates/section.html
@@ -4,7 +4,7 @@
       {{ content | safe }}
       <ul class="section-list" style="list-style-type: none; padding-left: 0;">
         {% for p in section.pages %}
-          <li><a href="{{ p.permalink }}">{{ p.title }}</a></li>
+          <li><a href="{{ base_url }}{{ p.permalink }}">{{ p.title }}</a></li>
         {% endfor %}
       </ul>
     </article>

--- a/examples/hyper-monolith/templates/taxonomy.html
+++ b/examples/hyper-monolith/templates/taxonomy.html
@@ -3,7 +3,7 @@
       <h1>{{ taxonomy.name | title }}</h1>
       <ul class="section-list" style="list-style-type: none; padding-left: 0;">
         {% for term in terms %}
-          <li><a href="{{ term.permalink }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
+          <li><a href="{{ base_url }}{{ term.permalink }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
         {% endfor %}
       </ul>
     </article>

--- a/examples/hyper-monolith/templates/taxonomy_term.html
+++ b/examples/hyper-monolith/templates/taxonomy_term.html
@@ -3,7 +3,7 @@
       <h1>{{ term.name }}</h1>
       <ul class="section-list" style="list-style-type: none; padding-left: 0;">
         {% for page in term.pages %}
-          <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+          <li><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></li>
         {% endfor %}
       </ul>
       {{ pagination }}

--- a/examples/hyper-prism-nova/templates/section.html
+++ b/examples/hyper-prism-nova/templates/section.html
@@ -66,7 +66,7 @@
     <div class="hyper-list">
       {% for p in section.pages %}
         <div class="hyper-card">
-          <a href="{{ p.url }}">{{ p.title }}</a>
+          <a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a>
           {% if p.date is defined %}
             <div class="date">{{ p.date | date("%Y.%m.%d") }}</div>
           {% endif %}
@@ -80,13 +80,13 @@
     {% if pagination is defined %}
     <nav class="pagination" style="margin-top: 3rem; display: flex; justify-content: center; gap: 1rem;">
       {% if pagination.prev is defined %}
-        <a href="{{ pagination.prev }}" class="sys-status" style="text-decoration: none;">&lt; Prev</a>
+        <a href="{{ base_url }}{{ pagination.prev }}" class="sys-status" style="text-decoration: none;">&lt; Prev</a>
       {% endif %}
       <span class="sys-status" style="border-color: var(--neon-magenta); color: var(--neon-magenta);">
         Page {{ pagination.current }}
       </span>
       {% if pagination.next is defined %}
-        <a href="{{ pagination.next }}" class="sys-status" style="text-decoration: none;">Next &gt;</a>
+        <a href="{{ base_url }}{{ pagination.next }}" class="sys-status" style="text-decoration: none;">Next &gt;</a>
       {% endif %}
     </nav>
     {% endif %}


### PR DESCRIPTION
Fix 404 risks and expand sparse content (batch r3-28)

- holo-glass-forge: prefix bare {{ p.permalink }} with {{ base_url }}
- holo-neon-pulse: prefix bare urls and pagination with {{ base_url }}, add 2 posts so posts has 3
- holo-vista: no changes needed
- holographic-blossom: no changes needed
- horizon-ai: no changes needed
- hour-glass: no changes needed
- hush: no changes needed
- hyper-loom: prefix bare urls and pagination with {{ base_url }}
- hyper-monolith: prefix bare urls with {{ base_url }} in templates
- hyper-prism-nova: prefix bare urls and pagination with {{ base_url }}

---
*PR created automatically by Jules for task [4189818662775588034](https://jules.google.com/task/4189818662775588034) started by @chei-l*