### PR TITLE
Fix 404 risks and expand sparse content (batch r3-27)

### DIFF
--- a/examples/haute-couture/templates/404.html
+++ b/examples/haute-couture/templates/404.html
@@ -5,6 +5,6 @@
     <h1 style="font-size: 6rem; margin-bottom: 1rem;">404</h1>
     <h2 style="font-size: 2rem; color: var(--secondary-text);">Page Not Found</h2>
     <p style="margin-top: 2rem;">The editorial you are looking for does not exist or has been moved.</p>
-    <a href="{{ site.base_url | default(value="") }}/" style="display: inline-block; margin-top: 2rem; padding: 1rem 2rem; border: 1px solid var(--text-color); text-transform: uppercase; letter-spacing: 1px;">Return Home</a>
+    <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 1rem 2rem; border: 1px solid var(--text-color); text-transform: uppercase; letter-spacing: 1px;">Return Home</a>
 </div>
 {% endblock content %}

--- a/examples/haute-couture/templates/base.html
+++ b/examples/haute-couture/templates/base.html
@@ -174,11 +174,11 @@
 </head>
 <body>
     <header>
-        <div class="brand"><a href="{{ site.base_url | default(value="") }}/">Haute Couture</a></div>
+        <div class="brand"><a href="{{ base_url }}/">Haute Couture</a></div>
         <nav>
-            <a href="{{ site.base_url | default(value="") }}/">Home</a>
-            <a href="{{ site.base_url | default(value="") }}/posts/">Editorials</a>
-            <a href="{{ site.base_url | default(value="") }}/about/">About</a>
+            <a href="{{ base_url }}/">Home</a>
+            <a href="{{ base_url }}/posts/">Editorials</a>
+            <a href="{{ base_url }}/about/">About</a>
         </nav>
     </header>
 

--- a/examples/haute-couture/templates/index.html
+++ b/examples/haute-couture/templates/index.html
@@ -5,7 +5,7 @@
     <div class="hero-text">
         <h1>The New Elegance</h1>
         <p>Discover the latest trends in high fashion, where classic silhouettes meet modern aesthetics. A curation of style, beauty, and culture.</p>
-        <a href="{{ site.base_url | default(value="") }}/posts/" style="display: inline-block; padding: 1rem 2rem; background: var(--text-color); color: var(--bg-color); text-transform: uppercase; font-weight: 600; font-family: 'Inter', sans-serif; letter-spacing: 1px;">Read the Issue</a>
+        <a href="{{ base_url }}/posts/" style="display: inline-block; padding: 1rem 2rem; background: var(--text-color); color: var(--bg-color); text-transform: uppercase; font-weight: 600; font-family: 'Inter', sans-serif; letter-spacing: 1px;">Read the Issue</a>
     </div>
     <!-- A solid color placeholder for an image to match the "no gradient" rule while keeping the layout -->
     <div style="background-color: #222; height: 600px; width: 100%;"></div>

--- a/examples/haute-couture/templates/page.html
+++ b/examples/haute-couture/templates/page.html
@@ -10,7 +10,7 @@
         {% if page.taxonomies and page.taxonomies.tags %}
         <div style="margin-top: 1rem;">
             {% for tag in page.taxonomies.tags %}
-            <a href="{{ site.base_url | default(value="") }}/tags/{{ tag | slugify }}/" style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 1px; padding: 0.2rem 0.5rem; border: 1px solid var(--border-color); margin-right: 0.5rem;">{{ tag }}</a>
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 1px; padding: 0.2rem 0.5rem; border: 1px solid var(--border-color); margin-right: 0.5rem;">{{ tag }}</a>
             {% endfor %}
         </div>
         {% endif %}

--- a/examples/haute-couture/templates/section.html
+++ b/examples/haute-couture/templates/section.html
@@ -14,7 +14,7 @@
         {% if page.date %}
         <span class="date">{{ page.date | date(format="%B %d, %Y") }}</span>
         {% endif %}
-        <h3><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+        <h3><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></h3>
         {% if page.summary %}
         <p>{{ page.summary }}</p>
         {% elif page.description %}

--- a/examples/haute-couture/templates/taxonomy.html
+++ b/examples/haute-couture/templates/taxonomy.html
@@ -7,7 +7,7 @@
 
 <div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem;">
     {% for term in terms %}
-    <a href="{{ term.permalink }}" style="font-size: 1.1rem; text-transform: uppercase; letter-spacing: 1px; padding: 1rem 2rem; border: 1px solid var(--text-color);">
+    <a href="{{ base_url }}{{ term.permalink }}" style="font-size: 1.1rem; text-transform: uppercase; letter-spacing: 1px; padding: 1rem 2rem; border: 1px solid var(--text-color);">
         {{ term.name }} ({{ term.pages | length }})
     </a>
     {% endfor %}

--- a/examples/haute-couture/templates/taxonomy_term.html
+++ b/examples/haute-couture/templates/taxonomy_term.html
@@ -12,7 +12,7 @@
         {% if page.date %}
         <span class="date">{{ page.date | date(format="%B %d, %Y") }}</span>
         {% endif %}
