### PR TITLE
Fix 404 in micro example by creating tags index

### DIFF
--- a/examples/micro/content/tags/_index.md
+++ b/examples/micro/content/tags/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Tags"
+description = "All tags"
+layout = "taxonomy"
++++


### PR DESCRIPTION
This PR creates the missing `_index.md` for the tags taxonomy in the `micro` example theme to fix a 404 broken link issue.

---
*PR created automatically by Jules for task [5987629083246526210](https://jules.google.com/task/5987629083246526210) started by @hahwul*