### PR TITLE
fix(minimalzen): correct post.url 404 broken links

### DIFF
--- a/examples/minimalzen/templates/index.html
+++ b/examples/minimalzen/templates/index.html
@@ -11,7 +11,7 @@
     <ul class="post-list">
         {% for post in posts_section.pages | slice(end=5) %}
         <li class="post-item" style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 1rem; border-bottom: 1px solid var(--border-color); padding-bottom: 1rem;">
-            <div class="post-title" style="margin: 0; font-size: 1.1rem;"><a href="{{ post.url }}">{{ post.title }}</a></div>
+            <div class="post-title" style="margin: 0; font-size: 1.1rem;"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></div>
             <time class="post-meta" style="margin: 0; min-width: 100px; text-align: right;">{{ post.date | date(format="%Y.%m.%d") }}</time>
         </li>
         {% endfor %}

--- a/examples/minimalzen/templates/section.html
+++ b/examples/minimalzen/templates/section.html
@@ -11,7 +11,7 @@
     {% for post in section.pages %}
     <li class="post-item">
         <time class="post-meta">{{ post.date | date(format="%B %d, %Y") }}</time>
-        <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         {% if post.summary %}
         <div class="post-summary">{{ post.summary | safe }}</div>
         {% endif %}


### PR DESCRIPTION
Fixed broken `post.url` links by prepending the `{{ base_url }}` in the `index.html` and `section.html` templates for the minimalzen example site, which corrects routing issues when hosted on a subdirectory.

---
*PR created automatically by Jules for task [11003309799537592843](https://jules.google.com/task/11003309799537592843) started by @hahwul*