-        <h3><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+        <h3><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></h3>
         {% if page.summary %}
         <p>{{ page.summary }}</p>
         {% elif page.description %}

--- a/examples/holo-cosmos/content/posts/first-contact.md
+++ b/examples/holo-cosmos/content/posts/first-contact.md
@@ -1,0 +1,10 @@
++++
+title = "First Contact"
+date = "2025-04-12"
+description = "Initial synchronization with the network."
++++
+The initial phase of our synchronization is complete. Data streams from the outer rim have begun to coalesce into meaningful patterns. The holographic universe theory suggests that our three-dimensional reality is merely a projection of information encoded on a distant two-dimensional surface. Today, we received the first packet of anomalies that lend credence to this.
+
+As we analyze the quantum fluctuations, it's becoming apparent that the 'static' we previously discarded as background noise contains structured data. Our next step is to decode these transmissions and attempt a full reconstruction of the source matrix. Stay tuned as we venture further into the unknown.
+
+These structured data packets are a significant leap forward. If the data mapping holds true, we might soon be able to visualize the outer edges of the projection matrix. Our team of theoretical physicists and data scientists are working around the clock to refine the decoding algorithms. The journey into the unknown has truly begun, and the first steps are incredibly promising.

--- a/examples/holo-cosmos/content/posts/holographic-principle.md
+++ b/examples/holo-cosmos/content/posts/holographic-principle.md
@@ -1,0 +1,10 @@
++++
+title = "The Holographic Principle"
+date = "2026-01-05"
+description = "A deep dive into the underlying theory."
++++
+At the core of our research lies the holographic principle. This theoretical framework posits that the entire universe can be seen as two-dimensional information on the cosmological horizon. What we perceive as a 3D reality is just a projection.
+
+Our recent experiments have focused on mapping these 2D information patterns. By interpreting the interference patterns of light and matter, we are beginning to see the 'source code' of reality. This is not just a philosophical concept; it has practical applications in data storage, quantum computing, and perhaps, one day, the ability to alter the projection itself. We are merely at the beginning of this journey.
+
+As we refine our models and improve our sensory apparatus, the resolution of these 2D patterns becomes clearer. We are slowly piecing together the fundamental grammar of the universe. While full manipulation of the projection remains a distant dream, understanding its structure is the crucial first step. The implications of this research extend far beyond mere observation; they touch upon the very nature of existence itself.

--- a/examples/holo-cosmos/content/posts/quantum-entanglement.md
+++ b/examples/holo-cosmos/content/posts/quantum-entanglement.md
@@ -1,0 +1,10 @@
++++
+title = "Quantum Entanglement"
+date = "2025-06-20"
+description = "Linking nodes across vast distances."
++++
+We have successfully established a stable quantum entanglement link between two primary nodes separated by thousands of miles. This breakthrough allows for instantaneous data transfer, bypassing traditional limitations of the speed of light. The implications for the Holo Cosmos project are profound.
+
+By utilizing this network, we can synchronize our holographic projections in real-time, creating a unified, seamless virtual environment. The nodes are currently sharing encrypted data streams, maintaining absolute security and integrity. As we expand the network, the possibility of a truly interconnected, instantaneous global projection becomes a reality.
+
+The next phase of our operation involves bringing a third node online, establishing a tri-nodal network that will increase our computational capabilities exponentially. This interconnected structure forms the backbone of the global projection framework. The stability of the current link gives us immense confidence in the viability of the overarching Holo Cosmos architecture.

--- a/examples/holo-cosmos/templates/section.html
+++ b/examples/holo-cosmos/templates/section.html
@@ -14,7 +14,7 @@
     <ul style="list-style-type: none; padding: 0;">
         {% for page in section.pages %}
         <li style="margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--glass-border);">
-            <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+            <h2><a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a></h2>
             {% if page.description %}
             <p style="color: var(--text-muted); margin-top: 0.5rem; margin-bottom: 0;">{{ page.description }}</p>
             {% endif %}

--- a/examples/holo-cosmos/templates/taxonomy_term.html
+++ b/examples/holo-cosmos/templates/taxonomy_term.html
@@ -13,7 +13,7 @@
     <ul style="list-style-type: none; padding: 0;">
         {% for p in page.pages %}
         <li style="margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--glass-border);">
-            <h2><a href="{{ p.permalink }}">{{ p.title }}</a></h2>
+            <h2><a href="{{ base_url }}{{ p.permalink }}">{{ p.title }}</a></h2>
             {% if p.description %}
             <p style="color: var(--text-muted); margin-top: 0.5rem; margin-bottom: 0;">{{ p.description }}</p>
             {% endif %}


### PR DESCRIPTION
Addresses the batch request for `r3-27`. Applied the `{{ base_url }}` string prefix to various template absolute urls across targeted examples to avoid internal path 404s. Also fleshed out `holo-cosmos/content/posts` with 3 properly scoped articles matching the constraints. Did not rename indexes or append helpers.

---
*PR created automatically by Jules for task [11627152077228995417](https://jules.google.com/task/11627152077228995417) started by @chei-l*