### PR TITLE
Fix template rendering and links in zen-stone

### DIFF
--- a/examples/zen-stone/templates/section.html
+++ b/examples/zen-stone/templates/section.html
@@ -1,10 +1,10 @@
 {% include "header.html" %}
   <main>
-    <h2 style="font-weight: 300; color: var(--stone-dark); border-bottom: 1px solid var(--stone-light); padding-bottom: 10px;">{{ section }}</h2>
+    <h2 style="font-weight: 300; color: var(--stone-dark); border-bottom: 1px solid var(--stone-light); padding-bottom: 10px;">{{ section.title }}</h2>
     <ul style="list-style: none; padding: 0;">
-      {% for page in pages %}
+      {% for page in section.pages %}
         <li style="margin-bottom: 15px;">
-          <a href="{{ page.url }}" style="font-size: 1.2rem; color: var(--text-color);">{{ page.title }}</a>
+          <a href="{{ base_url }}{{ page.url }}" style="font-size: 1.2rem; color: var(--text-color);">{{ page.title }}</a>
           <p style="font-size: 0.9rem; color: var(--accent-color); margin-top: 5px;">{{ page.description }}</p>
         </li>
       {% endfor %}

--- a/examples/zen-stone/templates/taxonomy.html
+++ b/examples/zen-stone/templates/taxonomy.html
@@ -2,9 +2,7 @@
   <main>
     <h2 style="font-weight: 300; color: var(--stone-dark);">{{ taxonomy }}</h2>
     <div style="display: flex; gap: 10px; flex-wrap: wrap; margin-top: 20px;">
-      {% for term in terms %}
-        <a href="{{ term.url }}" style="padding: 5px 15px; background: var(--stone-light); border-radius: 20px; font-size: 0.9rem; color: var(--text-color);">{{ term.name }} ({{ term.count }})</a>
-      {% endfor %}
+      {{ content | safe }}
     </div>
   </main>
 {% include "footer.html" %}

--- a/examples/zen-stone/templates/taxonomy_term.html
+++ b/examples/zen-stone/templates/taxonomy_term.html
@@ -4,7 +4,7 @@
     <ul style="list-style: none; padding: 0;">
       {% for page in pages %}
         <li style="margin-bottom: 15px;">
-          <a href="{{ page.url }}" style="font-size: 1.2rem; color: var(--text-color);">{{ page.title }}</a>
+          <a href="{{ base_url }}{{ page.url }}" style="font-size: 1.2rem; color: var(--text-color);">{{ page.title }}</a>
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
Fixed templates in zen-stone to properly prefix links with `base_url` to avoid 404s when deployed to subdirectories. Updated `section.html` to output `section.title` instead of the raw map. Updated `taxonomy.html` to output `content | safe` to preserve tags list formatting.

---
*PR created automatically by Jules for task [2508307704012415038](https://jules.google.com/task/2508307704012415038) started by @chei-l*