### PR TITLE
Fix 404 links and correct template variables in luxury-horology example

### DIFF
--- a/examples/luxury-horology/content/atelier/_index.md
+++ b/examples/luxury-horology/content/atelier/_index.md
@@ -1,3 +1,8 @@
 +++
-title = "Atelier"
+title = "The Atelier"
+description = "Where master watchmakers bring time to life."
 +++
+
+Our atelier in Geneva is a sanctuary of precision and tradition. Here, master watchmakers assemble and test each timepiece by hand, ensuring that every movement meets the highest standards of chronometry and finishing.
+
+The craft is passed down through generations, combining centuries-old techniques with modern innovation to create objects of enduring value.

--- a/examples/luxury-horology/templates/base.html
+++ b/examples/luxury-horology/templates/base.html
@@ -58,9 +58,9 @@
       </div>
       <nav class="site-nav">
         <a href="{{ base_url }}/">Collection</a>
-        <a href="{{ base_url }}/about">Heritage</a>
-        <a href="{{ base_url }}/journal">Journal</a>
-        <a href="{{ base_url }}/atelier">Atelier</a>
+        <a href="{{ base_url }}/about/">Heritage</a>
+        <a href="{{ base_url }}/journal/">Journal</a>
+        <a href="{{ base_url }}/atelier/">Atelier</a>
       </nav>
       <div class="header-aside">
         <span>Est. MCMXLVII</span>

--- a/examples/luxury-horology/templates/index.html
+++ b/examples/luxury-horology/templates/index.html
@@ -6,7 +6,7 @@
     <span class="hero-eyebrow">Calibre 2024</span>
     <h1 class="hero-title">Mastery in <em>Motion</em></h1>
     <p class="hero-subtitle">Two centuries of horological tradition, distilled into mechanisms of singular precision &mdash; finished entirely by hand in our Geneva atelier.</p>
-    <a href="{{ base_url }}/collection" class="btn-primary">
+    <a href="{{ base_url }}/collection/" class="btn-primary">
       Explore the Collection
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
     </a>
@@ -135,9 +135,9 @@
       <div class="article-meta">
         <time datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>
       </div>
-      <h3 class="article-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+      <h3 class="article-title"><a href="{{ base_url }}{{ page.url }}">{{ page.title }}</a></h3>
       <p class="article-summary">{{ page.description | default(value="A deeper look into our horological pursuits.") }}</p>
-      <a href="{{ page.permalink }}" class="read-more">
+      <a href="{{ base_url }}{{ page.url }}" class="read-more">
         Read Article
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
       </a>

--- a/examples/luxury-horology/templates/page.html
+++ b/examples/luxury-horology/templates/page.html
@@ -19,7 +19,7 @@
   {% if section is defined and section.pages is defined %}
   <ul class="section-list">
     {% for p in section.pages %}
-    <li><a href="{{ p.permalink }}">{{ p.title }}</a></li>
+    <li><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></li>
     {% endfor %}
   </ul>
   {% endif %}


### PR DESCRIPTION
Resolves broken links (404s) in the `luxury-horology` example site. 

The main navigation contained a link to a missing `atelier` page, which was resolved by adding `content/atelier/_index.md`. Navigation links in `base.html` and `index.html` were updated with trailing slashes to ensure correct resolution on static hosting deployments. Additionally, broken template variables referencing `.permalink` were corrected to use `.url` combined with `{{ base_url }}` for generated links in `index.html` and `page.html`.

---
*PR created automatically by Jules for task [12242519971976934151](https://jules.google.com/task/12242519971976934151) started by @hahwul*