### PR TITLE
Fix 404 broken links in cabin example site

### DIFF
--- a/examples/cabin/content/tags/_index.md
+++ b/examples/cabin/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+description = "All tags"
++++

--- a/examples/cabin/templates/home.html
+++ b/examples/cabin/templates/home.html
@@ -12,7 +12,7 @@
         <h2>Recent Entries</h2>
         {% for post in pages %}
         <article class="post-card">
-          <h2><a href="{{ base_url }}/{{ post.path }}">{{ post.title }}</a></h2>
+          <h2><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
           <div class="post-meta">
             <span>{{ post.date }}</span>
             {% if post.extra.reading_time %}
@@ -55,7 +55,7 @@
         <ul class="recent-posts-list">
           {% for post in pages %}
           <li>
-            <a href="{{ base_url }}/{{ post.path }}">{{ post.title }}</a>
+            <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
             <div class="post-date-small">{{ post.date }}</div>
           </li>
           {% endfor %}

--- a/examples/cabin/templates/page.html
+++ b/examples/cabin/templates/page.html
@@ -30,18 +30,18 @@
       </article>
 
       <nav class="post-nav">
-        {% if page.earlier %}
-        <a href="{{ base_url }}/{{ page.earlier.path }}" class="prev">
+        {% if page.lower %}
+        <a href="{{ base_url }}{{ page.lower.url }}" class="prev">
           <div class="nav-label">Previous</div>
-          <div class="nav-title">{{ page.earlier.title }}</div>
+          <div class="nav-title">{{ page.lower.title }}</div>
         </a>
         {% else %}
         <span></span>
         {% endif %}
-        {% if page.later %}
-        <a href="{{ base_url }}/{{ page.later.path }}" class="next">
+        {% if page.higher %}
+        <a href="{{ base_url }}{{ page.higher.url }}" class="next">
           <div class="nav-label">Next</div>
-          <div class="nav-title">{{ page.later.title }}</div>
+          <div class="nav-title">{{ page.higher.title }}</div>
         </a>
         {% else %}
         <span></span>

--- a/examples/cabin/templates/section.html
+++ b/examples/cabin/templates/section.html
@@ -7,7 +7,7 @@
 
       {% for post in paginator.pages %}
       <article class="post-card">
-        <h2><a href="{{ base_url }}/{{ post.path }}">{{ post.title }}</a></h2>
+        <h2><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         <div class="post-meta">
           <span>{{ post.date }}</span>
           {% if post.extra.reading_time %}

--- a/examples/cabin/templates/taxonomy_term.html
+++ b/examples/cabin/templates/taxonomy_term.html
@@ -5,7 +5,7 @@
 
   {% for post in term.pages %}
   <article class="post-card">
-    <h2><a href="{{ base_url }}/{{ post.path }}">{{ post.title }}</a></h2>
+    <h2><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
     <div class="post-meta">
       <span>{{ post.date }}</span>
     </div>


### PR DESCRIPTION
- Created `content/tags/_index.md` to resolve 404 for `/tags/` route.
- Updated templates to use `post.url`, `page.lower.url`, and `page.higher.url` instead of outdated `*.path` variables.
- Fixed absolute URL concatenation by removing the intermediate slash when combining `{{ base_url }}` with URL variables.

---
*PR created automatically by Jules for task [7068437686433840301](https://jules.google.com/task/7068437686433840301) started by @hahwul*