### PR TITLE
Fix 404 risks and expand sparse content (batch r3-26)

### DIFF
--- a/examples/graphene-weave-ui/templates/section.html
+++ b/examples/graphene-weave-ui/templates/section.html
@@ -13,7 +13,7 @@
         {% if section.pages %}
         <ul>
             {% for page in section.pages %}
-            <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+            <li><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></li>
             {% endfor %}
         </ul>
         {% else %}

--- a/examples/graphene-weave-ui/templates/taxonomy.html
+++ b/examples/graphene-weave-ui/templates/taxonomy.html
@@ -13,7 +13,7 @@
         {% if terms %}
         <ul>
             {% for term in terms %}
-            <li><a href="{{ term.permalink }}">{{ term.name }} ({{ term.pages | length }})</a></li>
+            <li><a href="{{ base_url }}{{ term.permalink }}">{{ term.name }} ({{ term.pages | length }})</a></li>
             {% endfor %}
         </ul>
         {% else %}

--- a/examples/graphene-weave-ui/templates/taxonomy_term.html
+++ b/examples/graphene-weave-ui/templates/taxonomy_term.html
@@ -13,7 +13,7 @@
         {% if term and term.pages %}
         <ul>
             {% for page in term.pages %}
-            <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+            <li><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></li>
             {% endfor %}
         </ul>
         {% else %}

--- a/examples/graphite-docs/templates/taxonomy.html
+++ b/examples/graphite-docs/templates/taxonomy.html
@@ -6,7 +6,7 @@
     <h1>{{ taxonomy.name | capitalize }}</h1>
     <ul class="section-list">
       {% for term in terms %}
-      <li><a href="{{ term.permalink }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
+      <li><a href="{{ base_url }}{{ term.permalink }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
       {% endfor %}
     </ul>
 {% include "footer.html" %}

--- a/examples/graphite-docs/templates/taxonomy_term.html
+++ b/examples/graphite-docs/templates/taxonomy_term.html
@@ -6,7 +6,7 @@
     <h1>{{ taxonomy.name | capitalize }}: {{ term.name }}</h1>
     <ul class="section-list">
       {% for page in pages %}
-      <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+      <li><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></li>
       {% endfor %}
     </ul>
 {% include "footer.html" %}

--- a/examples/greenroom/templates/taxonomy_term.html
+++ b/examples/greenroom/templates/taxonomy_term.html
@@ -4,7 +4,7 @@
   <p class="taxonomy-desc">Events &amp; entries tagged with this term.</p>
   <ul class="section-list">
     {% for p in taxonomy_pages %}
-      <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+      <li><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></li>
     {% endfor %}
   </ul>
 </section>

--- a/examples/handbook/templates/taxonomy.html
+++ b/examples/handbook/templates/taxonomy.html
@@ -9,7 +9,7 @@
         <ul style="list-style: none; padding: 0;">
             {% for term in taxonomy_terms %}
                 <li style="margin-bottom: 1rem;">
-                    <a href="{{ term.permalink }}" style="font-weight: 600;">{{ term.name }}</a>
+                    <a href="{{ base_url }}{{ term.permalink }}" style="font-weight: 600;">{{ term.name }}</a>
                     <span style="color: #64748b; font-size: 0.875rem;">({{ term.pages | length }} pages)</span>
                 </li>
             {% endfor %}

--- a/examples/handbook/templates/taxonomy_term.html
+++ b/examples/handbook/templates/taxonomy_term.html
@@ -11,7 +11,7 @@
             {% for page in taxonomy_pages %}
                 <li style="margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border-color);">
                     <h2 style="font-size: 1.25rem; margin-top: 0; margin-bottom: 0.5rem; border-bottom: none; padding-bottom: 0;">
-                        <a href="{{ page.permalink }}">{{ page.title }}</a>
+                        <a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a>
                     </h2>
                     {% if page.description %}
                         <p style="margin-bottom: 0; color: #64748b;">{{ page.description }}</p>


### PR DESCRIPTION
- Added `{{ base_url }}` prefixes to permalink strings in taxonomies for `graphene-weave-ui`, `graphite-docs`, `greenroom`, and `handbook`.
- All other checks were already satisfied.

---
*PR created automatically by Jules for task [5894110003694532758](https://jules.google.com/task/5894110003694532758) started by @chei-l*