### PR TITLE
Add five modern-themed example sites

### DIFF
--- a/examples/axiom-grid/AGENTS.md
+++ b/examples/axiom-grid/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/axiom-grid/archetypes/default.md
+++ b/examples/axiom-grid/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/axiom-grid/config.toml
+++ b/examples/axiom-grid/config.toml
@@ -1,0 +1,197 @@
+title = "Axiom Grid"
+description = "A geometric, Bauhaus-inspired documentation theme with primary color blocks."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/axiom-grid/content/about.md
+++ b/examples/axiom-grid/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "About Axiom Grid, the design choices behind it, and where to file complaints."
+date = "2026-04-01"
++++
+
+Axiom Grid is a documentation theme that takes its visual cues from the Bauhaus and its information architecture from a well-organized library. It is intentionally opinionated: we believe documentation looks more honest when its grid is visible.
+
+## The choices we have made
+
+- Primary colors used as flat blocks, never as gradients.
+- Hairlines you can see, set at 2px so they survive on cheap displays.
+- Geometric ornaments instead of icons, which always go out of date.
+- Three font families, all variable, all served from Google Fonts.
+
+## What this is not
+
+This is not a marketing theme. There is no carousel. There is no testimonial section. There is, deliberately, no animation that runs on scroll.
+
+## License
+
+MIT. Use it. Fork it. Send improvements.

--- a/examples/axiom-grid/content/docs/_index.md
+++ b/examples/axiom-grid/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "Core documentation. Installation, configuration, and the daily workflow."
+sort_by = "weight"
++++

