### PR TITLE
Fix 404 risks and expand sparse content (batch r3-12)

### DIFF
--- a/examples/copper-wire/templates/section.html
+++ b/examples/copper-wire/templates/section.html
@@ -12,7 +12,7 @@
         {% for p in site.pages | sort_by("date", reverse=true) %}
             <div class="post-item">
                 <div class="post-date">{% if p.date %}{{ p.date | date("%Y.%m.%d") }}{% endif %}</div>
-                <h2 class="post-title"><a href="{{ p.url }}">{{ p.title }}</a></h2>
+                <h2 class="post-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></h2>
                 <div class="post-summary">
                     {{ p.description | default("") | strip_html | truncate_words(30) }}
                 </div>

--- a/examples/copper-wire/templates/taxonomy_term.html
+++ b/examples/copper-wire/templates/taxonomy_term.html
@@ -11,7 +11,7 @@
         {% for p in taxonomy_pages | sort_by("date", reverse=true) %}
             <div class="post-item">
                 <div class="post-date">{% if p.date %}{{ p.date | date("%Y.%m.%d") }}{% endif %}</div>
-                <h2 class="post-title"><a href="{{ p.url }}">{{ p.title }}</a></h2>
+                <h2 class="post-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></h2>
                 <div class="post-summary">
                     {{ p.description | default("") | strip_html | truncate_words(30) }}
                 </div>

--- a/examples/cosmic-synth-forge/templates/section.html
+++ b/examples/cosmic-synth-forge/templates/section.html
@@ -16,7 +16,7 @@
         <div class="page-list">
             {% for p in paginator.pages %}
             <article class="list-item">
-                <h2 class="list-title"><a href="{{ p.url }}">{{ p.title }}</a></h2>
+                <h2 class="list-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></h2>
                 {% if p.date %}
                 <time class="list-date" datetime="{{ p.date | date("%Y-%m-%d") }}">{{ p.date | date("%B %d, %Y") }}</time>
                 {% endif %}
@@ -44,7 +44,7 @@
         <div class="page-list">
             {% for p in pages %}
             <article class="list-item">
-                <h2 class="list-title"><a href="{{ p.url }}">{{ p.title }}</a></h2>
+                <h2 class="list-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></h2>
                 {% if p.date %}
                 <time class="list-date" datetime="{{ p.date | date("%Y-%m-%d") }}">{{ p.date | date("%B %d, %Y") }}</time>
                 {% endif %}


### PR DESCRIPTION
Fix 404 risks by prefixing internal URLs with `{{ base_url }}` in the `copper-wire` and `cosmic-synth-forge` examples. No sparse content additions were needed for these 10 examples.

---
*PR created automatically by Jules for task [13960463096554421918](https://jules.google.com/task/13960463096554421918) started by @hahwul*