### PR TITLE
Fix 404 risks and expand sparse content (batch r3-06)

### DIFF
--- a/examples/butterfly-wing/templates/section.html
+++ b/examples/butterfly-wing/templates/section.html
@@ -16,7 +16,7 @@
 <div class="post-list">
     {% for post in section.pages %}
     <div class="card">
-        <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         {% if post.date %}
         <div class="post-meta">{{ post.date | date("%B %d, %Y") }}</div>
         {% endif %}
@@ -25,7 +25,7 @@
             {{ post.summary | safe }}
         </div>
         {% endif %}
-        <a href="{{ post.url }}" style="font-weight: 600; text-transform: uppercase; font-size: 0.9rem; letter-spacing: 1px;">Read More &rarr;</a>
+        <a href="{{ base_url }}{{ post.url }}" style="font-weight: 600; text-transform: uppercase; font-size: 0.9rem; letter-spacing: 1px;">Read More &rarr;</a>
     </div>
     {% endfor %}
 </div>

--- a/examples/butterfly-wing/templates/taxonomy_term.html
+++ b/examples/butterfly-wing/templates/taxonomy_term.html
@@ -9,11 +9,11 @@
 <div class="post-list">
     {% for post in taxonomy_pages %}
     <div class="card">
-        <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         {% if post.date %}
         <div class="post-meta">{{ post.date | date("%B %d, %Y") }}</div>
         {% endif %}
-        <a href="{{ post.url }}" style="font-weight: 600; text-transform: uppercase; font-size: 0.9rem; letter-spacing: 1px;">Read More &rarr;</a>
+        <a href="{{ base_url }}{{ post.url }}" style="font-weight: 600; text-transform: uppercase; font-size: 0.9rem; letter-spacing: 1px;">Read More &rarr;</a>
     </div>
     {% endfor %}
 </div>

--- a/examples/calligraphy/templates/section.html
+++ b/examples/calligraphy/templates/section.html
@@ -10,7 +10,7 @@
 <div class="space-y-16">
     {% for post in section.pages %}
         <article class="group">
-            <a href="{{ post.url | default(base_url ~ post.path) }}" class="block">
+            <a href="{{ base_url }}{{ post.url | default(post.path) }}" class="block">
                 <header class="mb-4">
                     {% if post.date %}
                         <span class="text-xs text-ash tracking-widest uppercase mb-2 block">{{ post.date | date("%Y-%m-%d") }}</span>
@@ -27,7 +27,7 @@
                     {% endif %}
                 </div>
             </a>
-            <a href="{{ post.url | default(base_url ~ post.path) }}" class="text-sm uppercase tracking-widest text-redseal font-bold flex items-center gap-2 group-hover:gap-4 transition-all">
+            <a href="{{ base_url }}{{ post.url | default(post.path) }}" class="text-sm uppercase tracking-widest text-redseal font-bold flex items-center gap-2 group-hover:gap-4 transition-all">
                 Read Expression <span class="text-lg">&rarr;</span>
             </a>
         </article>

--- a/examples/carbon-fiber/content/posts/epoxy-resins.md
+++ b/examples/carbon-fiber/content/posts/epoxy-resins.md
@@ -1,0 +1,23 @@
++++
+title = "Epoxy Resins in Matrix Systems"
+date = "2025-02-15"
+tags = ["materials", "chemistry", "resin"]
+categories = ["Tech"]
+description = "Understanding the critical role of epoxy resins as the binding matrix in advanced carbon fiber composites."
++++
+
+Carbon fiber alone is simply an extremely strong, lightweight thread. To create the rigid, structural components we see in high-performance applications, these fibers must be held together in a fixed shape. This is the role of the matrix system, and epoxy resins are the absolute gold standard for this task.
+
+## The Role of the Matrix
+
+The epoxy matrix serves several crucial functions in a composite part:
+
+1. **Load Transfer:** It distributes applied stress evenly across the thousands of individual carbon filaments, preventing localized failure.
+2. **Structural Integrity:** It holds the fibers in their designed orientation (the layup), maintaining the part's specific geometry under load.
+3. **Environmental Protection:** It shields the carbon fibers from chemical exposure, moisture, and abrasion.
+
+## Why Epoxy?
+
+While other matrix materials like polyester or vinyl ester resins exist, epoxy provides superior mechanical properties. It offers higher tensile strength, better fatigue resistance, and exceptional adhesion to the carbon fibers themselves.
+
+Furthermore, epoxy experiences minimal shrinkage during the curing process, which is vital for maintaining tight tolerances in precision parts like aerospace components or high-end sporting goods. The trade-off is often cost and the requirement for precise mixing ratios and controlled curing temperatures, but for uncompromised performance, the epoxy matrix is non-negotiable.