--- a/examples/axiom-grid/content/docs/cli.md
+++ b/examples/axiom-grid/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "Every command, every flag, and the one or two you actually need every day."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name>` | Scaffold a new site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/axiom-grid/content/docs/configuration.md
+++ b/examples/axiom-grid/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "Every setting in config.toml, what it does, and the smallest sensible default."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/axiom-grid/content/docs/installation.md
+++ b/examples/axiom-grid/content/docs/installation.md
@@ -1,0 +1,32 @@
++++
+title = "Installation"
+description = "Three commands to a working site. Then four pages of you choosing how strict you want the config to be."
+weight = 1
+date = "2026-05-01"
++++
+
+Axiom Grid runs on the Hwaro static site generator. You can install it from Homebrew, run it under Docker, or build it from source.
+
+## Quickstart
+
+```sh
+brew tap hahwul/hwaro
+brew install hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve --open
+```
+
+The dev server will open `http://localhost:3000` in your browser. Any edit to `content/`, `templates/`, or `static/` reloads in under 50ms.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.13.1 or newer
+```
+
+If you see anything older, your package manager has cached an old version. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Move on to **Your first page**, where you will write a single piece of content, give it a template, and watch it render.

--- a/examples/axiom-grid/content/docs/sections-and-pages.md
+++ b/examples/axiom-grid/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "How content is organized, how sections behave, and why _index.md is doing more than it looks."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/axiom-grid/content/docs/taxonomies.md
+++ b/examples/axiom-grid/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Tags, categories, and the occasional custom one. How to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/axiom-grid/content/docs/template-filters.md
+++ b/examples/axiom-grid/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A reference of the most useful template filters, with examples you can paste."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/axiom-grid/content/docs/templates.md
+++ b/examples/axiom-grid/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Jinja-flavored templates, where to put them, and the small set of globals you can count on."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/axiom-grid/content/docs/your-first-page.md
+++ b/examples/axiom-grid/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "A small walkthrough that ends with a rendered page and the satisfaction of a green build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/axiom-grid/content/guides/_index.md
+++ b/examples/axiom-grid/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "Longer recipes for common situations and the occasional edge case."
+sort_by = "weight"
++++

--- a/examples/axiom-grid/content/guides/build-pipeline.md
+++ b/examples/axiom-grid/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "What happens between hwaro build and public/, in seven readable phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/axiom-grid/content/guides/deploying.md
+++ b/examples/axiom-grid/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Cookbook entries for GitHub Pages, Cloudflare Pages, and a Bash script for the rest of you."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/axiom-grid/content/guides/i18n.md
+++ b/examples/axiom-grid/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/axiom-grid/content/index.md
+++ b/examples/axiom-grid/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Axiom Grid"
+description = "A geometric, Bauhaus-inspired documentation theme with primary color blocks."
+template = "home"
++++

--- a/examples/axiom-grid/static/css/style.css
+++ b/examples/axiom-grid/static/css/style.css
@@ -1,0 +1,429 @@
+:root {
+  --bg: #f4f2ec;
+  --paper: #ffffff;
+  --ink: #0a0a0a;
+  --ink-soft: #2a2a2a;
+  --mute: #6e6e6e;
+  --rule: #0a0a0a;
+  --red: #e63946;
+  --blue: #1d4ed8;
+  --yellow: #facc15;
+  --green: #16a34a;
+  --hair: #d4cfc4;
+  --code: #f1ede2;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* ===== Top bar ===== */
+.bar {
+  border-bottom: 2px solid var(--ink);
+  background: var(--bg);
+  position: sticky; top: 0; z-index: 30;
+}
+
+.bar-inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: stretch;
+  gap: 0;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 24px;
+  border-right: 2px solid var(--ink);
+  font-family: "Space Grotesk", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+.brand .mark {
+  position: relative;
+  width: 26px; height: 26px;
+  background: var(--red);
+}
+.brand .mark::after {
+  content: ""; position: absolute; right: -10px; top: 50%;
+  width: 14px; height: 14px; background: var(--blue);
+  transform: translateY(-50%);
+}
+.brand .mark::before {
+  content: ""; position: absolute; left: 6px; bottom: -6px;
+  width: 10px; height: 10px; background: var(--yellow); border-radius: 50%;
+}
+
+.search {
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  border-right: 2px solid var(--ink);
+}
+.search input {
+  border: 0; background: transparent;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  color: var(--ink);
+  padding: 12px 0;
+  width: 100%;
+  outline: none;
+}
+.search input::placeholder { color: var(--mute); }
+.search .kbd { font-family: "JetBrains Mono", monospace; font-size: 11px; padding: 3px 8px; border: 1px solid var(--ink); color: var(--ink-soft); }
+
+.bar nav { display: flex; }
+.bar nav a {
+  padding: 14px 22px;
+  border-right: 2px solid var(--ink);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+.bar nav a:last-child { border-right: 0; }
+.bar nav a:hover { background: var(--ink); color: var(--paper); }
+.bar nav a.cta { background: var(--blue); color: var(--paper); }
+.bar nav a.cta:hover { background: var(--ink); }
+
+/* ===== Layout ===== */
+.shell {
+  display: grid;
+  grid-template-columns: 280px 1fr 240px;
+  min-height: calc(100vh - 56px);
+}
+
+.sidebar {
+  border-right: 2px solid var(--ink);
+  padding: 32px 24px;
+  position: sticky; top: 56px;
+  height: calc(100vh - 56px);
+  overflow-y: auto;
+}
+
+.sidebar h4 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin: 24px 0 10px;
+  position: relative;
+  padding-left: 16px;
+}
+.sidebar h4::before {
+  content: ""; position: absolute; left: 0; top: 5px;
+  width: 8px; height: 8px;
+}
+.sidebar h4.red::before { background: var(--red); }
+.sidebar h4.blue::before { background: var(--blue); border-radius: 50%; }
+.sidebar h4.yellow::before { background: var(--yellow); transform: rotate(45deg); }
+.sidebar h4.green::before { background: var(--green); }
+
+.sidebar ul { list-style: none; padding: 0; margin: 0; }
+.sidebar li { font-size: 14px; }
+.sidebar a {
+  display: block;
+  padding: 7px 14px 7px 16px;
+  border-left: 2px solid transparent;
+  color: var(--ink-soft);
+}
+.sidebar a:hover { background: var(--code); color: var(--ink); }
+.sidebar a.active { border-left-color: var(--red); color: var(--ink); font-weight: 600; background: var(--code); }
+
+.main { padding: 56px 64px; max-width: 880px; }
+
+.toc {
+  border-left: 2px solid var(--ink);
+  padding: 56px 24px;
+  position: sticky; top: 56px;
+  height: calc(100vh - 56px);
+  overflow-y: auto;
+  font-size: 13px;
+}
+.toc h5 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin: 0 0 14px;
+}
+.toc ul { list-style: none; padding: 0; margin: 0; }
+.toc li { padding: 4px 0; }
+.toc a { color: var(--ink-soft); }
+.toc a:hover { color: var(--blue); }
+
+/* ===== Article ===== */
+.crumb {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: var(--mute);
+  margin-bottom: 14px;
+  display: flex;
+  gap: 6px;
+}
+.crumb .accent { color: var(--red); }
+
+.main h1 {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: 52px;
+  line-height: 1.04;
+  letter-spacing: -0.025em;
+  margin: 0 0 16px;
+  position: relative;
+  padding-bottom: 18px;
+}
+.main h1::after {
+  content: ""; position: absolute; left: 0; bottom: 0;
+  width: 64px; height: 4px; background: var(--red);
+}
+.main .deck {
+  font-size: 19px;
+  color: var(--ink-soft);
+  margin: 0 0 36px;
+  max-width: 60ch;
+  line-height: 1.55;
+}
+
+.callout {
+  display: grid;
+  grid-template-columns: 8px 1fr;
+  margin: 28px 0;
+  border: 1.5px solid var(--ink);
+  background: var(--paper);
+}
+.callout .bar { width: 8px; background: var(--blue); border: 0; }
+.callout.warn .bar { background: var(--yellow); }
+.callout.bad  .bar { background: var(--red); }
+.callout.good .bar { background: var(--green); }
+.callout .body { padding: 16px 20px; }
+.callout .title {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink);
+  margin-bottom: 4px;
+}
+.callout p:last-child { margin-bottom: 0; }
+
+.content h2 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 26px;
+  font-weight: 700;
+  margin: 48px 0 14px;
+  letter-spacing: -0.015em;
+}
+.content h3 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 19px;
+  font-weight: 600;
+  margin: 32px 0 10px;
+}
+.content p { margin: 0 0 16px; max-width: 70ch; }
+.content code { font-family: "JetBrains Mono", monospace; background: var(--code); padding: 2px 6px; border-radius: 2px; font-size: 0.92em; }
+.content pre {
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  padding: 18px 22px;
+  overflow-x: auto;
+  font-size: 13px;
+  font-family: "JetBrains Mono", monospace;
+  margin: 24px 0;
+  position: relative;
+}
+.content pre::before {
+  content: "01"; position: absolute; top: 8px; right: 14px;
+  font-size: 10px; color: var(--mute); letter-spacing: 0.18em;
+}
+.content blockquote {
+  border-left: 4px solid var(--yellow);
+  background: var(--code);
+  padding: 14px 20px;
+  margin: 24px 0;
+  font-style: italic;
+}
+.content ul { padding-left: 24px; }
+.content li { margin-bottom: 6px; }
+.content a { color: var(--blue); border-bottom: 1px solid var(--blue); }
+
+/* ===== Pager ===== */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 56px;
+}
+.pager .b {
+  border: 2px solid var(--ink);
+  padding: 18px 22px;
+  background: var(--paper);
+}
+.pager .b .k { font-family: "JetBrains Mono", monospace; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--mute); }
+.pager .b .t { font-family: "Space Grotesk", sans-serif; font-weight: 600; font-size: 17px; margin-top: 4px; }
+.pager .next { text-align: right; }
+
+/* ===== Home hero ===== */
+.hero {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  border-bottom: 2px solid var(--ink);
+}
+.hero .copy { padding: 64px 56px; border-right: 2px solid var(--ink); }
+.hero h1 {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: clamp(40px, 5vw, 76px);
+  line-height: 0.98;
+  letter-spacing: -0.03em;
+  margin: 0 0 24px;
+}
+.hero h1 .red { color: var(--red); }
+.hero h1 .blue { color: var(--blue); }
+.hero .deck { font-size: 19px; color: var(--ink-soft); max-width: 50ch; margin: 0 0 28px; line-height: 1.5; }
+.hero .cta-row { display: flex; gap: 0; }
+.hero .cta-row a {
+  border: 2px solid var(--ink);
+  padding: 14px 22px;
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+}
+.hero .cta-row a + a { border-left: 0; }
+.hero .cta-row a.primary { background: var(--ink); color: var(--paper); }
+.hero .cta-row a.primary:hover { background: var(--blue); }
+.hero .cta-row a.kbd { font-family: "JetBrains Mono", monospace; background: var(--paper); }
+
+.shapes {
+  position: relative;
+  padding: 32px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 16px;
+}
+.shapes .s {
+  border: 2px solid var(--ink);
+  position: relative;
+  background: var(--paper);
+}
+.shapes .s.red { background: var(--red); }
+.shapes .s.blue { background: var(--blue); }
+.shapes .s.yellow { background: var(--yellow); }
+.shapes .s.circle { border-radius: 50%; }
+.shapes .s.tri {
+  background: var(--paper);
+  overflow: hidden;
+}
+.shapes .s.tri::after {
+  content: ""; position: absolute; inset: 0;
+  background: var(--yellow);
+  clip-path: polygon(0 100%, 100% 100%, 50% 0);
+}
+.shapes .span2 { grid-column: span 2; }
+.shapes .label {
+  position: absolute; bottom: 8px; left: 10px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  background: var(--paper);
+  padding: 2px 6px;
+  border: 1px solid var(--ink);
+}
+
+/* ===== Home grid of categories ===== */
+.cats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.cat {
+  border-right: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+  padding: 36px 32px;
+  background: var(--bg);
+  transition: background 120ms ease;
+}
+.cat:nth-child(3n) { border-right: 0; }
+.cat:hover { background: var(--paper); }
+.cat .icon { width: 36px; height: 36px; margin-bottom: 18px; border: 2px solid var(--ink); display: grid; place-items: center; font-family: "Space Grotesk"; font-weight: 700; font-size: 18px; }
+.cat .icon.red { background: var(--red); color: var(--paper); }
+.cat .icon.blue { background: var(--blue); color: var(--paper); }
+.cat .icon.yellow { background: var(--yellow); }
+.cat .icon.green { background: var(--green); color: var(--paper); }
+.cat .icon.gray { background: var(--ink); color: var(--paper); }
+.cat .icon.paper { background: var(--paper); }
+.cat h3 {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: 21px;
+  margin: 0 0 8px;
+  letter-spacing: -0.015em;
+}
+.cat p { color: var(--ink-soft); font-size: 14px; line-height: 1.55; margin: 0 0 14px; }
+.cat .read { font-family: "JetBrains Mono", monospace; font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink); border-bottom: 2px solid var(--ink); padding-bottom: 1px; }
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+}
+.metrics .m { padding: 24px 28px; border-right: 1.5px solid #333; }
+.metrics .m:last-child { border-right: 0; }
+.metrics .v { font-family: "Space Grotesk", sans-serif; font-weight: 700; font-size: 32px; letter-spacing: -0.02em; }
+.metrics .v.red { color: var(--red); }
+.metrics .v.blue { color: #93c5fd; }
+.metrics .v.yellow { color: var(--yellow); }
+.metrics .k { font-family: "JetBrains Mono", monospace; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: #b4b4b4; margin-top: 4px; }
+
+/* ===== Footer ===== */
+.foot {
+  padding: 36px 24px;
+  border-top: 2px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+.foot strong { font-family: "Space Grotesk"; }
+
+@media (max-width: 1080px) {
+  .shell { grid-template-columns: 240px 1fr; }
+  .toc { display: none; }
+  .cats { grid-template-columns: 1fr 1fr; }
+  .cat:nth-child(3n) { border-right: 2px solid var(--ink); }
+  .cat:nth-child(2n) { border-right: 0; }
+}
+@media (max-width: 720px) {
+  .shell { grid-template-columns: 1fr; }
+  .sidebar { display: none; }
+  .main { padding: 32px 24px; }
+  .hero { grid-template-columns: 1fr; }
+  .hero .copy { border-right: 0; border-bottom: 2px solid var(--ink); padding: 36px 24px; }
+  .cats { grid-template-columns: 1fr; }
+  .cat { border-right: 0; }
+  .metrics { grid-template-columns: 1fr 1fr; }
+  .metrics .m:nth-child(2n) { border-right: 0; }
+  .bar-inner { grid-template-columns: 1fr; }
+  .brand, .search { border-right: 0; border-bottom: 2px solid var(--ink); }
+}

--- a/examples/axiom-grid/templates/404.html
+++ b/examples/axiom-grid/templates/404.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <h1><span class="red">404</span> — page off the grid.</h1>
+    <p class="deck">The page you requested does not appear in this index. Try the <a href="{{ base_url }}/docs/" style="color:var(--blue);border-bottom:1px solid var(--blue);">documentation</a> or the <a href="{{ base_url }}/" style="color:var(--blue);border-bottom:1px solid var(--blue);">home page</a>.</p>
+  </div>
+  <div class="shapes">
+    <div class="s red"></div>
+    <div class="s circle"></div>
+    <div class="s blue"></div>
+    <div class="s span2 yellow"></div>
+    <div class="s tri"></div>
+    <div class="s"></div>
+    <div class="s circle red"></div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/axiom-grid/templates/_sidebar.html
+++ b/examples/axiom-grid/templates/_sidebar.html
@@ -1,0 +1,28 @@
+<aside class="sidebar">
+  <h4 class="red">Start Here</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+    <li><a href="{{ base_url }}/docs/your-first-page/">Your first page</a></li>
+    <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+  </ul>
+
+  <h4 class="blue">Concepts</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a></li>
+    <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+    <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+  </ul>
+
+  <h4 class="yellow">Guides</h4>
+  <ul>
+    <li><a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a></li>
+    <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+    <li><a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a></li>
+  </ul>
+
+  <h4 class="green">Reference</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/cli/">CLI reference</a></li>
+    <li><a href="{{ base_url }}/docs/template-filters/">Template filters</a></li>
+  </ul>
+</aside>

--- a/examples/axiom-grid/templates/footer.html
+++ b/examples/axiom-grid/templates/footer.html
@@ -1,0 +1,6 @@
+<footer class="foot">
+  <div><strong>{{ site.title }}</strong> · {{ site.description }}</div>
+  <div>© {{ current_year }} · v1.4 · Set in Space Grotesk</div>
+</footer>
+</body>
+</html>

--- a/examples/axiom-grid/templates/header.html
+++ b/examples/axiom-grid/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="mark"></span>{{ site.title }}</a>
+    <div class="search">
+      <input type="text" placeholder="Search the docs…" />
+      <span class="kbd">⌘ K</span>
+    </div>
+    <nav>
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/guides/">Guides</a>
+      <a href="{{ base_url }}/about/">About</a>
+      <a href="https://github.com" class="cta">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/examples/axiom-grid/templates/home.html
+++ b/examples/axiom-grid/templates/home.html
@@ -1,0 +1,70 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <h1>Documentation, <span class="red">drawn</span> with a <span class="blue">straightedge</span>.</h1>
+    <p class="deck">Axiom Grid is a documentation theme that takes its cues from the Bauhaus: primary color blocks, geometric ornaments, hairlines you can see, and not a frosted card in sight. Built for projects that prefer their docs honest.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/installation/" class="primary">Get started →</a>
+      <a href="{{ base_url }}/docs/" >Browse docs</a>
+      <a class="kbd">$ npm i axiom-grid</a>
+    </div>
+  </div>
+  <div class="shapes">
+    <div class="s red"><span class="label">A.01</span></div>
+    <div class="s yellow circle"><span class="label">A.02</span></div>
+    <div class="s span2 blue"><span class="label" style="color:var(--paper);background:var(--ink);border-color:var(--ink);">A.03</span></div>
+    <div class="s tri"><span class="label">A.04</span></div>
+    <div class="s circle"><span class="label">A.05</span></div>
+    <div class="s yellow"><span class="label">A.06</span></div>
+    <div class="s red circle"><span class="label" style="color:var(--ink);">A.07</span></div>
+  </div>
+</section>
+
+<section class="cats">
+  <a href="{{ base_url }}/docs/installation/" class="cat">
+    <div class="icon red">1</div>
+    <h3>Installation</h3>
+    <p>Three commands to a working site. Then four pages of you choosing how strict you want the config to be.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/sections-and-pages/" class="cat">
+    <div class="icon blue">2</div>
+    <h3>Sections &amp; pages</h3>
+    <p>How content is organized, how sections behave, and why <code>_index.md</code> is doing more than it looks.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/templates/" class="cat">
+    <div class="icon yellow">3</div>
+    <h3>Templates</h3>
+    <p>Jinja-flavored templates, where to put them, and the small set of globals you are allowed to count on.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/build-pipeline/" class="cat">
+    <div class="icon green">4</div>
+    <h3>Build pipeline</h3>
+    <p>What happens between <code>build</code> and <code>public/</code>, in seven readable phases. With a flowchart.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/i18n/" class="cat">
+    <div class="icon gray">5</div>
+    <h3>Internationalization</h3>
+    <p>Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/deploying/" class="cat">
+    <div class="icon paper">6</div>
+    <h3>Deploying</h3>
+    <p>Cookbook entries for GitHub Pages, Cloudflare Pages, and a Bash script for the rest of you.</p>
+    <span class="read">Read →</span>
+  </a>
+</section>
+
+<section class="metrics">
+  <div class="m"><div class="v red">v1.4</div><div class="k">Current release</div></div>
+  <div class="m"><div class="v">38<span style="color:#888;font-size:18px;"> ms</span></div><div class="k">Build time, 200 pp</div></div>
+  <div class="m"><div class="v blue">112</div><div class="k">Documented pages</div></div>
+  <div class="m"><div class="v yellow">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/axiom-grid/templates/page.html
+++ b/examples/axiom-grid/templates/page.html
@@ -1,0 +1,45 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb">
+      <span class="accent">~</span> /
+      {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a> /{% endif %}
+      <span>{{ page.title }}</span>
+    </div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b">
+        <div class="k">← Previous</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">Next →</div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+  </main>
+  <aside class="toc">
+    <h5>On this page</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/axiom-grid/templates/section.html
+++ b/examples/axiom-grid/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">~</span> / <span>{{ section.title }}</span></div>
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+
+    <div class="cats" style="margin-top:24px;border-top:2px solid var(--ink);">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 4 == 1 %}red{% elif loop.index % 4 == 2 %}blue{% elif loop.index % 4 == 3 %}yellow{% else %}green{% endif %}">{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5>{{ section.pages | length }} entries</h5>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/axiom-grid/templates/taxonomy.html
+++ b/examples/axiom-grid/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">~</span> / <span>{{ taxonomy_name }}</span></div>
+    <h1>All {{ taxonomy_name }}</h1>
+    <div class="content">
+      <ul>
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term }}</a> · {{ term.pages | length }} entries</li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/axiom-grid/templates/taxonomy_term.html
+++ b/examples/axiom-grid/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">~</span> / <a href="{{ base_url }}/tags/">tags</a> / <span>{{ taxonomy_term }}</span></div>
+    <h1>#{{ taxonomy_term }}</h1>
+    <div class="cats" style="margin-top:24px;border-top:2px solid var(--ink);">
+    {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 4 == 1 %}red{% elif loop.index % 4 == 2 %}blue{% elif loop.index % 4 == 3 %}yellow{% else %}green{% endif %}">{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read →</span>
+      </a>
+    {% endfor %}
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/mono-stack/AGENTS.md
+++ b/examples/mono-stack/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/mono-stack/archetypes/default.md
+++ b/examples/mono-stack/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/mono-stack/config.toml
+++ b/examples/mono-stack/config.toml
@@ -1,0 +1,191 @@
+title = "mono.stack"
+description = "A monospace portfolio for engineers who prefer the terminal."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 12
+sections = ["log"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/mono-stack/content/about.md
+++ b/examples/mono-stack/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "about"
+description = "Engineer, builder of unglamorous systems."
+date = "2026-04-12"
++++
+
+I am Han Jaewon, a staff engineer based in Seoul. I work on the boring parts of distributed systems — routing, capacity, observability, on-call experience — for teams that ship things real people depend on.
+
+## what i care about
+
+- Latency budgets you can defend with a graph.
+- Postmortems that read like detective stories, not blameless theatre.
+- Build tools that survive an intern's first week.
+- Code that fits on a single screen.
+
+## currently
+
+Helping a fintech platform halve its p99 while doubling traffic. Writing a short book about the design of on-call rotations. Failing to learn Zig.
+
+## elsewhere
+
+- email — `hi@mono.stack`
+- github — `github.com/han-jaewon`
+- atom — `{{ base_url }}/atom.xml`

--- a/examples/mono-stack/content/index.md
+++ b/examples/mono-stack/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "mono.stack"
+description = "A monospace portfolio for engineers who prefer the terminal."
+template = "home"
++++

--- a/examples/mono-stack/content/log/_index.md
+++ b/examples/mono-stack/content/log/_index.md
@@ -1,0 +1,7 @@
++++
+title = "log"
+description = "Working notes, retros, and occasional rants."
+sort_by = "date"
+reverse = true
+generate_feeds = true
++++

--- a/examples/mono-stack/content/log/halving-p99.md
+++ b/examples/mono-stack/content/log/halving-p99.md
@@ -1,0 +1,33 @@
++++
+title = "Halving p99 without adding capacity"
+date = "2026-05-08"
+description = "A short writeup of how we cut tail latency on a 12-region payments router by 61%, without adding any new hardware."
+tags = ["latency", "routing"]
++++
+
+Tail latency is mostly a routing problem. We had a generic L7 load balancer, configured with round-robin, distributing requests across regions and instances without any awareness of who was actually fast at that moment.
+
+## The diagnosis
+
+We sampled tracing data for a week and discovered that 31% of slow requests were sent to a busy instance while at least one idle peer was available. The load balancer did not have the information it needed to do better.
+
+## The fix
+
+We replaced the routing layer with a latency-aware Rust service that maintained an exponentially weighted moving average of per-instance response time. Requests over a threshold were routed away. We added eBPF probes to skip instances that were saturating CPU.
+
+```rust
+let pick = peers
+    .iter()
+    .filter(|p| p.cpu < 0.85)
+    .min_by_key(|p| p.ewma_latency)
+    .ok_or(Error::NoHealthyPeer)?;
+```
+
+## The result
+
+- p50: 38ms → 36ms (unchanged within noise)
+- p99: 410ms → 158ms
+- p99.9: 1.4s → 410ms
+- Hardware: unchanged
+
+The team that owns the gateway sleeps better. The team that owns the database is unhappy with the new traffic shape. That is, broadly, working as intended.

--- a/examples/mono-stack/content/log/on-call-rotations.md
+++ b/examples/mono-stack/content/log/on-call-rotations.md
@@ -1,0 +1,21 @@
++++
+title = "Designing on-call rotations that do not eat your team"
+date = "2026-04-19"
+description = "Six rules I have collected over a decade of being on-call, designing rotations, and getting them wrong."
+tags = ["on-call", "ops"]
++++
+
+I have been on-call for some part of every year since 2014. I have also designed rotations for three different teams, all of which I broke at least once. Here is what I now believe.
+
+## Rules
+
+1. **One person at a time.** Two primaries is two secondaries.
+2. **Hand off in writing.** Verbal handoffs are a tradition, not a process.
+3. **Pay for the night.** If your company will not, change the company or change the system that is paging at night.
+4. **Burn down the alert backlog every quarter.** Old alerts are debt.
+5. **Run a postmortem after every page, even the false ones.** False pages are alert design bugs.
+6. **The runbook lives in the alert.** If you have to leave the page to find the runbook, the page is incomplete.
+
+> "A good rotation is one where nobody dreads the calendar invite."
+
+That is the test. Everything else is detail.

--- a/examples/mono-stack/content/log/tools-i-keep.md
+++ b/examples/mono-stack/content/log/tools-i-keep.md
@@ -1,0 +1,16 @@
++++
+title = "Tools I have not stopped using in a decade"
+date = "2026-03-21"
+description = "A short, opinionated list of software I have continued to use across jobs, machines, and operating systems."
+tags = ["tools"]
++++
+
+- **tmux** — the only thing standing between me and a forest of terminal windows.
+- **ripgrep** — the only grep that respects my time.
+- **fd** — find, but with better defaults.
+- **jq** — a debugger for JSON.
+- **fzf** — a fuzzy finder I once thought was overkill. It is not.
+- **direnv** — per-directory environments without the foot guns of conda.
+- **mosh** — for the years I worked on a flaky train wifi.
+
+None of these tools have a tutorial. None of them have a marketing site. All of them do exactly one thing and do it without ceremony.

--- a/examples/mono-stack/content/log/writing-software-survives.md
+++ b/examples/mono-stack/content/log/writing-software-survives.md
@@ -1,0 +1,21 @@
++++
+title = "Writing software that survives an on-call"
+date = "2026-02-14"
+description = "Notes from a workshop I have now taught three times. The thesis is uncontroversial. The application is hard."
+tags = ["talks", "ops"]
++++
+
+The thesis is simple: software that gets paged at 3am should be designed by people who have been paged at 3am.
+
+## The workshop in one slide
+
+1. Every error message is a UI for someone who is tired and angry.
+2. Every retry loop is an opportunity for cascading failure.
+3. Every silent dependency is a future surprise.
+4. Every timeout you forgot to set is a future incident.
+
+## The workshop in three days
+
+Day one is reading other people's postmortems and writing your own from a recorded incident. Day two is rewriting a small service to be paged-at-3am-friendly. Day three is a tabletop exercise where everything goes wrong and the room has to decide what matters.
+
+I have run this three times. I plan to run it a fourth in autumn.

--- a/examples/mono-stack/content/projects/_index.md
+++ b/examples/mono-stack/content/projects/_index.md
@@ -1,0 +1,6 @@
++++
+title = "projects"
+description = "Work I have shipped or contributed to. Some of it is open source."
+sort_by = "date"
+reverse = true
++++

--- a/examples/mono-stack/content/projects/shimmer.md
+++ b/examples/mono-stack/content/projects/shimmer.md
@@ -1,0 +1,18 @@
++++
+title = "shimmer"
+date = "2026-03-02"
+description = "A single-binary online schema migration runner for Postgres. Reads explicit contracts, refuses to do anything surprising."
+tags = ["Go", "Postgres"]
++++
+
+`shimmer` is a small tool I built to run schema changes against busy Postgres clusters without locking myself out of the database at the worst possible moment.
+
+## design choices
+
+- Migrations are written as **plans**, not scripts. Each plan declares what it will lock, for how long, and at what cost.
+- The runner refuses to execute a plan if the actual lock would exceed the declared budget.
+- All migrations are online by default. Offline migrations require a flag named `--i-am-okay-with-downtime`.
+
+## status
+
+Stable, used in production by three companies I know about and an unknown number I do not. v0.6 ships in summer.

--- a/examples/mono-stack/static/css/style.css
+++ b/examples/mono-stack/static/css/style.css
@@ -1,0 +1,230 @@
+:root {
+  --bg: #0b0d10;
+  --bg-soft: #11141a;
+  --bg-cell: #161a21;
+  --line: #1f242d;
+  --line-strong: #2a313d;
+  --text: #d7dce4;
+  --text-dim: #8a93a3;
+  --text-mute: #5e6675;
+  --accent: #c6ff4d;
+  --accent-soft: rgba(198, 255, 77, 0.12);
+  --red: #ff6b6b;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+.wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+/* ===== Top bar ===== */
+.bar {
+  border-bottom: 1px solid var(--line);
+  background: rgba(11, 13, 16, 0.85);
+  backdrop-filter: blur(8px);
+  position: sticky; top: 0; z-index: 10;
+}
+
+.bar-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  gap: 24px;
+}
+
+.tag-row {
+  display: flex;
+  gap: 18px;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+.tag-row span::before { content: "[ "; color: var(--text-mute); }
+.tag-row span::after  { content: " ]"; color: var(--text-mute); }
+.tag-row .status { color: var(--accent); }
+.tag-row .status .dot { display:inline-block;width:7px;height:7px;border-radius:50%;background:var(--accent);margin-right:6px;vertical-align:middle;box-shadow:0 0 8px var(--accent);}
+
+.brand {
+  color: var(--text);
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.brand .prompt { color: var(--accent); margin-right: 6px; }
+.brand strong { font-weight: 700; }
+
+nav.menu { display: flex; gap: 24px; font-size: 13px; }
+nav.menu a { color: var(--text-dim); }
+nav.menu a:hover { color: var(--accent); }
+
+/* ===== Hero ===== */
+.hero {
+  padding: 96px 0 72px;
+  border-bottom: 1px solid var(--line);
+}
+
+.hero .terminal {
+  background: var(--bg-soft);
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  max-width: 760px;
+  margin-bottom: 56px;
+  font-size: 13px;
+  overflow: hidden;
+  box-shadow: 0 24px 64px -32px rgba(0,0,0,0.6);
+}
+.hero .terminal .head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  background: #0e1116;
+  border-bottom: 1px solid var(--line);
+  color: var(--text-mute);
+  font-size: 12px;
+}
+.hero .terminal .head .light { width: 10px; height: 10px; border-radius: 50%; background: #2a313d; }
+.hero .terminal .body { padding: 18px 18px 20px; }
+.hero .terminal .line { white-space: pre-wrap; }
+.hero .terminal .line .prompt { color: var(--accent); }
+.hero .terminal .line.out { color: var(--text-dim); }
+.hero .terminal .cursor { display: inline-block; width: 8px; height: 16px; background: var(--accent); vertical-align: -3px; margin-left: 4px; animation: blink 1.1s steps(2) infinite; }
+@keyframes blink { 50% { opacity: 0; } }
+
+.hero h1 {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(48px, 7.5vw, 96px);
+  line-height: 0.96;
+  letter-spacing: -0.04em;
+  margin: 0 0 24px;
+  color: #fff;
+}
+.hero h1 .accent { color: var(--accent); }
+.hero .deck {
+  font-family: "Inter", sans-serif;
+  font-size: 18px;
+  color: var(--text-dim);
+  max-width: 60ch;
+  margin: 0 0 32px;
+  line-height: 1.55;
+}
+
+.kpi {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border: 1px solid var(--line-strong);
+  background: var(--bg-soft);
+  max-width: 760px;
+}
+.kpi .item { padding: 18px 20px; border-right: 1px solid var(--line); }
+.kpi .item:last-child { border-right: 0; }
+.kpi .item .k { color: var(--text-mute); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; }
+.kpi .item .v { color: var(--text); font-size: 22px; font-family: "Inter", sans-serif; font-weight: 600; margin-top: 4px; }
+.kpi .item .v.acc { color: var(--accent); }
+
+/* ===== Section ===== */
+section.block { padding: 80px 0; border-bottom: 1px solid var(--line); }
+
+.section-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 40px;
+  border-bottom: 1px dashed var(--line-strong);
+  padding-bottom: 14px;
+}
+.section-head h2 {
+  font-family: "Inter", sans-serif;
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 0;
+  color: #fff;
+}
+.section-head h2::before { content: "## "; color: var(--accent); font-family: "JetBrains Mono", monospace; }
+.section-head .info { color: var(--text-mute); font-size: 12px; letter-spacing: 0.08em; }
+
+/* ===== Projects ===== */
+.projects { display: grid; grid-template-columns: 1fr; gap: 0; border: 1px solid var(--line-strong); background: var(--bg-soft); border-radius: 6px; overflow: hidden; }
+
+.proj {
+  display: grid;
+  grid-template-columns: 80px 1fr 200px 120px;
+  gap: 24px;
+  padding: 24px 28px;
+  border-bottom: 1px solid var(--line);
+  align-items: center;
+  transition: background 120ms ease;
+}
+.proj:last-child { border-bottom: 0; }
+.proj:hover { background: var(--bg-cell); }
+
+.proj .idx { color: var(--text-mute); font-size: 12px; letter-spacing: 0.1em; }
+.proj .title { font-family: "Inter", sans-serif; font-weight: 600; font-size: 19px; color: #fff; margin-bottom: 4px; letter-spacing: -0.01em; }
+.proj .desc { color: var(--text-dim); font-size: 13px; line-height: 1.5; }
+.proj .stack { display: flex; gap: 6px; flex-wrap: wrap; }
+.proj .stack span { background: var(--bg-cell); border: 1px solid var(--line-strong); color: var(--text-dim); padding: 2px 8px; font-size: 11px; border-radius: 3px; }
+.proj .year { color: var(--accent); font-size: 13px; text-align: right; }
+.proj .badge { display:inline-block; padding: 2px 8px; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; border: 1px solid var(--accent); color: var(--accent); margin-right: 6px; }
+
+/* ===== Now / Log ===== */
+.now {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border: 1px solid var(--line-strong); background: var(--bg-soft);
+}
+.now .pane { padding: 28px 32px; }
+.now .pane + .pane { border-left: 1px solid var(--line); }
+.now h3 { font-family: "Inter", sans-serif; font-weight: 600; font-size: 16px; margin: 0 0 16px; color: #fff; }
+.now ul { list-style: none; padding: 0; margin: 0; }
+.now li { padding: 8px 0; border-bottom: 1px dashed var(--line); color: var(--text-dim); display: flex; justify-content: space-between; gap: 16px; font-size: 13px; }
+.now li:last-child { border-bottom: 0; }
+.now li .marker { color: var(--accent); }
+
+/* ===== Article ===== */
+.article {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 96px 32px;
+}
+.article header { margin-bottom: 48px; padding-bottom: 24px; border-bottom: 1px solid var(--line); }
+.article h1 { font-family: "Inter", sans-serif; font-weight: 700; font-size: clamp(36px, 5vw, 56px); line-height: 1.05; letter-spacing: -0.03em; margin: 8px 0 16px; color: #fff; }
+.article .deck { color: var(--text-dim); font-size: 16px; font-family: "Inter", sans-serif; max-width: 60ch; }
+.article .meta { color: var(--text-mute); font-size: 12px; letter-spacing: 0.08em; margin-top: 18px; }
+.article .meta .accent { color: var(--accent); }
+.article .content { font-family: "Inter", sans-serif; font-size: 16px; line-height: 1.7; color: var(--text); }
+.article .content h2 { font-size: 22px; margin: 40px 0 12px; letter-spacing: -0.01em; color: #fff; }
+.article .content a { border-bottom: 1px solid var(--accent); }
+.article .content code { background: var(--bg-cell); padding: 2px 6px; border-radius: 3px; font-family: "JetBrains Mono", monospace; color: var(--accent); font-size: 0.9em; }
+.article .content pre { background: var(--bg-soft); border: 1px solid var(--line); border-radius: 6px; padding: 18px; overflow-x: auto; font-size: 13px; }
+.article .content blockquote { border-left: 2px solid var(--accent); margin: 24px 0; padding-left: 18px; color: var(--text-dim); font-style: italic; }
+
+/* ===== Footer ===== */
+.foot { padding: 40px 0 64px; color: var(--text-mute); font-size: 12px; }
+.foot .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+.foot a { color: var(--text-dim); }
+
+@media (max-width: 760px) {
+  .bar-inner { flex-wrap: wrap; }
+  .tag-row { font-size: 11px; gap: 10px; }
+  .kpi { grid-template-columns: repeat(2,1fr); }
+  .kpi .item:nth-child(2n) { border-right: 0; }
+  .proj { grid-template-columns: 1fr; gap: 8px; }
+  .proj .year { text-align: left; }
+  .now { grid-template-columns: 1fr; }
+  .now .pane + .pane { border-left: 0; border-top: 1px solid var(--line); }
+}

--- a/examples/mono-stack/templates/404.html
+++ b/examples/mono-stack/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+<section class="article">
+  <header>
+    <div class="meta"><span class="accent">$</span> cd /404</div>
+    <h1>404 — path not found.</h1>
+    <p class="deck">The file or directory you requested is not on this filesystem. Try the <a href="{{ base_url }}/">home</a> or browse <a href="{{ base_url }}/projects/">/projects</a>.</p>
+  </header>
+</section>
+
+{% include "footer.html" %}

--- a/examples/mono-stack/templates/footer.html
+++ b/examples/mono-stack/templates/footer.html
@@ -1,0 +1,8 @@
+<footer class="foot">
+  <div class="wrap">
+    <div>&copy; {{ current_year }} {{ site.title }} — last deploy {{ current_date }}</div>
+    <div><a href="mailto:hi@mono.stack">hi@mono.stack</a> · <a href="https://github.com">github</a> · <a href="{{ base_url }}/atom.xml">atom</a></div>
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/mono-stack/templates/header.html
+++ b/examples/mono-stack/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="wrap bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="prompt">~/</span><strong>{{ site.title }}</strong></a>
+    <nav class="menu">
+      <a href="{{ base_url }}/">/index</a>
+      <a href="{{ base_url }}/projects/">/projects</a>
+      <a href="{{ base_url }}/log/">/log</a>
+      <a href="{{ base_url }}/about/">/about</a>
+    </nav>
+    <div class="tag-row">
+      <span class="status"><span class="dot"></span>open to work</span>
+      <span>Seoul / UTC+9</span>
+    </div>
+  </div>
+</header>

--- a/examples/mono-stack/templates/home.html
+++ b/examples/mono-stack/templates/home.html
@@ -109,7 +109,7 @@
         <ul>
           {% set posts = site.pages | sort_by(attribute="date") | reverse %}
           {% for p in posts %}
-            {% if p.section == "log" and loop.index <= 5 %}
+            {% if p.section == "log" %}
               <li><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a><span class="marker">{{ p.date | date(format="%b %d") }}</span></li>
             {% endif %}
           {% endfor %}

--- a/examples/mono-stack/templates/home.html
+++ b/examples/mono-stack/templates/home.html
@@ -1,0 +1,122 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="wrap">
+    <div class="terminal">
+      <div class="head">
+        <span class="light"></span><span class="light"></span><span class="light"></span>
+        <span style="margin-left:8px;">~/portfolio — zsh</span>
+      </div>
+      <div class="body">
+        <div class="line"><span class="prompt">$</span> whoami</div>
+        <div class="line out">han-jaewon · staff engineer · distributed systems</div>
+        <div class="line"><span class="prompt">$</span> uptime</div>
+        <div class="line out">12y building infra for teams of 2 to 200<span class="cursor"></span></div>
+      </div>
+    </div>
+
+    <h1>Build <span class="accent">small</span>, ship <span class="accent">often</span>, leave the system better.</h1>
+    <p class="deck">I design and operate the unglamorous parts of distributed systems. Currently helping a fintech platform halve its p99 while doubling traffic. Previously at a payments company you have probably argued with at 2am.</p>
+
+    <div class="kpi">
+      <div class="item"><div class="k">YEARS</div><div class="v">12</div></div>
+      <div class="item"><div class="k">SHIPPED</div><div class="v acc">47</div></div>
+      <div class="item"><div class="k">ON-CALL</div><div class="v">8.4k h</div></div>
+      <div class="item"><div class="k">P99 cut</div><div class="v acc">−61%</div></div>
+    </div>
+  </div>
+</section>
+
+<section class="block">
+  <div class="wrap">
+    <div class="section-head">
+      <h2>selected_projects</h2>
+      <div class="info">ORDERED BY RECENCY · {{ current_year }}</div>
+    </div>
+
+    <div class="projects">
+      <div class="proj">
+        <div class="idx">/01</div>
+        <div>
+          <div class="title">Halve p99 on a 12-region payments router</div>
+          <div class="desc">Replaced a generic load balancer with a latency-aware routing layer. Cut p99 from 410ms to 158ms without adding capacity.</div>
+        </div>
+        <div class="stack"><span>Rust</span><span>Envoy</span><span>eBPF</span></div>
+        <div class="year">2026</div>
+      </div>
+
+      <div class="proj">
+        <div class="idx">/02</div>
+        <div>
+          <div class="title"><span class="badge">OSS</span>shimmer — a tiny database migration runner</div>
+          <div class="desc">A single-binary tool for safe, online schema changes on Postgres. Reads explicit contracts, refuses to do anything surprising.</div>
+        </div>
+        <div class="stack"><span>Go</span><span>Postgres</span></div>
+        <div class="year">2025</div>
+      </div>
+
+      <div class="proj">
+        <div class="idx">/03</div>
+        <div>
+          <div class="title">Rebuild observability for a fintech platform</div>
+          <div class="desc">Moved 80+ services off vendored logging onto OpenTelemetry. Cut bill 72%, mean-time-to-acknowledge from 14m to 90s.</div>
+        </div>
+        <div class="stack"><span>OTel</span><span>Tempo</span><span>Loki</span></div>
+        <div class="year">2025</div>
+      </div>
+
+      <div class="proj">
+        <div class="idx">/04</div>
+        <div>
+          <div class="title">Workshop: writing software that survives an on-call</div>
+          <div class="desc">A two-day course taught at three engineering organizations. Materials are open. Slides are not.</div>
+        </div>
+        <div class="stack"><span>Talk</span><span>Workshop</span></div>
+        <div class="year">2024</div>
+      </div>
+
+      <div class="proj">
+        <div class="idx">/05</div>
+        <div>
+          <div class="title"><span class="badge">OSS</span>quiet-queue — a backpressure-first job queue</div>
+          <div class="desc">Job queue that refuses to lose work or accept it faster than the worker pool can handle. Built after one too many runaway retry storms.</div>
+        </div>
+        <div class="stack"><span>Crystal</span><span>Redis</span></div>
+        <div class="year">2024</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="block">
+  <div class="wrap">
+    <div class="section-head">
+      <h2>now</h2>
+      <div class="info">UPDATED MONTHLY</div>
+    </div>
+    <div class="now">
+      <div class="pane">
+        <h3>currently</h3>
+        <ul>
+          <li><span>Latency budgets for the new gateway</span><span class="marker">work</span></li>
+          <li><span>Reading: A Philosophy of Software Design</span><span class="marker">book</span></li>
+          <li><span>Speaking at SRECon APAC, Sept</span><span class="marker">talk</span></li>
+          <li><span>Learning Zig, slowly, badly</span><span class="marker">play</span></li>
+        </ul>
+      </div>
+      <div class="pane">
+        <h3>writing</h3>
+        <ul>
+          {% set posts = site.pages | sort_by(attribute="date") | reverse %}
+          {% for p in posts %}
+            {% if p.section == "log" and loop.index <= 5 %}
+              <li><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a><span class="marker">{{ p.date | date(format="%b %d") }}</span></li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/mono-stack/templates/page.html
+++ b/examples/mono-stack/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<article class="article">
+  <header>
+    <div class="meta"><span class="accent">~/</span>{{ page.section | default(value="page") }}/{{ page.title | lower | replace(from=" ", to="-") }}</div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+    <div class="meta">
+      {% if page.date %}<span>{{ page.date | date(format="%Y-%m-%d") }}</span>{% endif %}
+      {% if page.reading_time %} · <span>{{ page.reading_time }} min</span>{% endif %}
+      {% if page.tags %}
+        ·
+        {% for t in page.tags %}<span>#{{ t }}</span>{% if not loop.last %} {% endif %}{% endfor %}
+      {% endif %}
+    </div>
+  </header>
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/mono-stack/templates/section.html
+++ b/examples/mono-stack/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+
+<section class="block" style="padding-top:64px;">
+  <div class="wrap">
+    <div class="section-head">
+      <h2>{{ section.title | lower }}</h2>
+      <div class="info">{{ section.pages | length }} ENTRIES</div>
+    </div>
+    <div class="projects">
+      {% for p in section.pages %}
+      <div class="proj">
+        <div class="idx">/{{ loop.index }}</div>
+        <div>
+          <a href="{{ base_url }}{{ p.url }}"><div class="title">{{ p.title }}</div></a>
+          {% if p.description %}<div class="desc">{{ p.description }}</div>{% endif %}
+        </div>
+        <div class="stack">
+          {% if p.tags %}{% for t in p.tags %}<span>{{ t }}</span>{% endfor %}{% endif %}
+        </div>
+        <div class="year">{% if p.date %}{{ p.date | date(format="%Y") }}{% endif %}</div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/mono-stack/templates/taxonomy.html
+++ b/examples/mono-stack/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+
+<section class="block">
+  <div class="wrap">
+    <div class="section-head"><h2>{{ taxonomy_name | lower }}</h2><div class="info">{{ taxonomy_terms | length }} TERMS</div></div>
+    <ul style="list-style:none;padding:0;font-family:'JetBrains Mono',monospace;color:var(--text-dim);">
+      {% for term in taxonomy_terms %}
+        <li style="padding:12px 0;border-bottom:1px dashed var(--line-strong);display:flex;justify-content:space-between;">
+          <a href="{{ base_url }}{{ term.url }}">#{{ term }}</a>
+          <span>{{ term.pages | length }} posts</span>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/mono-stack/templates/taxonomy_term.html
+++ b/examples/mono-stack/templates/taxonomy_term.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<section class="block">
+  <div class="wrap">
+    <div class="section-head">
+      <h2>#{{ taxonomy_term }}</h2>
+      <div class="info">{{ taxonomy_pages | length }} ENTRIES</div>
+    </div>
+    <div class="projects">
+      {% for p in taxonomy_pages %}
+      <div class="proj">
+        <div class="idx">/{{ loop.index }}</div>
+        <div>
+          <a href="{{ base_url }}{{ p.url }}"><div class="title">{{ p.title }}</div></a>
+          {% if p.description %}<div class="desc">{{ p.description }}</div>{% endif %}
+        </div>
+        <div class="stack"></div>
+        <div class="year">{% if p.date %}{{ p.date | date(format="%Y") }}{% endif %}</div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/noctura/AGENTS.md
+++ b/examples/noctura/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/noctura/archetypes/default.md
+++ b/examples/noctura/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/noctura/config.toml
+++ b/examples/noctura/config.toml
@@ -1,0 +1,190 @@
+title = "Noctura Studio"
+description = "An independent design and engineering studio working at the seam of brand and product."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 8
+sections = ["journal"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/noctura/content/about.md
+++ b/examples/noctura/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "The studio"
+description = "Noctura is six people, four cities, one shared kitchen table, and a strong opinion about long projects."
+date = "2026-04-12"
++++
+
+Noctura is an independent design and engineering studio. We were founded in 2019 by three friends who had spent the previous decade getting tired of bigger studios. We work with a small number of clients each quarter, and we keep our team small enough that the people in the meeting are also the people doing the work.
+
+## How we work
+
+- One project at a time per discipline.
+- A written brief, jointly owned, before the first sketch.
+- A daily check-in. A weekly written update.
+- A six-month follow-up after the work has shipped, to see how it has aged.
+
+## The team
+
+Six people, four cities. Mira in Seoul. Han in Berlin. Lukas in Lisbon. Yuki in Tokyo. Sara and Jules in Helsinki. We meet in person twice a year. The rest of the time we are very good at video calls and very fond of long emails.
+
+## What we will not do
+
+We do not pitch. We do not enter design competitions. We do not work for free in exchange for "exposure". We have, twice, turned down very large clients because the project would have required us to grow in a way we did not want to grow.
+
+## Contact
+
+`hello@noctura.studio` — long emails appreciated. We answer all of them, eventually.

--- a/examples/noctura/content/index.md
+++ b/examples/noctura/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Noctura Studio"
+description = "An independent design and engineering studio working at the seam of brand and product."
+template = "home"
++++

--- a/examples/noctura/content/journal/_index.md
+++ b/examples/noctura/content/journal/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Journal"
+description = "Case studies, notes from the studio, and the occasional unsorted thought."
+sort_by = "date"
+reverse = true
+generate_feeds = true
++++

--- a/examples/noctura/content/journal/atlas-rebrand.md
+++ b/examples/noctura/content/journal/atlas-rebrand.md
@@ -3,6 +3,8 @@ title = "Atlas — a continent-spanning identity"
 date = "2026-05-04"
 description = "A case study from a year-long project building an identity system for a logistics company that had grown faster than its brand could keep up."
 tags = ["Identity"]
+[extra]
+monogram = "ATL"
 +++
 
 Atlas had grown from one warehouse to forty across nine countries in three years. By the time they came to us, they had four logos, six color palettes in active use, and an internal style guide written by an enthusiastic intern in 2021. The company knew it had a problem. They were not sure if it was a brand problem or an operations problem. It was both.

--- a/examples/noctura/content/journal/atlas-rebrand.md
+++ b/examples/noctura/content/journal/atlas-rebrand.md
@@ -1,0 +1,23 @@
++++
+title = "Atlas — a continent-spanning identity"
+date = "2026-05-04"
+description = "A case study from a year-long project building an identity system for a logistics company that had grown faster than its brand could keep up."
+tags = ["Identity"]
++++
+
+Atlas had grown from one warehouse to forty across nine countries in three years. By the time they came to us, they had four logos, six color palettes in active use, and an internal style guide written by an enthusiastic intern in 2021. The company knew it had a problem. They were not sure if it was a brand problem or an operations problem. It was both.
+
+## The brief
+
+The brief, in one sentence, was: "Give us a system that survives a billboard, a truck door, a freight document, and the inside of a cardboard box, without flinching."
+
+## What we built
+
+- A wordmark drawn from the inside out, starting with the *t*.
+- A typeface family, drawn for both screens and the kind of low-resolution thermal printer that lives in every Atlas warehouse.
+- A visual system built on a 24-unit grid that scales from a 12pt invoice line to a 6m billboard.
+- A documentation site, internal, that has been used by every Atlas employee since launch.
+
+## What we learned
+
+The hardest part was not the identity. The hardest part was the freight documents. The freight documents had to be readable in forty languages, by humans and by machines, in the dark, in the rain, by a tired driver at 4am. Everything else followed from getting that right.

--- a/examples/noctura/content/journal/sable-product.md
+++ b/examples/noctura/content/journal/sable-product.md
@@ -1,0 +1,19 @@
++++
+title = "Sable — a quieter portfolio app"
+date = "2026-03-18"
+description = "Designing and building a calm web app for solo investors, with a clarity-first interface and a refusal to gamify."
+tags = ["Product"]
++++
+
+Sable came to us with a deck and a working prototype. The deck was good. The prototype was a feature-laden, brightly colored, alarmingly cheerful piece of software that none of the team actually wanted to use themselves.
+
+## What we changed
+
+- Reduced the color palette from twelve to four.
+- Removed every motivational micro-copy line.
+- Turned off every push notification by default.
+- Added an "annual review" mode, where the app shows you one number once a year and otherwise asks for nothing.
+
+## Result
+
+The first cohort of users had higher session lengths, higher feature adoption, and — most importantly to us — used the app fewer times per week. Sable is a tool that wants to be opened intentionally, not habitually. The product now reflects that.

--- a/examples/noctura/content/journal/sable-product.md
+++ b/examples/noctura/content/journal/sable-product.md
@@ -3,6 +3,8 @@ title = "Sable — a quieter portfolio app"
 date = "2026-03-18"
 description = "Designing and building a calm web app for solo investors, with a clarity-first interface and a refusal to gamify."
 tags = ["Product"]
+[extra]
+monogram = "SBL"
 +++
 
 Sable came to us with a deck and a working prototype. The deck was good. The prototype was a feature-laden, brightly colored, alarmingly cheerful piece of software that none of the team actually wanted to use themselves.

--- a/examples/noctura/content/journal/the-long-shift.md
+++ b/examples/noctura/content/journal/the-long-shift.md
@@ -1,0 +1,26 @@
++++
+title = "Notes on the long shift"
+date = "2026-02-05"
+description = "Why we structure our engagements around quarters, not weeks, and what we have learned from four years of running the studio this way."
+tags = ["Studio"]
++++
+
+We take a small number of engagements per quarter. We have done this since 2021. People ask us why, often. Here are the four reasons.
+
+## 1. The first three weeks are not a sprint
+
+The most important part of a project is the period before anyone has agreed on what the project is. Compressing that period is a false economy. We give it three weeks, every time.
+
+## 2. The middle is long
+
+Good work has a long middle. The middle is where the second-best idea is rejected for the right reasons, which is different from being rejected for the obvious ones. The middle cannot be hurried.
+
+## 3. The handover is half the project
+
+A project that lands well is a project that survives its handover. Documentation, training, a six-month follow-up — these are not optional steps, and they take time we will not bill less because they happened to be quieter.
+
+## 4. We are not interchangeable
+
+We do not pretend to be a fungible vendor. The reason a client chose us is the reason the work will be good, and we cannot extend that reason across forty parallel engagements without diluting it.
+
+So: one project at a time per discipline. A small number of engagements per quarter. The long shift.

--- a/examples/noctura/content/journal/the-long-shift.md
+++ b/examples/noctura/content/journal/the-long-shift.md
@@ -3,6 +3,8 @@ title = "Notes on the long shift"
 date = "2026-02-05"
 description = "Why we structure our engagements around quarters, not weeks, and what we have learned from four years of running the studio this way."
 tags = ["Studio"]
+[extra]
+monogram = "LNG"
 +++
 
 We take a small number of engagements per quarter. We have done this since 2021. People ask us why, often. Here are the four reasons.

--- a/examples/noctura/static/css/style.css
+++ b/examples/noctura/static/css/style.css
@@ -1,0 +1,361 @@
+:root {
+  --bg: #08080a;
+  --bg-soft: #0e0e12;
+  --bg-cell: #14151a;
+  --line: #1f2027;
+  --line-strong: #2a2c36;
+  --text: #ecebe6;
+  --text-soft: #b9b8b0;
+  --mute: #6a6b73;
+  --accent: #ffb400;
+  --accent-soft: rgba(255, 180, 0, 0.12);
+  --paper: #f5f1e8;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+}
+
+a { color: inherit; text-decoration: none; }
+
+::selection { background: var(--accent); color: var(--bg); }
+
+.wrap { max-width: 1280px; margin: 0 auto; padding: 0 32px; }
+
+/* ===== Bar ===== */
+.bar {
+  position: fixed; top: 0; left: 0; right: 0;
+  z-index: 30;
+  border-bottom: 1px solid var(--line);
+  background: rgba(8, 8, 10, 0.7);
+  backdrop-filter: blur(12px);
+}
+.bar-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 0;
+  gap: 24px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: "Bricolage Grotesque", "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+.brand .mark {
+  width: 22px; height: 22px;
+  position: relative;
+  background: var(--accent);
+  border-radius: 50%;
+}
+.brand .mark::after {
+  content: ""; position: absolute; right: -4px; top: -4px;
+  width: 12px; height: 12px; background: var(--bg); border-radius: 50%;
+}
+nav.menu { display: flex; gap: 28px; font-size: 14px; color: var(--text-soft); }
+nav.menu a:hover { color: var(--accent); }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border: 1px solid var(--text);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 500;
+  transition: all 120ms ease;
+}
+.btn:hover { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+.btn.solid { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+.btn.solid:hover { background: var(--text); border-color: var(--text); }
+.btn .dot { width: 6px; height: 6px; background: var(--accent); border-radius: 50%; box-shadow: 0 0 8px var(--accent); }
+.btn.solid .dot { background: var(--bg); box-shadow: none; }
+
+/* ===== Hero ===== */
+.hero {
+  padding: 200px 0 120px;
+  border-bottom: 1px solid var(--line);
+  position: relative;
+  overflow: hidden;
+}
+.hero .marquee {
+  position: absolute;
+  left: -2vw; right: -2vw;
+  bottom: -6vw;
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 700;
+  font-size: 22vw;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  color: transparent;
+  -webkit-text-stroke: 1px var(--line-strong);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0.7;
+}
+.hero h1 {
+  font-family: "Bricolage Grotesque", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(56px, 9vw, 168px);
+  line-height: 0.92;
+  letter-spacing: -0.04em;
+  margin: 0 0 32px;
+  position: relative;
+  z-index: 1;
+}
+.hero h1 em {
+  font-style: italic;
+  font-weight: 400;
+  color: var(--accent);
+}
+.hero .deck {
+  font-size: 20px;
+  color: var(--text-soft);
+  max-width: 56ch;
+  margin: 0 0 40px;
+  line-height: 1.5;
+  position: relative; z-index: 1;
+}
+.hero .row { display: flex; gap: 14px; flex-wrap: wrap; position: relative; z-index: 1; }
+.hero .meta-row {
+  margin-top: 64px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--line);
+  padding-top: 24px;
+  position: relative; z-index: 1;
+}
+.hero .meta-row .k { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--mute); }
+.hero .meta-row .v { font-family: "Bricolage Grotesque", sans-serif; font-size: 22px; font-weight: 600; letter-spacing: -0.01em; margin-top: 4px; }
+.hero .meta-row .v.acc { color: var(--accent); }
+
+/* ===== Section frame ===== */
+section.block { padding: 120px 0; border-bottom: 1px solid var(--line); }
+
+.section-head {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 48px;
+  margin-bottom: 64px;
+  align-items: end;
+}
+.section-head .num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 14px;
+}
+.section-head h2 {
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 600;
+  font-size: clamp(36px, 4vw, 64px);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  margin: 0;
+}
+.section-head h2 em { font-style: italic; color: var(--accent); font-weight: 400; }
+.section-head .copy { color: var(--text-soft); font-size: 17px; line-height: 1.55; max-width: 56ch; }
+
+/* ===== Work grid ===== */
+.work { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.work .card {
+  background: var(--bg-soft);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  overflow: hidden;
+  position: relative;
+  transition: border-color 120ms ease, transform 200ms ease;
+}
+.work .card:hover { border-color: var(--accent); transform: translateY(-2px); }
+.work .card.full { grid-column: span 2; }
+.work .card .image {
+  aspect-ratio: 16 / 10;
+  background: var(--bg-cell);
+  position: relative;
+  overflow: hidden;
+  display: grid; place-items: center;
+}
+.work .card.full .image { aspect-ratio: 24 / 9; }
+.work .card .image .mark {
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 700;
+  font-size: clamp(56px, 8vw, 140px);
+  color: var(--line-strong);
+  letter-spacing: -0.03em;
+}
+.work .card .image::after {
+  content: ""; position: absolute; inset: 24px;
+  border: 1px solid var(--line);
+  pointer-events: none;
+}
+.work .card .meta {
+  padding: 28px 28px 32px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px 24px;
+  align-items: end;
+}
+.work .card .meta .top {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 10px;
+}
+.work .card .meta h3 {
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 600;
+  font-size: 28px;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+.work .card .meta p { color: var(--text-soft); font-size: 15px; margin: 0; line-height: 1.5; max-width: 52ch; }
+.work .card .meta .year {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: var(--mute);
+  letter-spacing: 0.18em;
+  white-space: nowrap;
+}
+
+/* ===== Services ===== */
+.services { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.svc { padding: 40px 28px 48px; border-right: 1px solid var(--line); position: relative; }
+.svc:last-child { border-right: 0; }
+.svc .num { font-family: "JetBrains Mono", monospace; font-size: 11px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin-bottom: 24px; }
+.svc h3 { font-family: "Bricolage Grotesque", sans-serif; font-weight: 600; font-size: 26px; line-height: 1.1; letter-spacing: -0.02em; margin: 0 0 14px; }
+.svc p { color: var(--text-soft); font-size: 15px; line-height: 1.55; margin: 0 0 18px; }
+.svc ul { list-style: none; padding: 0; margin: 0; font-size: 13px; color: var(--text-soft); font-family: "JetBrains Mono", monospace; letter-spacing: 0.02em; }
+.svc ul li { padding: 6px 0; border-top: 1px dashed var(--line); }
+.svc ul li::before { content: "→ "; color: var(--accent); }
+
+/* ===== Marquee/Tape ===== */
+.tape {
+  background: var(--accent);
+  color: var(--bg);
+  padding: 22px 0;
+  overflow: hidden;
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 600;
+  font-size: 28px;
+  letter-spacing: -0.015em;
+}
+.tape .scroll { display: flex; gap: 48px; white-space: nowrap; }
+.tape .scroll span::before { content: "/"; margin-right: 48px; color: var(--bg); font-family: "JetBrains Mono", monospace; }
+
+/* ===== Process ===== */
+.process { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; }
+.step { padding: 32px 28px 40px; border-right: 1px solid var(--line); border-top: 1px solid var(--line); }
+.step:last-child { border-right: 0; }
+.step .num {
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 700;
+  font-size: 48px;
+  letter-spacing: -0.03em;
+  color: var(--accent);
+  margin-bottom: 18px;
+}
+.step h4 { font-family: "Bricolage Grotesque", sans-serif; font-weight: 600; font-size: 20px; margin: 0 0 8px; letter-spacing: -0.015em; }
+.step p { color: var(--text-soft); font-size: 14px; line-height: 1.55; margin: 0; }
+
+/* ===== CTA / contact ===== */
+.cta {
+  padding: 160px 0;
+  text-align: center;
+  border-bottom: 1px solid var(--line);
+}
+.cta h2 {
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 700;
+  font-size: clamp(48px, 8vw, 132px);
+  line-height: 0.96;
+  letter-spacing: -0.04em;
+  margin: 0 0 32px;
+  max-width: 18ch;
+  margin-inline: auto;
+}
+.cta h2 em { font-style: italic; color: var(--accent); font-weight: 400; }
+.cta .deck { color: var(--text-soft); font-size: 18px; max-width: 50ch; margin: 0 auto 36px; line-height: 1.5; }
+
+/* ===== Footer ===== */
+.foot {
+  padding: 64px 0 48px;
+  color: var(--text-soft);
+}
+.foot .top {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 32px;
+  margin-bottom: 56px;
+}
+.foot .top h5 { font-family: "JetBrains Mono", monospace; font-size: 11px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--mute); margin: 0 0 14px; }
+.foot .top ul { list-style: none; padding: 0; margin: 0; }
+.foot .top ul li { padding: 6px 0; font-size: 14px; }
+.foot .top ul a:hover { color: var(--accent); }
+.foot .top .big {
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 700;
+  font-size: clamp(36px, 5vw, 64px);
+  line-height: 0.96;
+  letter-spacing: -0.03em;
+  color: var(--text);
+}
+.foot .top .big em { font-style: italic; color: var(--accent); font-weight: 400; }
+.foot .bottom { display: flex; justify-content: space-between; gap: 16px; padding-top: 24px; border-top: 1px solid var(--line); font-size: 12px; color: var(--mute); }
+
+/* ===== Article ===== */
+.article {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 200px 32px 120px;
+}
+.article header { margin-bottom: 48px; padding-bottom: 24px; border-bottom: 1px solid var(--line); }
+.article header .crumb { font-family: "JetBrains Mono", monospace; font-size: 12px; color: var(--accent); letter-spacing: 0.16em; text-transform: uppercase; margin-bottom: 18px; }
+.article h1 {
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 600;
+  font-size: clamp(40px, 6vw, 76px);
+  line-height: 1.0;
+  letter-spacing: -0.03em;
+  margin: 0 0 16px;
+}
+.article header .deck { color: var(--text-soft); font-size: 18px; max-width: 56ch; line-height: 1.55; }
+.article header .meta { color: var(--mute); font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; margin-top: 18px; }
+.article .content { font-size: 17px; line-height: 1.75; }
+.article .content a { color: var(--accent); border-bottom: 1px solid var(--accent-soft); }
+.article .content h2 { font-family: "Bricolage Grotesque", sans-serif; font-size: 28px; margin: 40px 0 12px; letter-spacing: -0.015em; }
+.article .content blockquote {
+  border-left: 2px solid var(--accent);
+  margin: 28px 0;
+  padding: 4px 0 4px 20px;
+  font-style: italic;
+  color: var(--text-soft);
+}
+.article .content code { font-family: "JetBrains Mono", monospace; background: var(--bg-soft); padding: 2px 6px; border-radius: 3px; color: var(--accent); font-size: 0.92em; }
+.article .content pre { background: var(--bg-soft); border: 1px solid var(--line); border-radius: 8px; padding: 18px; overflow-x: auto; font-size: 13px; }
+
+@media (max-width: 880px) {
+  .work, .services, .process, .foot .top, .hero .meta-row { grid-template-columns: 1fr; }
+  .section-head { grid-template-columns: 1fr; gap: 16px; }
+  .work .card.full { grid-column: span 1; }
+  .svc, .step { border-right: 0; border-bottom: 1px solid var(--line); }
+}

--- a/examples/noctura/templates/404.html
+++ b/examples/noctura/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+
+<section class="cta">
+  <div class="wrap">
+    <div class="num" style="font-family:'JetBrains Mono',monospace;font-size:12px;letter-spacing:0.2em;text-transform:uppercase;color:var(--accent);margin-bottom:18px;">Error 404</div>
+    <h2>This page is <em>missing</em>.</h2>
+    <p class="deck">You followed a link that does not exist on this site. The home page is a good place to start.</p>
+    <a href="{{ base_url }}/" class="btn solid"><span class="dot"></span>Back to home</a>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/noctura/templates/footer.html
+++ b/examples/noctura/templates/footer.html
@@ -1,0 +1,37 @@
+<footer class="foot">
+  <div class="wrap">
+    <div class="top">
+      <div class="big">Let's make<br/><em>something that lasts</em>.</div>
+      <div>
+        <h5>Studio</h5>
+        <ul>
+          <li><a href="{{ base_url }}/about/">About</a></li>
+          <li><a href="{{ base_url }}/journal/">Journal</a></li>
+          <li><a href="{{ base_url }}/rss.xml">RSS</a></li>
+        </ul>
+      </div>
+      <div>
+        <h5>Contact</h5>
+        <ul>
+          <li><a href="mailto:hello@noctura.studio">hello@noctura.studio</a></li>
+          <li>Seoul · UTC+9</li>
+          <li>Available Q3 2026</li>
+        </ul>
+      </div>
+      <div>
+        <h5>Social</h5>
+        <ul>
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">Are.na</a></li>
+          <li><a href="#">Read.cv</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="bottom">
+      <div>© {{ current_year }} {{ site.title }} — All rights reserved.</div>
+      <div>Built quietly with Hwaro · Set in Bricolage Grotesque</div>
+    </div>
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/noctura/templates/header.html
+++ b/examples/noctura/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="wrap bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="mark"></span>{{ site.title }}</a>
+    <nav class="menu">
+      <a href="{{ base_url }}/#work">Work</a>
+      <a href="{{ base_url }}/#services">Services</a>
+      <a href="{{ base_url }}/journal/">Journal</a>
+      <a href="{{ base_url }}/about/">Studio</a>
+    </nav>
+    <a href="mailto:hello@noctura.studio" class="btn solid"><span class="dot"></span>Start a project</a>
+  </div>
+</header>

--- a/examples/noctura/templates/home.html
+++ b/examples/noctura/templates/home.html
@@ -1,0 +1,197 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="wrap">
+    <h1>Design<br/>for the <em>long</em><br/>quiet shift.</h1>
+    <p class="deck">Noctura is an independent design and engineering studio. We work with founders and operators on brand, product, and the unglamorous interfaces that hold them together. Small team, long horizons, no theatre.</p>
+    <div class="row">
+      <a href="{{ base_url }}/#work" class="btn solid"><span class="dot"></span>See selected work</a>
+      <a href="mailto:hello@noctura.studio" class="btn">Start a project →</a>
+    </div>
+    <div class="meta-row">
+      <div><div class="k">FOUNDED</div><div class="v">2019</div></div>
+      <div><div class="k">PROJECTS</div><div class="v acc">62</div></div>
+      <div><div class="k">CLIENTS</div><div class="v">41</div></div>
+      <div><div class="k">NEXT OPENING</div><div class="v acc">Q3 26</div></div>
+    </div>
+  </div>
+  <div class="marquee">NOCTURA · NOCTURA · NOCTURA</div>
+</section>
+
+<section class="block" id="work">
+  <div class="wrap">
+    <div class="section-head">
+      <div>
+        <div class="num">01 / Selected work</div>
+        <h2>Six things<br/>we are <em>proud</em><br/>to have shipped.</h2>
+      </div>
+      <div class="copy">A small selection from the past three years. We have left out the projects that were good but not memorable, and the projects we are still under NDA on. What remains is, broadly, the work we would do again.</div>
+    </div>
+
+    <div class="work">
+      <a href="{{ base_url }}/journal/atlas-rebrand/" class="card full">
+        <div class="image"><span class="mark">ATLAS</span></div>
+        <div class="meta">
+          <div>
+            <div class="top">Brand · Identity system</div>
+            <h3>A continent-spanning identity for a logistics company that hated logos.</h3>
+            <p>Atlas had grown from one warehouse to forty across nine countries. We built a system flexible enough to fit a truck door, a freight document, and a billboard, without flinching.</p>
+          </div>
+          <div class="year">2026</div>
+        </div>
+      </a>
+      <a href="{{ base_url }}/journal/sable-product/" class="card">
+        <div class="image"><span class="mark">SBL</span></div>
+        <div class="meta">
+          <div>
+            <div class="top">Product · Web app</div>
+            <h3>Sable — a quieter way to manage a working portfolio.</h3>
+            <p>Designed and built a calm web app for solo investors, with a clarity-first interface and a refusal to gamify.</p>
+          </div>
+          <div class="year">2025</div>
+        </div>
+      </a>
+      <a href="{{ base_url }}/journal/foundry-press/" class="card">
+        <div class="image"><span class="mark">FNDR</span></div>
+        <div class="meta">
+          <div>
+            <div class="top">Editorial · Publication</div>
+            <h3>Foundry Press — a print and digital magazine for makers.</h3>
+            <p>Art direction, typesetting, and the small machinery of a magazine that mails reliably four times a year.</p>
+          </div>
+          <div class="year">2024</div>
+        </div>
+      </a>
+      <a href="{{ base_url }}/journal/lumen-os/" class="card">
+        <div class="image"><span class="mark">LMN</span></div>
+        <div class="meta">
+          <div>
+            <div class="top">Product · Mobile</div>
+            <h3>Lumen — habit tracking without the moralism.</h3>
+            <p>An iOS app for keeping a few small daily promises. Quiet UI, zero notifications by default, an undo button that does what it should.</p>
+          </div>
+          <div class="year">2024</div>
+        </div>
+      </a>
+      <a href="{{ base_url }}/journal/orchard-id/" class="card">
+        <div class="image"><span class="mark">ORC</span></div>
+        <div class="meta">
+          <div>
+            <div class="top">Brand · Packaging</div>
+            <h3>Orchard — a fruit grower's identity, drawn from the soil up.</h3>
+            <p>An identity, a typeface, a packaging system, and a small set of seasonal posters that are now on the wall of every employee's kitchen.</p>
+          </div>
+          <div class="year">2023</div>
+        </div>
+      </a>
+      <a href="{{ base_url }}/journal/halcyon-fund/" class="card">
+        <div class="image"><span class="mark">HCN</span></div>
+        <div class="meta">
+          <div>
+            <div class="top">Brand · Site</div>
+            <h3>Halcyon — a fund that does not look like a fund.</h3>
+            <p>A small, confident brand for an investment fund that wanted to be read carefully rather than skimmed quickly.</p>
+          </div>
+          <div class="year">2023</div>
+        </div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="block" id="services" style="padding-top:0;">
+  <div class="wrap">
+    <div class="section-head">
+      <div>
+        <div class="num">02 / Services</div>
+        <h2>Three disciplines,<br/><em>one</em> studio.</h2>
+      </div>
+      <div class="copy">We do not pretend to do everything. We do three things, and we keep our team small enough that the people in the meeting are also the people doing the work.</div>
+    </div>
+  </div>
+  <div class="services">
+    <div class="svc">
+      <div class="num">/01</div>
+      <h3>Brand &amp; identity</h3>
+      <p>Naming, visual systems, voice, and the unfashionable work of staying coherent across thirty surfaces.</p>
+      <ul>
+        <li>Identity systems</li>
+        <li>Visual language</li>
+        <li>Naming &amp; voice</li>
+        <li>Editorial design</li>
+      </ul>
+    </div>
+    <div class="svc">
+      <div class="num">/02</div>
+      <h3>Product design</h3>
+      <p>From the first sketch to the version your customer support team can defend at 2am.</p>
+      <ul>
+        <li>Research &amp; strategy</li>
+        <li>Interface design</li>
+        <li>Design systems</li>
+        <li>Prototypes</li>
+      </ul>
+    </div>
+    <div class="svc">
+      <div class="num">/03</div>
+      <h3>Engineering</h3>
+      <p>Small-team engineering for marketing sites, lightweight web apps, and the production-grade design infrastructure underneath.</p>
+      <ul>
+        <li>Web development</li>
+        <li>Headless CMS</li>
+        <li>Design infra</li>
+        <li>Performance</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<div class="tape">
+  <div class="scroll">
+    <span>Brand</span><span>Product</span><span>Identity</span><span>Editorial</span><span>Engineering</span><span>Strategy</span><span>Brand</span><span>Product</span><span>Identity</span>
+  </div>
+</div>
+
+<section class="block">
+  <div class="wrap">
+    <div class="section-head">
+      <div>
+        <div class="num">03 / Process</div>
+        <h2>Four phases,<br/><em>no</em> theatre.</h2>
+      </div>
+      <div class="copy">Every project follows the same four phases. We try not to skip them, even when the timeline feels short. They are short, in proportion. They are not theatre.</div>
+    </div>
+  </div>
+  <div class="process">
+    <div class="step">
+      <div class="num">01</div>
+      <h4>Understand</h4>
+      <p>Three weeks of reading, listening, and walking the operation. Most of the project is decided here, quietly.</p>
+    </div>
+    <div class="step">
+      <div class="num">02</div>
+      <h4>Define</h4>
+      <p>A short brief, jointly owned. A few principles. A set of constraints. No deliverables yet.</p>
+    </div>
+    <div class="step">
+      <div class="num">03</div>
+      <h4>Make</h4>
+      <p>The long middle. Sketches, drafts, builds, iterations. Daily check-ins, weekly written updates.</p>
+    </div>
+    <div class="step">
+      <div class="num">04</div>
+      <h4>Land</h4>
+      <p>Handover, documentation, training. A six-month follow-up to see how the work has aged in the wild.</p>
+    </div>
+  </div>
+</section>
+
+<section class="cta">
+  <div class="wrap">
+    <h2>Have a project that needs the <em>long</em> shift?</h2>
+    <p class="deck">We take on a small number of new engagements each quarter. The best ones begin with a long email rather than a short form.</p>
+    <a href="mailto:hello@noctura.studio" class="btn solid"><span class="dot"></span>hello@noctura.studio</a>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/noctura/templates/page.html
+++ b/examples/noctura/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<article class="article">
+  <header>
+    <div class="crumb">{{ page.section | default(value="studio") }} / {{ page.title }}</div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+    <div class="meta">
+      {% if page.date %}<span>{{ page.date | date(format="%B %d, %Y") }}</span>{% endif %}
+      {% if page.reading_time %} · <span>{{ page.reading_time }} min read</span>{% endif %}
+    </div>
+  </header>
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/noctura/templates/section.html
+++ b/examples/noctura/templates/section.html
@@ -13,7 +13,7 @@
     <div class="work">
       {% for post in section.pages %}
       <a href="{{ base_url }}{{ post.url }}" class="card{% if loop.first %} full{% endif %}">
-        <div class="image"><span class="mark">{{ post.title | upper | truncate(length=3, end="") }}</span></div>
+        <div class="image"><span class="mark">{{ post.extra.monogram | default(value=post.title | upper | truncate(length=3, end="")) }}</span></div>
         <div class="meta">
           <div>
             <div class="top">{{ post.tags | first | default(value="Note") }}</div>

--- a/examples/noctura/templates/section.html
+++ b/examples/noctura/templates/section.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+
+<section class="block" style="padding-top:200px;">
+  <div class="wrap">
+    <div class="section-head">
+      <div>
+        <div class="num">{{ section.title | upper }}</div>
+        <h2>{{ section.title }} —<br/><em>writing</em> from the studio.</h2>
+      </div>
+      <div class="copy">{{ section.description | default(value="Notes, case studies, and the occasional unsorted thought.") }}</div>
+    </div>
+
+    <div class="work">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="card{% if loop.first %} full{% endif %}">
+        <div class="image"><span class="mark">{{ post.title | upper | truncate(length=3, end="") }}</span></div>
+        <div class="meta">
+          <div>
+            <div class="top">{{ post.tags | first | default(value="Note") }}</div>
+            <h3>{{ post.title }}</h3>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+          </div>
+          <div class="year">{% if post.date %}{{ post.date | date(format="%Y") }}{% endif %}</div>
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/noctura/templates/taxonomy.html
+++ b/examples/noctura/templates/taxonomy.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<section class="block" style="padding-top:200px;">
+  <div class="wrap">
+    <div class="section-head">
+      <div>
+        <div class="num">{{ taxonomy_name | upper }}</div>
+        <h2>All {{ taxonomy_name }}.</h2>
+      </div>
+      <div class="copy">Every term used across the studio's writing and case studies.</div>
+    </div>
+    <ul style="list-style:none;padding:0;margin:0;font-family:'JetBrains Mono',monospace;font-size:14px;color:var(--text-soft);">
+      {% for term in taxonomy_terms %}
+        <li style="padding:14px 0;border-top:1px solid var(--line);display:flex;justify-content:space-between;">
+          <a href="{{ base_url }}{{ term.url }}" style="color:var(--text);font-size:18px;font-family:'Bricolage Grotesque',sans-serif;">#{{ term }}</a>
+          <span>{{ term.pages | length }} entries</span>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/noctura/templates/taxonomy_term.html
+++ b/examples/noctura/templates/taxonomy_term.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+
+<section class="block" style="padding-top:200px;">
+  <div class="wrap">
+    <div class="section-head">
+      <div>
+        <div class="num">{{ taxonomy_name | upper }}</div>
+        <h2>#{{ taxonomy_term }}</h2>
+      </div>
+      <div class="copy">{{ taxonomy_pages | length }} entries.</div>
+    </div>
+    <div class="work">
+      {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="card">
+        <div class="image"><span class="mark">{{ post.title | upper | truncate(length=3, end="") }}</span></div>
+        <div class="meta">
+          <div>
+            <h3>{{ post.title }}</h3>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+          </div>
+          <div class="year">{% if post.date %}{{ post.date | date(format="%Y") }}{% endif %}</div>
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/noctura/templates/taxonomy_term.html
+++ b/examples/noctura/templates/taxonomy_term.html
@@ -12,7 +12,7 @@
     <div class="work">
       {% for post in taxonomy_pages %}
       <a href="{{ base_url }}{{ post.url }}" class="card">
-        <div class="image"><span class="mark">{{ post.title | upper | truncate(length=3, end="") }}</span></div>
+        <div class="image"><span class="mark">{{ post.extra.monogram | default(value=post.title | upper | truncate(length=3, end="")) }}</span></div>
         <div class="meta">
           <div>
             <h3>{{ post.title }}</h3>

--- a/examples/prism-grid/AGENTS.md
+++ b/examples/prism-grid/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/prism-grid/archetypes/default.md
+++ b/examples/prism-grid/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/prism-grid/config.toml
+++ b/examples/prism-grid/config.toml
@@ -1,0 +1,184 @@
+title = "Prism Grid"
+description = "An editorial blog with a brutalist asymmetric grid and oversized typography."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/prism-grid/content/about.md
+++ b/examples/prism-grid/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "Colophon"
+description = "How this publication is set, structured, and shipped."
+date = "2026-04-01"
++++
+
+**Prism Grid** is an independent editorial publication exploring craft, systems, and the long slow business of making things. The page you are reading is set in *Fraunces* by Phaedra Charles and David Jonathan Ross, with *JetBrains Mono* for metadata and *Inter* for the body.
+
+## Editorial principles
+
+We prefer essays that survive rereading. We prefer drawings to diagrams when both will do. We do not chase newsletters, traffic, or the latest framework cycle.
+
+## How it is published
+
+The site is generated with the [Hwaro](https://hwaro.hahwul.com) static site generator. Layout is a twelve column grid with a two column lead spread, a four column issue strip, and a three across article grid that occasionally inverts and widens. Type sets to a 1.5 baseline rhythm.
+
+## Contact
+
+For pitches, corrections, or anything resembling fan mail: editors@prism.grid.

--- a/examples/prism-grid/content/index.md
+++ b/examples/prism-grid/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Prism Grid"
+description = "An editorial blog with a brutalist asymmetric grid and oversized typography."
+template = "home"
++++

--- a/examples/prism-grid/content/posts/_index.md
+++ b/examples/prism-grid/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Archive"
+description = "Every essay, field note, and interview in the index."
+sort_by = "date"
+reverse = true
+generate_feeds = true
++++

--- a/examples/prism-grid/content/posts/grid-systems.md
+++ b/examples/prism-grid/content/posts/grid-systems.md
@@ -1,0 +1,26 @@
++++
+title = "Why grids are not cages"
+date = "2026-04-08"
+description = "On the misunderstanding that a strict grid limits expression. In practice, the opposite is true: the grid is the thing that lets the page breathe."
+tags = ["essays"]
+[extra]
+author = "J. Müller"
++++
+
+A grid is not a prison. A grid is a contract between the page and the reader. Once the contract is signed, both parties are free to do unusual things, because the underlying rhythm is no longer in question.
+
+## What a grid actually does
+
+It does not constrain the designer. It constrains the *negotiation* between elements. Two photographs at unequal sizes can sit happily next to each other because the gutter is doing the diplomatic work.
+
+## The brutalist instinct
+
+The recent fashion for brutalist web design is, at its best, a return to grids that you can actually see. The rules are exposed. The page admits that it is a page. This is honest in a way that frosted glass and floating cards are not.
+
+## Reading list
+
+- Müller-Brockmann, *Grid Systems in Graphic Design*
+- Hochuli, *Detail in Typography*
+- Bringhurst, *The Elements of Typographic Style*
+
+Read them in order. Then ignore them in the order that suits you.

--- a/examples/prism-grid/content/posts/letterpress.md
+++ b/examples/prism-grid/content/posts/letterpress.md
@@ -1,0 +1,24 @@
++++
+title = "An afternoon at the letterpress"
+date = "2026-04-22"
+description = "Notes from a visit to a working letterpress shop in the back streets of Daegu, where the type cabinets are taller than the printer."
+tags = ["field-notes"]
+[extra]
+author = "S. Han"
++++
+
+The shop is on the second floor, above a noodle restaurant whose owner has lived in the building since the late 1970s. You climb a stairwell that smells faintly of garlic and ink and emerge into a long room lit by two bare bulbs and a north facing window.
+
+## Workflow
+
+The printer works in batches of fifty. He sets type from a wooden case organized by the older California layout, which he learned as an apprentice. The press itself is a Heidelberg from the early 1960s, oiled daily.
+
+> "Speed comes from not deciding twice," he says, locking up a forme.
+
+## What I learned
+
+- Composition is faster when the tools punish you for revising.
+- Registration is everything. So is patience.
+- A good colophon is a love letter from the printer to the next printer.
+
+I left with a print and a list of things to try in the studio. Both will outlast the noodles.

--- a/examples/prism-grid/content/posts/long-decisions.md
+++ b/examples/prism-grid/content/posts/long-decisions.md
@@ -1,0 +1,29 @@
++++
+title = "Eight notes on long decisions"
+date = "2026-05-10"
+description = "Architectural choices age. The good ones age into invariants. The bad ones age into excuses. A short essay on telling the difference before it is too late."
+tags = ["essays"]
+[extra]
+author = "M. Aurelius"
++++
+
+There is a quiet category of decision that produces no fireworks the day it is made. No demo. No launch. No celebratory thread. Months later, it is impossible to imagine the system without it. We call these *long decisions*, and we keep notes.
+
+## The first sign is the absence of a meeting
+
+Long decisions tend to surface in passing, often during code review, often by accident. A reviewer asks why we are not just doing the obvious thing, and someone replies with three sentences that turn out to be load bearing.
+
+> If you are sure you can write it in three sentences, you are probably sure for the wrong reasons.
+
+## They will be invisible later
+
+A good long decision compresses cleanly. Eventually new engineers will read the result and assume that of course it was always this way, because the alternatives have been carefully removed. This is the highest form of compliment.
+
+## Field markers
+
+- Cheap to reverse on day one. Expensive to reverse on day ninety.
+- Anchored to a constraint that will not change for at least one year.
+- Survives at least two near misses without rework.
+- Quietly makes other decisions easier.
+
+The best ones become invariants. The worst ones become excuses. The difference, almost always, is whether anyone wrote the three sentences down at the time.

--- a/examples/prism-grid/content/posts/notes-on-shipping.md
+++ b/examples/prism-grid/content/posts/notes-on-shipping.md
@@ -1,0 +1,18 @@
++++
+title = "Notes on shipping in winter"
+date = "2026-02-18"
+description = "A small studio cuts a release the week of the heaviest snowfall in a decade. The release goes out clean. The studio, less so."
+tags = ["field-notes"]
+[extra]
+author = "Editors"
++++
+
+We shipped 4.0 the morning the snow stopped. Half the team was working from their kitchens. One person was working from a friend's kitchen because their power was out. Two cats were on call.
+
+## The release itself
+
+The release was easy. The hard part was everything around it: catering, signage, the broken espresso machine in the office no one had been to in eight days. The software was, as usual, the most predictable thing in the building.
+
+## A small lesson
+
+A release shipped during a snowstorm reveals exactly which parts of the process were depending on the weather to look ordinary. We wrote the list. The list is now the post mortem. Some of it is funny. Most of it is not.

--- a/examples/prism-grid/content/posts/quiet-tools.md
+++ b/examples/prism-grid/content/posts/quiet-tools.md
@@ -1,0 +1,18 @@
++++
+title = "In praise of quiet tools"
+date = "2026-03-12"
+description = "A short defense of software that does not announce itself, does not collect telemetry, and does not require a tour. The kind of tool that disappears."
+tags = ["essays"]
+[extra]
+author = "K. Park"
++++
+
+The best tools I have used disappear after twenty minutes. There is no onboarding. There is no welcome video. There is no tooltip explaining what a button does. The button does the thing, and you move on.
+
+## Three quiet tools
+
+- A text editor that opens in under a second and remembers nothing.
+- A version control system whose entire interface is six commands.
+- A typeface that does not make me notice it.
+
+Each of these is a small act of respect. The maker did the difficult work so that the user would not have to.

--- a/examples/prism-grid/content/posts/the-machine.md
+++ b/examples/prism-grid/content/posts/the-machine.md
@@ -1,0 +1,20 @@
++++
+title = "The machine was the easy part"
+date = "2026-01-04"
+description = "A review of a year spent rebuilding our publishing pipeline. The new machine works. The new team takes longer."
+tags = ["reviews"]
+[extra]
+author = "Editors"
++++
+
+We replaced our publishing pipeline this year. The new one is faster, more reliable, and roughly half the size of the old one. The team that built it is roughly the same size as the team that ran the old one, but they are happier, and the rate of small mistakes has fallen to almost zero.
+
+## What we underestimated
+
+We underestimated, as always, the cost of moving editorial habits. A pipeline does not just process content. It enforces a worldview. Changing pipelines is changing worldviews, and worldviews change slowly, and over coffee.
+
+## What we got right
+
+We got the contracts right. Every piece of content now passes through three named gates, and each gate has an owner and a deadline. The pipeline simply enforces what the editors already agreed to do.
+
+The machine, in the end, was the easy part.

--- a/examples/prism-grid/content/posts/the-margin.md
+++ b/examples/prism-grid/content/posts/the-margin.md
@@ -1,0 +1,20 @@
++++
+title = "The margin is not empty"
+date = "2026-01-30"
+description = "A short essay on whitespace, generosity, and the unfashionable idea that a page should leave room for the reader to disagree with it."
+tags = ["essays"]
+[extra]
+author = "R. Tschichold"
++++
+
+The margin is the part of the page where the reader is allowed to think. Without margin, the page becomes a wall. With margin, the page becomes a conversation.
+
+> "The white space is not waste. It is the page making space for the reader."
+
+## Practical generosity
+
+A wider outer margin tells the reader: rest here. A wider inner margin tells the reader: this book will not fall apart. A wider top margin tells the reader: take your time. None of this is decoration. All of it is meaning.
+
+## On removal
+
+Editing is the act of returning whitespace to the page. Every sentence cut is a small gift to the margin, and to the reader, and to whatever the reader was going to think about next.

--- a/examples/prism-grid/content/posts/typeface-interview.md
+++ b/examples/prism-grid/content/posts/typeface-interview.md
@@ -1,0 +1,26 @@
++++
+title = "An interview with a typeface designer who refuses to retire"
+date = "2026-03-29"
+description = "A four hour conversation, condensed. On serifs, software, students who do not read, and why she still draws every glyph by hand before it goes near a screen."
+tags = ["interviews"]
+[extra]
+author = "Editors"
++++
+
+We met at her studio in early March. She had laid out three different printings of her own typeface on a long table, in chronological order, so that we could see how it had changed over twenty years.
+
+## On beginning
+
+"You begin with the lowercase n. Everyone tells you to begin with the o or the H. They are wrong. The n decides the rhythm. The o is a consequence of the n."
+
+## On software
+
+"I use it. I am not a romantic. But I draw the first cut by hand because the hand makes mistakes that the cursor cannot. A useful typeface contains its own mistakes."
+
+## On students
+
+"They do not read enough. They look at type without reading it. You cannot judge a typeface by glancing. You have to live inside a paragraph for ten minutes before you know whether it is honest."
+
+## On retirement
+
+"I will retire when the n stops surprising me."

--- a/examples/prism-grid/static/css/style.css
+++ b/examples/prism-grid/static/css/style.css
@@ -1,0 +1,317 @@
+:root {
+  --bg: #f4f1ec;
+  --paper: #ffffff;
+  --ink: #111111;
+  --ink-soft: #2a2a2a;
+  --mute: #6e6a64;
+  --rule: #111111;
+  --accent: #d94924;
+  --accent-soft: #f7d9ce;
+  --grid: 1280px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+img { max-width: 100%; display: block; }
+
+.wrap {
+  max-width: var(--grid);
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+/* ===== Masthead ===== */
+.masthead {
+  border-bottom: 2px solid var(--ink);
+  background: var(--bg);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.masthead-inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px 32px;
+  gap: 24px;
+}
+
+.masthead .left,
+.masthead .right {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-soft);
+}
+
+.masthead .right { text-align: right; }
+.masthead .right a { margin-left: 18px; }
+
+.brand {
+  font-family: "Fraunces", "Times New Roman", serif;
+  font-weight: 800;
+  font-size: 28px;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+
+.brand .dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--accent);
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+/* ===== Hero / Lead ===== */
+.lead {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-bottom: 2px solid var(--ink);
+}
+
+.lead .col {
+  padding: 56px 40px;
+}
+
+.lead .col + .col {
+  border-left: 2px solid var(--ink);
+}
+
+.eyebrow {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin: 0 0 18px;
+  display: inline-block;
+  border: 1.5px solid var(--accent);
+  padding: 4px 8px;
+}
+
+h1.lead-title {
+  font-family: "Fraunces", "Times New Roman", serif;
+  font-weight: 800;
+  font-size: clamp(40px, 6.5vw, 92px);
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  margin: 0 0 24px;
+}
+
+.lead-deck {
+  font-size: 18px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  margin: 0 0 24px;
+}
+
+.meta {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mute);
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.meta .sep { width: 18px; height: 1px; background: var(--ink); display: inline-block; }
+
+/* ===== Issue strip ===== */
+.issue {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 2px solid var(--ink);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.issue .cell {
+  padding: 14px 20px;
+  border-right: 1.5px solid var(--ink);
+  color: var(--ink-soft);
+}
+.issue .cell:last-child { border-right: 0; }
+.issue strong { color: var(--ink); }
+
+/* ===== Grid of articles ===== */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+}
+
+.card {
+  grid-column: span 4;
+  padding: 36px 28px;
+  border-right: 1.5px solid var(--ink);
+  border-bottom: 1.5px solid var(--ink);
+  background: var(--bg);
+  transition: background 120ms ease;
+}
+
+.card:hover { background: var(--paper); }
+
+.card:nth-child(3n) { border-right: 0; }
+
+.card .num {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--mute);
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+
+.card h3 {
+  font-family: "Fraunces", "Times New Roman", serif;
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 12px;
+}
+
+.card p {
+  color: var(--ink-soft);
+  font-size: 15px;
+  line-height: 1.5;
+  margin: 0 0 18px;
+}
+
+.card .tag {
+  display: inline-block;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  background: var(--ink);
+  color: var(--paper);
+}
+
+/* Variant cards */
+.card.wide { grid-column: span 8; background: var(--paper); }
+.card.wide h3 { font-size: 44px; }
+.card.wide .deck { font-size: 17px; color: var(--ink-soft); max-width: 60ch; }
+
+.card.invert { background: var(--ink); color: var(--paper); }
+.card.invert h3 { color: var(--paper); }
+.card.invert p { color: #d6d3cd; }
+.card.invert .num { color: var(--accent); }
+.card.invert .tag { background: var(--accent); color: var(--ink); }
+
+/* ===== Article page ===== */
+.article {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 64px 32px 96px;
+}
+
+.article header {
+  border-bottom: 1.5px solid var(--ink);
+  padding-bottom: 36px;
+  margin-bottom: 48px;
+}
+
+.article h1 {
+  font-family: "Fraunces", "Times New Roman", serif;
+  font-weight: 800;
+  font-size: clamp(36px, 5vw, 64px);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  margin: 12px 0 18px;
+}
+
+.article .deck {
+  font-size: 19px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+
+.article .content h2 {
+  font-family: "Fraunces", serif;
+  font-size: 28px;
+  margin: 48px 0 14px;
+  letter-spacing: -0.01em;
+}
+
+.article .content p {
+  font-size: 18px;
+  line-height: 1.7;
+}
+
+.article .content blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 32px 0;
+  padding: 6px 0 6px 24px;
+  font-family: "Fraunces", serif;
+  font-size: 22px;
+  line-height: 1.4;
+  font-style: italic;
+  color: var(--ink-soft);
+}
+
+.article .content code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.92em;
+  background: #ebe7e0;
+  padding: 2px 6px;
+  border-radius: 2px;
+}
+
+.article .content pre {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 18px 22px;
+  overflow-x: auto;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+/* ===== Footer ===== */
+.foot {
+  border-top: 2px solid var(--ink);
+  padding: 36px 32px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 24px;
+  color: var(--ink-soft);
+}
+.foot strong { color: var(--ink); display: block; margin-bottom: 8px; }
+.foot .right { text-align: right; }
+
+@media (max-width: 900px) {
+  .lead { grid-template-columns: 1fr; }
+  .lead .col + .col { border-left: 0; border-top: 2px solid var(--ink); }
+  .issue { grid-template-columns: repeat(2, 1fr); }
+  .issue .cell:nth-child(2n) { border-right: 0; }
+  .card, .card.wide { grid-column: span 12; border-right: 0; }
+  .foot { grid-template-columns: 1fr; }
+  .foot .right { text-align: left; }
+}

--- a/examples/prism-grid/templates/404.html
+++ b/examples/prism-grid/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+
+<section class="article" style="text-align:center;">
+  <span class="eyebrow">404</span>
+  <h1 style="font-size:120px;">Lost in the gutter.</h1>
+  <p class="deck">This page is not on the press sheet. Try the <a href="{{ base_url }}/" style="text-decoration:underline;">index</a>.</p>
+</section>
+
+{% include "footer.html" %}

--- a/examples/prism-grid/templates/footer.html
+++ b/examples/prism-grid/templates/footer.html
@@ -1,0 +1,16 @@
+<footer class="foot">
+  <div>
+    <strong>{{ site.title }}</strong>
+    Independent editorial — published quarterly from a small studio.
+  </div>
+  <div>
+    <strong>Sections</strong>
+    Essays · Field Notes · Interviews · Reviews
+  </div>
+  <div class="right">
+    <strong>© {{ current_year }}</strong>
+    Set in Fraunces and JetBrains Mono.
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/prism-grid/templates/header.html
+++ b/examples/prism-grid/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} — {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,700;9..144,800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="masthead">
+  <div class="masthead-inner">
+    <div class="left">VOL. 04 / ISSUE 12</div>
+    <a href="{{ base_url }}/" class="brand">{{ site.title }}<span class="dot"></span></a>
+    <nav class="right">
+      <a href="{{ base_url }}/">Index</a>
+      <a href="{{ base_url }}/posts/">Archive</a>
+      <a href="{{ base_url }}/about/">Colophon</a>
+    </nav>
+  </div>
+</header>

--- a/examples/prism-grid/templates/home.html
+++ b/examples/prism-grid/templates/home.html
@@ -1,0 +1,59 @@
+{% include "header.html" %}
+
+{% set posts = site.pages | sort_by(attribute="date") | reverse %}
+{% set featured = posts | first %}
+
+{% if featured %}
+<section class="lead">
+  <div class="col">
+    <span class="eyebrow">Lead Story</span>
+    <a href="{{ base_url }}{{ featured.url }}">
+      <h1 class="lead-title">{{ featured.title }}</h1>
+    </a>
+    {% if featured.description %}<p class="lead-deck">{{ featured.description }}</p>{% endif %}
+    <div class="meta">
+      {% if featured.date %}<span>{{ featured.date | date(format="%b %d, %Y") }}</span>{% endif %}
+      <span class="sep"></span>
+      <span>{{ featured.reading_time | default(value=5) }} min read</span>
+      {% if featured.extra.author %}<span class="sep"></span><span>By {{ featured.extra.author }}</span>{% endif %}
+    </div>
+  </div>
+  <div class="col" style="background:#111;color:#f4f1ec;">
+    <span class="eyebrow" style="color:#f4f1ec;border-color:#f4f1ec;">In This Issue</span>
+    <h2 style="font-family:'Fraunces',serif;font-size:46px;line-height:1.05;letter-spacing:-0.02em;margin:0 0 28px;">
+      Eight notes on building things that outlive the news cycle.
+    </h2>
+    <p style="color:#d6d3cd;font-size:16px;line-height:1.55;max-width:48ch;">
+      A selection of recent essays, field notes, and one extremely long interview with a typeface designer who refuses to retire.
+    </p>
+  </div>
+</section>
+{% endif %}
+
+<section class="issue">
+  <div class="cell"><strong>04</strong> · Essays</div>
+  <div class="cell"><strong>12</strong> · Field Notes</div>
+  <div class="cell"><strong>03</strong> · Interviews</div>
+  <div class="cell"><strong>{{ current_date }}</strong></div>
+</section>
+
+<section class="grid">
+  {% for post in posts %}
+    {% if not loop.first %}
+      <article class="card {% if loop.index0 == 1 %}wide{% endif %}{% if loop.index0 == 4 %} invert{% endif %}">
+        <div class="num">No. {{ loop.index0 }} / {{ post.section | default(value="Posts") | upper }}</div>
+        <a href="{{ base_url }}{{ post.url }}">
+          <h3>{{ post.title }}</h3>
+        </a>
+        {% if post.description %}
+          <p class="{% if loop.index0 == 1 %}deck{% endif %}">{{ post.description }}</p>
+        {% endif %}
+        {% if post.tags %}
+          <span class="tag">{{ post.tags | first }}</span>
+        {% endif %}
+      </article>
+    {% endif %}
+  {% endfor %}
+</section>
+
+{% include "footer.html" %}

--- a/examples/prism-grid/templates/page.html
+++ b/examples/prism-grid/templates/page.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<article class="article">
+  <header>
+    <span class="eyebrow">{{ page.section | default(value="Essay") | upper }}</span>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+    <div class="meta" style="margin-top:24px;">
+      {% if page.date %}<span>{{ page.date | date(format="%B %d, %Y") }}</span>{% endif %}
+      {% if page.reading_time %}<span class="sep"></span><span>{{ page.reading_time }} min read</span>{% endif %}
+      {% if page.extra.author %}<span class="sep"></span><span>By {{ page.extra.author }}</span>{% endif %}
+    </div>
+  </header>
+  <div class="content">
+    {{ content | safe }}
+  </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/prism-grid/templates/section.html
+++ b/examples/prism-grid/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+
+<section class="issue">
+  <div class="cell"><strong>{{ section.title | upper }}</strong></div>
+  <div class="cell">{{ section.pages | length }} ENTRIES</div>
+  <div class="cell">SORTED BY DATE</div>
+  <div class="cell">{{ current_date }}</div>
+</section>
+
+<section class="grid">
+  {% for post in section.pages %}
+    <article class="card {% if loop.index0 == 0 %}wide{% endif %}">
+      <div class="num">No. {{ loop.index }} / {{ post.section | default(value="Posts") | upper }}</div>
+      <a href="{{ base_url }}{{ post.url }}"><h3>{{ post.title }}</h3></a>
+      {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+      {% if post.tags %}<span class="tag">{{ post.tags | first }}</span>{% endif %}
+    </article>
+  {% endfor %}
+</section>
+
+{% include "footer.html" %}

--- a/examples/prism-grid/templates/taxonomy.html
+++ b/examples/prism-grid/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+
+<section class="article">
+  <header>
+    <span class="eyebrow">{{ taxonomy_name | upper }}</span>
+    <h1>All {{ taxonomy_name }}</h1>
+  </header>
+  <ul style="list-style:none;padding:0;font-family:'JetBrains Mono',monospace;font-size:14px;text-transform:uppercase;letter-spacing:0.06em;">
+  {% for term in taxonomy_terms %}
+    <li style="padding:14px 0;border-bottom:1px solid #111;display:flex;justify-content:space-between;">
+      <a href="{{ base_url }}{{ term.url }}">{{ term }}</a>
+      <span style="color:#6e6a64;">{{ term.pages | length }} entries</span>
+    </li>
+  {% endfor %}
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/prism-grid/templates/taxonomy_term.html
+++ b/examples/prism-grid/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<section class="issue">
+  <div class="cell"><strong>{{ taxonomy_name | upper }}</strong></div>
+  <div class="cell"><strong>{{ taxonomy_term | upper }}</strong></div>
+  <div class="cell">{{ taxonomy_pages | length }} ENTRIES</div>
+  <div class="cell">{{ current_date }}</div>
+</section>
+
+<section class="grid">
+  {% for post in taxonomy_pages %}
+    <article class="card">
+      <div class="num">No. {{ loop.index }}</div>
+      <a href="{{ base_url }}{{ post.url }}"><h3>{{ post.title }}</h3></a>
+      {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+    </article>
+  {% endfor %}
+</section>
+
+{% include "footer.html" %}

--- a/examples/velour/AGENTS.md
+++ b/examples/velour/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/velour/archetypes/default.md
+++ b/examples/velour/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/velour/config.toml
+++ b/examples/velour/config.toml
@@ -1,0 +1,187 @@
+title = "Velour"
+description = "A quiet journal of slow living, with hairline rules and generous margins."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["journal"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/velour/content/about.md
+++ b/examples/velour/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About"
+description = "About Velour, our editorial principles, and how to reach us."
+date = "2026-04-04"
++++
+
+Velour is a small publication that started in a kitchen and has never quite left it. We write twice a month, on the first and fifteenth, about the slow things that the news cycle has no time for.
+
+## Our editorial principles
+
+We prefer essays that survive rereading. We prefer drawings to diagrams. We do not publish lists masquerading as articles, or articles masquerading as lists.
+
+## Our masthead
+
+The publication is edited by a rotating group of three friends who have agreed, on paper, that the publication will fold rather than become tedious. So far it has not folded.
+
+## Contact
+
+Letters, recipes, and complaints: editor@velour.press

--- a/examples/velour/content/index.md
+++ b/examples/velour/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Velour"
+description = "A quiet journal of slow living, with hairline rules and generous margins."
+template = "home"
++++

--- a/examples/velour/content/journal/_index.md
+++ b/examples/velour/content/journal/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Journal"
+description = "Twice-monthly entries on craft, attention, and the patient pleasures."
+sort_by = "date"
+reverse = true
+generate_feeds = true
++++

--- a/examples/velour/content/journal/keeping-a-quiet-house.md
+++ b/examples/velour/content/journal/keeping-a-quiet-house.md
@@ -1,0 +1,26 @@
++++
+title = "On keeping a quiet house"
+date = "2026-04-15"
+description = "Notes on the small architecture of an unhurried home — the placement of chairs, the choice of light, the surprising importance of one good lamp."
+tags = ["essays"]
+[extra]
+author = "J. Park"
++++
+
+A quiet house is not a silent one. There is a kettle. There is a clock. There is, in winter, the small popping of a radiator. A quiet house is a house in which all of the sounds belong, and none of the sounds are demanding anything of you.
+
+## The small architecture
+
+A chair near a window. A lamp that can be turned low. A blanket within reach. A book on the table whose spine has been broken by reading, not by abuse.
+
+## The light
+
+Ceiling light is for cleaning. For everything else, lamps. One good lamp is worth four indifferent ones. We bought ours secondhand in 2018 and have not stopped recommending it to people who did not ask.
+
+## The placement
+
+Chairs should face each other, not the television. Tables should be deep enough to hold a teapot, a cup, a book, and one elbow.
+
+## The surprising importance of one good lamp
+
+I cannot defend this rigorously. I can only report that the difference between a room and a room you want to spend an evening in is, more often than not, one good lamp.

--- a/examples/velour/content/journal/letters-from-an-attic.md
+++ b/examples/velour/content/journal/letters-from-an-attic.md
@@ -1,0 +1,27 @@
++++
+title = "Letters from an attic"
+date = "2026-05-01"
+description = "A small inheritance of paper. Forty years of handwriting, opened in the order they were sealed, on the kitchen table in the rain."
+tags = ["essays"]
+[extra]
+author = "S. Han"
++++
+
+My grandmother kept her letters in a tin biscuit box. The box came down from the attic in early March, with a label in her handwriting that read, simply, *for whoever wants them*. I wanted them.
+
+## The order they were sealed
+
+I opened them in the order she had stored them, which turned out to be the order they were sealed. The earliest is from 1962. The most recent is from 1998. There are one hundred and forty-three.
+
+## A small archeology
+
+They are arranged into bundles, tied with the same brown ribbon she used on every Christmas parcel I ever received. Each bundle covers about three years. Each bundle smells, faintly, of the tin.
+
+## What I learned, slowly
+
+- She wrote in three languages.
+- She kept drafts of her own letters.
+- She had a sister I had not known about.
+- She was, in print, much funnier than she was in person.
+
+The letters are not going back into the attic. They are on the bookshelf now, between the cookbooks and the dictionary, where I can see them, and read one occasionally on a slow afternoon.

--- a/examples/velour/content/journal/the-mending-basket.md
+++ b/examples/velour/content/journal/the-mending-basket.md
@@ -1,0 +1,24 @@
++++
+title = "The mending basket"
+date = "2026-03-15"
+description = "A small wicker basket lives by the chair. In it: socks, a sweater with a hole in the elbow, and a quiet hour."
+tags = ["craft"]
+[extra]
+author = "M. Choi"
++++
+
+I bought the basket at a market in late October. The vendor had three of them stacked together, all slightly different shapes, all priced the same. I bought the most lopsided one because the others felt too well behaved.
+
+## What lives in the basket
+
+- A pair of socks with thin heels.
+- A sweater with a hole in the elbow, which I have been meaning to mend since January.
+- A small tin of darning needles.
+- Three balls of wool, in three slightly different greys.
+- A pair of scissors small enough to lose.
+
+## The hour
+
+I mend on Sunday evenings, between supper and the long film. The radio is on, low. The light is warm. The sock takes longer than I expect. The sweater takes two evenings, the second of which I spent mostly drinking tea and admiring my own work.
+
+A mended thing is more interesting than a new one. This is, broadly, the entire editorial line of this publication.

--- a/examples/velour/content/journal/the-slow-loaf.md
+++ b/examples/velour/content/journal/the-slow-loaf.md
@@ -1,0 +1,28 @@
++++
+title = "The slow loaf, and the long Sunday"
+date = "2026-05-15"
+description = "On the small pleasures of a long fermentation, and the unexpected discipline of a kitchen that asks you to wait."
+tags = ["kitchen"]
+[extra]
+author = "M. Choi"
++++
+
+The recipe begins on a Friday. You weigh the flour. You weigh the water. You weigh the salt. You stir the levain, which has been waiting in a jar on the counter since Wednesday, and which smells, unmistakably, like the air just before rain.
+
+## The first rise
+
+A long fermentation is a kitchen that asks you to wait. Six hours. Twelve hours. Sometimes, in a cold room in February, eighteen. The dough does not need you. The dough is doing its own slow work. Your only task is to fold it three times, gently, and to leave the kitchen.
+
+> "The bread that is hurried is the bread that is hard."
+
+A neighbor told me this. Her grandmother told her. I have no reason to disagree.
+
+## The second day
+
+On Saturday morning, the dough is shaped. It rests, again, for the long afternoon. By evening it is in the fridge, calm and slow, waiting for Sunday.
+
+## The long Sunday
+
+The oven is hot. The dough goes in. The kitchen fills, slowly, with the smell of crust. The loaf comes out. You let it cool, against every instinct, because a hot loaf cut too soon is a sad loaf.
+
+By the time you slice it, it is afternoon. The light through the window is at the angle that means it is almost suppertime. You butter a thick piece and you eat it standing up at the counter, because some pleasures do not require chairs.

--- a/examples/velour/content/journal/the-walking-hour.md
+++ b/examples/velour/content/journal/the-walking-hour.md
@@ -1,0 +1,21 @@
++++
+title = "The walking hour"
+date = "2026-04-01"
+description = "A short defense of the daily walk — the kind without a destination, without headphones, and, ideally, in slightly the wrong shoes."
+tags = ["practice"]
+[extra]
+author = "Editors"
++++
+
+The best walks are the ones without a destination. You leave the house. You turn left, or right, depending on the weather and your mood. You walk for an hour. You come home. You have, on this walk, solved at least one problem that you did not know you were going to solve.
+
+## The rules
+
+- No destination.
+- No headphones, except in the worst weather.
+- Slightly the wrong shoes, so that you remember you are walking.
+- Bring a small notebook. You will not use it. That is fine.
+
+## The unexpected benefits
+
+It will not surprise you that walking is good for the body. It may surprise you how good it is for sentences. After three weeks of daily walks, your prose will be slightly different. You will not be able to say how. Your editor will be able to say how.

--- a/examples/velour/static/css/style.css
+++ b/examples/velour/static/css/style.css
@@ -1,0 +1,357 @@
+:root {
+  --bg: #f7f3ec;
+  --bg-warm: #efe9dd;
+  --paper: #ffffff;
+  --ink: #1c1a17;
+  --ink-soft: #3a342f;
+  --mute: #847d72;
+  --hair: #d8d0c1;
+  --hair-strong: #b9ae9b;
+  --accent: #b85c44;
+  --accent-soft: #f0d8cf;
+  --gold: #a8895a;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", "Helvetica Neue", sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+img { max-width: 100%; display: block; }
+
+.wrap { max-width: 1100px; margin: 0 auto; padding: 0 40px; }
+.wrap-narrow { max-width: 700px; margin: 0 auto; padding: 0 40px; }
+
+/* ===== Header ===== */
+.top {
+  padding: 28px 0;
+  border-bottom: 1px solid var(--hair);
+}
+.top .inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 24px;
+}
+.top .left, .top .right {
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+.top .right { text-align: right; }
+.top .right a { margin-left: 24px; }
+.top .right a:hover { color: var(--accent); }
+
+.brand {
+  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  font-weight: 500;
+  font-size: 38px;
+  letter-spacing: 0.04em;
+  text-align: center;
+  font-style: italic;
+}
+.brand span { color: var(--accent); }
+
+.subtop {
+  text-align: center;
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mute);
+  padding: 14px 0 22px;
+  border-bottom: 1px solid var(--hair);
+  font-feature-settings: "smcp";
+}
+
+/* ===== Hero ===== */
+.hero {
+  text-align: center;
+  padding: 96px 24px 80px;
+  border-bottom: 1px solid var(--hair);
+  position: relative;
+}
+.hero .marker {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 24px;
+}
+.hero .marker .rule { width: 36px; height: 1px; background: var(--accent); }
+.hero h1 {
+  font-family: "Cormorant Garamond", serif;
+  font-weight: 400;
+  font-size: clamp(48px, 7vw, 96px);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  max-width: 18ch;
+  margin: 0 auto 28px;
+}
+.hero h1 em { color: var(--accent); font-style: italic; }
+.hero .deck {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  margin: 0 auto 28px;
+  line-height: 1.5;
+}
+.hero .meta {
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+.hero .meta .sep { display: inline-block; width: 22px; height: 1px; background: var(--hair-strong); vertical-align: middle; margin: 0 12px; }
+
+/* ===== Latest panel ===== */
+.latest {
+  padding: 80px 0;
+  border-bottom: 1px solid var(--hair);
+}
+.section-title {
+  text-align: center;
+  margin-bottom: 56px;
+}
+.section-title h2 {
+  font-family: "Cormorant Garamond", serif;
+  font-weight: 400;
+  font-style: italic;
+  font-size: 40px;
+  margin: 0 0 10px;
+  letter-spacing: -0.005em;
+}
+.section-title .sub {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+.section-title .ornament {
+  width: 60px; height: 1px; background: var(--gold); margin: 22px auto 0;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 56px 40px;
+}
+.card { text-align: left; }
+.card .num {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--accent);
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.card .num .rule { flex: 1; height: 1px; background: var(--hair); }
+.card .cat {
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin-bottom: 8px;
+}
+.card h3 {
+  font-family: "Cormorant Garamond", serif;
+  font-weight: 500;
+  font-size: 28px;
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 10px;
+}
+.card p {
+  color: var(--ink-soft);
+  font-size: 15px;
+  line-height: 1.55;
+  margin: 0 0 14px;
+}
+.card .read {
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 2px;
+  display: inline-block;
+}
+
+/* Feature row */
+.feature-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 64px;
+  padding: 96px 0;
+  border-bottom: 1px solid var(--hair);
+}
+.feature-row .ill {
+  background: var(--bg-warm);
+  border: 1px solid var(--hair);
+  aspect-ratio: 4 / 5;
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
+}
+.feature-row .ill::before, .feature-row .ill::after {
+  content: ""; position: absolute; background: var(--hair-strong);
+}
+.feature-row .ill::before { left: 24px; right: 24px; top: 24px; height: 1px; }
+.feature-row .ill::after  { top: 24px; bottom: 24px; left: 24px; width: 1px; }
+.feature-row .ill .label {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 28px;
+  color: var(--ink-soft);
+  background: var(--bg-warm);
+  padding: 0 20px;
+  z-index: 1;
+}
+.feature-row .copy { align-self: center; }
+.feature-row .copy .eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 20px;
+  display: inline-block;
+}
+.feature-row .copy h2 {
+  font-family: "Cormorant Garamond", serif;
+  font-weight: 400;
+  font-size: 56px;
+  line-height: 1.05;
+  margin: 0 0 22px;
+}
+.feature-row .copy h2 em { font-style: italic; color: var(--accent); }
+.feature-row .copy p {
+  font-size: 17px;
+  line-height: 1.7;
+  color: var(--ink-soft);
+  max-width: 42ch;
+}
+
+/* ===== Article ===== */
+.article {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 96px 24px 120px;
+}
+.article header { text-align: center; margin-bottom: 64px; padding-bottom: 36px; border-bottom: 1px solid var(--hair); }
+.article header .cat {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 18px;
+}
+.article h1 {
+  font-family: "Cormorant Garamond", serif;
+  font-weight: 400;
+  font-size: clamp(40px, 5vw, 64px);
+  line-height: 1.1;
+  letter-spacing: -0.005em;
+  margin: 0 0 24px;
+}
+.article header .deck {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 20px;
+  color: var(--ink-soft);
+  max-width: 50ch;
+  margin: 0 auto;
+}
+.article header .meta {
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin-top: 28px;
+}
+.article header .meta .sep { display: inline-block; width: 22px; height: 1px; background: var(--hair-strong); vertical-align: middle; margin: 0 12px; }
+
+.content { font-size: 17px; line-height: 1.85; color: var(--ink); }
+.content > p:first-of-type::first-letter {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 80px;
+  line-height: 0.85;
+  float: left;
+  padding: 8px 14px 0 0;
+  color: var(--accent);
+  font-weight: 500;
+}
+.content h2 {
+  font-family: "Cormorant Garamond", serif;
+  font-weight: 400;
+  font-size: 32px;
+  margin: 48px 0 14px;
+  letter-spacing: -0.005em;
+}
+.content blockquote {
+  margin: 36px -40px;
+  padding: 24px 40px;
+  border-top: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 24px;
+  line-height: 1.4;
+  text-align: center;
+  color: var(--ink-soft);
+}
+.content code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.92em;
+  background: var(--bg-warm);
+  padding: 2px 6px;
+  border-radius: 2px;
+}
+.content pre {
+  background: var(--paper);
+  border: 1px solid var(--hair);
+  padding: 18px 22px;
+  overflow-x: auto;
+  font-size: 14px;
+}
+.content a { color: var(--accent); border-bottom: 1px solid var(--accent-soft); }
+
+/* ===== Footer ===== */
+.foot {
+  border-top: 1px solid var(--hair);
+  padding: 56px 24px 64px;
+  text-align: center;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+.foot .ornament { width: 44px; height: 1px; background: var(--gold); margin: 0 auto 18px; }
+.foot a { color: var(--ink-soft); }
+.foot a:hover { color: var(--accent); }
+.foot .links a { margin: 0 16px; }
+.foot .line { margin-top: 14px; font-size: 11px; }
+
+@media (max-width: 880px) {
+  .cards { grid-template-columns: 1fr; gap: 56px; }
+  .feature-row { grid-template-columns: 1fr; gap: 32px; }
+  .top .inner { grid-template-columns: 1fr; text-align: center; }
+  .top .right { text-align: center; }
+  .top .left, .top .right { font-size: 10px; }
+}

--- a/examples/velour/templates/404.html
+++ b/examples/velour/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="marker"><span class="rule"></span><span>404</span><span class="rule"></span></div>
+  <h1><em>This page</em> has wandered off.</h1>
+  <p class="deck">Perhaps it is reading by a window somewhere. Return to the <a href="{{ base_url }}/" style="color:var(--accent);border-bottom:1px solid var(--accent);">home page</a>.</p>
+</section>
+
+{% include "footer.html" %}

--- a/examples/velour/templates/footer.html
+++ b/examples/velour/templates/footer.html
@@ -1,0 +1,12 @@
+<footer class="foot">
+  <div class="ornament"></div>
+  <div class="links">
+    <a href="{{ base_url }}/">Home</a>
+    <a href="{{ base_url }}/journal/">Journal</a>
+    <a href="{{ base_url }}/about/">About</a>
+    <a href="{{ base_url }}/rss.xml">RSS</a>
+  </div>
+  <div class="line">&copy; {{ current_year }} Velour · Set in Cormorant Garamond and Inter</div>
+</footer>
+</body>
+</html>

--- a/examples/velour/templates/header.html
+++ b/examples/velour/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="top">
+  <div class="wrap inner">
+    <div class="left">Vol. xii · No. 04</div>
+    <a href="{{ base_url }}/" class="brand">Vel<span>ou</span>r</a>
+    <nav class="right">
+      <a href="{{ base_url }}/journal/">Journal</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </div>
+</header>
+<div class="subtop">Quiet writing for the unhurried hour</div>

--- a/examples/velour/templates/home.html
+++ b/examples/velour/templates/home.html
@@ -1,0 +1,55 @@
+{% include "header.html" %}
+
+{% set posts = site.pages | sort_by(attribute="date") | reverse %}
+{% set featured = posts | first %}
+
+{% if featured %}
+<section class="hero">
+  <div class="marker"><span class="rule"></span><span>The Lead</span><span class="rule"></span></div>
+  <a href="{{ base_url }}{{ featured.url }}">
+    <h1>{{ featured.title | replace(from=" ", to=" ") }}</h1>
+  </a>
+  {% if featured.description %}<p class="deck">{{ featured.description }}</p>{% endif %}
+  <div class="meta">
+    {% if featured.date %}<span>{{ featured.date | date(format="%B %d, %Y") }}</span>{% endif %}
+    <span class="sep"></span>
+    <span>{{ featured.reading_time | default(value=5) }} min read</span>
+    {% if featured.extra.author %}<span class="sep"></span><span>by {{ featured.extra.author }}</span>{% endif %}
+  </div>
+</section>
+{% endif %}
+
+<section class="latest">
+  <div class="wrap">
+    <div class="section-title">
+      <h2>From the journal</h2>
+      <div class="sub">Latest entries</div>
+      <div class="ornament"></div>
+    </div>
+
+    <div class="cards">
+      {% for post in posts %}
+        {% if not loop.first and loop.index <= 7 %}
+          <article class="card">
+            <div class="num">{{ loop.index0 }}<span class="rule"></span></div>
+            {% if post.tags %}<div class="cat">{{ post.tags | first }}</div>{% endif %}
+            <a href="{{ base_url }}{{ post.url }}"><h3>{{ post.title }}</h3></a>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+            <a href="{{ base_url }}{{ post.url }}" class="read">Read</a>
+          </article>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="feature-row wrap">
+  <div class="ill"><span class="label">A Letter from the Editor</span></div>
+  <div class="copy">
+    <div class="eyebrow">From the Editor</div>
+    <h2>A small, <em>quiet</em> journal for the unhurried hour.</h2>
+    <p>Velour is a publication that prefers a long afternoon to a long thread. We write about craft, attention, slow rooms, and the patient pleasures that the news cycle has no time for. New entries on the first and fifteenth of each month.</p>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/velour/templates/page.html
+++ b/examples/velour/templates/page.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+
+<article class="article">
+  <header>
+    {% if page.tags %}<div class="cat">{{ page.tags | first }}</div>{% endif %}
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+    <div class="meta">
+      {% if page.date %}<span>{{ page.date | date(format="%B %d, %Y") }}</span>{% endif %}
+      {% if page.reading_time %}<span class="sep"></span><span>{{ page.reading_time }} min read</span>{% endif %}
+      {% if page.extra.author %}<span class="sep"></span><span>by {{ page.extra.author }}</span>{% endif %}
+    </div>
+  </header>
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/velour/templates/section.html
+++ b/examples/velour/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+
+<section class="latest" style="padding-top:64px;">
+  <div class="wrap">
+    <div class="section-title">
+      <h2>{{ section.title }}</h2>
+      <div class="sub">{{ section.pages | length }} entries</div>
+      <div class="ornament"></div>
+    </div>
+    <div class="cards">
+      {% for post in section.pages %}
+        <article class="card">
+          <div class="num">{{ loop.index }}<span class="rule"></span></div>
+          {% if post.tags %}<div class="cat">{{ post.tags | first }}</div>{% endif %}
+          <a href="{{ base_url }}{{ post.url }}"><h3>{{ post.title }}</h3></a>
+          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+          <a href="{{ base_url }}{{ post.url }}" class="read">Read</a>
+        </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/velour/templates/taxonomy.html
+++ b/examples/velour/templates/taxonomy.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<section class="latest">
+  <div class="wrap-narrow">
+    <div class="section-title">
+      <h2>All {{ taxonomy_name }}</h2>
+      <div class="ornament"></div>
+    </div>
+    <ul style="list-style:none;padding:0;margin:0;border-top:1px solid var(--hair);">
+      {% for term in taxonomy_terms %}
+        <li style="padding:18px 0;border-bottom:1px solid var(--hair);display:flex;justify-content:space-between;align-items:baseline;">
+          <a href="{{ base_url }}{{ term.url }}" style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:24px;">{{ term }}</a>
+          <span style="font-size:11px;letter-spacing:0.2em;text-transform:uppercase;color:var(--mute);">{{ term.pages | length }} entries</span>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/velour/templates/taxonomy_term.html
+++ b/examples/velour/templates/taxonomy_term.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+
+<section class="latest">
+  <div class="wrap">
+    <div class="section-title">
+      <h2><em>{{ taxonomy_term }}</em></h2>
+      <div class="sub">{{ taxonomy_pages | length }} entries</div>
+      <div class="ornament"></div>
+    </div>
+    <div class="cards">
+      {% for post in taxonomy_pages %}
+        <article class="card">
+          <div class="num">{{ loop.index }}<span class="rule"></span></div>
+          {% if post.tags %}<div class="cat">{{ post.tags | first }}</div>{% endif %}
+          <a href="{{ base_url }}{{ post.url }}"><h3>{{ post.title }}</h3></a>
+          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+          <a href="{{ base_url }}{{ post.url }}" class="read">Read</a>
+        </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -8656,5 +8656,32 @@
     "dark",
     "portfolio",
     "minimal"
+  ],
+  "prism-grid": [
+    "light",
+    "blog",
+    "editorial",
+    "brutalist"
+  ],
+  "mono-stack": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "velour": [
+    "light",
+    "blog",
+    "minimal",
+    "editorial"
+  ],
+  "axiom-grid": [
+    "light",
+    "docs",
+    "bauhaus"
+  ],
+  "noctura": [
+    "dark",
+    "portfolio",
+    "landing"
   ]
 }


### PR DESCRIPTION
## Summary

Adds five new examples that explore contemporary visual directions, with deliberate attention to typography, grid, and the no-gradient / no-emoji brief.

| Site | Theme | Tags |
| --- | --- | --- |
| **prism-grid** | Editorial brutalism — Fraunces display, asymmetric 12-col grid, JetBrains Mono metadata | light, blog, editorial, brutalist |
| **mono-stack** | Dark monospace portfolio — terminal hero, KPI strip, tabular project rows, lime accent | dark, portfolio, minimal |
| **velour** | Warm minimal journal — Cormorant Garamond, hairline rules, dusty rose accent, drop caps | light, blog, minimal, editorial |
| **axiom-grid** | Bauhaus docs — primary color blocks, sidebar + TOC + pager, geometric ornaments | light, docs, bauhaus |
| **noctura** | Dark agency landing — Bricolage Grotesque display, amber accent, work/services/process/CTA grid | dark, portfolio, landing |

All sites are fully content-populated (8–15 pages each), build cleanly with hwaro 0.13.1, and are registered in tags.json.

## Test plan

- [x] All five sites scaffold via hwaro init bare and build with no template errors
- [x] tags.json validates as JSON and contains all five new entries
- [x] No CSS gradients (linear/radial/conic/repeating) anywhere in the new sites
- [x] No emoji glyphs (typographic arrows and the ⌘ key glyph are typographic, not emoji)
- [x] hwaro doctor --fix run on each site