### PR TITLE
Fix 404 risks and expand sparse content (batch r3-18)

### DIFF
--- a/examples/empyrean/templates/section.html
+++ b/examples/empyrean/templates/section.html
@@ -11,7 +11,7 @@
         <div class="celestial-list">
           {% for post in section.pages %}
           <div class="celestial-item">
-            <h3 class="item-title"><a href="{{ post.permalink }}">{{ post.title }}</a></h3>
+            <h3 class="item-title"><a href="{{ base_url }}{{ post.permalink }}">{{ post.title }}</a></h3>
             {% if post.description %}
             <p class="item-description">{{ post.description }}</p>
             {% endif %}

--- a/examples/enigma/templates/section.html
+++ b/examples/enigma/templates/section.html
@@ -9,7 +9,7 @@
         <div class="puzzle-grid">
           {% for post in section.pages %}
           <div class="puzzle-card">
-            <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+            <h3><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
             {% if post.description %}
             <p class="puzzle-description">{{ post.description }}</p>
             {% endif %}

--- a/examples/ephemeral-glow/templates/section.html
+++ b/examples/ephemeral-glow/templates/section.html
@@ -10,7 +10,7 @@
 
     <div class="gallery-grid">
       {% for p in section.pages %}
-      <a href="{{ p.url }}" class="glass-card">
+      <a href="{{ base_url }}{{ p.url }}" class="glass-card">
         <h2 class="card-title">{{ p.title | e }}</h2>
         <p class="card-desc">{{ p.description | default("No description") | e }}</p>
       </a>


### PR DESCRIPTION
Fix 404 risks by adding {{ base_url }} prefixes to post URLs in section templates for empyrean, enigma, and ephemeral-glow. No other examples in the batch required content expansion or URL fixes based on the constraints.

---
*PR created automatically by Jules for task [12497653436367040080](https://jules.google.com/task/12497653436367040080) started by @chei-l*