--- a/examples/carbon-fiber/templates/section.html
+++ b/examples/carbon-fiber/templates/section.html
@@ -18,9 +18,9 @@
         <span>{{ post.categories | join(", ") }}</span>
         {% endif %}
       </div>
-      <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+      <h2><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
       <p>{{ post.summary | strip_html | truncate_words(30) }}</p>
-      <a href="{{ post.url }}" class="btn">Read More</a>
+      <a href="{{ base_url }}{{ post.url }}" class="btn">Read More</a>
     </div>
     {% endfor %}
   </div>

--- a/examples/carnival/templates/section.html
+++ b/examples/carnival/templates/section.html
@@ -15,7 +15,7 @@
   <ul class="post-list">
     {% for post in section.pages %}
     <li class="post-item">
-      <a href="{{ post.url }}" class="post-link">
+      <a href="{{ base_url }}{{ post.url }}" class="post-link">
         <h2 class="post-item-title">{{ post.title }}</h2>
         <div class="post-item-meta">
           <time datetime="{{ post.date | date('%Y-%m-%d') }}">{{ post.date | date('%B %d, %Y') }}</time>

--- a/fix_all.py
+++ b/fix_all.py
@@ -1,0 +1,31 @@
+import os
+import re
+
+sites = [
+    'bubble-talk', 'butterfly-wing', 'calligraphy', 'canvas-easel',
+    'carbon-fiber', 'carnival', 'carousel-gallery', 'cartoon-flat',
+    'cartoon-network', 'cartoon-noir'
+]
+
+# We need to ensure we DO SOMETHING for all examples, or explicitly verify.
+# Let's double check ALL hardcoded paths. The issue said:
+# "Hardcoded absolute paths like `href="/about/"`, `href="/posts/"`, `src="/style.css"`, `href="/tags/foo/"` should be prefixed with `{{ base_url }}` (keep trailing slashes)."
+
+for site in sites:
+    templates_dir = os.path.join('examples', site, 'templates')
+    for root, dirs, files in os.walk(templates_dir):
+        for file in files:
+            if not file.endswith('.html'): continue
+            path = os.path.join(root, file)
+            with open(path, 'r') as f:
+                content = f.read()
+
+            # Find any href="/..." or src="/..." that IS NOT prefixed with base_url
+            # but wait, I already did that and found NOTHING in test6.py?
+            # Let's re-run a very careful regex:
+
+            # This regex looks for href="/..." where the preceding chars are NOT '{{ base_url }}'
+            # Because regex lookbehind can be tricky, let's just find all href="/..." and see.
+            links = re.findall(r'(?:href|src)="(/[^"]*)"', content)
+            if links:
+                print(f"{path} has hardcoded links: {links}")

--- a/test8.py
+++ b/test8.py
@@ -1,0 +1,26 @@
+import os
+import re
+
+sites = [
+    'bubble-talk', 'butterfly-wing', 'calligraphy', 'canvas-easel',
+    'carbon-fiber', 'carnival', 'carousel-gallery', 'cartoon-flat',
+    'cartoon-network', 'cartoon-noir'
+]
+
+for site in sites:
+    templates_dir = os.path.join('examples', site, 'templates')
+    for root, dirs, files in os.walk(templates_dir):
+        for file in files:
+            if not file.endswith('.html'): continue
+            path = os.path.join(root, file)
+            with open(path, 'r') as f:
+                content = f.read()
+
+            # Find any .url usage
+            matches = re.findall(r'\{\{[^\}]*\.url[^\}]*\}\}', content)
+            for m in matches:
+                # print the line to see if it's prefixed
+                lines = content.split('\n')
+                for line in lines:
+                    if m in line and 'base_url' not in line:
+                        print(f"{path}: {line.strip()}")


### PR DESCRIPTION
Fixes 404 risks by prefixing bare URL template variables like `{{ post.url }}` with `{{ base_url }}` in target Hwaro examples. Expanding sparse content in `carbon-fiber` to have at least 3 entries in its main section. Unmodified examples were found to already adhere to the rules and did not require changes.

---
*PR created automatically by Jules for task [9009589671790315217](https://jules.google.com/task/9009589671790315217) started by @hahwul*