### PR TITLE
- apolo-luxe: Fix broken authors taxonomy link by creating the missing index page

### DIFF
--- a/examples/apolo-luxe/content/authors/_index.md
+++ b/examples/apolo-luxe/content/authors/_index.md
@@ -1,0 +1,3 @@
++++
+title = "Authors"
++++


### PR DESCRIPTION
- apolo-luxe: Fix broken authors taxonomy link by creating the missing index page

---
*PR created automatically by Jules for task [4949950251838243128](https://jules.google.com/task/4949950251838243128) started by @chei-l*