### PR TITLE
Fix 404 broken links in inventory example

### DIFF
--- a/examples/inventory/content/categories/_index.md
+++ b/examples/inventory/content/categories/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Categories"
+description = "Browse inventory by categories"
+template = "taxonomy"
++++

--- a/examples/inventory/templates/taxonomy.html
+++ b/examples/inventory/templates/taxonomy.html
@@ -2,13 +2,13 @@
 
 <div class="space-y-6 max-w-4xl mx-auto">
     <div class="text-center py-12">
-        <h1 class="text-4xl font-bold tracking-tight text-text mb-4">{{ taxonomy.name | capitalize }}</h1>
-        <p class="text-textMuted text-lg max-w-2xl mx-auto">Browse inventory items by {{ taxonomy.name }}.</p>
+        <h1 class="text-4xl font-bold tracking-tight text-text mb-4">{{ taxonomy_name | capitalize }}</h1>
+        <p class="text-textMuted text-lg max-w-2xl mx-auto">Browse inventory items by {{ taxonomy_name }}.</p>
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {% for term in taxonomy_terms %}
-        <a href="{{ term.permalink }}" class="card p-6 hover:-translate-y-1 hover:shadow-md transition-all duration-200">
+        <a href="{{ base_url }}{{ term.url }}" class="card p-6 hover:-translate-y-1 hover:shadow-md transition-all duration-200">
             <h2 class="text-xl font-semibold text-text mb-2">{{ term.name }}</h2>
             <div class="text-textMuted text-sm flex items-center justify-between">
                 <span>{{ term.pages | length }} items</span>


### PR DESCRIPTION
This PR fixes 404 broken links in the `inventory` example site. 
- Created `content/categories/_index.md` to define the `/categories` taxonomy index page which fixes the 404 from the `href="{{ base_url }}/categories"` link in the header.
- Updated `term.permalink` to `{{ base_url }}{{ term.url }}` in `templates/taxonomy.html` to generate correct URL paths. 
- Updated `taxonomy.name` to `taxonomy_name` in `templates/taxonomy.html` to prevent `taxonomy is undefined` template rendering errors.

---
*PR created automatically by Jules for task [9756013968375389052](https://jules.google.com/task/9756013968375389052) started by @hahwul*