### PR TITLE
Fix 404 risks and expand sparse content (batch r3-04)

### DIFF
--- a/examples/aurora-nexus/templates/404.html
+++ b/examples/aurora-nexus/templates/404.html
@@ -4,7 +4,7 @@
     <h1 style="font-size: 6rem; margin-bottom: 1rem; background: linear-gradient(to right, var(--aurora-cyan), var(--aurora-magenta)); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">404</h1>
     <h2>Lost in the Aurora</h2>
     <p style="margin-bottom: 2rem;">The cosmic coordinates you provided lead to a void sector.</p>
-    <a href="/" style="display: inline-block; padding: 0.75rem 1.5rem; background: rgba(255,255,255,0.1); border: 1px solid var(--glass-border); border-radius: 8px; color: #fff; font-weight: 500;">Return to Base</a>
+    <a href="{{ base_url }}/" style="display: inline-block; padding: 0.75rem 1.5rem; background: rgba(255,255,255,0.1); border: 1px solid var(--glass-border); border-radius: 8px; color: #fff; font-weight: 500;">Return to Base</a>
 </article>
 
 {% include "footer.html" %}

--- a/examples/aurora-nexus/templates/section.html
+++ b/examples/aurora-nexus/templates/section.html
@@ -20,7 +20,7 @@
     <ul class="post-list">
         {% for p in section.pages %}
         <li class="post-item">
-            <a href="{{ p.permalink }}" class="post-link glass-panel">
+            <a href="{{ base_url }}{{ p.url }}" class="post-link glass-panel">
                 <h2>{{ p.title }}</h2>
                 {% if p.description is defined and p.description %}
                 <p>{{ p.description }}</p>

--- a/examples/aurum/templates/section.html
+++ b/examples/aurum/templates/section.html
@@ -11,7 +11,7 @@
   <ul class="section-list">
     {% for post in section.pages %}
       <li>
-        <a href="{{ post.url }}">{{ post.title }}</a>
+        <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
         <div class="post-meta">
           {% if post.date %}
             {{ post.date | date("%B %d, %Y") }}

--- a/examples/aurum/templates/taxonomy_term.html
+++ b/examples/aurum/templates/taxonomy_term.html
@@ -9,7 +9,7 @@
   <ul class="section-list">
     {% for post in taxonomy_pages %}
       <li>
-        <a href="{{ post.url }}">{{ post.title }}</a>
+        <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
         <div class="post-meta">
           {% if post.date %}
             {{ post.date | date("%B %d, %Y") }}

--- a/examples/bioluminescence/templates/section.html
+++ b/examples/bioluminescence/templates/section.html
@@ -12,14 +12,14 @@
     <div class="posts-grid">
         {% for post in section.pages %}
         <article class="post-card glowing-box">
-            <h2 class="post-title"><a href="{{ post.permalink | default(value=post.path) }}">{{ post.title }}</a></h2>
+            <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
             {% if post.date %}
             <div class="post-date">{{ post.date | date(format="%B %d, %Y") }}</div>
             {% endif %}
             {% if post.summary %}
             <p class="post-summary">{{ post.summary }}</p>
             {% endif %}
-            <a href="{{ post.permalink | default(value=post.path) }}" class="read-more">Read More &rarr;</a>
+            <a href="{{ base_url }}{{ post.url }}" class="read-more">Read More &rarr;</a>
         </article>
         {% endfor %}
     </div>

--- a/examples/bioluminescence/templates/taxonomy.html
+++ b/examples/bioluminescence/templates/taxonomy.html
@@ -5,7 +5,7 @@
     <div class="content-body">
         <ul>
         {% for term in terms %}
-            <li><a href="{{ term.permalink }}">{{ term.name }}</a></li>
+            <li><a href="{{ base_url }}{{ term.url }}">{{ term.name }}</a></li>
         {% endfor %}
         </ul>
     </div>

--- a/examples/bioluminescence/templates/taxonomy_term.html
+++ b/examples/bioluminescence/templates/taxonomy_term.html
@@ -5,14 +5,14 @@
     <div class="posts-grid">
         {% for post in term.pages %}
         <article class="post-card glowing-box">
-            <h2 class="post-title"><a href="{{ post.permalink }}">{{ post.title }}</a></h2>
+            <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
             {% if post.date %}
             <div class="post-date">{{ post.date | date(format="%B %d, %Y") }}</div>
             {% endif %}
             {% if post.summary %}
             <p class="post-summary">{{ post.summary }}</p>
             {% endif %}
-            <a href="{{ post.permalink }}" class="read-more">Read More &rarr;</a>
+            <a href="{{ base_url }}{{ post.url }}" class="read-more">Read More &rarr;</a>
         </article>
         {% endfor %}
     </div>


### PR DESCRIPTION
Fixes 404 risks in `aurora-nexus` and `aurum` by ensuring `{{ base_url }}` is prepended to relative links and bare URLs. Checked all 10 repositories for sparse content, but found no valid missing content instances to append.

---
*PR created automatically by Jules for task [404195978618258316](https://jules.google.com/task/404195978618258316) started by @hahwul*