### PR TITLE
Add five more modern-themed example sites

### DIFF
--- a/examples/luminal/AGENTS.md
+++ b/examples/luminal/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter can use TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start) — TOML is the default.
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/luminal/archetypes/default.md
+++ b/examples/luminal/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/luminal/config.toml
+++ b/examples/luminal/config.toml
@@ -1,0 +1,207 @@
+title = "Luminal"
+description = "The control plane for modern data teams."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+]
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = ["changelog"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/luminal/content/changelog/2026-03-cli-v3.md
+++ b/examples/luminal/content/changelog/2026-03-cli-v3.md
@@ -1,0 +1,14 @@
++++
+title = "Luminal CLI v3"
+date = "2026-03-19"
+description = "A rebuilt CLI with project-aware completions, offline mode, and a faster planner."
+tags = ["cli", "tooling"]
++++
+
+The CLI has been rewritten end-to-end in Rust. Same commands you already know, an order of magnitude faster on cold start.
+
+- 110 ms cold start on macOS, down from 1.8 s in v2
+- Project-aware shell completions for fish, zsh, bash, and PowerShell
+- New `luminal plan --offline` runs against a local snapshot of your catalog
+- Streaming progress for `luminal apply` with a live dependency graph
+- Drop-in compatible with every v2 config; deprecation flags surface in `luminal doctor`

--- a/examples/luminal/content/changelog/2026-03-row-level-security.md
+++ b/examples/luminal/content/changelog/2026-03-row-level-security.md
@@ -1,0 +1,14 @@
++++
+title = "Row-level security policies"
+date = "2026-03-03"
+description = "Declarative row filters that compile down to native warehouse policies."
+tags = ["security", "governance"]
++++
+
+Define row-level access once in your model spec and Luminal compiles it into native policies on every supported warehouse.
+
+- Single `access` block compiles to Snowflake, BigQuery, Redshift, and Databricks policies
+- Attribute-based rules that reference your IdP claims (department, region, clearance)
+- Preview mode renders the effective SQL for each grant before apply
+- Audit log captures every grant change with the responsible principal and commit
+- Compatible with existing column-level masking introduced in February

--- a/examples/luminal/content/changelog/2026-04-incident-response.md
+++ b/examples/luminal/content/changelog/2026-04-incident-response.md
@@ -1,0 +1,14 @@
++++
+title = "Incident response workflows"
+date = "2026-04-08"
+description = "Route freshness, volume, and schema alerts to the on-call engineer with full context."
+tags = ["alerting", "observability"]
++++
+
+Alerts now carry the lineage graph, last successful run, and a suggested rollback target into your incident channel.
+
+- PagerDuty, Opsgenie, and Slack destinations with deduplication windows
+- Inline rollback to the previous green commit from the alert payload
+- Snooze rules scoped by pipeline, table, or environment for planned maintenance
+- New `freshness_sla` and `volume_sla` declarations in the model spec
+- Postmortem template auto-generated and posted to the incident thread on resolution

--- a/examples/luminal/content/changelog/2026-04-warehouse-connectors.md
+++ b/examples/luminal/content/changelog/2026-04-warehouse-connectors.md
@@ -1,0 +1,14 @@
++++
+title = "Warehouse connectors for Databricks and Fabric"
+date = "2026-04-22"
+description = "Native push-down connectors for Databricks Unity Catalog and Microsoft Fabric OneLake."
+tags = ["connectors", "warehouse"]
++++
+
+Two long-requested destinations join the supported warehouse list.
+
+- Databricks Unity Catalog with native Delta Lake writes and column-level lineage
+- Microsoft Fabric OneLake destination, including direct lake mode for Power BI
+- Both connectors support partition pruning, schema evolution, and `MERGE` semantics
+- Workspace-scoped credentials managed through the existing secret store
+- Migration guide published for teams moving off the community Spark connector

--- a/examples/luminal/content/changelog/2026-05-streaming-replication.md
+++ b/examples/luminal/content/changelog/2026-05-streaming-replication.md
@@ -1,0 +1,14 @@
++++
+title = "Streaming replication, generally available"
+date = "2026-05-10"
+description = "Sub-second change data capture from Postgres, MySQL, and MongoDB into your warehouse."
+tags = ["replication", "ga"]
++++
+
+Streaming replication moves out of preview today after eight months of private beta with 64 design partners.
+
+- Logical replication slots for Postgres 12+ with automatic catch-up on connector restart
+- Binlog-based CDC for MySQL 5.7 and 8.0, including row image and DDL events
+- Change streams for MongoDB 5.0+ with resume tokens persisted in your warehouse
+- p99 end-to-end latency under 900 ms for typed workloads up to 200 GB/day
+- New `luminal stream tail` CLI for live debugging of replication lag and conflict resolution

--- a/examples/luminal/content/changelog/_index.md
+++ b/examples/luminal/content/changelog/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Changelog"
+description = "Every shipped release, in order."
+sort_by = "date"
+reverse = true
+generate_feeds = true
+tags = ["changelog"]
++++
+
+Every release of Luminal, oldest at the bottom. Subscribe via RSS to get release notes the moment they ship.

--- a/examples/luminal/content/customers.md
+++ b/examples/luminal/content/customers.md
@@ -1,0 +1,29 @@
++++
+title = "Customers"
+description = "Teams shipping data products with Luminal."
+tags = ["customers"]
++++
+
+# Customers
+
+More than 180 data teams use Luminal to operate their warehouse, from two-person seed startups to publicly traded retailers.
+
+## Trusted by
+
+ATLAS · HALCYON · NORDIC · FERROUS · ORBIT · CALYX · LATTICE · SIGNAL · MERIDIAN · QUARRY
+
+## Halcyon Logistics — cut pipeline incidents by 84%
+
+Halcyon ships 1.4 billion shipment events a day across 22 carriers. Before Luminal, on-call rotations were burning out senior engineers and SLA misses were costing real money in carrier credits.
+
+After consolidating ingestion onto Luminal, mean time to detect dropped from 38 minutes to under 4. Their data platform team retired four homegrown services and reinvested the headcount into a forecasting team that now sits beside operations.
+
+"Luminal gave us a single place to reason about the warehouse. The lineage graph alone paid for the contract." — Anya Petrova, Director of Data Platform
+
+## Ferrous Studios — onboarded a 40-person analytics org in two weeks
+
+Ferrous acquired three game studios in 2025 and needed to merge their analytics stacks before the holiday release. Each studio brought a different warehouse, a different transform tool, and a different deploy story.
+
+With Luminal's branch-based deploys, every analyst got a personal preview environment on day one. The migration shipped on schedule, and the combined team now runs 600+ models on a shared mainline with no scheduled freeze windows.
+
+"We deleted twelve Notion pages of tribal knowledge the week we adopted Luminal." — Marcus Chen, Head of Analytics Engineering

--- a/examples/luminal/content/index.md
+++ b/examples/luminal/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Luminal"
+description = "The control plane for modern data teams."
+template = "home"
+tags = ["home"]
++++
+
+Luminal is the unified control plane for ingestion, transformation, and observability across your warehouse. Build pipelines once, ship them everywhere, sleep through the night.

--- a/examples/luminal/content/pricing.md
+++ b/examples/luminal/content/pricing.md
@@ -1,0 +1,42 @@
++++
+title = "Pricing"
+description = "Simple, predictable pricing that scales with your team."
+tags = ["pricing"]
++++
+
+# Pricing
+
+Flat per-seat billing. No row counts, no surprise invoices, no usage tiers buried in a PDF. Cancel any time.
+
+## Starter — $0 / month
+
+For solo operators and small teams getting started.
+
+- Up to 3 connected warehouses
+- 5 active pipelines
+- 7-day metadata retention
+- Community Slack support
+- All core transforms and connectors
+- Personal API tokens
+
+## Team — $49 / seat / month
+
+For growing data teams running production workloads.
+
+- Unlimited warehouses and pipelines
+- 90-day metadata and lineage retention
+- Role-based access control with SCIM
+- PagerDuty and Opsgenie routing
+- Branch-based deploys with preview environments
+- Priority email support, 8h response SLO
+
+## Enterprise — Custom
+
+For regulated environments and global org rollouts.
+
+- Single tenant deployments in your VPC
+- SOC 2 Type II, HIPAA, and GDPR DPA
+- Customer-managed encryption keys
+- Audit log export to S3 or BigQuery
+- Dedicated solutions architect
+- 24/7 follow-the-sun support, 1h response SLO

--- a/examples/luminal/static/css/style.css
+++ b/examples/luminal/static/css/style.css
@@ -1,0 +1,868 @@
+/* =============================================================================
+   Luminal — bold light SaaS product landing
+   ============================================================================= */
+
+:root {
+  --bg: #fafaf7;
+  --bg-pure: #ffffff;
+  --text: #0a0a0a;
+  --text-dim: #5a5a5a;
+  --text-soft: #8a8a8a;
+  --line: #0a0a0a;
+  --line-soft: #e4e4dc;
+  --accent: #c8ff00;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 96px;
+  --space-10: 128px;
+
+  --radius: 4px;
+  --container: 1280px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover { text-decoration: underline; }
+
+img, svg { display: block; max-width: 100%; }
+
+::selection {
+  background: var(--accent);
+  color: var(--text);
+}
+
+/* ---------- Header ---------- */
+
+.lm-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--bg);
+  border-bottom: 1px solid var(--line);
+}
+
+.lm-header-inner {
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 18px 32px;
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+
+.lm-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.lm-brand:hover { text-decoration: none; }
+
+.lm-mark { color: var(--text); flex: none; }
+
+.lm-nav {
+  display: flex;
+  gap: 28px;
+  margin-left: 24px;
+  flex: 1;
+}
+
+.lm-nav a {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: -0.005em;
+}
+
+.lm-nav a:hover { text-decoration: none; color: var(--text-dim); }
+
+.lm-header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.lm-signin {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+/* ---------- Buttons ---------- */
+
+.lm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  border-radius: 4px;
+  border: 1px solid var(--text);
+  background: var(--text);
+  color: var(--bg-pure);
+  cursor: pointer;
+  transition: transform 0.05s ease;
+  text-decoration: none;
+}
+
+.lm-btn:hover {
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.lm-btn-primary {
+  background: var(--text);
+  color: var(--bg-pure);
+}
+
+.lm-btn-secondary {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--text);
+}
+
+.lm-btn-on-dark {
+  background: var(--accent);
+  color: var(--text);
+  border: 1px solid var(--accent);
+}
+
+/* ---------- Page container ---------- */
+
+.lm-page {
+  background: var(--bg);
+}
+
+.lm-main {
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+/* ---------- Hero ---------- */
+
+.lm-hero {
+  padding: 120px 0 96px;
+  border-bottom: 1px solid var(--line);
+}
+
+.lm-eyebrow {
+  display: inline-block;
+  padding: 6px 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  background: var(--bg-pure);
+}
+
+.lm-hero-title {
+  margin: 28px 0 28px;
+  font-size: clamp(56px, 9vw, 144px);
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  color: var(--text);
+}
+
+.lm-accent {
+  color: var(--accent);
+  background: var(--text);
+  padding: 0 0.08em;
+  display: inline-block;
+}
+
+.lm-hero-deck {
+  max-width: 640px;
+  margin: 0 0 36px;
+  font-size: 20px;
+  line-height: 1.4;
+  color: var(--text-dim);
+  letter-spacing: -0.01em;
+}
+
+.lm-hero-cta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+/* ---------- KPI strip ---------- */
+
+.lm-kpis {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--line);
+}
+
+.lm-kpi {
+  padding: 56px 32px;
+  border-right: 1px solid var(--line);
+  font-variant-numeric: tabular-nums;
+}
+
+.lm-kpi:last-child { border-right: none; }
+
+.lm-kpi-num {
+  font-size: clamp(40px, 5vw, 64px);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--text);
+  margin-bottom: 18px;
+}
+
+.lm-kpi-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+/* ---------- Section heads ---------- */
+
+.lm-section-head {
+  padding: 96px 0 40px;
+}
+
+.lm-section-head-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.lm-section-title {
+  margin: 18px 0 0;
+  font-size: clamp(36px, 5vw, 64px);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.035em;
+  color: var(--text);
+}
+
+.lm-link {
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+/* ---------- Feature grid ---------- */
+
+.lm-features {
+  padding-bottom: 96px;
+  border-bottom: 1px solid var(--line);
+}
+
+.lm-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.lm-feature {
+  padding: 40px 32px 48px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-pure);
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.lm-feature-icon {
+  color: var(--text);
+  width: 28px;
+  height: 28px;
+}
+
+.lm-feature-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+.lm-feature-desc {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+/* ---------- Logo wall ---------- */
+
+.lm-logos {
+  padding: 80px 0 80px;
+  border-bottom: 1px solid var(--line);
+  text-align: center;
+}
+
+.lm-logos-eyebrow {
+  margin-bottom: 32px;
+}
+
+.lm-logo-wall {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.lm-logo-cell {
+  padding: 32px 16px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  color: var(--text);
+  background: var(--bg-pure);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ---------- Quote ---------- */
+
+.lm-quote {
+  padding: 120px 0;
+  border-bottom: 1px solid var(--line);
+  max-width: 1100px;
+}
+
+.lm-quote-body {
+  margin: 0 0 32px;
+  font-size: clamp(32px, 4.5vw, 56px);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  color: var(--text);
+}
+
+.lm-quote-attr {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+}
+
+.lm-quote-name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.lm-quote-role {
+  color: var(--text-dim);
+}
+
+/* ---------- Changelog ---------- */
+
+.lm-recent {
+  padding-bottom: 80px;
+  border-bottom: 1px solid var(--line);
+}
+
+.lm-changelog-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.lm-changelog-row {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 32px;
+  padding: 28px 0;
+  border-top: 1px solid var(--line-soft);
+}
+
+.lm-changelog-row:first-child {
+  border-top: 1px solid var(--line);
+}
+
+.lm-changelog-row:last-child {
+  border-bottom: 1px solid var(--line);
+}
+
+.lm-changelog-list-home .lm-changelog-row:last-child {
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.lm-changelog-date {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+  padding-top: 4px;
+}
+
+.lm-changelog-title {
+  margin: 0 0 8px;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.lm-changelog-title a {
+  color: var(--text);
+}
+
+.lm-changelog-title a:hover {
+  text-decoration: none;
+  color: var(--text-dim);
+}
+
+.lm-changelog-desc {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+/* ---------- CTA strip ---------- */
+
+.lm-cta {
+  margin: 96px 0 96px;
+  background: var(--text);
+  color: var(--bg-pure);
+  border: 1px solid var(--text);
+}
+
+.lm-cta-inner {
+  padding: 96px 48px;
+  text-align: center;
+}
+
+.lm-cta-title {
+  margin: 0 0 16px;
+  font-size: clamp(40px, 6vw, 80px);
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  line-height: 1;
+}
+
+.lm-cta-deck {
+  margin: 0 auto 32px;
+  max-width: 520px;
+  color: #c7c7c0;
+  font-size: 18px;
+}
+
+/* ---------- Generic page / article ---------- */
+
+.lm-page-main,
+.lm-section-main {
+  padding-top: 80px;
+  padding-bottom: 96px;
+}
+
+.lm-article {
+  max-width: 760px;
+}
+
+.lm-article-head {
+  padding-bottom: 40px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 48px;
+}
+
+.lm-article-title {
+  margin: 18px 0 16px;
+  font-size: clamp(40px, 6vw, 80px);
+  font-weight: 800;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+}
+
+.lm-article-deck {
+  margin: 0;
+  font-size: 20px;
+  color: var(--text-dim);
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+
+.lm-article-body {
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.lm-article-body h1 {
+  font-size: 40px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 56px 0 16px;
+  line-height: 1.05;
+}
+
+.lm-article-body h2 {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  margin: 48px 0 12px;
+  padding-top: 32px;
+  border-top: 1px solid var(--line);
+}
+
+.lm-article-body h2:first-child { border-top: none; padding-top: 0; margin-top: 0; }
+
+.lm-article-body h3 {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  margin: 32px 0 8px;
+}
+
+.lm-article-body p { margin: 0 0 18px; color: var(--text); }
+
+.lm-article-body ul,
+.lm-article-body ol {
+  padding-left: 0;
+  list-style: none;
+  margin: 18px 0;
+}
+
+.lm-article-body ul li,
+.lm-article-body ol li {
+  position: relative;
+  padding-left: 24px;
+  margin-bottom: 10px;
+  line-height: 1.5;
+}
+
+.lm-article-body ul li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 10px;
+  width: 10px;
+  height: 1px;
+  background: var(--text);
+}
+
+.lm-article-body ol { counter-reset: lm-ol; }
+.lm-article-body ol li { counter-increment: lm-ol; }
+.lm-article-body ol li::before {
+  content: counter(lm-ol) ".";
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.lm-article-body a {
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+.lm-article-body code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.88em;
+  padding: 2px 6px;
+  background: var(--bg-pure);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+}
+
+.lm-article-body pre {
+  background: var(--bg-pure);
+  border: 1px solid var(--line);
+  padding: 20px;
+  overflow-x: auto;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.lm-article-body pre code {
+  border: none;
+  background: none;
+  padding: 0;
+}
+
+.lm-article-body blockquote {
+  margin: 24px 0;
+  padding: 4px 0 4px 20px;
+  border-left: 2px solid var(--text);
+  font-size: 19px;
+  font-style: normal;
+  color: var(--text);
+}
+
+/* ---------- Section intro ---------- */
+
+.lm-section-intro {
+  margin-bottom: 32px;
+}
+
+/* ---------- Taxonomy lists ---------- */
+
+.lm-taxonomy ul {
+  list-style: none;
+  padding: 0;
+}
+
+.lm-taxonomy li {
+  border-bottom: 1px solid var(--line-soft);
+  padding: 14px 0;
+  font-size: 16px;
+}
+
+.lm-taxonomy a {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.lm-taxonomy a:hover { color: var(--text-dim); }
+
+/* ---------- Pagination ---------- */
+
+nav.pagination {
+  margin: 40px 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+}
+
+nav.pagination a,
+nav.pagination span {
+  display: inline-block;
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  color: var(--text);
+}
+
+nav.pagination a:hover {
+  background: var(--text);
+  color: var(--bg-pure);
+  text-decoration: none;
+}
+
+.pagination-current span {
+  background: var(--text);
+  color: var(--bg-pure);
+}
+
+.pagination-disabled span {
+  color: var(--text-soft);
+  border-color: var(--line-soft);
+}
+
+/* ---------- 404 ---------- */
+
+.lm-404 {
+  padding: 160px 32px;
+  text-align: center;
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lm-404-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.lm-404-mark {
+  margin: 0 auto 24px;
+}
+
+.lm-404-title {
+  margin: 24px 0 24px;
+  font-size: clamp(48px, 8vw, 112px);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.lm-404-deck {
+  font-size: 18px;
+  color: var(--text-dim);
+  margin: 0 0 36px;
+}
+
+.lm-404 .lm-hero-cta {
+  justify-content: center;
+}
+
+/* ---------- Footer ---------- */
+
+.lm-footer {
+  background: var(--bg-pure);
+  border-top: 1px solid var(--line);
+}
+
+.lm-footer-inner {
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 64px 32px 40px;
+}
+
+.lm-footer-cols {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 48px;
+  padding-bottom: 48px;
+  border-bottom: 1px solid var(--line);
+}
+
+.lm-footer-brand .lm-brand-footer {
+  margin-bottom: 16px;
+}
+
+.lm-footer-tag {
+  margin: 12px 0 0;
+  max-width: 320px;
+  color: var(--text-dim);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.lm-footer-col h4 {
+  margin: 0 0 16px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  font-family: "JetBrains Mono", monospace;
+}
+
+.lm-footer-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.lm-footer-col li {
+  margin-bottom: 10px;
+}
+
+.lm-footer-col a {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.lm-footer-col a:hover {
+  color: var(--text-dim);
+  text-decoration: none;
+}
+
+.lm-footer-bottom {
+  padding-top: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--text-dim);
+  font-family: "JetBrains Mono", monospace;
+  letter-spacing: 0.02em;
+}
+
+.lm-badges {
+  display: flex;
+  gap: 8px;
+}
+
+.lm-badges span {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 960px) {
+  .lm-header-inner { gap: 16px; padding: 14px 20px; }
+  .lm-nav { display: none; }
+  .lm-main { padding: 0 20px; }
+  .lm-hero { padding: 72px 0 64px; }
+  .lm-kpis { grid-template-columns: repeat(2, 1fr); }
+  .lm-kpi { padding: 36px 20px; }
+  .lm-kpi:nth-child(2) { border-right: none; }
+  .lm-kpi:nth-child(1), .lm-kpi:nth-child(2) { border-bottom: 1px solid var(--line); }
+  .lm-feature-grid { grid-template-columns: repeat(2, 1fr); }
+  .lm-logo-wall { grid-template-columns: repeat(3, 1fr); }
+  .lm-section-head-row { flex-direction: column; align-items: flex-start; }
+  .lm-cta-inner { padding: 64px 24px; }
+  .lm-footer-cols { grid-template-columns: 1fr 1fr; gap: 32px; }
+  .lm-changelog-row { grid-template-columns: 1fr; gap: 8px; }
+  .lm-footer-bottom { flex-direction: column; align-items: flex-start; }
+}
+
+@media (max-width: 560px) {
+  .lm-header-right .lm-signin { display: none; }
+  .lm-feature-grid { grid-template-columns: 1fr; }
+  .lm-logo-wall { grid-template-columns: repeat(2, 1fr); }
+  .lm-kpis { grid-template-columns: 1fr; }
+  .lm-kpi { border-right: none; border-bottom: 1px solid var(--line); }
+  .lm-kpi:last-child { border-bottom: none; }
+  .lm-footer-cols { grid-template-columns: 1fr; }
+}

--- a/examples/luminal/templates/404.html
+++ b/examples/luminal/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<main class="lm-main lm-404">
+  <div class="lm-404-inner">
+    <svg class="lm-mark lm-404-mark" width="36" height="36" viewBox="0 0 18 18" aria-hidden="true"><rect x="0" y="0" width="18" height="18" fill="currentColor"/></svg>
+    <span class="lm-eyebrow">Error 404</span>
+    <h1 class="lm-404-title">This page is missing<br><span class="lm-accent">from the catalog.</span></h1>
+    <p class="lm-404-deck">The URL you followed does not match any known route. Head back to the homepage, or jump straight to the changelog.</p>
+    <div class="lm-hero-cta">
+      <a href="{{ base_url }}/" class="lm-btn lm-btn-primary">Back to home</a>
+      <a href="{{ base_url }}/changelog/" class="lm-btn lm-btn-secondary">View changelog</a>
+    </div>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/luminal/templates/footer.html
+++ b/examples/luminal/templates/footer.html
@@ -1,0 +1,53 @@
+</div>
+<footer class="lm-footer">
+  <div class="lm-footer-inner">
+    <div class="lm-footer-cols">
+      <div class="lm-footer-col lm-footer-brand">
+        <a href="{{ base_url }}/" class="lm-brand lm-brand-footer">
+          <svg class="lm-mark" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><rect x="0" y="0" width="18" height="18" fill="currentColor"/></svg>
+          <span>{{ site.title }}</span>
+        </a>
+        <p class="lm-footer-tag">{{ site.description }}</p>
+      </div>
+      <div class="lm-footer-col">
+        <h4>Product</h4>
+        <ul>
+          <li><a href="{{ base_url }}/">Overview</a></li>
+          <li><a href="{{ base_url }}/pricing/">Pricing</a></li>
+          <li><a href="{{ base_url }}/changelog/">Changelog</a></li>
+          <li><a href="{{ base_url }}/customers/">Customers</a></li>
+        </ul>
+      </div>
+      <div class="lm-footer-col">
+        <h4>Resources</h4>
+        <ul>
+          <li><a href="{{ base_url }}/changelog/">Docs</a></li>
+          <li><a href="{{ base_url }}/changelog/rss.xml">RSS</a></li>
+          <li><a href="{{ base_url }}/changelog/">API reference</a></li>
+          <li><a href="{{ base_url }}/changelog/">Status</a></li>
+        </ul>
+      </div>
+      <div class="lm-footer-col">
+        <h4>Company</h4>
+        <ul>
+          <li><a href="{{ base_url }}/customers/">Customers</a></li>
+          <li><a href="{{ base_url }}/pricing/">Careers</a></li>
+          <li><a href="{{ base_url }}/pricing/">Security</a></li>
+          <li><a href="{{ base_url }}/pricing/">Contact</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="lm-footer-bottom">
+      <div>(c) 2026 Luminal Systems, Inc.</div>
+      <div class="lm-badges">
+        <span>SOC 2</span>
+        <span>GDPR</span>
+        <span>HIPAA</span>
+      </div>
+    </div>
+  </div>
+</footer>
+{{ highlight_js }}
+{{ auto_includes_js }}
+</body>
+</html>

--- a/examples/luminal/templates/header.html
+++ b/examples/luminal/templates/header.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page is defined and page.description is defined %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page is defined and page.title is defined %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_tags | safe }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{% if page is defined %}{{ page.section }}{% endif %}">
+<header class="lm-header">
+  <div class="lm-header-inner">
+    <a href="{{ base_url }}/" class="lm-brand">
+      <svg class="lm-mark" width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><rect x="0" y="0" width="18" height="18" fill="currentColor"/></svg>
+      <span>{{ site.title }}</span>
+    </a>
+    <nav class="lm-nav">
+      <a href="{{ base_url }}/">Product</a>
+      <a href="{{ base_url }}/pricing/">Pricing</a>
+      <a href="{{ base_url }}/customers/">Customers</a>
+      <a href="{{ base_url }}/changelog/">Changelog</a>
+      <a href="{{ base_url }}/changelog/">Docs</a>
+    </nav>
+    <div class="lm-header-right">
+      <a href="{{ base_url }}/pricing/" class="lm-signin">Sign in</a>
+      <a href="{{ base_url }}/pricing/" class="lm-btn lm-btn-primary">Start free</a>
+    </div>
+  </div>
+</header>
+<div class="lm-page">

--- a/examples/luminal/templates/home.html
+++ b/examples/luminal/templates/home.html
@@ -1,0 +1,151 @@
+{% include "header.html" %}
+<main class="lm-main lm-home">
+
+  <section class="lm-hero">
+    <span class="lm-eyebrow">Now in general availability</span>
+    <h1 class="lm-hero-title">
+      The control plane for<br>
+      <span class="lm-accent">modern data teams.</span>
+    </h1>
+    <p class="lm-hero-deck">
+      Build pipelines once, ship them everywhere. Luminal unifies ingestion, transformation, and observability so your team can stop firefighting and start compounding.
+    </p>
+    <div class="lm-hero-cta">
+      <a href="{{ base_url }}/pricing/" class="lm-btn lm-btn-primary">Start free</a>
+      <a href="{{ base_url }}/customers/" class="lm-btn lm-btn-secondary">Book a demo</a>
+    </div>
+  </section>
+
+  <section class="lm-kpis">
+    <div class="lm-kpi">
+      <div class="lm-kpi-num">99.999%</div>
+      <div class="lm-kpi-label">Uptime, last 12 months</div>
+    </div>
+    <div class="lm-kpi">
+      <div class="lm-kpi-num">12 ms</div>
+      <div class="lm-kpi-label">p50 query overhead</div>
+    </div>
+    <div class="lm-kpi">
+      <div class="lm-kpi-num">180+</div>
+      <div class="lm-kpi-label">Teams in production</div>
+    </div>
+    <div class="lm-kpi">
+      <div class="lm-kpi-num">$2.4B</div>
+      <div class="lm-kpi-label">ARR routed through Luminal</div>
+    </div>
+  </section>
+
+  <section class="lm-features">
+    <header class="lm-section-head">
+      <span class="lm-eyebrow">Platform</span>
+      <h2 class="lm-section-title">One platform. Every warehouse.</h2>
+    </header>
+    <div class="lm-feature-grid">
+
+      <article class="lm-feature">
+        <div class="lm-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><rect x="2" y="2" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+        </div>
+        <h3 class="lm-feature-title">Declarative pipelines</h3>
+        <p class="lm-feature-desc">Define ingestion, transforms, and tests in one spec. Plan and apply with the safety of infrastructure-as-code.</p>
+      </article>
+
+      <article class="lm-feature">
+        <div class="lm-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><circle cx="14" cy="14" r="11" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+        </div>
+        <h3 class="lm-feature-title">Streaming CDC</h3>
+        <p class="lm-feature-desc">Sub-second change data capture from Postgres, MySQL, and MongoDB with automatic schema evolution.</p>
+      </article>
+
+      <article class="lm-feature">
+        <div class="lm-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><polygon points="14,3 25,25 3,25" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+        </div>
+        <h3 class="lm-feature-title">Lineage everywhere</h3>
+        <p class="lm-feature-desc">Column-level lineage across every connector and transform, exposed in the catalog and in every alert payload.</p>
+      </article>
+
+      <article class="lm-feature">
+        <div class="lm-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><line x1="14" y1="3" x2="14" y2="25" stroke="currentColor" stroke-width="1.5"/><line x1="3" y1="14" x2="25" y2="14" stroke="currentColor" stroke-width="1.5"/></svg>
+        </div>
+        <h3 class="lm-feature-title">Branch deploys</h3>
+        <p class="lm-feature-desc">Every pull request gets a preview warehouse. Review the diff in SQL, the lineage, and the cost before you merge.</p>
+      </article>
+
+      <article class="lm-feature">
+        <div class="lm-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><polygon points="14,3 25,14 14,25 3,14" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+        </div>
+        <h3 class="lm-feature-title">Row-level policies</h3>
+        <p class="lm-feature-desc">Declare access once. Luminal compiles it down to native row and column policies in every supported warehouse.</p>
+      </article>
+
+      <article class="lm-feature">
+        <div class="lm-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><line x1="3" y1="14" x2="25" y2="14" stroke="currentColor" stroke-width="1.5"/></svg>
+        </div>
+        <h3 class="lm-feature-title">Incident response</h3>
+        <p class="lm-feature-desc">Freshness, volume, and schema alerts arrive with the lineage graph and a one-click rollback to the last green commit.</p>
+      </article>
+
+    </div>
+  </section>
+
+  <section class="lm-logos">
+    <p class="lm-eyebrow lm-logos-eyebrow">Trusted by data teams shipping in production</p>
+    <div class="lm-logo-wall">
+      <div class="lm-logo-cell">ATLAS</div>
+      <div class="lm-logo-cell">HALCYON</div>
+      <div class="lm-logo-cell">NORDIC</div>
+      <div class="lm-logo-cell">FERROUS</div>
+      <div class="lm-logo-cell">ORBIT</div>
+      <div class="lm-logo-cell">CALYX</div>
+    </div>
+  </section>
+
+  <section class="lm-quote">
+    <blockquote class="lm-quote-body">
+      &ldquo;Luminal gave us a single place to reason about the warehouse. The lineage graph alone paid for the contract.&rdquo;
+    </blockquote>
+    <div class="lm-quote-attr">
+      <span class="lm-quote-name">Anya Petrova</span>
+      <span class="lm-quote-role">Director of Data Platform, Halcyon Logistics</span>
+    </div>
+  </section>
+
+  <section class="lm-recent">
+    <header class="lm-section-head lm-section-head-row">
+      <div>
+        <span class="lm-eyebrow">Changelog</span>
+        <h2 class="lm-section-title">What shipped recently</h2>
+      </div>
+      <a href="{{ base_url }}/changelog/" class="lm-link">View all releases</a>
+    </header>
+    {% set changelog_section = get_section(path="changelog/_index.md") %}
+    <ul class="lm-changelog-list lm-changelog-list-home">
+      {% for p in changelog_section.pages | sort(attribute="date") | reverse %}
+        {% if loop.index <= 3 %}
+        <li class="lm-changelog-row">
+          <time class="lm-changelog-date">{{ p.date }}</time>
+          <div class="lm-changelog-body">
+            <h3 class="lm-changelog-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></h3>
+            <p class="lm-changelog-desc">{{ p.description }}</p>
+          </div>
+        </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </section>
+
+  <section class="lm-cta">
+    <div class="lm-cta-inner">
+      <h2 class="lm-cta-title">Ship pipelines, not pager duty.</h2>
+      <p class="lm-cta-deck">Start free. Connect your warehouse in under five minutes. No credit card.</p>
+      <a href="{{ base_url }}/pricing/" class="lm-btn lm-btn-on-dark">Start free</a>
+    </div>
+  </section>
+
+</main>
+{% include "footer.html" %}

--- a/examples/luminal/templates/page.html
+++ b/examples/luminal/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<main class="lm-main lm-page-main">
+  <article class="lm-article">
+    <header class="lm-article-head">
+      <span class="lm-eyebrow">{% if page.section is defined and page.section %}{{ page.section }}{% else %}Page{% endif %}</span>
+      <h1 class="lm-article-title">{{ page.title | e }}</h1>
+      {% if page.description is defined %}
+      <p class="lm-article-deck">{{ page.description | e }}</p>
+      {% endif %}
+    </header>
+    <div class="lm-article-body">
+      {{ content | safe }}
+    </div>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/luminal/templates/section.html
+++ b/examples/luminal/templates/section.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+<main class="lm-main lm-section-main">
+  {% if page is defined %}
+  <header class="lm-article-head">
+    <span class="lm-eyebrow">Section</span>
+    <h1 class="lm-article-title">{{ page.title | e }}</h1>
+    {% if page.description is defined %}
+    <p class="lm-article-deck">{{ page.description | e }}</p>
+    {% endif %}
+  </header>
+  <div class="lm-article-body lm-section-intro">
+    {{ content | safe }}
+  </div>
+  {% endif %}
+
+  <ul class="lm-changelog-list">
+    {% if section is defined and section.pages is defined %}
+      {% for p in section.pages | sort(attribute="date") | reverse %}
+      <li class="lm-changelog-row">
+        <time class="lm-changelog-date">{{ p.date }}</time>
+        <div class="lm-changelog-body">
+          <h2 class="lm-changelog-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a></h2>
+          <p class="lm-changelog-desc">{{ p.description }}</p>
+        </div>
+      </li>
+      {% endfor %}
+    {% endif %}
+  </ul>
+
+  {{ pagination }}
+</main>
+{% include "footer.html" %}

--- a/examples/luminal/templates/shortcodes/alert.html
+++ b/examples/luminal/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/luminal/templates/taxonomy.html
+++ b/examples/luminal/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main class="lm-main lm-page-main">
+  <header class="lm-article-head">
+    <span class="lm-eyebrow">Taxonomy</span>
+    <h1 class="lm-article-title">{{ page.title | e }}</h1>
+    <p class="lm-article-deck">All terms in this taxonomy.</p>
+  </header>
+  <div class="lm-article-body lm-taxonomy">
+    {{ content | safe }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/luminal/templates/taxonomy_term.html
+++ b/examples/luminal/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main class="lm-main lm-page-main">
+  <header class="lm-article-head">
+    <span class="lm-eyebrow">Tag</span>
+    <h1 class="lm-article-title">{{ page.title | e }}</h1>
+    <p class="lm-article-deck">Releases and pages tagged with this term.</p>
+  </header>
+  <div class="lm-article-body lm-taxonomy">
+    {{ content | safe }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/obsidian-press/AGENTS.md
+++ b/examples/obsidian-press/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter can use TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start) — TOML is the default.
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/obsidian-press/archetypes/default.md
+++ b/examples/obsidian-press/archetypes/default.md
@@ -1,0 +1,12 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
+[extra]
+author = ""
+deck = ""
++++
+
+Write your essay here.

--- a/examples/obsidian-press/config.toml
+++ b/examples/obsidian-press/config.toml
@@ -1,0 +1,231 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Obsidian Press"
+description = "An editorial journal on design, culture, and the long form."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = true
+per_page = 6
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+feed = false
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["features"]
+
+# =============================================================================
+# Markdown
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/obsidian-press/content/about.md
+++ b/examples/obsidian-press/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About the Press"
+description = "Obsidian Press is a quarterly journal of essays, criticism, and conversation."
++++
+
+Obsidian Press is a quarterly journal devoted to writing that resists the speed of the feed. We publish essays on design, architecture, criticism, and the long form, and we ask our writers for the second draft rather than the first.
+
+The Press began in a printshop in the winter of 2024, with a hand-cranked Vandercook and an editor who believed that a sentence should earn its keep. Five issues later we have moved most of our work online, but the discipline of the page still informs everything we do: the rule line, the deck, the dropped capital, the slow turn of an argument that prefers to walk.
+
+We are a small staff. We do not chase a news cycle. We publish four issues a year, with occasional letters in between, and we read every piece aloud before it goes to press. If a paragraph does not survive that reading, it does not survive at all.
+
+We invite correspondence at the address below, and we are particularly interested in essays from writers who have spent time in a craft — any craft — and would like to write about it carefully.

--- a/examples/obsidian-press/content/features/_index.md
+++ b/examples/obsidian-press/content/features/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Features"
+description = "Long-form essays, criticism, and interviews from the Obsidian Press."
+sort_by = "date"
+reverse = true
+paginate_by = 6
+generate_feeds = true
++++

--- a/examples/obsidian-press/content/features/an-interview-with-ines-marot.md
+++ b/examples/obsidian-press/content/features/an-interview-with-ines-marot.md
@@ -1,0 +1,47 @@
++++
+title = "An Interview with Ines Marot"
+date = "2026-02-02"
+description = "The painter on small canvases, the slowness of oil, and why she has not shown work for seven years."
+tags = ["interview", "art"]
+[extra]
+author = "Theo Renaud"
+deck = "Ines Marot has not shown work for seven years. We spoke in her studio in Marseille."
++++
+
+Ines Marot's studio is a converted laundry on a narrow street above the Vieux-Port. The light is southern, which she dislikes. The room smells of linseed oil and turpentine and, faintly, of the bakery on the floor below. We met on a Tuesday in January. There were four paintings on the wall, all small, none finished. She made tea on a hot plate. We spoke for three hours.
+
+**The last show was in 2019. Why the silence?**
+
+The silence is not silence. The silence is work. I have been working every day for seven years. What I have not been doing is showing the work. There is a difference.
+
+**Why not show it?**
+
+Because I was not finished. The work was not ready. The dealer wanted a show every eighteen months. The work does not arrive every eighteen months. The work arrives when it arrives. I cannot accelerate it, and I have stopped trying.
+
+**You used to paint large canvases. These are very small.**
+
+Yes. The large canvases were a kind of insistence. I was younger. I wanted the work to take up space in a room. I wanted the room to be about the painting. Now I am older and the room is not about the painting. The painting is about the painting. A small canvas can hold as much as a large one. Sometimes more. The viewer has to come closer.
+
+**Oil is a slow medium. You have always painted in oil.**
+
+Always. I have tried other things. Acrylic, when I was a student. Egg tempera, briefly. They are not slow enough. Oil takes its time. A glaze takes three days. A passage of underpainting takes a week. You cannot hurry oil, and I do not want to hurry. The slowness is part of the thinking.
+
+**What are you thinking about, in those days of waiting?**
+
+The painting, mostly. What it wants. What it is refusing. A painting refuses many things. It refuses the colors I want to use. It refuses the composition I had planned. It refuses, sometimes, to be the painting I intended at all. The painter's job is to listen to the refusals.
+
+**That sounds very passive.**
+
+It is not passive. It is attentive. There is a difference. A passive painter does nothing. An attentive painter does everything, but slowly, and with respect for what the painting is telling them.
+
+**When will you show the work?**
+
+When it is ready. I do not know. Perhaps next year. Perhaps in five years. I am not in a hurry. The work is not in a hurry. The dealer is in a hurry, but the dealer is not painting.
+
+**Is there anything you miss about showing?**
+
+The conversation. A painting is not finished until someone has looked at it. I miss that. But I also do not miss it enough to show work that is not ready.
+
+**Thank you.**
+
+Thank you. Have more tea.

--- a/examples/obsidian-press/content/features/notes-from-a-pressroom.md
+++ b/examples/obsidian-press/content/features/notes-from-a-pressroom.md
@@ -1,0 +1,31 @@
++++
+title = "Notes from a Pressroom"
+date = "2026-03-28"
+description = "On the persistence of print in a digital era, and the small ceremonies of ink on paper."
+tags = ["essays", "print"]
+[extra]
+author = "Daniel Ortiz"
+deck = "The pressroom is not nostalgia. It is, still, a working room."
++++
+
+The Vandercook is a machine that asks for your attention. It is heavy, deliberate, and entirely unforgiving of the inattentive hand. You feed it one sheet at a time. You roll the cylinder across the form. You hear the kiss of ink on paper, which is the only sound on earth that a printer hears the way a musician hears a held note.
+
+People sometimes ask whether the pressroom is nostalgia. I understand the question. The presses are old. The type is older. The ritual of mixing ink on a slab, of locking up a form, of pulling a proof and finding a single letter upside down — all of it is older than anyone in the room.
+
+But nostalgia is the wrong word. The pressroom is not a museum. The pressroom is a working room. We print invitations there. We print broadsides. We print, on a slow afternoon, a single page of an essay that someone wants to read in a paper form. Every sheet is a small argument that the digital is not the only place a sentence can live.
+
+## What the screen cannot do
+
+A screen is a wonderful thing. It is bright, mutable, searchable, and infinitely correctable. A printed page is none of these. It is dim, fixed, and final. That finality is the gift. A printed sentence has weight because it cannot be edited after the fact. It has decided.
+
+I have watched young writers come into the pressroom and edit their own work for the first time the way an editor would, because they understand that the press will not negotiate. The press will not autocorrect. The press will print exactly what you have given it, and then it will print it again, twelve hundred times, and you will live with every comma you did not catch.
+
+This is good for prose. It is, perhaps, the best thing for prose.
+
+## The small ceremonies
+
+There are small ceremonies in a pressroom that the digital has no analogue for. The cleaning of the rollers at the end of the day. The wrapping of the type in oil cloth. The careful return of each piece of furniture to its drawer. These are not productive acts. They are the acts that make the productive acts possible the next morning.
+
+I think, sometimes, that the trouble with the screen is not the screen itself but the absence of these small ceremonies. There is no closing of the screen. There is no oilcloth.
+
+We have not solved this. We may not solve it. But on the days when we print, we remember what it is to put something away.

--- a/examples/obsidian-press/content/features/quiet-architecture.md
+++ b/examples/obsidian-press/content/features/quiet-architecture.md
@@ -1,0 +1,33 @@
++++
+title = "Quiet Architecture"
+date = "2026-03-08"
+description = "On the Japanese tradition of small rooms, soft light, and the building that prefers not to announce itself."
+tags = ["features", "architecture"]
+[extra]
+author = "Asako Hirano"
+deck = "A building can choose to be loud. The best ones choose otherwise."
++++
+
+There is a small tea house outside Kyoto that I have visited four times. It is, in every measurable way, an unimpressive building. It is one room, with a low ceiling, a packed earth floor, and a single small window cut into the eastern wall. You enter on your knees through a door so low it requires you to bow. Inside, there is room for four people and a kettle.
+
+It is the best building I have ever been in.
+
+## Smallness as a virtue
+
+We have been taught, in the Western tradition, that great architecture announces itself. The cathedral rises. The skyscraper towers. The civic monument insists, through sheer scale, that you are in the presence of something important. There is an honesty to this. A building that wants to be important can simply be tall.
+
+The Japanese tradition has, in places, taken the opposite road. The tea house is small because smallness is the argument. It says: come in, and be here, and notice that there is nothing else to notice. The window is small because smallness frames. The door is low because lowness humbles. The room is bare because bareness is the point.
+
+This is not minimalism in the contemporary sense. Minimalism, in our era, has come to mean an aesthetic of white walls and expensive chairs. The tea house is not that. The tea house is a building that has decided what it is for and removed everything that is not.
+
+## What the room teaches
+
+You sit in the tea house and, after some time, the room begins to teach you. It teaches you that the kettle has a sound. That the light shifts, on a clear afternoon, from one corner to another, slowly, like a clock that does not need a face. That a conversation in a small room is a different conversation than the same conversation in a large one. That four people at a low table do not need to raise their voices.
+
+These are not metaphors. They are observations about a particular room, in a particular afternoon, with a particular kettle. But the observations accumulate, and after some time you begin to understand that the building is not a backdrop for the tea. The building is the tea.
+
+## A quieter practice
+
+I think often of this room when I am working on larger projects. A library. An office. A house. The temptation in every case is to make the building grand — to give it a tall ceiling, a sweeping stair, a wall of glass. There is nothing wrong with these gestures. But the quieter question is also worth asking. What would this building be if it were small? What would it be if it bowed at the door?
+
+The answer, sometimes, is a better building.

--- a/examples/obsidian-press/content/features/the-language-of-shadow.md
+++ b/examples/obsidian-press/content/features/the-language-of-shadow.md
@@ -1,0 +1,31 @@
++++
+title = "The Language of Shadow"
+date = "2026-04-12"
+description = "On negative space, the silence between marks, and the discipline of leaving things out."
+tags = ["essays", "design"]
+[extra]
+author = "Helene Marot"
+deck = "An essay on negative space, and what a page chooses not to say."
++++
+
+A drawing is made of two things: the mark and the absence of the mark. We tend to talk only about the first. We praise the line, the stroke, the gesture. We rarely praise the inch of paper to its left, which is doing as much of the work.
+
+## The shape of what is not there
+
+A designer once told me that she spent her first decade learning to put things on a page and her second learning to take them off. Subtraction is the harder discipline. To add a mark is to make a decision; to leave the field empty is to make a hundred. Every white inch is a hundred small refusals.
+
+In the Western tradition we have been trained, perhaps from the medieval scriptorium, to fear the empty page. The illuminated manuscript fills every corner with a curlicue. The modern book jacket fills every corner with a quote from a famous author. The instinct is the same: to prove that the page has been earned.
+
+The instinct is wrong. A page proves itself by what it refuses. A composition is strongest at its edges, where the eye is invited to step away.
+
+## Negative space as argument
+
+There is a temptation to treat negative space as decoration — a soothing wash around the content, like cream on coffee. It is not decoration. It is argument. It says: this matters, and the rest does not. It says: rest here, and then move on. It says: I have edited.
+
+The best editorial pages I know are nine-tenths blank. They are not lazy. They are confident. A magazine that gives its lead essay a single image and three columns of air is a magazine that believes in its own essay. A magazine that crowds the lead with twelve sidebars and four pull quotes is a magazine that does not.
+
+## A small exercise
+
+Take a page you have designed recently. Cover half of it with your hand. Ask whether the remaining half is enough. If it is, you have your design. If it is not, you have your next draft.
+
+It is a small exercise. It will save you years.

--- a/examples/obsidian-press/content/features/the-second-draft.md
+++ b/examples/obsidian-press/content/features/the-second-draft.md
@@ -1,0 +1,29 @@
++++
+title = "The Second Draft"
+date = "2026-02-19"
+description = "On editing as a discipline, and the writer who learns to murder the first sentence they loved."
+tags = ["essays", "writing"]
+[extra]
+author = "Margaret Lowell"
+deck = "The first draft is a private act. The second draft is the writer becoming a reader."
++++
+
+Every writer I have ever edited has the same conviction about their first draft. It is, they tell me, almost there. A polish. A pass. A few small changes. The shape is correct. The voice is correct. The argument is correct. The work is essentially done.
+
+Every writer I have ever edited is wrong about their first draft. This is not a comment on their talent. It is a comment on the nature of first drafts.
+
+A first draft is the writer thinking aloud. It is the record of the mind finding its way. The arguments are there because the writer needed to make them in order to discover what the essay was about. The paragraphs are in the order they are in because that was the order the writer found them in. The sentences are the sentences that came. None of this is wrong, exactly. But none of it is the essay yet.
+
+The essay is the second draft.
+
+The second draft is what happens when the writer becomes, for the first time, a reader. They put the pages down. They walk away. They come back, a week later if they can manage it, and they read what is there as if a stranger had written it. The arguments that seemed necessary are now optional. The opening that felt inevitable is now arbitrary. The metaphor the writer was proud of is now slightly embarrassing.
+
+This is not a bad day. This is the good day. The good day is the day the writer can see the work clearly enough to know what to remove.
+
+The hardest sentence to remove is the sentence the writer loved. Every essay has one. It is usually somewhere in the middle of a paragraph that is otherwise functional, and the writer remembers writing it — remembers the small private pleasure of having written it well. It does not belong in the essay. It belongs in the writer's notebook, where it can be remembered fondly. The essay is not a museum for sentences the writer was proud of. The essay is the argument. The sentence either serves the argument or it goes.
+
+I tell young writers: kill the sentence you loved. They look at me as if I have asked them to harm an animal. I understand. I have killed many sentences I loved, and I remember each of them with affection. But the essays are better.
+
+Editing is a discipline. It is not a talent, exactly, and it is not a feeling. It is a practice — the practice of reading what you have written as if you did not write it, and asking, of each sentence, whether the essay would survive its loss. Most sentences would. This is the secret of essays: most of them are mostly missing.
+
+The good news is that the missing parts are the parts the reader supplies. A well-edited essay is one in which the reader is given the work of making the connections. They make them gladly. They make them better than the writer could have. The writer's job is to leave the room.

--- a/examples/obsidian-press/content/index.md
+++ b/examples/obsidian-press/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Obsidian Press"
+description = "An editorial journal on design, culture, and the long form."
+template = "home"
++++

--- a/examples/obsidian-press/static/css/style.css
+++ b/examples/obsidian-press/static/css/style.css
@@ -1,0 +1,1038 @@
+/* =============================================================================
+   Obsidian Press — dark editorial magazine
+   Display: Fraunces (serif)
+   Body:    Inter (sans)
+   No gradients. No emojis. Hairlines and typography only.
+   ========================================================================== */
+
+:root {
+  --ink: #0e0e0e;
+  --ink-2: #161616;
+  --paper: #f0ece4;
+  --paper-dim: #b9b3a8;
+  --paper-mute: #7c776e;
+  --rule: #2a2722;
+  --rule-soft: #1d1b18;
+  --accent: #c0524a;
+  --serif: "Fraunces", "Times New Roman", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --measure: 38rem;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--sans);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "liga", "kern";
+}
+
+body {
+  min-height: 100vh;
+}
+
+a {
+  color: var(--paper);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 120ms linear, color 120ms linear;
+}
+
+a:hover {
+  border-bottom-color: var(--accent);
+  color: var(--paper);
+}
+
+img { max-width: 100%; height: auto; display: block; }
+
+::selection { background: var(--accent); color: var(--paper); }
+
+/* =============================================================================
+   Typography primitives
+   ========================================================================== */
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--serif);
+  color: var(--paper);
+  font-weight: 500;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+p { margin: 0 0 1.2em 0; }
+
+.num {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}
+
+.sep { color: var(--paper-mute); margin: 0 0.5em; }
+
+/* =============================================================================
+   Masthead
+   ========================================================================== */
+
+.masthead {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--ink);
+}
+
+.masthead-rule {
+  height: 1px;
+  background: var(--rule);
+}
+
+.masthead-inner {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 16px 32px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 24px;
+}
+
+.masthead-issue {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  font-weight: 500;
+}
+
+.masthead-brand {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--paper);
+  white-space: nowrap;
+  border-bottom: none;
+}
+
+.masthead-brand:hover { border-bottom: none; color: var(--paper); }
+
+.masthead-nav {
+  display: flex;
+  justify-content: flex-end;
+  gap: 28px;
+}
+
+.masthead-nav a {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--paper-dim);
+  font-weight: 500;
+}
+
+.masthead-nav a:hover { color: var(--paper); }
+
+/* =============================================================================
+   Cover (home)
+   ========================================================================== */
+
+.cover {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 32px 96px;
+}
+
+.cover-masthead {
+  padding: 72px 0 56px;
+  text-align: center;
+  border-bottom: 1px solid var(--rule);
+}
+
+.cover-tagline {
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  margin-bottom: 28px;
+}
+
+.cover-title {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: clamp(80px, 14vw, 200px);
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+  color: var(--paper);
+  margin: 0 0 36px;
+}
+
+.cover-dateline {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--paper-dim);
+}
+
+.cover-dateline .dot { color: var(--paper-mute); margin: 0 12px; }
+
+/* Lead feature */
+
+.cover-lead {
+  padding: 72px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.lead-frame {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.lead-label {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 36px;
+}
+
+.lead-label .num { font-size: 14px; }
+
+.lead-kicker {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  font-weight: 500;
+}
+
+.lead-link { border-bottom: none; }
+.lead-link:hover { border-bottom: none; }
+
+.lead-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(44px, 6vw, 88px);
+  line-height: 1.0;
+  letter-spacing: -0.025em;
+  color: var(--paper);
+  margin: 0 0 28px;
+}
+
+.lead-link:hover .lead-title { color: var(--paper); }
+
+.lead-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(20px, 2vw, 26px);
+  line-height: 1.4;
+  color: var(--paper-dim);
+  max-width: 38em;
+  margin: 0 0 32px;
+}
+
+.lead-meta {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  margin-bottom: 32px;
+}
+
+.lead-meta .byline { color: var(--paper-dim); }
+.lead-meta .sep { margin: 0 12px; }
+
+.lead-cta {
+  display: inline-block;
+  padding: 12px 0;
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent);
+  font-weight: 500;
+}
+
+.lead-cta:hover {
+  color: var(--paper);
+  border-bottom-color: var(--paper);
+}
+
+/* Cover grid (remaining features) */
+
+.cover-grid {
+  padding: 72px 0 24px;
+}
+
+.grid-heading {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 24px;
+  margin-bottom: 48px;
+}
+
+.grid-rule {
+  height: 1px;
+  background: var(--rule);
+}
+
+.grid-title {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 18px;
+  letter-spacing: 0.02em;
+  color: var(--paper-dim);
+  white-space: nowrap;
+}
+
+.grid-rows {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--rule);
+}
+
+.grid-row {
+  border-bottom: 1px solid var(--rule);
+  padding: 32px 32px 32px 0;
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.grid-row:nth-child(odd) {
+  border-right: 1px solid var(--rule);
+  padding-right: 32px;
+}
+
+.grid-row:nth-child(even) {
+  padding-left: 32px;
+  padding-right: 0;
+}
+
+.row-num .num { font-size: 13px; }
+
+.row-body a { border-bottom: none; }
+.row-body a:hover { border-bottom: none; }
+
+.row-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+  color: var(--paper);
+  margin: 0 0 14px;
+}
+
+.row-body a:hover .row-title { color: var(--accent); }
+
+.row-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--paper-dim);
+  margin: 0 0 16px;
+}
+
+.row-meta {
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+}
+
+.row-meta .sep { margin: 0 8px; }
+.row-tag { color: var(--accent); }
+
+/* Editors pull quote */
+
+.cover-editors {
+  padding: 96px 0 24px;
+  text-align: center;
+}
+
+.editors-rule {
+  height: 1px;
+  background: var(--rule);
+  max-width: 200px;
+  margin: 0 auto 32px;
+}
+
+.cover-editors .editors-rule:last-child {
+  margin: 32px auto 0;
+}
+
+.editors-label {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  margin-bottom: 32px;
+}
+
+.editors-quote {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(28px, 3.6vw, 44px);
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--paper);
+  max-width: 24em;
+  margin: 0 auto 28px;
+  padding: 0;
+  border: none;
+  quotes: "\201C" "\201D";
+}
+
+.editors-quote::before { content: open-quote; color: var(--accent); margin-right: 0.05em; }
+.editors-quote::after { content: close-quote; color: var(--accent); margin-left: 0.05em; }
+
+.editors-attribution {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+}
+
+.editors-attribution em {
+  font-family: var(--serif);
+  font-style: italic;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  font-size: 15px;
+  color: var(--paper-dim);
+  margin-left: 6px;
+}
+
+/* =============================================================================
+   Article page
+   ========================================================================== */
+
+.article-page {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 32px 96px;
+}
+
+.article {
+  max-width: 40rem;
+  margin: 0 auto;
+  padding-top: 72px;
+}
+
+.article-rule {
+  height: 1px;
+  background: var(--rule);
+  margin-bottom: 36px;
+}
+
+.article-eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 32px;
+  font-weight: 500;
+}
+
+.article-eyebrow .sep { color: var(--paper-mute); margin: 0 10px; }
+
+.article-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(40px, 5.5vw, 72px);
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  color: var(--paper);
+  margin: 0 0 28px;
+}
+
+.article-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(20px, 2vw, 24px);
+  line-height: 1.45;
+  color: var(--paper-dim);
+  margin: 0 0 36px;
+}
+
+.article-byline {
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  margin-bottom: 28px;
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.byline-author { color: var(--paper); }
+
+.article-thinrule {
+  height: 1px;
+  background: var(--rule);
+  margin-bottom: 40px;
+}
+
+/* Article body */
+
+.article-content {
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.75;
+  color: var(--paper);
+}
+
+.article-content p {
+  margin: 0 0 1.4em;
+}
+
+/* Drop cap on first paragraph */
+.article-content > p:first-of-type::first-letter {
+  font-family: var(--serif);
+  font-weight: 500;
+  float: left;
+  font-size: 5.2em;
+  line-height: 0.85;
+  padding: 0.08em 0.08em 0 0;
+  margin-top: 0.04em;
+  color: var(--accent);
+  font-feature-settings: "ss01";
+}
+
+.article-content h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 32px;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  color: var(--paper);
+  margin: 2em 0 0.6em;
+}
+
+.article-content h3 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--paper);
+  margin: 1.6em 0 0.5em;
+}
+
+.article-content a {
+  color: var(--paper);
+  border-bottom: 1px solid var(--accent);
+}
+
+.article-content a:hover {
+  color: var(--accent);
+}
+
+.article-content blockquote {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.45;
+  color: var(--paper-dim);
+  margin: 1.8em 0;
+  padding: 0 0 0 28px;
+  border-left: 1px solid var(--accent);
+}
+
+.article-content blockquote p { margin: 0; }
+
+.article-content strong { color: var(--paper); font-weight: 600; }
+.article-content em { color: var(--paper-dim); }
+
+.article-content ul, .article-content ol {
+  margin: 0 0 1.4em;
+  padding-left: 1.4em;
+}
+
+.article-content li { margin: 0.4em 0; }
+
+.article-content code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--ink-2);
+  padding: 0.1em 0.4em;
+  border: 1px solid var(--rule);
+}
+
+.article-content pre {
+  background: var(--ink-2);
+  border: 1px solid var(--rule);
+  padding: 18px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.article-content pre code { background: none; border: none; padding: 0; }
+
+.article-content hr {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 2.4em auto;
+  max-width: 60%;
+}
+
+/* Article tags */
+
+.article-tags {
+  margin-top: 56px;
+  padding-top: 24px;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: baseline;
+}
+
+.tags-label {
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  margin-right: 8px;
+}
+
+.tag-pill {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--paper-dim);
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 1px;
+}
+
+.tag-pill:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.article .article-rule:last-of-type {
+  margin: 56px 0 32px;
+}
+
+.article-nav {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--paper-dim);
+}
+
+.article-nav a:hover { color: var(--accent); }
+
+/* =============================================================================
+   Section / Index pages
+   ========================================================================== */
+
+.section-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 32px 96px;
+}
+
+.section-header {
+  padding: 72px 0 48px;
+  text-align: center;
+}
+
+.section-rule {
+  height: 1px;
+  background: var(--rule);
+}
+
+.section-eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  margin: 32px 0 20px;
+  font-weight: 500;
+}
+
+.section-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(56px, 9vw, 128px);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  color: var(--paper);
+  margin: 0 0 20px;
+}
+
+.section-title em {
+  font-style: italic;
+  color: var(--accent);
+}
+
+.section-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 20px;
+  line-height: 1.45;
+  color: var(--paper-dim);
+  max-width: 30em;
+  margin: 0 auto 20px;
+}
+
+.section-count {
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  margin: 0 0 32px;
+}
+
+.features-index {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--rule);
+}
+
+.feature-row {
+  border-bottom: 1px solid var(--rule);
+}
+
+.feature-link {
+  display: grid;
+  grid-template-columns: 80px 140px 1fr;
+  gap: 32px;
+  padding: 36px 0;
+  border-bottom: none;
+  align-items: baseline;
+}
+
+.feature-link:hover { border-bottom: none; }
+
+.feature-num .num { font-size: 14px; }
+
+.feature-date {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+}
+
+.feature-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 34px;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  color: var(--paper);
+  margin: 0 0 10px;
+  transition: color 120ms linear;
+}
+
+.feature-link:hover .feature-title { color: var(--accent); }
+
+.feature-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--paper-dim);
+  margin: 0 0 12px;
+}
+
+.feature-meta {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+}
+
+.feature-meta .sep { margin: 0 8px; }
+.feature-tag { color: var(--accent); }
+
+/* =============================================================================
+   Taxonomy list (hwaro auto-renders into .taxonomy-body)
+   ========================================================================== */
+
+.taxonomy-body {
+  padding-top: 24px;
+}
+
+.taxonomy-body ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--rule);
+}
+
+.taxonomy-body li {
+  border-bottom: 1px solid var(--rule);
+  padding: 22px 0;
+  display: flex;
+  align-items: baseline;
+}
+
+.taxonomy-body li a {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 26px;
+  color: var(--paper);
+  border-bottom: none;
+  letter-spacing: 0.005em;
+}
+
+.taxonomy-body li a:hover {
+  color: var(--accent);
+  border-bottom: none;
+}
+
+/* per-term list of posts inside taxonomy_term content */
+.taxonomy-body li:has(> a[href*="/features/"]) a {
+  font-family: var(--serif);
+  font-style: normal;
+  font-size: 22px;
+  letter-spacing: -0.005em;
+}
+
+/* =============================================================================
+   About (plain page)
+   ========================================================================== */
+
+main.site-main, body[data-section=""] main {
+  /* fallback */
+}
+
+/* About uses page.html template; styled via .article */
+
+/* =============================================================================
+   Pagination
+   ========================================================================== */
+
+nav.pagination {
+  margin: 48px 0 0;
+  display: flex;
+  justify-content: center;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  display: flex;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  align-items: center;
+}
+
+nav.pagination a,
+nav.pagination .pagination-current span,
+nav.pagination .pagination-disabled span {
+  display: inline-block;
+  padding: 8px 14px;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--paper-dim);
+  border: 1px solid var(--rule);
+  font-family: var(--sans);
+}
+
+nav.pagination a {
+  text-decoration: none;
+}
+
+nav.pagination a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.pagination-current span {
+  color: var(--paper);
+  border-color: var(--paper);
+}
+
+.pagination-disabled span {
+  color: var(--paper-mute);
+  opacity: 0.5;
+}
+
+/* =============================================================================
+   404
+   ========================================================================== */
+
+.page-404 {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 96px 32px;
+  text-align: center;
+}
+
+.four-rule {
+  height: 1px;
+  background: var(--rule);
+}
+
+.four-eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  margin: 32px 0 20px;
+}
+
+.four-number {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: clamp(140px, 22vw, 280px);
+  line-height: 0.9;
+  letter-spacing: -0.05em;
+  color: var(--accent);
+  margin: 0 0 28px;
+}
+
+.four-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.45;
+  color: var(--paper-dim);
+  max-width: 28em;
+  margin: 0 auto 36px;
+}
+
+.four-actions {
+  display: flex;
+  gap: 32px;
+  justify-content: center;
+  margin-bottom: 48px;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.four-actions a {
+  color: var(--paper);
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 2px;
+}
+
+.four-actions a:hover {
+  color: var(--accent);
+}
+
+/* =============================================================================
+   Colophon (footer)
+   ========================================================================== */
+
+.colophon {
+  margin-top: 96px;
+}
+
+.colophon-rule {
+  height: 1px;
+  background: var(--rule);
+}
+
+.colophon-inner {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 36px 32px 56px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.colophon-line {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--paper-dim);
+}
+
+.colophon-meta {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--paper-mute);
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.colophon-meta a {
+  color: var(--paper-dim);
+  border-bottom: none;
+}
+
+.colophon-meta a:hover { color: var(--accent); }
+
+/* =============================================================================
+   Responsive
+   ========================================================================== */
+
+@media (max-width: 880px) {
+  .masthead-inner {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    text-align: center;
+    padding: 16px 20px;
+  }
+  .masthead-nav { justify-content: center; gap: 18px; }
+
+  .cover { padding: 0 20px 64px; }
+  .cover-masthead { padding: 48px 0 36px; }
+
+  .grid-rows {
+    grid-template-columns: 1fr;
+  }
+  .grid-row,
+  .grid-row:nth-child(odd),
+  .grid-row:nth-child(even) {
+    border-right: none;
+    padding: 24px 0;
+    grid-template-columns: 56px 1fr;
+    gap: 16px;
+  }
+
+  .feature-link {
+    grid-template-columns: 56px 1fr;
+    gap: 14px;
+  }
+  .feature-date {
+    grid-column: 2 / 3;
+    margin-bottom: 8px;
+  }
+
+  .article-page { padding: 0 20px 64px; }
+  .article { padding-top: 48px; }
+  .article-content > p:first-of-type::first-letter {
+    font-size: 4.2em;
+  }
+
+  .colophon-inner { flex-direction: column; padding: 28px 20px 40px; }
+}
+
+@media (max-width: 520px) {
+  .cover-title { font-size: 64px; letter-spacing: -0.04em; }
+  .section-title { font-size: 52px; }
+  .article-title { font-size: 36px; }
+  .lead-title { font-size: 38px; }
+}

--- a/examples/obsidian-press/templates/404.html
+++ b/examples/obsidian-press/templates/404.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+
+<main class="page-404">
+  <div class="four-rule"></div>
+  <div class="four-eyebrow">Error</div>
+  <h1 class="four-number">404</h1>
+  <p class="four-deck">The page you are looking for is not in this issue. It may have been removed, renamed, or it may have never existed at all.</p>
+  <div class="four-actions">
+    <a href="{{ base_url }}/">Return to the cover</a>
+    <a href="{{ base_url }}/features/">Browse features</a>
+  </div>
+  <div class="four-rule"></div>
+</main>
+
+{% include "footer.html" %}

--- a/examples/obsidian-press/templates/footer.html
+++ b/examples/obsidian-press/templates/footer.html
@@ -1,0 +1,16 @@
+<footer class="colophon">
+  <div class="colophon-rule"></div>
+  <div class="colophon-inner">
+    <div class="colophon-line">Set in Fraunces and Inter. Published quarterly from Marseille and Brooklyn.</div>
+    <div class="colophon-meta">
+      <span>&copy; 2026 Obsidian Press. All rights reserved.</span>
+      <a href="{{ base_url }}/rss.xml">RSS</a>
+      <a href="{{ base_url }}/features/">Features</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </div>
+  </div>
+</footer>
+{{ highlight_js }}
+{{ auto_includes_js }}
+</body>
+</html>

--- a/examples/obsidian-press/templates/header.html
+++ b/examples/obsidian-press/templates/header.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+
+<header class="masthead">
+  <div class="masthead-rule"></div>
+  <div class="masthead-inner">
+    <div class="masthead-issue">ISSUE NO. 04 &middot; WINTER 2026</div>
+    <a href="{{ base_url }}/" class="masthead-brand">OBSIDIAN PRESS</a>
+    <nav class="masthead-nav">
+      <a href="{{ base_url }}/">Cover</a>
+      <a href="{{ base_url }}/features/">Features</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </div>
+  <div class="masthead-rule"></div>
+</header>

--- a/examples/obsidian-press/templates/home.html
+++ b/examples/obsidian-press/templates/home.html
@@ -1,0 +1,77 @@
+{% include "header.html" %}
+
+{% set all_sorted = site.pages | sort_by(attribute="date") | reverse %}
+
+<main class="cover">
+
+  <section class="cover-masthead">
+    <div class="cover-tagline">An editorial journal on design, culture, and the long form.</div>
+    <h1 class="cover-title">Obsidian<br>Press</h1>
+    <div class="cover-dateline">
+      <span>Winter 2026</span>
+      <span class="dot">&middot;</span>
+      <span>Five Features</span>
+      <span class="dot">&middot;</span>
+      <span>One Interview</span>
+    </div>
+  </section>
+
+  {# Lead feature: the newest features-section page #}
+  <section class="cover-lead">
+    <div class="lead-frame">
+      <div class="lead-label"><span class="num">&#8470;&nbsp;01</span><span class="lead-kicker">The Lead Feature</span></div>
+      {% for post in all_sorted %}
+        {% if post.section == "features" and loop.index0 == 0 %}
+      <a class="lead-link" href="{{ base_url }}{{ post.url }}">
+        <h2 class="lead-title">{{ post.title | e }}</h2>
+      </a>
+      {% if post.extra.deck %}<p class="lead-deck">{{ post.extra.deck | e }}</p>{% endif %}
+      <div class="lead-meta">
+        {% if post.extra.author %}<span class="byline">By {{ post.extra.author | e }}</span><span class="sep">&middot;</span>{% endif %}
+        {% if post.date %}<span class="dateline">{{ post.date | date(format="%B %d, %Y") }}</span>{% endif %}
+      </div>
+      <a class="lead-cta" href="{{ base_url }}{{ post.url }}">Read the essay</a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="cover-grid">
+    <div class="grid-heading">
+      <span class="grid-rule"></span>
+      <h3 class="grid-title">Also in this issue</h3>
+      <span class="grid-rule"></span>
+    </div>
+    <div class="grid-rows">
+      {% for post in all_sorted %}
+        {% if post.section == "features" and loop.index0 > 0 %}
+        <article class="grid-row">
+          <div class="row-num"><span class="num">&#8470;&nbsp;0{{ loop.index0 + 1 }}</span></div>
+          <div class="row-body">
+            <a href="{{ base_url }}{{ post.url }}"><h4 class="row-title">{{ post.title | e }}</h4></a>
+            {% if post.extra.deck %}<p class="row-deck">{{ post.extra.deck | e }}</p>{% elif post.description %}<p class="row-deck">{{ post.description | e }}</p>{% endif %}
+            <div class="row-meta">
+              {% if post.extra.author %}<span>{{ post.extra.author | e }}</span><span class="sep">&middot;</span>{% endif %}
+              {% if post.date %}<span>{{ post.date | date(format="%b %d, %Y") }}</span>{% endif %}
+              {% if post.tags %}<span class="sep">&middot;</span><span class="row-tag">{{ post.tags | first | e }}</span>{% endif %}
+            </div>
+          </div>
+        </article>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="cover-editors">
+    <div class="editors-rule"></div>
+    <div class="editors-label">From the Editors</div>
+    <blockquote class="editors-quote">
+      The essay is not a museum for sentences the writer was proud of. It is the argument. The sentence either serves the argument or it goes.
+    </blockquote>
+    <div class="editors-attribution">&mdash; Margaret Lowell, <em>The Second Draft</em></div>
+    <div class="editors-rule"></div>
+  </section>
+
+</main>
+
+{% include "footer.html" %}

--- a/examples/obsidian-press/templates/home.html
+++ b/examples/obsidian-press/templates/home.html
@@ -1,6 +1,6 @@
 {% include "header.html" %}
 
-{% set all_sorted = site.pages | sort_by(attribute="date") | reverse %}
+{% set features = site.pages | where("section", "features") | sort_by(attribute="date") | reverse %}
 
 <main class="cover">
 
@@ -20,8 +20,8 @@
   <section class="cover-lead">
     <div class="lead-frame">
       <div class="lead-label"><span class="num">&#8470;&nbsp;01</span><span class="lead-kicker">The Lead Feature</span></div>
-      {% for post in all_sorted %}
-        {% if post.section == "features" and loop.index0 == 0 %}
+      {% for post in features %}
+        {% if loop.first %}
       <a class="lead-link" href="{{ base_url }}{{ post.url }}">
         <h2 class="lead-title">{{ post.title | e }}</h2>
       </a>
@@ -43,10 +43,10 @@
       <span class="grid-rule"></span>
     </div>
     <div class="grid-rows">
-      {% for post in all_sorted %}
-        {% if post.section == "features" and loop.index0 > 0 %}
+      {% for post in features %}
+        {% if not loop.first %}
         <article class="grid-row">
-          <div class="row-num"><span class="num">&#8470;&nbsp;0{{ loop.index0 + 1 }}</span></div>
+          <div class="row-num"><span class="num">&#8470;&nbsp;{{ "%02d" | format(loop.index) }}</span></div>
           <div class="row-body">
             <a href="{{ base_url }}{{ post.url }}"><h4 class="row-title">{{ post.title | e }}</h4></a>
             {% if post.extra.deck %}<p class="row-deck">{{ post.extra.deck | e }}</p>{% elif post.description %}<p class="row-deck">{{ post.description | e }}</p>{% endif %}

--- a/examples/obsidian-press/templates/page.html
+++ b/examples/obsidian-press/templates/page.html
@@ -1,0 +1,49 @@
+{% include "header.html" %}
+
+<main class="article-page">
+  <article class="article">
+    <div class="article-rule"></div>
+
+    <div class="article-eyebrow">
+      {% if page.section %}<span>{{ page.section | upper }}</span>{% endif %}
+      {% if page.tags %}<span class="sep">&middot;</span><span>{{ page.tags | first | upper | e }}</span>{% endif %}
+    </div>
+
+    <h1 class="article-title">{{ page.title | e }}</h1>
+
+    {% if page.extra.deck %}
+    <p class="article-deck">{{ page.extra.deck | e }}</p>
+    {% elif page.description %}
+    <p class="article-deck">{{ page.description | e }}</p>
+    {% endif %}
+
+    <div class="article-byline">
+      {% if page.extra.author %}<span class="byline-author">By {{ page.extra.author | e }}</span>{% endif %}
+      {% if page.date %}<span class="byline-date">{{ page.date | date(format="%B %d, %Y") }}</span>{% endif %}
+    </div>
+
+    <div class="article-thinrule"></div>
+
+    <div class="article-content content">
+      {{ content | safe }}
+    </div>
+
+    {% if page.tags %}
+    <div class="article-tags">
+      <span class="tags-label">Filed under</span>
+      {% for tag in page.tags %}
+        <a class="tag-pill" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag | e }}</a>
+      {% endfor %}
+    </div>
+    {% endif %}
+
+    <div class="article-rule"></div>
+
+    <nav class="article-nav">
+      <a href="{{ base_url }}/features/">&larr; All features</a>
+      <a href="{{ base_url }}/">Back to cover</a>
+    </nav>
+  </article>
+</main>
+
+{% include "footer.html" %}

--- a/examples/obsidian-press/templates/section.html
+++ b/examples/obsidian-press/templates/section.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+
+<main class="section-page">
+  <header class="section-header">
+    <div class="section-rule"></div>
+    <div class="section-eyebrow">Index</div>
+    <h1 class="section-title">{{ section.title | e }}</h1>
+    {% if section.description %}<p class="section-deck">{{ section.description | e }}</p>{% endif %}
+    <div class="section-count">{{ section.pages | length }} essays in this issue</div>
+    <div class="section-rule"></div>
+  </header>
+
+  <ol class="features-index">
+    {% for post in section.pages | sort_by(attribute="date") | reverse %}
+    <li class="feature-row">
+      <a class="feature-link" href="{{ base_url }}{{ post.url }}">
+        <div class="feature-num"><span class="num">&#8470;&nbsp;0{{ loop.index }}</span></div>
+        <div class="feature-date">{% if post.date %}{{ post.date | date(format="%b %d, %Y") }}{% endif %}</div>
+        <div class="feature-body">
+          <h2 class="feature-title">{{ post.title | e }}</h2>
+          {% if post.extra.deck %}<p class="feature-deck">{{ post.extra.deck | e }}</p>{% elif post.description %}<p class="feature-deck">{{ post.description | e }}</p>{% endif %}
+          <div class="feature-meta">
+            {% if post.extra.author %}<span>{{ post.extra.author | e }}</span>{% endif %}
+            {% if post.tags %}<span class="sep">&middot;</span><span class="feature-tag">{{ post.tags | first | e }}</span>{% endif %}
+          </div>
+        </div>
+      </a>
+    </li>
+    {% endfor %}
+  </ol>
+
+  {{ pagination }}
+</main>
+
+{% include "footer.html" %}

--- a/examples/obsidian-press/templates/shortcodes/alert.html
+++ b/examples/obsidian-press/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/obsidian-press/templates/taxonomy.html
+++ b/examples/obsidian-press/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<main class="section-page">
+  <header class="section-header">
+    <div class="section-rule"></div>
+    <div class="section-eyebrow">Index</div>
+    <h1 class="section-title">All {{ taxonomy_name | default(value="terms") | e }}</h1>
+    <div class="section-rule"></div>
+  </header>
+
+  <div class="taxonomy-body">
+    {{ content | safe }}
+  </div>
+</main>
+
+{% include "footer.html" %}

--- a/examples/obsidian-press/templates/taxonomy_term.html
+++ b/examples/obsidian-press/templates/taxonomy_term.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<main class="section-page">
+  <header class="section-header">
+    <div class="section-rule"></div>
+    <div class="section-eyebrow">Filed under</div>
+    <h1 class="section-title"><em>{{ taxonomy_term | default(value=page.title) | e }}</em></h1>
+    <div class="section-rule"></div>
+  </header>
+
+  <div class="taxonomy-body">
+    {{ content | safe }}
+  </div>
+</main>
+
+{% include "footer.html" %}

--- a/examples/slate-journal/AGENTS.md
+++ b/examples/slate-journal/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter can use TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start) — TOML is the default.
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/slate-journal/archetypes/default.md
+++ b/examples/slate-journal/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = ["essays"]
++++
+
+Open with a single, calm sentence that establishes a place and a time. Write in serif. Resist the headline. Let the paragraph carry the idea.

--- a/examples/slate-journal/config.toml
+++ b/examples/slate-journal/config.toml
@@ -1,0 +1,186 @@
+title = "Slate Journal"
+description = "Essays on software, attention, and the slow internet, by Augustin Park."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = true
+per_page = 10
+
+[series]
+enabled = false
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = false
+sitemap = false
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+
+[feeds]
+enabled = true
+filename = ""
+type = "atom"
+truncate = 0
+full_content = true
+limit = 20
+sections = ["essays"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/slate-journal/content/about.md
+++ b/examples/slate-journal/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About"
+description = "A short note on the journal and its author."
++++
+
+Augustin Park is a software engineer and essayist living in a small river town. He writes the *Slate Journal* in the margins of a working life: in the half hour before the rest of the house wakes, on long walks, in the quiet between meetings. The journal began as a private folder of notes and grew, slowly, into something he was willing to publish.
+
+The interests are narrow on purpose. *Software*, but mostly the small, well-mannered kind. *Attention*, because it is the resource everything in our work seems to be quietly competing for. *The slow internet*, because the word "slow" still names a value worth defending, even online.
+
+Augustin holds no strong opinions about productivity. He believes most tools are too eager, most feeds too loud, and most pages too clever. He prefers a long sentence to a clever one, and a footnote to a tweet.
+
+If you would like to write to him, the address is plain text and the reply will be too. He answers letters in the order they arrive, and rarely on the same day.

--- a/examples/slate-journal/content/colophon.md
+++ b/examples/slate-journal/content/colophon.md
@@ -1,0 +1,14 @@
++++
+title = "Colophon"
+description = "How the journal is made."
++++
+
+This site is set in *Fraunces*, a contemporary serif designed by Phaedra Charles and Flavia Zimbardi, distributed by Undercase Type. UI labels are set in *Inter*, by Rasmus Andersson. Both faces are served from Google Fonts.
+
+The site is built with Hwaro, a small static site generator. There is no JavaScript on the page except what arrives with embedded fonts. There is no analytics, no telemetry, and no tracking pixel. The HTML is plain. The CSS is hand-written. The author considers this a feature.
+
+Drafts are written in a plain Markdown file in a plain folder on a plain laptop. Revisions happen on long walks and then, at a desk, in a single text editor. There is no content management system. There is no editor besides the author. There is no schedule, only a habit.
+
+Hosting is the kind that costs a few dollars a month and does not phone home. The server returns the same bytes to every reader. If you read with JavaScript disabled, the journal will look exactly the same to you as it does to the author.
+
+If you would like to read offline, every essay is available as a Markdown file on request. Email Augustin and he will send it to you, set in whatever face you like.

--- a/examples/slate-journal/content/essays/_index.md
+++ b/examples/slate-journal/content/essays/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Essays"
+description = "All essays, most recent first."
+sort_by = "date"
+reverse = true
+paginate = 10
+pagination_enabled = true
+generate_feeds = true
++++
+
+A complete index of the essays, gathered in the order they were written. Each piece is the result of a long walk, a quiet hour, and a few rounds of editing on paper.

--- a/examples/slate-journal/content/essays/against-the-feed.md
+++ b/examples/slate-journal/content/essays/against-the-feed.md
@@ -1,0 +1,20 @@
++++
+title = "Against the Feed"
+description = "On algorithmic timelines, and the long task of building a reading life around something else."
+date = "2026-02-09"
+tags = ["essays", "attention"]
++++
+
+The first thing I did, when I decided to read better, was leave the feed. By "the feed" I mean the algorithmically ordered timeline, the one that decides, on my behalf, which sentence I am about to read next. I left it in stages. I left the first one easily, the second with effort, the third with a long, embarrassing period of relapse. I am still, in some quiet corner, leaving the last of them.
+
+I do not believe the feed is evil. I do not believe the engineers who maintain it are evil. The feed is, structurally, a particular kind of attention-allocation device, and like all such devices it has the values that its loss function makes it have. Its loss function does not contain a term for the quality of my afternoon. There is no reason it would. The remarkable thing is not that the feed neglects me. The remarkable thing is how long it took me to notice.
+
+The case against the feed is not the obvious case. It is not that the feed is full of bad writing, though it is. It is not that the feed encourages outrage, though it does. It is not even that the feed wastes time, though it certainly does. The case is more particular: the feed teaches the reader to behave like a feed. After enough time on the timeline, my own internal sense of what to read next begins to mimic the timeline's. I scan. I jump. I expect the next sentence to be louder than the last. I expect, in fact, a sentence at all, where I used to expect a paragraph.
+
+What I am after, now, is the opposite habit. I want a reading life in which the next thing I read was chosen by me, an hour or a week or a decade ago, for reasons I can articulate. I want, in fact, a small backlog. A folder of essays that I have selected and have not yet read. A pile of books on the bedside table. A list of writers I subscribe to. A short queue, in the language of the engineer, that is not constantly being reordered by an outside party while my back is turned.
+
+The hardest part of this is not avoiding the feed. The hardest part is the hour or two, every week, when I have to do the work the feed used to do for me. I have to choose. I have to remember what I cared about last month. I have to look at the queue and pick the next thing on my terms. The feed is, in part, popular because choosing is hard. There is a real labour involved in being a reader, and the feed offers, in exchange for our attention, to do that labour for us. The exchange is bad. But it is, undeniably, an exchange.
+
+So I have begun to think of curation as a daily, ordinary activity, in the way that cooking is a daily activity. The day on which I do not curate my reading is the day on which someone else will curate it for me, and the someone else will not be a friend with a good library. The someone else will be a system whose loss function does not contain a term for my afternoon. There is no reason it would.
+
+I am not, in the end, against the feed in the way one might be against a vice. I am against it the way one might be against a particular kind of architecture. A feed is a building shape that does not have any chairs, only escalators. I would like to read in a room with chairs. So I am, with effort and not entirely successfully, building one.

--- a/examples/slate-journal/content/essays/keeping-a-commonplace.md
+++ b/examples/slate-journal/content/essays/keeping-a-commonplace.md
@@ -1,0 +1,20 @@
++++
+title = "Keeping a Commonplace"
+description = "On the old habit of the commonplace book, and why I keep one in a folder of plain text files."
+date = "2026-01-18"
+tags = ["essays", "writing"]
++++
+
+A commonplace book is a private anthology. You read a great deal, and as you read, you copy out, by hand, the sentences that strike you. There is no system. There is no theme. There is no intended audience. The book accumulates over years, and slowly, in the way that a coastline accumulates, becomes a shape. It is one of the oldest reading habits in the European tradition, and it is, I have come to think, one of the most useful habits available to a person who reads at all seriously.
+
+I keep mine in a folder of plain text files. Each file is named for the year. Inside, the entries are short: the author, the source, the sentence or passage, and very occasionally a single line of my own response. The folder is mirrored, redundantly, on three machines and one piece of paper. I do not show it to anyone. I do not have an "export" feature, and I do not want one. The point is that the commonplace is private. It is the place where the reader is, finally, alone with what was read.
+
+The reason this matters, I think, is that the act of copying is different in kind from the act of highlighting. A highlight is fast. It says, *I saw this; the page will remember it for me*. A copied passage is slow. It says, *I wanted this sentence enough to write it out, in my own hand, at my own pace*. The latter changes me; the former does not. I have, in twenty years of reading on screens, never once been changed by a highlight. I have been changed, very often, by a sentence I sat with long enough to copy.
+
+There is also the matter of what the commonplace teaches the reader, over time, about the reader. After a few years, the entries cohere. The same kind of sentence keeps showing up. Certain images recur. Certain rhythms. Certain rare verbs. The book begins to describe, very accurately, what the reader is actually drawn to, in a way that the reader could not have described in advance. It is a portrait, drawn over time, of a particular taste. I have learned more about my own reading from my commonplace than from any course I ever took.
+
+I think anyone who writes should keep one. The reason is selfish: a commonplace book is a private supply of well-formed sentences in your immediate vicinity. When the prose stalls, when the page is blank, when the right word will not come, you can open the commonplace and read for ten minutes. You are not stealing anything. You are reminding yourself what good sentences sound like, in your own ear, in your own voice. You are tuning the instrument.
+
+But the commonplace is not, in the end, a writer's tool. It is a reader's tool. Anyone who reads can keep one. The format does not matter. The technology does not matter. A leather notebook is no better than a folder of text files; a folder of text files is no better than a stack of index cards in a shoebox. What matters is the habit, which is simply: when a sentence stops you, do not move on. Write it down. Write down where it came from. Write the date. And then, on a quiet evening in February five years from now, read your book back to yourself.
+
+You will find that you have been keeping good company. You will find, in the long quiet shape of your own commonplace, the outline of the reader you actually are, which is almost certainly a finer reader than you knew.

--- a/examples/slate-journal/content/essays/notation-as-thought.md
+++ b/examples/slate-journal/content/essays/notation-as-thought.md
@@ -1,0 +1,20 @@
++++
+title = "Notation as Thought"
+description = "On the systems we write with, and how they quietly shape the shape of what we think."
+date = "2026-04-12"
+tags = ["essays", "writing"]
++++
+
+I learned to write in a notation that did not fit my thinking. I do not mean my native language, which fits as well as any language fits. I mean the shape of the page: paragraphs of equal density, indented openings, headings every few pages, footnotes when needed. The shape was older than I was and it taught me, before any teacher did, what an idea was supposed to look like.
+
+We talk about notation as if it were neutral. We say, of an equation, that it expresses an idea, as though the idea existed first and the equation came along to dress it. But anyone who has changed notations halfway through a problem knows the truth. A different notation produces a different idea, or, more honestly, makes a different idea possible. The notation is not the costume of the thought. The notation is part of the thought.
+
+In software the notation is usually a language. When I was younger I believed that the choice of programming language did not matter much, that all languages were translations of one underlying logic. I do not believe this any more. The languages I have spent the most time in have left their grammar in the shape of my thinking. I notice it most when I switch. The first hour in a new language is the hour of recovering the ideas the old language was hiding.
+
+Mathematical notation is the same. Leibniz won his fight with Newton over the calculus partly on the strength of his notation, which made it easy to do things that, in Newton's, were merely possible. The notation taught generations of students what to look for. Some of the deepest discoveries in mathematics are, on inspection, the invention of a notation that made the discovery the next obvious step.
+
+The same is true of writing prose. The shape of the paragraph, the choice between footnote and parenthetical, the rhythm of the sentence, the decision to italicize or to set a phrase in roman, the whitespace around a section break: these are not ornaments. They are the medium in which the thought is, for the first time, fully a thought. Anyone who has revised an essay knows that there is a moment when the prose, having been adjusted, reveals what the writer was actually trying to say.
+
+So I have come to take notation seriously, in all its forms. I keep a notebook with wider margins than seems reasonable, because I have learned that thinking in the margin is a different kind of thinking than thinking on the line. I keep my code in narrow columns, because the shape of the column reveals when a function has grown beyond the idea it was meant to carry. I write essays in plain text, because plain text refuses to flatter the writer with anything other than the sentence itself.
+
+A notation, I now suspect, is the place where attention and thought meet. It is the geometry of what can be attended to at once. Change the geometry, and the available thoughts change. This is, in the end, why I care so much what tools I write with. They are not, for me, ergonomic preferences. They are the rooms in which I think.

--- a/examples/slate-journal/content/essays/the-long-tail-of-tools.md
+++ b/examples/slate-journal/content/essays/the-long-tail-of-tools.md
@@ -1,0 +1,22 @@
++++
+title = "The Long Tail of Tools"
+description = "Small software, kept by one person, used by a few hundred — and why it is among the most interesting work being done now."
+date = "2026-03-22"
+tags = ["essays", "software"]
++++
+
+If you spend long enough around software, you begin to notice a particular kind of tool. It is written by one person, often as a side project. It is hosted on a static page. It does one thing well. The author is reachable. The user list is small. The release cadence is irregular, occasionally generous, occasionally silent for a year. The tool is, by any standard the industry would recognise, a failure. It is also, very often, the thing I use every day.
+
+I have been thinking lately about what to call this category. *Small software* is the term I have settled on, though I have heard *artisanal*, *boutique*, *handmade*, and, less charitably, *toy*. None of these capture it exactly. The defining quality is not that the tool is small in features — many small tools are richer than their industrial counterparts — but that the author can hold the whole thing in their head, can answer a question about it in a single email, and is making it for a reason that begins inside their own life.
+
+What follows from this is a long tail. The famous tools, the ones used by millions, are a few. The tools used by tens of thousands are more numerous. The tools used by a few hundred are countless, and they make up, taken together, an enormous share of the software I actually love. There is no equivalent of this in most industries. We do not have a long tail of cars. We have, perhaps, a long tail of books — and the comparison is the right one. Small software, like a book, is a thing a person can make.
+
+The economics of small software are odd. They mostly do not work, in the venture-funded sense. The author is not getting rich; sometimes the tool pays for the author's coffee, sometimes for nothing at all. But the cost of making and maintaining a useful piece of software has, over twenty years, fallen dramatically. A single thoughtful person can now ship a tool that twenty years ago would have required a small team. The result is that a great deal of small software is now made by people who simply wanted the tool to exist, and who are content if the tool earns enough to justify itself in their own life.
+
+I have a small list of these tools open right now. A note-taking app written by one person, who answers emails himself. A timer that does not have an account system. A text editor with a manifesto for a README. A feed reader that has had the same maintainer for fifteen years. A backup utility distributed as a single binary, signed by a person whose photograph is on the project page. Each of them does its thing. Each of them, in some quiet way, is a refusal of the dominant economic model of software.
+
+The case for small software is not nostalgic, though it can sound that way. It is practical. Software in this category is *intelligible*: I can read the documentation and understand what it will do. It is *stable*: the author has not been pressured into shipping a quarterly redesign. It is *humane*: its bug tracker is run by the person who wrote the bug. It is *accountable*: if it stops working, the author has not been promoted to vice president of a new division. It is, in short, the kind of software you can have a relationship with.
+
+I would like the long tail of tools to be longer. I would like the people who write the dependable little tools to be paid a fair, modest amount for their work. I would like the rest of us to acknowledge, more often, that the small tool we use every day is a quiet act of generosity by someone who could have spent that time on almost anything else. The economics will follow, slowly, if we manage that.
+
+In the meantime, I keep a folder of them, and a small annual list of which ones earned a donation. It is the least I can do. It is also a form of attention. The tools we choose to use, and to pay for, are the tools that will exist in five years. That is worth being deliberate about.

--- a/examples/slate-journal/content/essays/the-quiet-protocols.md
+++ b/examples/slate-journal/content/essays/the-quiet-protocols.md
@@ -1,0 +1,22 @@
++++
+title = "The Quiet Protocols"
+description = "In praise of email and RSS, the slow protocols that still let the reader set the pace."
+date = "2026-05-02"
+tags = ["essays", "attention"]
++++
+
+There are two protocols I still keep open on a quiet machine in the corner of my flat. The first is mail. The second is a feed reader, hunched politely over a list of folders, pulling new posts on a schedule that is mine and not somebody else's. Between them, they manage almost everything I read that is worth reading.
+
+Both of these are slow protocols. By "slow" I mean only this: they wait for the reader. Nothing in mail or in a feed insists on a particular order. Nothing reshuffles when I look away. Nothing pushes itself in front of something else to win an auction I did not enter. Mail arrives, queues up, and waits. A feed is a list of writers I have chosen, in the order they chose to publish, with their full sentences intact.
+
+I think about these two protocols when I am tired of the others. The loud protocols are the ones we know best. They are designed to be reentered constantly, to never come to an end, to suggest, just past the next swipe, a payoff that the design itself ensures will never quite arrive. A loud protocol is a machine for shortening the present moment. A slow protocol is a machine for lengthening it.
+
+> A slow protocol is one that waits for the reader, and trusts the reader's pace. A loud protocol is one that interrupts the reader, and distrusts the reader's pace. Almost every product decision follows from this difference.
+
+Mail in particular is older than most of the people who now declare it dead. It has been declared dead, by my count, in 1996, 1999, 2004, 2010, 2014, and twice in 2021. It is, of course, perfectly alive. It is alive because no single company owns it, because anyone can run a server, because the inbox is the rare social space online where the people who write to me must spell out who they are and what they want before I read them.
+
+A feed reader is similar. The list of writers I follow is mine; I can prune it without negotiating with an algorithm; I can take a writer off it without explaining myself to a recommendation system. When a writer falls silent for a season, I can wait. When a writer publishes three pieces in a week, I can read all three. The pace is set by the writing, not by the platform.
+
+What surprises me is how rare this experience has become. Most of the internet I encounter through my phone has the opposite shape. It does not wait. It does not trust me to find the thing I came for. It does not let the writers I have chosen choose for me. There is a quiet violence in all this, the violence of being told, gently and constantly, that what you wanted to read is not what you should be reading.
+
+So I have made a small commitment to the slow protocols. I read mail in the morning, with coffee, and I do not look at it again until evening. I read my feeds on Sundays. I write back when there is something to say. I have, in this way, recovered a small island of the older internet, where the reader, and not the feed, is the unit of attention. It is a quiet place. It is a useful place. It is, increasingly, the only place I want to read.

--- a/examples/slate-journal/content/essays/walking-as-revision.md
+++ b/examples/slate-journal/content/essays/walking-as-revision.md
@@ -1,0 +1,20 @@
++++
+title = "Walking as Revision"
+description = "Why a long walk is the only editor that consistently improves my prose."
+date = "2026-03-01"
+tags = ["essays", "craft"]
++++
+
+I revise on foot. The first draft, almost always, is done at a desk, in a cramped half-hour before the day has properly begun. The revision happens on the towpath, two miles out and two miles back, with no notebook and no phone. I have come to trust this more than any of the tools that were sold to me as a way of improving my writing.
+
+The thing a walk does that an editor does not, and that a screen cannot, is set the prose against the body's own time. A sentence I would have left on the page reveals itself, around the third or fourth lamppost, as a sentence that is not quite mine. The rhythm goes wrong on the breath. The clause that looked balanced in a serif font on a backlit screen turns out, in the air, to limp. I can almost always tell where the bad sentence is, even before I can tell what is wrong with it, because the walk has changed pace.
+
+Writers have known this for a long time. Wordsworth composed on foot. Dickens walked twenty miles before breakfast. The composer Mahler set his summer house in the mountains because the work began on the walk. The pattern is too consistent to be a coincidence of temperament. I think what is happening is more concrete: the body, freed from the chair, is the editor that the mind cannot quite be.
+
+There is a useful trick here, for anyone willing to try it. Write the draft on the page. Read it once, aloud, in the room. Then leave the page on the desk, put on your shoes, and walk. Do not bring the page. Do not bring a notebook. Do not bring a phone with a voice memo app, and do not try to compose new sentences. Walk, and let the draft come back to you in whatever pieces it wants to. The sentences that come back are usually the ones that were already good. The sentences that do not come back are the ones to cut, or to rewrite, when you get home.
+
+I would not have believed this if I had not tried it. I trained as an engineer; I learned, professionally, to revise things by sitting with them at a screen for longer. Almost everything I now know about writing prose I learned by doing the opposite. Sit with the sentence for less time at the screen. Spend more time away from it. Trust the part of the mind that does its work below the level of the desk.
+
+There is, I think, a wider lesson. A great many activities improve when they are done in two media: one for production, one for review. The first medium is where the work is made. The second medium is where the work is corrected by something that the first medium could not see. For software, that second medium is often a long pause and a fresh eye in the morning. For writing, for me, it is the towpath. For other people it may be a swimming pool, a long drive, a single hour with no music. What matters is the geometry: a different room, a different rhythm, a different scale of attention.
+
+The walk is also, of course, simply good for the body. I would not want to overstate the case. But the case is real. A long walk is the only editor that has ever consistently improved my prose, and it is also the cheapest, and the kindest. I recommend it without reservation.

--- a/examples/slate-journal/content/index.md
+++ b/examples/slate-journal/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "Slate Journal"
+description = "Essays on software, attention, and the slow internet, by Augustin Park."
+template = "home"
++++
+
+A journal of essays on software, attention, and the slow internet. Written and edited by Augustin Park, who lives near a river and reads on paper when he can.

--- a/examples/slate-journal/static/css/style.css
+++ b/examples/slate-journal/static/css/style.css
@@ -1,0 +1,920 @@
+/* =========================================================================
+   Slate Journal
+   A light editorial journal. Serif body. Cool off-white background.
+   One muted slate-blue accent. No gradients. No emoji.
+   ========================================================================= */
+
+:root {
+  --bg: #fafaf8;
+  --bg-soft: #f3f1ec;
+  --ink: #171715;
+  --ink-dim: #6e6c66;
+  --rule: #dcd8d0;
+  --rule-strong: #c8c3b9;
+  --accent: #3a5a78;
+
+  --serif: "Fraunces", "EB Garamond", "Source Serif Pro", Georgia, "Times New Roman", serif;
+  --ui: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+
+  --measure: 640px;
+  --frame: 1240px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { background: var(--bg); }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--serif);
+  font-variation-settings: "opsz" 14, "SOFT" 50;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+a:hover {
+  border-bottom-color: var(--accent);
+}
+
+p { margin: 0 0 1.1em; }
+
+em, i { font-style: italic; }
+
+/* -------------------------------------------------------------------------
+   Masthead
+   ------------------------------------------------------------------------- */
+
+.masthead {
+  background: var(--bg);
+  border-bottom: 1px solid var(--rule);
+}
+
+.masthead-inner {
+  max-width: var(--frame);
+  margin: 0 auto;
+  padding: 2.4rem 2rem 1.6rem;
+  text-align: center;
+}
+
+.brand {
+  display: inline-block;
+  font-family: var(--serif);
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+  font-weight: 500;
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  border-bottom: none;
+  line-height: 1.05;
+}
+
+.brand:hover { border-bottom: none; color: var(--ink); }
+
+.brand-italic {
+  font-style: italic;
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+}
+
+.issue-line {
+  margin: 0.45rem 0 1rem;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-dim);
+}
+
+.primary-nav {
+  font-family: var(--ui);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+.primary-nav a {
+  color: var(--ink-dim);
+  border-bottom: none;
+  padding: 0 0.3rem;
+  transition: color 120ms ease;
+}
+
+.primary-nav a:hover { color: var(--accent); border-bottom: none; }
+
+.nav-sep {
+  color: var(--rule-strong);
+  margin: 0 0.15rem;
+}
+
+.bullet { color: var(--rule-strong); }
+
+/* -------------------------------------------------------------------------
+   Page frame
+   ------------------------------------------------------------------------- */
+
+.page-frame {
+  max-width: var(--frame);
+  margin: 0 auto;
+  padding: 3.5rem 2rem 4rem;
+}
+
+/* -------------------------------------------------------------------------
+   Kickers + small caps tracked metadata (UI labels)
+   ------------------------------------------------------------------------- */
+
+.kicker,
+.bio-label,
+.tag-label,
+.essay-meta-top,
+.foot-meta,
+.essay-list-meta,
+.recent-date,
+.below-date,
+.essay-tags,
+.section-rule {
+  font-family: var(--ui);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+.kicker {
+  margin: 0 0 1rem;
+  display: inline-block;
+}
+
+.section-rule {
+  display: block;
+  padding-bottom: 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+/* -------------------------------------------------------------------------
+   Home page: lead asymmetric grid
+   ------------------------------------------------------------------------- */
+
+.home {}
+
+.lead-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 3.5rem 3rem;
+  align-items: start;
+  padding-bottom: 4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 4rem;
+}
+
+.lead {
+  grid-column: span 8;
+}
+
+.lead-headline {
+  font-family: var(--serif);
+  font-variation-settings: "opsz" 144, "SOFT" 20;
+  font-weight: 400;
+  font-size: clamp(2.4rem, 5.4vw, 4.2rem);
+  line-height: 1.02;
+  letter-spacing: -0.018em;
+  margin: 0.4rem 0 1.4rem;
+  color: var(--ink);
+}
+
+.lead-headline a {
+  color: var(--ink);
+  border-bottom: none;
+}
+
+.lead-headline a:hover { color: var(--ink); border-bottom: none; }
+
+.lead-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.32rem;
+  line-height: 1.45;
+  color: var(--ink-dim);
+  max-width: 36em;
+  margin: 0 0 1.6rem;
+}
+
+.lead-meta {
+  font-family: var(--ui);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--ink-dim);
+  margin: 0 0 1.4rem;
+}
+
+.lead-meta .byline { font-style: normal; color: var(--ink); font-weight: 500; }
+
+.lead-cta {
+  font-family: var(--ui);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+.lead-cta a {
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 2px;
+}
+
+/* Side rail */
+
+.lead-side {
+  grid-column: span 4;
+  padding-left: 2rem;
+  border-left: 1px solid var(--rule);
+}
+
+.recent-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.recent-item {
+  padding: 0 0 1.5rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.recent-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin-bottom: 0;
+}
+
+.recent-date {
+  display: block;
+  margin-bottom: 0.45rem;
+}
+
+.recent-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 1.18;
+  margin: 0 0 0.5rem;
+  font-variation-settings: "opsz" 36;
+  letter-spacing: -0.01em;
+}
+
+.recent-title a { color: var(--ink); border-bottom: none; }
+.recent-title a:hover { color: var(--accent); }
+
+.recent-excerpt {
+  font-family: var(--serif);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  font-style: italic;
+  margin: 0;
+}
+
+/* -------------------------------------------------------------------------
+   Below: 3-column balanced grid
+   ------------------------------------------------------------------------- */
+
+.below-grid { margin-bottom: 4.5rem; }
+
+.below-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2.8rem;
+}
+
+.below-item {}
+
+.below-date {
+  display: block;
+  margin-bottom: 0.6rem;
+}
+
+.below-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 1.45rem;
+  line-height: 1.18;
+  margin: 0 0 0.6rem;
+  font-variation-settings: "opsz" 36;
+  letter-spacing: -0.005em;
+}
+
+.below-title a { color: var(--ink); border-bottom: none; }
+.below-title a:hover { color: var(--accent); }
+
+.below-excerpt {
+  font-family: var(--serif);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  margin: 0;
+}
+
+/* -------------------------------------------------------------------------
+   Archive pull quote
+   ------------------------------------------------------------------------- */
+
+.archive-quote {
+  margin: 4rem 0 3rem;
+  padding: 0 0 0 2rem;
+}
+
+.pull-quote-display {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.7rem, 3.3vw, 2.4rem);
+  line-height: 1.28;
+  color: var(--ink);
+  margin: 0 0 1.2rem;
+  max-width: 26em;
+  border-left: 1px solid var(--accent);
+  padding-left: 1.6rem;
+  font-variation-settings: "opsz" 72, "SOFT" 30;
+}
+
+.quote-attribution {
+  font-family: var(--ui);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  padding-left: 1.6rem;
+  margin: 0;
+}
+
+.quote-attribution a { color: var(--ink-dim); border-bottom: 1px solid var(--rule-strong); }
+.quote-attribution a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+.all-essays-link {
+  margin: 4rem 0 0;
+  padding-top: 2rem;
+  border-top: 1px solid var(--rule);
+  text-align: center;
+  font-family: var(--ui);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.all-essays-link a {
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 2px;
+}
+
+/* -------------------------------------------------------------------------
+   Essay article page (page.html)
+   ------------------------------------------------------------------------- */
+
+.essay-page {
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: 1rem 0 0;
+}
+
+.essay-meta-top {
+  margin: 0 0 1.6rem;
+}
+
+.dot {
+  color: var(--rule-strong);
+  margin: 0 0.35rem;
+}
+
+.essay-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.2rem, 4.4vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.018em;
+  margin: 0 0 1.2rem;
+  color: var(--ink);
+  font-variation-settings: "opsz" 144, "SOFT" 20;
+}
+
+.essay-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.25rem;
+  line-height: 1.45;
+  color: var(--ink-dim);
+  margin: 0 0 2rem;
+  max-width: 32em;
+}
+
+.essay-rule {
+  width: 60px;
+  height: 1px;
+  background: var(--rule-strong);
+  margin: 2rem 0 2.4rem;
+}
+
+.essay-body {
+  font-family: var(--serif);
+  font-size: 1.06rem;
+  line-height: 1.78;
+  color: var(--ink);
+}
+
+.essay-body p {
+  margin: 0 0 1.3em;
+}
+
+/* Drop cap on first paragraph of essay body */
+.essay-body > p:first-of-type::first-letter {
+  font-family: var(--serif);
+  font-style: normal;
+  font-weight: 500;
+  float: left;
+  font-size: 4.2em;
+  line-height: 0.88;
+  padding: 0.06em 0.1em 0 0;
+  margin-right: 0.05em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+}
+
+.essay-body h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.55rem;
+  line-height: 1.25;
+  margin: 2.6rem 0 1rem;
+  letter-spacing: -0.005em;
+}
+
+.essay-body h3 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 1.25rem;
+  line-height: 1.3;
+  margin: 2.2rem 0 0.8rem;
+}
+
+.essay-body blockquote {
+  margin: 2rem 0;
+  padding: 0.2rem 0 0.2rem 1.6rem;
+  border-left: 1px solid var(--accent);
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.45rem;
+  line-height: 1.4;
+  color: var(--ink);
+  font-variation-settings: "opsz" 60, "SOFT" 40;
+  max-width: 28em;
+}
+
+.essay-body blockquote p { margin: 0 0 0.6em; }
+.essay-body blockquote p:last-child { margin-bottom: 0; }
+
+.essay-body a {
+  color: var(--accent);
+  border-bottom: 1px solid var(--rule-strong);
+}
+
+.essay-body a:hover { border-bottom-color: var(--accent); }
+
+.essay-body code {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  background: var(--bg-soft);
+  padding: 0.1em 0.35em;
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.essay-body pre {
+  background: var(--bg-soft);
+  padding: 1rem 1.2rem;
+  overflow-x: auto;
+  border: 1px solid var(--rule);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.essay-body pre code {
+  background: transparent;
+  padding: 0;
+  font-size: 1em;
+}
+
+.essay-body hr {
+  border: none;
+  height: 1px;
+  background: var(--rule);
+  margin: 2.5rem 0;
+}
+
+.essay-body ul, .essay-body ol {
+  padding-left: 1.4rem;
+  margin: 0 0 1.3em;
+}
+
+.essay-body li { margin-bottom: 0.4em; }
+
+/* Tag chips on essay footer */
+.essay-tags {
+  margin: 3rem 0 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+}
+
+.essay-tags .tag-label { color: var(--ink-dim); margin-right: 0.5rem; }
+
+.essay-tags a {
+  color: var(--accent);
+  border-bottom: 1px solid var(--rule-strong);
+  margin-right: 0.2rem;
+}
+
+.essay-tags a:hover { border-bottom-color: var(--accent); }
+
+/* Author bio block */
+.author-bio {
+  margin: 2rem 0 2rem;
+  padding: 1.6rem 0 0;
+  border-top: 1px solid var(--rule);
+}
+
+.bio-label { margin: 0 0 0.6rem; }
+
+.bio-body {
+  font-family: var(--serif);
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  margin: 0;
+}
+
+.bio-body strong { color: var(--ink); font-weight: 500; }
+
+.essay-nav {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--ui);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.essay-nav a {
+  color: var(--ink-dim);
+  border-bottom: none;
+}
+
+.essay-nav a:hover { color: var(--accent); }
+
+/* -------------------------------------------------------------------------
+   Section / Archive listings
+   ------------------------------------------------------------------------- */
+
+.section-page,
+.taxonomy-page {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.section-head {
+  margin: 0 0 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.section-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.4rem, 4.6vw, 3.6rem);
+  line-height: 1.05;
+  letter-spacing: -0.018em;
+  margin: 0.4rem 0 0.8rem;
+  color: var(--ink);
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+}
+
+.section-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-dim);
+  margin: 0;
+  max-width: 36em;
+}
+
+.section-intro {
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: var(--ink);
+  margin: 0 0 2.6rem;
+  max-width: 36em;
+}
+
+.section-intro p { margin: 0 0 1em; }
+
+.essay-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.essay-list-item {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 2rem;
+  padding: 1.8rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.essay-list-item:first-child { padding-top: 0; }
+.essay-list-item:last-child { border-bottom: none; }
+
+.essay-list-rail {
+  font-family: var(--ui);
+  text-align: left;
+  padding-top: 0.4rem;
+}
+
+.rail-date {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-bottom: 0.2rem;
+}
+
+.rail-month {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+
+.essay-list-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 1.7rem;
+  line-height: 1.15;
+  margin: 0 0 0.55rem;
+  letter-spacing: -0.01em;
+  font-variation-settings: "opsz" 60;
+}
+
+.essay-list-title a { color: var(--ink); border-bottom: none; }
+.essay-list-title a:hover { color: var(--accent); }
+
+.essay-list-deck {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0 0 0.65rem;
+  max-width: 40em;
+}
+
+.essay-list-meta {
+  margin: 0;
+}
+
+.essay-list-meta a {
+  color: var(--ink-dim);
+  border-bottom: 1px solid var(--rule-strong);
+  font-family: var(--ui);
+}
+
+.essay-list-meta a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* -------------------------------------------------------------------------
+   Taxonomy tag index
+   ------------------------------------------------------------------------- */
+
+.tag-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tag-list-item {
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.tag-link {
+  font-family: var(--serif);
+  font-size: 1.6rem;
+  font-weight: 400;
+  color: var(--ink);
+  border-bottom: none;
+  font-variation-settings: "opsz" 36;
+}
+
+.tag-link:hover { color: var(--accent); }
+
+/* -------------------------------------------------------------------------
+   Pagination
+   ------------------------------------------------------------------------- */
+
+nav.pagination {
+  margin: 3rem 0 0;
+  padding-top: 2rem;
+  border-top: 1px solid var(--rule);
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  align-items: center;
+  font-family: var(--ui);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+}
+
+nav.pagination a,
+nav.pagination span {
+  display: inline-block;
+  padding: 0.35rem 0.7rem;
+  color: var(--ink-dim);
+}
+
+nav.pagination a {
+  border-bottom: 1px solid transparent;
+}
+
+nav.pagination a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.pagination-current span {
+  color: var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+
+.pagination-disabled span { opacity: 0.4; }
+
+/* -------------------------------------------------------------------------
+   Generic page (about, colophon) — reuse essay-body styling
+   ------------------------------------------------------------------------- */
+
+.essay-page .essay-body > p:first-of-type::first-letter {
+  /* keep drop cap for all pages using essay-page wrapper */
+}
+
+/* -------------------------------------------------------------------------
+   404
+   ------------------------------------------------------------------------- */
+
+.not-found {
+  max-width: var(--measure);
+  margin: 4rem auto;
+  text-align: left;
+}
+
+.nf-headline {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.4rem, 5vw, 3.8rem);
+  line-height: 1.05;
+  letter-spacing: -0.018em;
+  margin: 0.4rem 0 1.4rem;
+  color: var(--ink);
+  font-variation-settings: "opsz" 144, "SOFT" 20;
+}
+
+.nf-body {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.2rem;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0 0 2rem;
+}
+
+.nf-return {
+  font-family: var(--ui);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nf-return a {
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 2px;
+}
+
+/* -------------------------------------------------------------------------
+   Footer
+   ------------------------------------------------------------------------- */
+
+.colophon-foot {
+  border-top: 1px solid var(--rule);
+  margin-top: 4rem;
+  padding: 2.4rem 2rem 3rem;
+}
+
+.colophon-foot-inner {
+  max-width: var(--frame);
+  margin: 0 auto;
+  text-align: center;
+}
+
+.foot-italic {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-dim);
+  margin: 0 0 0.8rem;
+}
+
+.foot-meta {
+  font-family: var(--ui);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin: 0;
+}
+
+.foot-meta a {
+  color: var(--ink-dim);
+  border-bottom: 1px solid var(--rule-strong);
+}
+
+.foot-meta a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* -------------------------------------------------------------------------
+   Responsive
+   ------------------------------------------------------------------------- */
+
+@media (max-width: 960px) {
+  .lead-grid {
+    grid-template-columns: 1fr;
+    gap: 3rem;
+  }
+  .lead, .lead-side {
+    grid-column: 1 / -1;
+  }
+  .lead-side {
+    padding-left: 0;
+    padding-top: 2.5rem;
+    border-left: none;
+    border-top: 1px solid var(--rule);
+  }
+  .below-row {
+    grid-template-columns: 1fr;
+    gap: 2.4rem;
+  }
+}
+
+@media (max-width: 640px) {
+  body { font-size: 17px; }
+  .page-frame { padding: 2.4rem 1.4rem 3rem; }
+  .masthead-inner { padding: 2rem 1.4rem 1.4rem; }
+  .essay-list-item {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+  .essay-list-rail {
+    display: flex;
+    gap: 0.8rem;
+    padding-top: 0;
+  }
+  .primary-nav { font-size: 10px; }
+  .archive-quote { padding-left: 0; }
+  .essay-body > p:first-of-type::first-letter {
+    font-size: 3.4em;
+  }
+}

--- a/examples/slate-journal/templates/404.html
+++ b/examples/slate-journal/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<main class="not-found">
+  <p class="kicker">Error</p>
+  <h1 class="nf-headline">404. <em>Lost the page.</em></h1>
+  <p class="nf-body">The essay you were looking for has wandered off, or perhaps was never published here. Try the <a href="{{ base_url }}/essays/">archive</a> instead.</p>
+  <p class="nf-return"><a href="{{ base_url }}/">Return &rarr;</a></p>
+</main>
+
+{% include "footer.html" %}

--- a/examples/slate-journal/templates/footer.html
+++ b/examples/slate-journal/templates/footer.html
@@ -1,0 +1,15 @@
+  </div>
+  <footer class="colophon-foot">
+    <div class="colophon-foot-inner">
+      <p class="foot-italic"><em>Set in Fraunces. Hosted with intention.</em></p>
+      <p class="foot-meta">
+        &copy; {{ current_year }} Augustin Park <span class="bullet">&middot;</span>
+        <a href="{{ base_url }}/atom.xml">RSS</a> <span class="bullet">&middot;</span>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </p>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/slate-journal/templates/header.html
+++ b/examples/slate-journal/templates/header.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page is defined and page.description is defined %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page is defined and page.title is defined %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,300..700,0..100;1,9..144,300..700,0..100&family=Inter:wght@400;500;600&display=swap">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_tags | safe }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{% if page is defined %}{{ page.section }}{% endif %}">
+  <header class="masthead">
+    <div class="masthead-inner">
+      <a href="{{ base_url }}/" class="brand">Slate <span class="brand-italic">Journal</span></a>
+      <p class="issue-line">Vol. III <span class="bullet">&middot;</span> Issue 04 <span class="bullet">&middot;</span> Summer 2026</p>
+      <nav class="primary-nav">
+        <a href="{{ base_url }}/essays/">Essays</a>
+        <span class="nav-sep">&middot;</span>
+        <a href="{{ base_url }}/about/">About</a>
+        <span class="nav-sep">&middot;</span>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+        <span class="nav-sep">&middot;</span>
+        <a href="{{ base_url }}/atom.xml">RSS</a>
+      </nav>
+    </div>
+  </header>
+  <div class="page-frame">

--- a/examples/slate-journal/templates/home.html
+++ b/examples/slate-journal/templates/home.html
@@ -1,0 +1,86 @@
+{% include "header.html" %}
+{% set essays = get_section(path="essays/_index.md") %}
+{% set pages = essays.pages | sort(attribute="date") | reverse %}
+
+<main class="home">
+  {% if pages | length > 0 %}
+    {% set lead = pages | first %}
+    <section class="lead-grid">
+      <article class="lead">
+        <p class="kicker">The Lead Essay <span class="bullet">&middot;</span> {{ lead.date | date(format="%B %Y") }}</p>
+        <h1 class="lead-headline">
+          <a href="{{ base_url }}{{ lead.url }}">
+            {{ lead.title }}
+          </a>
+        </h1>
+        {% if lead.description %}
+          <p class="lead-deck"><em>{{ lead.description }}</em></p>
+        {% endif %}
+        <p class="lead-meta">
+          <span class="byline">By Augustin Park</span>
+          <span class="bullet">&middot;</span>
+          <time>{{ lead.date | date(format="%B %-d, %Y") }}</time>
+          {% if lead.reading_time %}
+            <span class="bullet">&middot;</span>
+            <span>{{ lead.reading_time }} min read</span>
+          {% endif %}
+        </p>
+        <p class="lead-cta"><a href="{{ base_url }}{{ lead.url }}">Read the essay &rarr;</a></p>
+      </article>
+
+      <aside class="lead-side">
+        <p class="kicker">Recent</p>
+        <ol class="recent-list">
+          {% for p in pages | slice(start=1, end=3) %}
+            <li class="recent-item">
+              <time class="recent-date">{{ p.date | date(format="%b %-d, %Y") }}</time>
+              <h2 class="recent-title">
+                <a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a>
+              </h2>
+              {% if p.description %}
+                <p class="recent-excerpt">{{ p.description }}</p>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ol>
+      </aside>
+    </section>
+
+    {% if pages | length > 3 %}
+      <section class="below-grid">
+        <p class="kicker section-rule">Further Reading</p>
+        <div class="below-row">
+          {% for p in pages | slice(start=3, end=6) %}
+            <article class="below-item">
+              <time class="below-date">{{ p.date | date(format="%b %-d, %Y") }}</time>
+              <h3 class="below-title">
+                <a href="{{ base_url }}{{ p.url }}"><em>{{ p.title }}</em></a>
+              </h3>
+              {% if p.description %}
+                <p class="below-excerpt">{{ p.description }}</p>
+              {% endif %}
+            </article>
+          {% endfor %}
+        </div>
+      </section>
+    {% endif %}
+
+    <section class="archive-quote">
+      <p class="kicker section-rule">From the Archive</p>
+      <blockquote class="pull-quote-display">
+        A slow protocol is one that waits for the reader, and trusts the reader's pace. A loud protocol is one that interrupts the reader, and distrusts the reader's pace.
+      </blockquote>
+      <p class="quote-attribution">
+        &mdash; <a href="{{ base_url }}/essays/the-quiet-protocols/">The Quiet Protocols</a>, May 2026
+      </p>
+    </section>
+
+    <section class="all-essays-link">
+      <a href="{{ base_url }}/essays/">All essays in the archive &rarr;</a>
+    </section>
+  {% else %}
+    <p>No essays yet.</p>
+  {% endif %}
+</main>
+
+{% include "footer.html" %}

--- a/examples/slate-journal/templates/page.html
+++ b/examples/slate-journal/templates/page.html
@@ -1,0 +1,50 @@
+{% include "header.html" %}
+
+<main class="essay-page">
+  <article class="essay">
+    {% if page.section == "essays" %}
+      <p class="essay-meta-top">
+        ESSAY
+        <span class="dot">&middot;</span>
+        {{ page.date | date(format="%Y.%m.%d") }}
+        {% if page.reading_time %}
+          <span class="dot">&middot;</span>
+          {{ page.reading_time }} MIN
+        {% endif %}
+      </p>
+    {% endif %}
+
+    <h1 class="essay-title">{{ page.title }}</h1>
+
+    {% if page.description %}
+      <p class="essay-deck"><em>{{ page.description }}</em></p>
+    {% endif %}
+
+    <div class="essay-rule"></div>
+
+    <div class="essay-body">
+      {{ content | safe }}
+    </div>
+
+    {% if page.tags %}
+      <p class="essay-tags">
+        <span class="tag-label">Filed under</span>
+        {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/"><em>{{ tag }}</em></a>{% if not loop.last %},{% endif %}
+        {% endfor %}
+      </p>
+    {% endif %}
+
+    <aside class="author-bio">
+      <p class="bio-label">About the author</p>
+      <p class="bio-body"><strong>Augustin Park</strong> writes essays on software, attention, and the slow internet. He lives in a small river town and answers letters in the order they arrive.</p>
+    </aside>
+
+    <nav class="essay-nav">
+      <a href="{{ base_url }}/essays/">&larr; All essays</a>
+      <a href="{{ base_url }}/">Return to cover</a>
+    </nav>
+  </article>
+</main>
+
+{% include "footer.html" %}

--- a/examples/slate-journal/templates/section.html
+++ b/examples/slate-journal/templates/section.html
@@ -1,0 +1,47 @@
+{% include "header.html" %}
+
+<main class="section-page">
+  <header class="section-head">
+    <p class="kicker">The Archive</p>
+    <h1 class="section-title"><em>{{ section.title }}</em></h1>
+    {% if section.description %}
+      <p class="section-deck">{{ section.description }}</p>
+    {% endif %}
+  </header>
+
+  {% if content %}
+    <div class="section-intro">
+      {{ content | safe }}
+    </div>
+  {% endif %}
+
+  <ol class="essay-list">
+    {% for p in section.pages | sort(attribute="date") | reverse %}
+      <li class="essay-list-item">
+        <div class="essay-list-rail">
+          <time class="rail-date">{{ p.date | date(format="%Y") }}</time>
+          <span class="rail-month">{{ p.date | date(format="%b %-d") }}</span>
+        </div>
+        <div class="essay-list-body">
+          <h2 class="essay-list-title">
+            <a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a>
+          </h2>
+          {% if p.description %}
+            <p class="essay-list-deck"><em>{{ p.description }}</em></p>
+          {% endif %}
+          <p class="essay-list-meta">
+            {% if p.reading_time %}{{ p.reading_time }} min read{% endif %}
+            {% if p.tags %}
+              <span class="dot">&middot;</span>
+              {% for tag in p.tags %}<a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+            {% endif %}
+          </p>
+        </div>
+      </li>
+    {% endfor %}
+  </ol>
+
+  {{ pagination }}
+</main>
+
+{% include "footer.html" %}

--- a/examples/slate-journal/templates/shortcodes/alert.html
+++ b/examples/slate-journal/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/slate-journal/templates/taxonomy.html
+++ b/examples/slate-journal/templates/taxonomy.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<main class="taxonomy-page">
+  <header class="section-head">
+    <p class="kicker">Index</p>
+    <h1 class="section-title"><em>Tags</em></h1>
+    <p class="section-deck">Essays gathered by subject.</p>
+  </header>
+
+  <ul class="tag-list">
+    {% if terms is defined %}
+      {% for term in terms %}
+        <li class="tag-list-item">
+          <a href="{{ base_url }}/{{ taxonomy }}/{{ term }}/" class="tag-link">
+            <em>{{ term }}</em>
+          </a>
+        </li>
+      {% endfor %}
+    {% endif %}
+  </ul>
+</main>
+
+{% include "footer.html" %}

--- a/examples/slate-journal/templates/taxonomy_term.html
+++ b/examples/slate-journal/templates/taxonomy_term.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+
+<main class="taxonomy-page">
+  <header class="section-head">
+    <p class="kicker">Tagged</p>
+    <h1 class="section-title"><em>{{ page.title }}</em></h1>
+    <p class="section-deck">Every essay filed under this subject.</p>
+  </header>
+
+  <ol class="essay-list">
+    {% if pages is defined %}
+      {% for p in pages %}
+        <li class="essay-list-item">
+          <div class="essay-list-rail">
+            <time class="rail-date">{{ p.date | date(format="%Y") }}</time>
+            <span class="rail-month">{{ p.date | date(format="%b %-d") }}</span>
+          </div>
+          <div class="essay-list-body">
+            <h2 class="essay-list-title">
+              <a href="{{ base_url }}{{ p.url }}">{{ p.title }}</a>
+            </h2>
+            {% if p.description %}
+              <p class="essay-list-deck"><em>{{ p.description }}</em></p>
+            {% endif %}
+          </div>
+        </li>
+      {% endfor %}
+    {% endif %}
+  </ol>
+</main>
+
+{% include "footer.html" %}

--- a/examples/terra-folio/AGENTS.md
+++ b/examples/terra-folio/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter can use TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start) — TOML is the default.
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/terra-folio/archetypes/default.md
+++ b/examples/terra-folio/archetypes/default.md
@@ -1,0 +1,15 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
+
+[extra]
+client = ""
+year = 2026
+discipline = ""
+swatch = "#a14732"
++++
+
+{{ title }}

--- a/examples/terra-folio/config.toml
+++ b/examples/terra-folio/config.toml
@@ -1,0 +1,187 @@
+title = "Terra Folio"
+description = "Selected work, 2018–2026. Identity, editorial, and packaging by Iris Voronova."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = true
+per_page = 12
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Personal portfolio. Please credit Iris Voronova when referencing."
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = ["work"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/terra-folio/content/about.md
+++ b/examples/terra-folio/content/about.md
@@ -1,0 +1,14 @@
++++
+title = "About"
+description = "About Iris Voronova — a designer working in identity, editorial, and packaging from Lisbon."
++++
+
+I am a designer working independently from a small studio above a flower shop in Príncipe Real, Lisbon. My work is mostly print, mostly typography-driven, and almost always made in close conversation with the people who will live with it afterwards. I care about books, careful logotypes, restrained colour, and packaging that does not lie about what is inside.
+
+Before going out on my own in 2018, I spent four years at Atelier Carvalho Bernau in The Hague, where I learned to set a paragraph and to argue politely about a comma. I trained in graphic design at the Royal Academy of Art in The Hague and, before that, studied printmaking in Saint Petersburg, where I am from. I still keep a small Adana 8x5 press here in the studio, and most projects begin with a few proofs pulled by hand before anything goes near a screen.
+
+The studio is intentionally small — usually it is just me, sometimes with one collaborator on a long project. I take on three or four engagements a year, which lets each one go deep. I work most often with independent publishers, small food and ceramics makers, cultural institutions, and the occasional festival. I prefer relationships that last several seasons over single deliverables, and I am most useful when a client wants to think about the whole identity rather than a single artefact.
+
+I lecture twice a year at ESAD.cr in Caldas da Rainha, where I run a short workshop on editorial systems. My work has been shown at the Brno Biennial and the Lisbon Architecture Triennale, and Foundling Press published a short monograph of selected logotypes in 2024. None of that feels as important to me as the morning a client opens a finished book.
+
+If we have not met, the easiest way to begin is a short email. I read everything, and I reply within a week, even to say no.

--- a/examples/terra-folio/content/contact.md
+++ b/examples/terra-folio/content/contact.md
@@ -1,0 +1,14 @@
++++
+title = "Contact"
+description = "Get in touch with the studio."
++++
+
+The studio is open for new work from late summer 2026. Identity systems, editorial commissions, and packaging are the engagements I am best at — please write with a short note about what you are making and the season you have in mind.
+
+**Email** — iris@terrafolio.studio
+
+**Studio** — Rua da Rosa 224, 2.º andar, 1200-389 Lisboa, Portugal
+
+**Hours** — Tuesday to Friday, 10:00 — 18:00 WET. Visits by appointment.
+
+For press and lecture requests, please write to the same address with "press" in the subject line. I do not take on logo-only commissions, and I do not work on spec.

--- a/examples/terra-folio/content/index.md
+++ b/examples/terra-folio/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Iris Voronova"
+description = "Selected work, 2018–2026. Identity, editorial, and packaging."
+template = "home"
++++

--- a/examples/terra-folio/content/work/_index.md
+++ b/examples/terra-folio/content/work/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Work"
+description = "Selected projects, 2018 to present."
+sort_by = "date"
+reverse = true
+paginate = 12
++++
+
+A working archive of recent commissions. Most pieces here were made between 2023 and 2026; the older work lives in a printed monograph available on request.

--- a/examples/terra-folio/content/work/cadence-festival.md
+++ b/examples/terra-folio/content/work/cadence-festival.md
@@ -1,0 +1,22 @@
++++
+title = "Cadence Festival"
+date = "2025-06-18"
+description = "A flexible identity for a three-day chamber music festival in the Douro valley, anchored by a single warm ochre and a rotating set of metronome marks."
+tags = ["identity"]
+
+[extra]
+client = "Cadence Festival"
+year = 2025
+discipline = "Identity"
+swatch = "#d09a3c"
++++
+
+Cadence is a small chamber music festival held each June in a working vineyard above the Douro. The 2025 edition was its fifth, and the founders — a violinist and a winemaker who married during the second edition — felt the previous identity, designed quickly in 2021, had become too literal. They wanted something that could survive being silkscreened onto a wine label and being printed onto a programme booklet without losing its own personality.
+
+The mark we landed on is a small triangular metronome figure that rotates by a few degrees each year, marking the tempo of that season's programming. In 2025 the angle is twelve degrees, which the violinist tells me corresponds, roughly, to a moderately slow lento. In 2026 it will tilt to twenty-two. The angle is not a gimmick. It gives each year of the festival a distinct silhouette while keeping the underlying identity continuous, and it gave the founders a small annual ritual they enjoy.
+
+We paired the mark with a single typeface, GT Sectra, set tightly in a warm ochre against an uncoated cream stock for everything printed. The website uses the same ochre on a near-identical cream, and the only photograph in the entire system is a single image of the vineyard at dusk on the opening evening, used once on the programme cover and nowhere else.
+
+The most difficult part of the project was negotiating with the festival's three sponsors, who each wanted their logos at sizes that would have crushed the cover. We solved this by treating sponsor marks as part of a stamped "colophon block" on the back of every artefact, set in a single small size in a single small colour, the way a publisher would handle a co-imprint. The sponsors agreed, the cover stayed clean, and we have used the same block on each programme since.
+
+The 2026 edition is in production now. The metronome tilts further this year, but the wordmark, the ochre, and the cream are exactly where we left them.

--- a/examples/terra-folio/content/work/foundling-press.md
+++ b/examples/terra-folio/content/work/foundling-press.md
@@ -1,0 +1,22 @@
++++
+title = "Foundling Press"
+date = "2026-03-14"
+description = "A new identity for an independent publisher of essays and translated fiction, built around a single hand-drawn ligature."
+tags = ["identity", "print"]
+
+[extra]
+client = "Foundling Press"
+year = 2026
+discipline = "Identity"
+swatch = "#a14732"
++++
+
+Foundling Press came to the studio in the autumn of 2025 with a small but pressing problem. After eight years of publishing essays and translated short fiction out of a flat in Porto, they were preparing to release their first hardcover novel and felt the existing mark — a serviceable wordmark drawn quickly in 2017 — no longer carried the weight of the catalogue. They wanted an identity that could sit on a paperback spine and a cloth-bound dust jacket without apology, and that could carry a translated author from Lithuanian into the hands of a reader in Lisbon.
+
+We began with the spine. Most publishers begin with the cover, but Foundling's books live shelved, edge-out, and the spine is the surface a reader actually meets first. The new mark is a single ligature of the lowercase **f** and **p**, drawn by hand and then refined over six weeks of proofs. The crossbar of the **f** slips under the bowl of the **p** and gives the pair a slight forward lean, which reads, to my eye, like a small bow.
+
+The wider system is built from one serif, Bely, used at three carefully measured sizes, and a single accent colour — a burnt brick pulled from a 1930s edition of *Konstantin Vaginov* that the publisher keeps on her desk. There are no secondary colours, no patterns, and no photographs in the identity. Everything that needed visual energy was given over to the books themselves.
+
+We delivered the system across a year's worth of titles — six paperbacks, two hardcovers, a quarterly newsletter, the website, and a small set of stationery — along with a 32-page manual that doubles as a typesetting guide for the in-house editor. The press now sets each book without our involvement, which was the goal from the beginning.
+
+The most useful thing I learned on this project was to trust a single ligature to do most of the work. We sketched maybe eighty variants before returning to the second one I drew. That is, I think, how most good marks happen: you find them early and then spend three months earning the right to keep them.

--- a/examples/terra-folio/content/work/halcyon-ceramics.md
+++ b/examples/terra-folio/content/work/halcyon-ceramics.md
@@ -1,0 +1,22 @@
++++
+title = "Halcyon Ceramics"
+date = "2024-04-08"
+description = "Identity and packaging for a two-person ceramics studio outside Caldas da Rainha, built around a single hand-cut wood stamp."
+tags = ["identity", "packaging"]
+
+[extra]
+client = "Halcyon Ceramics"
+year = 2024
+discipline = "Packaging"
+swatch = "#7d5a44"
++++
+
+Halcyon is a ceramics studio run by Tomás and Mariana in a converted stable outside Caldas da Rainha. They throw stoneware vessels — bowls, jars, simple plates — in a quiet, terracotta-brown clay they dig themselves twice a year from a friend's land in the Tejo valley. They came to us in late 2023 with a single, very specific request: an identity that could be stamped, by them, onto every piece, every box, and every invoice, without any digital intermediary.
+
+We made them a wood block. The mark is a small lowercase **h** with an extended descender that curves under the rest of the letter, drawn in a way that survives being cut into end-grain maple by a friend of the studio who runs a small letterpress shop in Lisbon. The block exists in two sizes — one for vessels, one for paper goods — and Tomás presses each one by hand. There is no digital version of the mark for general use. Each pressing is therefore slightly different, and the variation is part of the identity.
+
+The packaging is brown corrugated board with a single strip of unbleached cotton tape, hand-tied. Each box is stamped twice — once on the lid with the wordmark, once inside with the name of the maker, the date, and the field the clay was dug from. Customers have told the studio they keep the box, which is what we hoped.
+
+The wordmark is set in Caslon, the only typeface in the system. It appears on the website (where the stamp also lives, photographed on a single sheet of stoneware-coloured paper), on invoices, and on a small printed price list. There is no secondary palette and no patterns. The clay, the cotton, and the wood block are the identity, and everything else is set quietly out of the way.
+
+What I learned on this project is that the right answer is sometimes to make less, and to make it by hand. We could have delivered a perfectly serviceable digital identity in two weeks. Instead we spent eight weeks finding a friend with a sharp knife, and the studio now has something that cannot be copy-pasted.

--- a/examples/terra-folio/content/work/north-light.md
+++ b/examples/terra-folio/content/work/north-light.md
@@ -1,0 +1,22 @@
++++
+title = "North Light"
+date = "2025-10-02"
+description = "Packaging for a small-batch candle brand made in the Alentejo, built around a quiet wordmark and uncoated kraft tubes."
+tags = ["packaging"]
+
+[extra]
+client = "North Light Atelier"
+year = 2025
+discipline = "Packaging"
+swatch = "#2c3b3a"
++++
+
+North Light is a two-person candle workshop in Vila Nova de Milfontes that pours soy wax in tin from beeswax recovered from an apiary forty kilometres inland. The founders, Inês and Marc, came to us in the spring of 2025 after eighteen months of selling out of the same plain brown tubes at every market they attended. They wanted to look like a small house, not a startup, and they did not want a single illustration of a candle anywhere near the box.
+
+We made them a wordmark first, set in Söhne, and a flat blue-green pulled from a fragment of fishing-boat hull paint we photographed on the beach below their workshop. The colour appears nowhere on the packaging itself — it lives only on the inside of each lid, so that a customer opens a kraft tube and meets the colour as a small surprise. The exterior is uncoated brown board with a single line of text letterpressed in dark ink: the product name, the weight, and the words "made in the Alentejo."
+
+The system extends to a small set of inserts — a stiff card with the burn instructions, a slim folded leaflet on the wax sourcing, and a return slip for the glass vessel, which the studio refills at a discount. Each insert uses the same one-colour scheme on the same board, and the leaflets are folded by hand at the workshop.
+
+What I am proudest of is the restraint. There is no varnish, no spot foil, no inner liner. The whole identity reads at a market table from three metres away because the box looks like an honest box, and it reads in a customer's hand because the inside of the lid is the colour of the sea behind the workshop.
+
+The brand grew by 60% in the year after launch, which is gratifying but, more importantly, the founders did not have to redesign anything when they added a second scent. The system simply absorbed it.

--- a/examples/terra-folio/content/work/orchard-quarterly.md
+++ b/examples/terra-folio/content/work/orchard-quarterly.md
@@ -1,0 +1,22 @@
++++
+title = "Orchard Quarterly"
+date = "2024-11-20"
+description = "An editorial redesign for a slow-food magazine published in Galway, with a new grid, a single display serif, and pull quotes set as marginalia."
+tags = ["editorial", "print"]
+
+[extra]
+client = "Orchard Quarterly"
+year = 2024
+discipline = "Editorial"
+swatch = "#5e6b3a"
++++
+
+Orchard Quarterly is a small, beautifully ambitious magazine about food, agriculture, and ecology that has been published from Galway since 2019. The founding editor, Niamh, took it over from her predecessor in late 2023 and asked the studio for a redesign that could carry the magazine into its next decade without abandoning the readers it had already collected. We worked on the redesign across the summer of 2024 and shipped with the autumn issue, which closes our involvement.
+
+The previous design was lovely but crowded — three-column features, a different display face every issue, and pull quotes treated as architectural events that broke the reading flow. We replaced all of it with a single, well-mannered grid: a wide reading column for the body, set in Lyon Text at a comfortable 11pt over 16pt of leading, with a generous outer margin that does most of the typographic work. Pull quotes, captions, and small graphics live in that margin as honest marginalia, the way they would in a 1960s scholarly journal.
+
+There is one display serif — Tiempos Headline — and one accent colour, a deep olive pulled from a photograph of a Galway hedge in late October. Everything else is black ink on cream uncoated stock. The cover treatment is consistent issue to issue: a single full-bleed photograph, the masthead set small in the top left, and the issue's table of contents printed in full down the right-hand side, the way *Granta* used to handle it.
+
+The decision that made the rest of the redesign possible was a structural one rather than a typographic one. We persuaded the editorial team to commit to a fixed page count per section, which made the layout templates radically simpler and shaved roughly a week off each issue's production. The art director told me afterwards that this was the single most useful gift the redesign gave her, which was satisfying to hear.
+
+I am sad we are not designing the magazine ongoing — Niamh has hired a wonderful in-house designer who is taking it on from issue ten — but I am glad the system is small enough that a single person can hold all of it in her head. That is what an editorial redesign is for.

--- a/examples/terra-folio/content/work/the-quiet-issue.md
+++ b/examples/terra-folio/content/work/the-quiet-issue.md
@@ -1,0 +1,22 @@
++++
+title = "The Quiet Issue"
+date = "2023-09-12"
+description = "A standalone book commissioned by a Lisbon contemporary art space, designed around silence, breath, and a single deep blue."
+tags = ["book", "editorial"]
+
+[extra]
+client = "Galeria Maumaus"
+year = 2023
+discipline = "Book"
+swatch = "#3b4a5e"
++++
+
+*The Quiet Issue* was a one-off book commissioned by Galeria Maumaus in Lisbon to mark the closing of a year-long programme on silence in contemporary art. The brief was unusually open: design a book that "reads like the experience of standing in the empty gallery before the doors open." The director, João, and the curator, Sofia, gave us six months and a small budget. We took both happily.
+
+The decision that shaped the rest of the project was made early. We persuaded the editors to remove three of the thirteen commissioned essays — not because the essays were weak but because the book did not have room for all of them. The remaining ten essays were given full breathing room: each one opens on a recto, after a verso left almost entirely blank, with only the essay number set small in the bottom outer corner. The body is set in Plantin at 10pt over 17pt of leading, which is loose for the size and was the single most argued-about decision in production. I think we got it right.
+
+The book is bound in a deep navy cloth — the only colour in the entire object besides the cream of the paper and the black of the ink — with a blind-debossed title on the front cover. There is no jacket. The endpapers are the same navy as the cloth, which gives the opening of the book a small moment of resistance before the reader meets the title page.
+
+We printed 800 copies at Maiadouro in Porto, on a Munken Pure 120gsm body and a 240gsm cover. The print is offset, two colours throughout — black for the text, a slightly cooler black for the photographs — and the entire book uses a single grid. There are no captions in the running text. Captions live in a 24-page index at the back, which the curator and I built together over a long afternoon in her kitchen.
+
+The book sold out within four months, which surprised everyone, and a second edition was printed in the spring of 2024 without changes. I am still in touch with João and Sofia, and we are slowly working on a second project, which I cannot yet describe.

--- a/examples/terra-folio/static/css/style.css
+++ b/examples/terra-folio/static/css/style.css
@@ -1,0 +1,624 @@
+/* =============================================================================
+   Terra Folio — Iris Voronova
+   Warm cream + serif italic display, asymmetric editorial portfolio.
+   No gradients. No emoji. Solid colors only.
+============================================================================= */
+
+:root {
+  --cream:        #f3eee5;
+  --cream-deep:   #ece5d6;
+  --hairline:     #d9d2c4;
+  --ink:          #1a1612;
+  --ink-soft:     #4a423a;
+  --ink-mute:     #7a6f63;
+  --accent:       #a14732; /* burnt sienna — use sparingly */
+  --serif:        "Fraunces", "Cormorant Garamond", "DM Serif Display", Georgia, "Times New Roman", serif;
+  --sans:         "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --measure:      62ch;
+  --pad-x:        clamp(1.25rem, 5vw, 3rem);
+  --section-gap:  clamp(64px, 12vw, 160px);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--cream);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.65;
+  font-weight: 400;
+  font-variant-numeric: oldstyle-nums;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+img, svg { max-width: 100%; display: block; }
+
+a {
+  color: var(--ink);
+  text-decoration: none;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 1px;
+  transition: color 200ms ease;
+}
+a:hover { color: var(--accent); }
+main a:not([class]) {
+  border-bottom: 1px solid var(--hairline);
+}
+main a:not([class]):hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+p { margin: 0 0 1.1em; }
+
+/* ---------------------------------------------------------------------------
+   Typography
+--------------------------------------------------------------------------- */
+h1, h2, h3, h4 {
+  font-family: var(--serif);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+  margin: 0 0 0.5em;
+  color: var(--ink);
+}
+h1 { font-size: clamp(2.4rem, 6vw, 4.4rem); }
+h2 { font-size: clamp(1.7rem, 3.6vw, 2.6rem); }
+h3 { font-size: 1.35rem; }
+
+em { font-style: italic; }
+
+.eyebrow {
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-mute);
+  margin: 0 0 1.25rem;
+  font-weight: 500;
+}
+
+.smallcaps {
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-mute);
+  font-weight: 500;
+}
+
+/* ---------------------------------------------------------------------------
+   Header
+--------------------------------------------------------------------------- */
+.site-header {
+  border-bottom: 1px solid var(--hairline);
+  background: var(--cream);
+}
+.site-header__inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 1.75rem var(--pad-x);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+.brand {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  color: var(--ink);
+}
+.brand__name {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+}
+.brand__mark {
+  color: var(--ink-mute);
+  font-size: 0.9rem;
+}
+.brand__loc {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.site-nav {
+  display: flex;
+  gap: 1.6rem;
+}
+.site-nav a {
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.site-nav a:hover { color: var(--accent); }
+
+/* ---------------------------------------------------------------------------
+   Home
+--------------------------------------------------------------------------- */
+.home {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: var(--section-gap) var(--pad-x);
+}
+
+.intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  margin-bottom: var(--section-gap);
+}
+.intro__lede {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(1.9rem, 4.6vw, 3.4rem);
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  max-width: 22ch;
+  margin: 0;
+  color: var(--ink);
+}
+.intro__lede em {
+  font-style: italic;
+}
+
+.selected__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-top: 1px solid var(--hairline);
+  padding-top: 1.25rem;
+  margin-bottom: 2.5rem;
+}
+.selected__count {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+.works {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(2.5rem, 6vw, 4.5rem);
+}
+
+.work {
+  border-top: 1px solid var(--hairline);
+  padding-top: 2rem;
+}
+
+.work__link {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  color: var(--ink);
+  transition: transform 200ms ease;
+}
+.work__link:hover { transform: translateY(-2px); color: var(--ink); }
+.work__link:hover .work__title { text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 6px; }
+
+.work__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.work__title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.4rem, 6vw, 4.6rem);
+  line-height: 0.98;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.work__title em { font-style: italic; }
+.work__discipline {
+  font-family: var(--sans);
+  color: var(--ink-soft);
+  margin: 0;
+  font-size: 0.95rem;
+}
+.work__discipline em {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink);
+}
+.work__swatch {
+  height: 280px;
+  width: 100%;
+  background-color: var(--ink-mute);
+  border: 1px solid var(--hairline);
+}
+
+@media (min-width: 760px) {
+  .work__link {
+    grid-template-columns: 7fr 5fr;
+    grid-template-areas:
+      "meta meta"
+      "title swatch"
+      "disc swatch";
+    column-gap: 2.5rem;
+    row-gap: 1rem;
+    align-items: end;
+  }
+  .work__meta { grid-area: meta; }
+  .work__title { grid-area: title; }
+  .work__discipline { grid-area: disc; }
+  .work__swatch { grid-area: swatch; height: 280px; align-self: end; }
+}
+
+.currently {
+  margin-top: var(--section-gap);
+  padding-top: 2rem;
+  border-top: 1px solid var(--hairline);
+}
+.currently__line {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
+  color: var(--ink-soft);
+  margin-top: 0.6rem;
+}
+.currently__line a {
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent);
+}
+
+/* ---------------------------------------------------------------------------
+   Case study (page.html)
+--------------------------------------------------------------------------- */
+.case {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: var(--section-gap) var(--pad-x);
+}
+.case__header {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  max-width: 60ch;
+  margin-bottom: 3rem;
+}
+.case__title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.8rem, 7vw, 5.4rem);
+  line-height: 1.0;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.case__title em { font-style: italic; }
+.case__client {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 1.15rem;
+  margin-top: 0.6rem;
+}
+.case__swatch {
+  width: 100%;
+  height: clamp(280px, 42vw, 400px);
+  border: 1px solid var(--hairline);
+  margin-bottom: 3rem;
+}
+.case__details {
+  border-top: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--hairline);
+  padding: 1.5rem 0;
+  margin-bottom: 3rem;
+}
+.case__details dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  margin: 0;
+}
+.case__details dt {
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 0.35rem;
+}
+.case__details dd {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 1.1rem;
+  font-style: italic;
+  color: var(--ink);
+}
+.case__details dd a { color: var(--accent); }
+
+.case__body {
+  max-width: var(--measure);
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--ink-soft);
+}
+.case__body p { margin: 0 0 1.4em; }
+.case__body p:first-of-type::first-line { color: var(--ink); }
+.case__body strong { color: var(--ink); font-weight: 600; }
+.case__body em { font-family: var(--serif); font-style: italic; color: var(--ink); }
+.case__body h2, .case__body h3 { color: var(--ink); margin-top: 2.5rem; }
+
+.case__nav {
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--hairline);
+  font-family: var(--sans);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.case__nav a { color: var(--ink-soft); }
+.case__nav a:hover { color: var(--accent); }
+
+/* Generic page (about / contact) */
+.page__header {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: var(--section-gap) var(--pad-x) 1rem;
+}
+.page__title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.6rem, 6vw, 4.8rem);
+  margin: 0 0 0.5rem;
+}
+.page__title em { font-style: italic; }
+.page__desc {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 1.15rem;
+  max-width: 50ch;
+}
+.page__body {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 var(--pad-x) var(--section-gap);
+}
+.page__body > * { max-width: var(--measure); }
+.page__body p { font-size: 1.05rem; line-height: 1.8; color: var(--ink-soft); margin-bottom: 1.4em; }
+.page__body strong { color: var(--ink); font-weight: 600; }
+.page__body a { color: var(--accent); border-bottom: 1px solid var(--hairline); }
+.page__body a:hover { border-bottom-color: var(--accent); }
+
+/* ---------------------------------------------------------------------------
+   Section index (work/)
+--------------------------------------------------------------------------- */
+.section {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: var(--section-gap) var(--pad-x);
+}
+.section__header {
+  margin-bottom: 3rem;
+  border-bottom: 1px solid var(--hairline);
+  padding-bottom: 2rem;
+}
+.section__title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.6rem, 7vw, 5rem);
+  line-height: 1.0;
+  margin: 0 0 0.75rem;
+}
+.section__title em { font-style: italic; }
+.section__desc {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 1.2rem;
+  max-width: 50ch;
+}
+.section__intro {
+  margin-top: 1.2rem;
+  max-width: var(--measure);
+  color: var(--ink-soft);
+}
+
+.works--grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(2.5rem, 5vw, 4rem);
+}
+@media (min-width: 760px) {
+  .works--grid { grid-template-columns: 1fr 1fr; }
+}
+
+/* ---------------------------------------------------------------------------
+   Taxonomy & 404
+--------------------------------------------------------------------------- */
+.taxonomy {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: var(--section-gap) var(--pad-x);
+}
+.taxonomy__list ul, .taxonomy__terms ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+.taxonomy__list li, .taxonomy__terms li {
+  border-top: 1px solid var(--hairline);
+  padding: 0.9rem 0;
+  font-family: var(--serif);
+  font-size: 1.2rem;
+}
+.taxonomy__list li:last-child, .taxonomy__terms li:last-child {
+  border-bottom: 1px solid var(--hairline);
+}
+.taxonomy__list a, .taxonomy__terms a {
+  color: var(--ink);
+  font-style: italic;
+}
+.taxonomy__list a:hover, .taxonomy__terms a:hover { color: var(--accent); }
+
+.notfound {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: calc(var(--section-gap) * 1.2) var(--pad-x);
+  text-align: left;
+}
+.notfound__title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(3rem, 8vw, 5.5rem);
+  margin: 0 0 1.2rem;
+}
+.notfound__title em { font-style: italic; }
+.notfound__line {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.25rem;
+  color: var(--ink-soft);
+}
+.notfound__line a { color: var(--accent); border-bottom: 1px solid var(--accent); }
+
+/* ---------------------------------------------------------------------------
+   Pagination
+--------------------------------------------------------------------------- */
+nav.pagination { margin: 3rem 0 0; }
+nav.pagination .pagination-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-family: var(--sans);
+  font-size: 0.85rem;
+}
+nav.pagination a {
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--hairline);
+  color: var(--ink-soft);
+}
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+.pagination-current span {
+  display: inline-block;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--ink);
+  background: var(--cream-deep);
+  color: var(--ink);
+}
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--hairline);
+  color: var(--ink-mute);
+  opacity: 0.6;
+}
+
+/* ---------------------------------------------------------------------------
+   Footer
+--------------------------------------------------------------------------- */
+.site-footer {
+  border-top: 1px solid var(--hairline);
+  margin-top: var(--section-gap);
+  background: var(--cream);
+}
+.site-footer__inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 3rem var(--pad-x);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+}
+@media (min-width: 760px) {
+  .site-footer__inner {
+    grid-template-columns: 1fr auto 1fr;
+    align-items: baseline;
+  }
+}
+.colophon {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-soft);
+  margin: 0;
+}
+.site-footer__links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1.5rem;
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.site-footer__links a { color: var(--ink-soft); }
+.site-footer__links a:hover { color: var(--accent); }
+.copyright {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  color: var(--ink-mute);
+  margin: 0;
+  text-align: right;
+}
+@media (max-width: 759px) {
+  .copyright { text-align: left; }
+}
+
+/* ---------------------------------------------------------------------------
+   Code
+--------------------------------------------------------------------------- */
+code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--cream-deep);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--hairline);
+}
+pre {
+  background: var(--cream-deep);
+  border: 1px solid var(--hairline);
+  padding: 1.2rem;
+  overflow-x: auto;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+pre code { background: transparent; border: none; padding: 0; }
+
+/* ---------------------------------------------------------------------------
+   Responsive
+--------------------------------------------------------------------------- */
+@media (max-width: 600px) {
+  .site-header__inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.9rem;
+  }
+  .site-nav { gap: 1.1rem; }
+}

--- a/examples/terra-folio/templates/404.html
+++ b/examples/terra-folio/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<main class="notfound">
+  <p class="eyebrow">404</p>
+  <h1 class="notfound__title"><em>Page not found</em></h1>
+  <p class="notfound__line"><a href="{{ base_url }}/">Return to the studio &rarr;</a></p>
+</main>
+{% include "footer.html" %}

--- a/examples/terra-folio/templates/footer.html
+++ b/examples/terra-folio/templates/footer.html
@@ -1,0 +1,15 @@
+  <footer class="site-footer">
+    <div class="site-footer__inner">
+      <p class="colophon">Set in Fraunces and Inter. Built with care, in Lisbon.</p>
+      <ul class="site-footer__links" aria-label="Elsewhere">
+        <li><a href="https://instagram.com/">Instagram</a></li>
+        <li><a href="https://are.na/">Are.na</a></li>
+        <li><a href="mailto:iris@terrafolio.studio">Email</a></li>
+      </ul>
+      <p class="copyright">© 2018–2026 Iris Voronova. All work shown with permission.</p>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/terra-folio/templates/header.html
+++ b/examples/terra-folio/templates/header.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="brand__name">Iris Voronova</span>
+        <span class="brand__mark" aria-hidden="true">·</span>
+        <span class="brand__loc">Lisbon, est. 2018</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/work/">Work</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/contact/">Contact</a>
+      </nav>
+    </div>
+  </header>

--- a/examples/terra-folio/templates/home.html
+++ b/examples/terra-folio/templates/home.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+<main class="home">
+  <section class="intro">
+    <p class="eyebrow">Iris Voronova — studio</p>
+    <h1 class="intro__lede">
+      <em>Iris Voronova</em> &mdash; designer working in
+      <em>identity</em>, <em>editorial</em>, and <em>packaging</em>
+      from Lisbon. Selected work below.
+    </h1>
+  </section>
+
+  <section class="selected">
+    <header class="selected__header">
+      <span class="smallcaps">Selected works, 2018–2026</span>
+      <span class="selected__count">{% set works = get_section(path="work/_index.md") %}{{ works.pages | length }} projects</span>
+    </header>
+
+    {% set works = get_section(path="work/_index.md") %}
+    {% set total = works.pages | length %}
+    <ol class="works">
+      {% for post in works.pages %}
+      <li class="work">
+        <a class="work__link" href="{{ base_url }}{{ post.url }}">
+          <div class="work__meta">
+            <span class="work__num">{% if loop.index < 10 %}0{% endif %}{{ loop.index }} / {% if total < 10 %}0{% endif %}{{ total }}</span>
+            <span class="work__year">{{ post.extra.year }}</span>
+          </div>
+          <h2 class="work__title"><em>{{ post.title | e }}</em></h2>
+          <p class="work__discipline"><em>{{ post.extra.discipline }}</em> &mdash; {{ post.extra.client | e }}</p>
+          <div class="work__swatch" style="background-color: {{ post.extra.swatch }};" aria-hidden="true"></div>
+        </a>
+      </li>
+      {% endfor %}
+    </ol>
+  </section>
+
+  <section class="currently">
+    <p class="smallcaps">Currently</p>
+    <p class="currently__line">Available for projects from late summer 2026. <a href="mailto:iris@terrafolio.studio">iris@terrafolio.studio</a></p>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/terra-folio/templates/page.html
+++ b/examples/terra-folio/templates/page.html
@@ -1,0 +1,45 @@
+{% include "header.html" %}
+<main class="case">
+  {% if page.extra.swatch is defined %}
+    <header class="case__header">
+      <p class="eyebrow">
+        {% if page.extra.year is defined %}{{ page.extra.year }} &mdash; {% endif %}
+        {% if page.extra.discipline is defined %}<em>{{ page.extra.discipline }}</em>{% endif %}
+      </p>
+      <h1 class="case__title"><em>{{ page.title | e }}</em></h1>
+      {% if page.extra.client is defined %}
+        <p class="case__client">For {{ page.extra.client | e }}</p>
+      {% endif %}
+    </header>
+    <div class="case__swatch" style="background-color: {{ page.extra.swatch }};" aria-hidden="true"></div>
+    <div class="case__details">
+      <dl>
+        {% if page.extra.client is defined %}<div><dt>Client</dt><dd>{{ page.extra.client | e }}</dd></div>{% endif %}
+        {% if page.extra.year is defined %}<div><dt>Year</dt><dd>{{ page.extra.year }}</dd></div>{% endif %}
+        {% if page.extra.discipline is defined %}<div><dt>Discipline</dt><dd>{{ page.extra.discipline }}</dd></div>{% endif %}
+        {% if page.taxonomies is defined and page.taxonomies.tags is defined %}
+          <div><dt>Tags</dt><dd>
+            {% for tag in page.taxonomies.tags %}<a href="{{ base_url }}/tags/{{ tag }}/">{{ tag }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+          </dd></div>
+        {% endif %}
+      </dl>
+    </div>
+    <article class="case__body">
+      {{ content | safe }}
+    </article>
+    <nav class="case__nav" aria-label="More work">
+      <a href="{{ base_url }}/work/">&larr; All work</a>
+    </nav>
+  {% else %}
+    <header class="page__header">
+      <h1 class="page__title"><em>{{ page.title | e }}</em></h1>
+      {% if page.description is defined %}
+        <p class="page__desc">{{ page.description | e }}</p>
+      {% endif %}
+    </header>
+    <article class="page__body">
+      {{ content | safe }}
+    </article>
+  {% endif %}
+</main>
+{% include "footer.html" %}

--- a/examples/terra-folio/templates/section.html
+++ b/examples/terra-folio/templates/section.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+<main class="section">
+  <header class="section__header">
+    <p class="eyebrow">Index</p>
+    <h1 class="section__title"><em>{{ page.title | e }}</em></h1>
+    {% if page.description is defined %}
+      <p class="section__desc">{{ page.description | e }}</p>
+    {% endif %}
+    <div class="section__intro">{{ content | safe }}</div>
+  </header>
+
+  {% if section is defined and section.pages is defined %}
+    {% set total = section.pages | length %}
+    <ol class="works works--grid">
+      {% for post in section.pages %}
+        <li class="work">
+          <a class="work__link" href="{{ base_url }}{{ post.url }}">
+            <div class="work__meta">
+              <span class="work__num">{% if loop.index < 10 %}0{% endif %}{{ loop.index }} / {% if total < 10 %}0{% endif %}{{ total }}</span>
+              {% if post.extra.year is defined %}<span class="work__year">{{ post.extra.year }}</span>{% endif %}
+            </div>
+            <h2 class="work__title"><em>{{ post.title | e }}</em></h2>
+            {% if post.extra.discipline is defined %}
+              <p class="work__discipline"><em>{{ post.extra.discipline }}</em>{% if post.extra.client is defined %} &mdash; {{ post.extra.client | e }}{% endif %}</p>
+            {% endif %}
+            {% if post.extra.swatch is defined %}
+              <div class="work__swatch" style="background-color: {{ post.extra.swatch }};" aria-hidden="true"></div>
+            {% endif %}
+          </a>
+        </li>
+      {% endfor %}
+    </ol>
+  {% endif %}
+
+  {{ pagination }}
+</main>
+{% include "footer.html" %}

--- a/examples/terra-folio/templates/shortcodes/alert.html
+++ b/examples/terra-folio/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/terra-folio/templates/taxonomy.html
+++ b/examples/terra-folio/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main class="taxonomy">
+  <header class="section__header">
+    <p class="eyebrow">Index</p>
+    <h1 class="section__title"><em>{{ page.title | e }}</em></h1>
+    <p class="section__desc">All terms in this taxonomy.</p>
+  </header>
+  <div class="taxonomy__terms">
+    {{ content | safe }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/terra-folio/templates/taxonomy_term.html
+++ b/examples/terra-folio/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<main class="taxonomy">
+  <header class="section__header">
+    <p class="eyebrow">Tagged</p>
+    <h1 class="section__title"><em>{{ page.title | e }}</em></h1>
+    <p class="section__desc">Projects filed under this tag.</p>
+  </header>
+  <div class="taxonomy__list">
+    {{ content | safe }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/vector-os/AGENTS.md
+++ b/examples/vector-os/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter can use TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start) — TOML is the default.
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/vector-os/archetypes/default.md
+++ b/examples/vector-os/archetypes/default.md
@@ -1,0 +1,14 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+weight = 0
+tags = {{ tags }}
+
+[extra]
+section_label = ""
+section_number = ""
++++
+
+Start the page here.

--- a/examples/vector-os/config.toml
+++ b/examples/vector-os/config.toml
@@ -1,0 +1,209 @@
+# =============================================================================
+# Vector OS — Documentation
+# =============================================================================
+
+title = "Vector OS"
+description = "An operating layer for distributed compute. Documentation."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = true
+per_page = 20
+
+# =============================================================================
+# SEO
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+# =============================================================================
+# Feeds
+# =============================================================================
+
+[feeds]
+enabled = true
+type = "rss"
+sections = ["changelog"]
+
+# =============================================================================
+# Markdown
+# =============================================================================
+
+[markdown]
+safe = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/vector-os/content/docs/_index.md
+++ b/examples/vector-os/content/docs/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Docs"
+description = "Core documentation for Vector OS."
+sort_by = "weight"
+template = "section"
+
+[extra]
+section_label = "01 · Docs"
+section_number = "01.00"
++++
+
+The core documentation. Read in order on a first pass; jump in by chapter on
+return visits.

--- a/examples/vector-os/content/docs/architecture.md
+++ b/examples/vector-os/content/docs/architecture.md
@@ -1,0 +1,70 @@
++++
+title = "01.03 — Architecture"
+description = "How the control plane, workers, and event log fit together."
+weight = 3
+
+[extra]
+section_label = "01 · Docs"
+section_number = "01.03"
++++
+
+A Vector OS deployment has three moving parts: a control plane, a fleet of
+workers, and an event log that connects them. Everything else — the CLI, the
+HTTP gateway, the metrics endpoint — is a thin layer over those three.
+
+```
+                      +---------------------+
+                      |   control plane     |
+                      |  (scheduler + api)  |
+                      +----------+----------+
+                                 |
+                  +--------------+--------------+
+                  |       event log (raft)      |
+                  +--------------+--------------+
+                                 |
+        +-----------+------------+------------+-----------+
+        |           |            |            |           |
+    +---+---+   +---+---+    +---+---+    +---+---+   +---+---+
+    | node  |   | node  |    | node  |    | node  |   | node  |
+    |  a01  |   |  a02  |    |  b01  |    |  b02  |   |  c01  |
+    +-------+   +-------+    +-------+    +-------+   +-------+
+```
+
+## Control plane
+
+The control plane is a single binary running in HA mode behind a virtual IP.
+Three replicas is the standard deployment; five for regulated workloads. The
+replicas elect a leader using Raft and serialize writes through the leader. All
+reads are linearizable by default; clients can opt in to stale reads with a
+header.
+
+The scheduler is the core of the control plane. It consumes the resource
+catalog and the pending queue, produces placements, and writes them to the
+event log. Placements are advisory until a worker accepts them; workers may
+refuse a placement (for example, if a local disk is full) and the scheduler
+will retry on a different node.
+
+## Workers
+
+A worker is the `vector-os` binary running with `--role=worker`. On startup it
+registers its capabilities — CPU count, memory, attached accelerators, local
+storage, network zones — and opens a long-lived gRPC stream to the control
+plane. Tasks arrive on that stream; status and metrics are pushed back the
+same way.
+
+Workers are stateless from the cluster's perspective. A worker that loses its
+connection and re-registers within the grace window picks up where it left off.
+A worker that exceeds the grace window is fenced — the control plane revokes
+its leases and reschedules its tasks elsewhere.
+
+## Event log
+
+The event log is the system's source of truth. Every placement, every status
+change, every lease grant is an entry in the log. The log is append-only and
+replicated across the control plane replicas. Operators can stream the log
+through the `vector-os events` command for audit and debugging.
+
+The log is also where Vector OS earns its name: every entry is a typed vector
+of fields, and the scheduler reasons about state by folding the log into a
+materialized view. This makes recovery cheap — a fresh replica catches up by
+replaying the log from the last snapshot.

--- a/examples/vector-os/content/docs/configuration.md
+++ b/examples/vector-os/content/docs/configuration.md
@@ -1,0 +1,84 @@
++++
+title = "01.04 — Configuration"
+description = "The single configuration file: layout, defaults, and overrides."
+weight = 4
+
+[extra]
+section_label = "01 · Docs"
+section_number = "01.04"
++++
+
+Vector OS reads one configuration file at startup. The default path is
+`/etc/vector-os/vector.toml` on Linux and `~/.config/vector-os/vector.toml` on
+macOS. Override the path with `--config` or the `VECTOR_CONFIG` environment
+variable. Everything else can be set at the command line; the file is the
+canonical source.
+
+## Minimum viable config
+
+A single-node deployment needs only the data directory and a listen address:
+
+```toml
+[control_plane]
+listen = "0.0.0.0:7700"
+data_dir = "/var/lib/vector-os"
+
+[worker]
+enabled = true
+```
+
+## Production config
+
+A three-node control plane with a worker pool and Postgres-backed state:
+
+```toml
+[control_plane]
+listen = "0.0.0.0:7700"
+advertise = "10.0.0.11:7700"
+peers = ["10.0.0.12:7700", "10.0.0.13:7700"]
+data_dir = "/var/lib/vector-os"
+
+[control_plane.store]
+backend = "postgres"
+dsn = "postgres://vector:secret@db.internal:5432/vector"
+pool_size = 16
+
+[scheduler]
+strategy = "binpack"
+preempt = true
+fairness = "weighted"
+
+[worker]
+enabled = false
+
+[metrics]
+listen = "0.0.0.0:9100"
+format = "prometheus"
+
+[audit]
+enabled = true
+sink = "file:///var/log/vector-os/audit.jsonl"
+```
+
+## Per-node overrides
+
+A worker node typically disables the control plane block and points at the
+upstream cluster:
+
+```toml
+[control_plane]
+enabled = false
+
+[worker]
+enabled = true
+upstream = "https://control.vector.internal:7700"
+zone = "us-east-1a"
+labels = { gpu = "h100", storage = "nvme" }
+capacity = { cpu = 96, memory_gb = 768, gpu = 8 }
+```
+
+## Validation
+
+The `vector-os config check` command parses the file, applies the same
+validation as the runtime, and prints any problems it finds. It exits non-zero
+on any error, which makes it suitable for CI.

--- a/examples/vector-os/content/docs/installation.md
+++ b/examples/vector-os/content/docs/installation.md
@@ -1,0 +1,65 @@
++++
+title = "01.02 — Installation"
+description = "Install the Vector OS binary on Linux, macOS, or Windows."
+weight = 2
+
+[extra]
+section_label = "01 · Docs"
+section_number = "01.02"
++++
+
+Vector OS ships as a single static binary. There is one release artifact per
+platform; pick the one that matches your target and put it somewhere on your
+path.
+
+## Quick install
+
+The install script downloads the latest stable release, verifies the checksum,
+and places the binary in `/usr/local/bin`:
+
+```shell
+curl -fsSL https://get.vector-os.dev/install.sh | sh
+```
+
+Pass `VECTOR_VERSION` to pin to a specific release:
+
+```shell
+curl -fsSL https://get.vector-os.dev/install.sh | VECTOR_VERSION=0.4.2 sh
+```
+
+## Package managers
+
+On macOS the Homebrew tap mirrors the release schedule:
+
+```shell
+brew install vector-os/tap/vector-os
+```
+
+On Debian and Ubuntu the apt repository ships the same binaries with a systemd
+unit:
+
+```shell
+curl -fsSL https://get.vector-os.dev/apt.gpg | sudo tee /etc/apt/trusted.gpg.d/vector.gpg
+echo "deb https://apt.vector-os.dev stable main" | sudo tee /etc/apt/sources.list.d/vector.list
+sudo apt-get update
+sudo apt-get install vector-os
+```
+
+## Verifying the install
+
+The binary prints version and build provenance on `--version`:
+
+```shell
+vector-os --version
+# vector-os 0.4.2 (rev 9f3a1c8, built 2026-04-09)
+```
+
+Run the doctor command to check for missing kernel features and recommended
+sysctls before starting the control plane:
+
+```shell
+vector-os doctor
+```
+
+A clean run should print `all checks passed`. Any warnings are explained in the
+output and linked to the matching reference entry.

--- a/examples/vector-os/content/docs/introduction.md
+++ b/examples/vector-os/content/docs/introduction.md
@@ -1,0 +1,55 @@
++++
+title = "01.01 — Introduction"
+description = "What Vector OS is, what it is not, and why it exists."
+weight = 1
+
+[extra]
+section_label = "01 · Docs"
+section_number = "01.01"
++++
+
+Vector OS is an operating layer for distributed compute. It does one thing well:
+it lets you describe what should run, where the data lives, and how much it is
+worth — and it schedules the rest. It is not a container runtime, not an
+orchestrator in the Kubernetes sense, and not a workflow engine. It is the
+small, opinionated piece that sits between those things.
+
+A Vector OS cluster is a set of nodes — bare metal, virtual machines, or
+attached accelerators — exposed through a single control plane. The control
+plane keeps a typed catalog of resources, an event log of placements, and a
+queue of pending work. Workers pull tasks, report progress, and surrender
+resources when the deadline elapses or a higher-priority claim arrives.
+
+The project began in 2024 as a tool for running short-lived inference jobs
+across a mixed fleet of consumer GPUs. We wanted something that booted in under
+a second, exposed a real HTTP API, and did not require a service mesh to get to
+hello-world. The scope has widened — batch compute, scheduled tasks, and a
+small storage interface — but the constraints have not. Every release must
+build from a clean checkout in under sixty seconds, ship as a single static
+binary, and pass the entire end-to-end suite without external services.
+
+Vector OS is written in Rust. The binary is twelve megabytes. There are no
+required runtime dependencies. State is kept in an embedded log; the control
+plane can be backed by Postgres for multi-region deployments. The wire format
+is protobuf over HTTP/2, with a JSON gateway for clients that need it.
+
+The documentation is organized into three parts. The Docs section covers the
+concepts and the day-one experience. The Guides section walks through specific
+deployments. The Reference section is the long tail — every flag, endpoint,
+and term, in alphabetical order.
+
+## What you should read first
+
+If you have never run Vector OS before, read the installation chapter, then the
+architecture chapter. They are short. Skip the configuration chapter on a first
+pass — the defaults are good.
+
+If you are evaluating Vector OS against another tool, the architecture chapter
+is the honest answer to most of the questions you will have. The trade-offs
+are stated up front.
+
+## Where to ask questions
+
+Issues and discussions live on the project tracker. The maintainers triage on
+Tuesday and Friday. There is no chat room; we have found that asynchronous
+review produces better answers and keeps the archive searchable.

--- a/examples/vector-os/content/guides/_index.md
+++ b/examples/vector-os/content/guides/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Guides"
+description = "Task-oriented walkthroughs."
+sort_by = "weight"
+template = "section"
+
+[extra]
+section_label = "02 · Guides"
+section_number = "02.00"
++++
+
+Task-oriented walkthroughs. Each guide is a single sitting from a clean
+checkout. Read in order or jump to what you need.

--- a/examples/vector-os/content/guides/cluster-bootstrap.md
+++ b/examples/vector-os/content/guides/cluster-bootstrap.md
@@ -1,0 +1,68 @@
++++
+title = "02.02 — Cluster bootstrap"
+description = "Bring up a three-node control plane from scratch."
+weight = 2
+
+[extra]
+section_label = "02 · Guides"
+section_number = "02.02"
++++
+
+This guide brings up a three-node control plane from scratch on a fresh
+network. The same procedure works for five nodes; substitute the count where
+indicated.
+
+## Plan the topology
+
+Pick three machines in the same region but in different failure domains. For
+each, decide on a stable hostname or IP and open TCP 7700 between them. The
+control plane talks Raft over this port; do not put a load balancer between
+the peers.
+
+| Role       | Hostname                   | Address       |
+|------------|----------------------------|---------------|
+| Bootstrap  | control-01.vector.internal | 10.0.0.11     |
+| Peer       | control-02.vector.internal | 10.0.0.12     |
+| Peer       | control-03.vector.internal | 10.0.0.13     |
+
+## Bootstrap the first node
+
+On `control-01`, run the bootstrap command. This initializes the Raft cluster
+with the local node as the sole voter.
+
+```shell
+vector-os control bootstrap \
+  --listen 0.0.0.0:7700 \
+  --advertise 10.0.0.11:7700 \
+  --data-dir /var/lib/vector-os
+```
+
+The command prints a join command for the remaining peers. Copy it.
+
+## Join the remaining peers
+
+On `control-02` and `control-03`, run the join command produced above. Each
+peer downloads the current snapshot, replays the log, and is promoted to voter
+once it has caught up.
+
+```shell
+vector-os control join \
+  --upstream https://control-01.vector.internal:7700 \
+  --token vct_…
+```
+
+## Verify quorum
+
+From any of the three nodes:
+
+```shell
+vector-os control status
+# leader:   control-01.vector.internal
+# term:     4
+# peers:
+#   - control-01.vector.internal  voter  in-sync
+#   - control-02.vector.internal  voter  in-sync
+#   - control-03.vector.internal  voter  in-sync
+```
+
+You now have a working cluster. Add workers using the deploying-a-node guide.

--- a/examples/vector-os/content/guides/deploying-a-node.md
+++ b/examples/vector-os/content/guides/deploying-a-node.md
@@ -1,0 +1,59 @@
++++
+title = "02.01 — Deploying a node"
+description = "Join a single worker to an existing cluster."
+weight = 1
+
+[extra]
+section_label = "02 · Guides"
+section_number = "02.01"
++++
+
+This guide walks through joining a single worker to an existing cluster. The
+guide assumes a control plane is already running and reachable on the
+network. If you do not have one yet, see the cluster bootstrap guide first.
+
+## Prerequisites
+
+You will need root or sudo on the new machine, network connectivity to the
+control plane on TCP port 7700, and a join token. Tokens are short-lived; ask
+the operator who runs the control plane to generate one, or run:
+
+```shell
+vector-os admin token create --role worker --ttl 1h
+```
+
+The command prints a token of the form `vot_…`. Treat it as a secret.
+
+## Install and register
+
+Install the binary using the script from the installation chapter, then run
+the join command on the new node:
+
+```shell
+vector-os worker join \
+  --upstream https://control.vector.internal:7700 \
+  --token vot_8f3a2c19b04e \
+  --zone us-east-1a \
+  --label gpu=h100,storage=nvme
+```
+
+The command exchanges the token for a long-lived worker certificate, writes it
+to `/etc/vector-os/worker.crt`, and registers the node's capabilities with the
+control plane.
+
+## Verify
+
+From any client with admin credentials, list the nodes and confirm the new one
+is `ready`:
+
+```shell
+vector-os nodes list
+# NAME    ZONE         STATUS  CPU  MEM  GPU  AGE
+# a01     us-east-1a   ready   96   768  8    14d
+# a02     us-east-1a   ready   96   768  8    14d
+# a03     us-east-1a   ready   96   768  8    7s
+```
+
+A node that fails to reach `ready` within five minutes is almost always a
+firewall or DNS problem. Run `vector-os doctor --remote control.vector.internal`
+on the worker to diagnose.

--- a/examples/vector-os/content/guides/network-overlays.md
+++ b/examples/vector-os/content/guides/network-overlays.md
@@ -1,0 +1,57 @@
++++
+title = "02.03 — Network overlays"
+description = "Configure WireGuard mesh between nodes in different networks."
+weight = 3
+
+[extra]
+section_label = "02 · Guides"
+section_number = "02.03"
++++
+
+Vector OS ships with an optional overlay network for clusters that span more
+than one L2 domain. The overlay uses WireGuard under the hood and exchanges
+peer keys through the control plane.
+
+## When to use the overlay
+
+You need the overlay if any of the following is true:
+
+- Nodes are in different VPCs, regions, or providers.
+- Workers are behind NAT and cannot accept inbound connections directly.
+- Pod-to-pod traffic must be encrypted in transit.
+
+You do not need the overlay if all nodes share an L2 segment and you already
+encrypt traffic at a lower layer.
+
+## Enable on the control plane
+
+Add the overlay block to the control plane config and restart:
+
+```toml
+[overlay]
+enabled = true
+cidr = "10.66.0.0/16"
+mtu = 1380
+keepalive = "25s"
+```
+
+The control plane allocates an overlay address per node out of the CIDR and
+distributes peer public keys.
+
+## Enroll a worker
+
+The worker enrolls automatically on next reconnect. Confirm the overlay is up
+on the worker:
+
+```shell
+vector-os overlay status
+# device:   vector0
+# address:  10.66.0.14/16
+# peers:    9 (9 active)
+# rx:       1.4 GiB
+# tx:       820 MiB
+```
+
+The `peers` count should match the total number of nodes minus one. If a peer
+is listed but inactive, run `vector-os overlay diagnose <peer>` to see the last
+handshake time and the most recent error.

--- a/examples/vector-os/content/index.md
+++ b/examples/vector-os/content/index.md
@@ -1,0 +1,17 @@
++++
+title = "Vector OS"
+description = "An operating layer for distributed compute. Documentation."
+template = "home"
+
+[extra]
+section_label = "00 · Home"
+section_number = "00.00"
++++
+
+Vector OS is an operating layer for distributed compute. It provides a single
+declarative interface over heterogeneous machines, GPU pools, and storage
+fabrics — and a small, predictable runtime that does not get in the way.
+
+These pages document the v0.4 line. Start with the introduction, then move into
+the installation and architecture chapters. The reference section lists every
+flag, endpoint, and term.

--- a/examples/vector-os/content/reference/_index.md
+++ b/examples/vector-os/content/reference/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Reference"
+description = "The complete reference: flags, endpoints, terms."
+sort_by = "weight"
+template = "section"
+
+[extra]
+section_label = "03 · Reference"
+section_number = "03.00"
++++
+
+Exhaustive reference material. Not designed to be read top to bottom — use the
+table of contents to jump to what you need.

--- a/examples/vector-os/content/reference/api.md
+++ b/examples/vector-os/content/reference/api.md
@@ -1,0 +1,60 @@
++++
+title = "03.02 — HTTP API"
+description = "Endpoints exposed by the control plane gateway."
+weight = 2
+
+[extra]
+section_label = "03 · Reference"
+section_number = "03.02"
++++
+
+The control plane exposes a JSON HTTP gateway alongside the native gRPC API.
+The gateway is a thin translation layer; every endpoint maps to a single RPC.
+All endpoints accept a bearer token in the `Authorization` header.
+
+## Endpoints
+
+| Method | Path                          | Description                                       |
+|--------|-------------------------------|---------------------------------------------------|
+| GET    | `/v1/health`                  | Liveness probe. Always 200 if the process is up.  |
+| GET    | `/v1/ready`                   | Readiness probe. 200 once Raft is in sync.        |
+| GET    | `/v1/nodes`                   | List all registered nodes.                        |
+| GET    | `/v1/nodes/{id}`              | Get a single node by ID.                          |
+| DELETE | `/v1/nodes/{id}`              | Fence and remove a node.                          |
+| GET    | `/v1/tasks`                   | List tasks. Supports `?state=` filter.            |
+| POST   | `/v1/tasks`                   | Submit a task. Returns the task ID.               |
+| GET    | `/v1/tasks/{id}`              | Get task status and metadata.                     |
+| DELETE | `/v1/tasks/{id}`              | Cancel a task. Idempotent.                        |
+| GET    | `/v1/events`                  | Stream the event log as newline-delimited JSON.   |
+| GET    | `/v1/metrics`                 | Prometheus exposition format.                     |
+
+## Example request
+
+Submit a task that runs a single container image with a one-hour deadline:
+
+```json
+{
+  "name": "build-2026-05-17",
+  "image": "registry.internal/builder:v3",
+  "command": ["./build.sh", "--release"],
+  "resources": {
+    "cpu": 8,
+    "memory_gb": 16,
+    "gpu": 0
+  },
+  "deadline": "1h",
+  "priority": 100
+}
+```
+
+The response includes the task ID and the placement decision, if one was made
+synchronously:
+
+```json
+{
+  "id": "tsk_01jc8w7nvz",
+  "state": "scheduled",
+  "node": "a02",
+  "scheduled_at": "2026-05-17T09:14:22Z"
+}
+```

--- a/examples/vector-os/content/reference/cli.md
+++ b/examples/vector-os/content/reference/cli.md
@@ -1,0 +1,53 @@
++++
+title = "03.01 — CLI"
+description = "All command-line flags accepted by the vector-os binary."
+weight = 1
+
+[extra]
+section_label = "03 · Reference"
+section_number = "03.01"
++++
+
+The `vector-os` binary accepts a single subcommand followed by flags. Global
+flags are accepted by every subcommand and are listed first.
+
+## Global flags
+
+| Flag                    | Type    | Default                       | Description                                      |
+|-------------------------|---------|-------------------------------|--------------------------------------------------|
+| `--config`              | path    | `/etc/vector-os/vector.toml`  | Configuration file path.                         |
+| `--log-level`           | string  | `info`                        | One of `trace`, `debug`, `info`, `warn`, `error`. |
+| `--log-format`          | string  | `text`                        | `text` or `json`.                                |
+| `--no-color`            | bool    | `false`                       | Disable ANSI color in terminal output.           |
+| `--profile`             | path    | unset                         | Write pprof CPU profile to the given path.       |
+| `--version`             | bool    | `false`                       | Print version and exit.                          |
+
+## Control plane flags
+
+The `control` subcommand accepts the following flags in addition to the global
+set.
+
+| Flag                    | Type    | Default                       | Description                                      |
+|-------------------------|---------|-------------------------------|--------------------------------------------------|
+| `--listen`              | addr    | `0.0.0.0:7700`                | Listen address for gRPC and HTTP.                |
+| `--advertise`           | addr    | derived                       | Address advertised to peers and workers.         |
+| `--peers`               | list    | empty                         | Comma-separated peer addresses for Raft.         |
+| `--data-dir`            | path    | `/var/lib/vector-os`          | Local state directory.                           |
+| `--snapshot-interval`   | dur     | `10m`                         | Take a Raft snapshot every interval.             |
+| `--election-timeout`    | dur     | `1s`                          | Raft election timeout.                           |
+
+## Worker flags
+
+The `worker` subcommand accepts the following flags in addition to the global
+set.
+
+| Flag                    | Type    | Default                       | Description                                      |
+|-------------------------|---------|-------------------------------|--------------------------------------------------|
+| `--upstream`            | url     | required                      | Control plane URL.                               |
+| `--token`               | string  | unset                         | Join token; required for first start.            |
+| `--zone`                | string  | unset                         | Failure domain label.                            |
+| `--label`               | list    | empty                         | Additional `key=value` labels, comma-separated.  |
+| `--capacity-cpu`        | int     | autodetect                    | Override advertised CPU count.                   |
+| `--capacity-memory-gb`  | int     | autodetect                    | Override advertised memory in GiB.               |
+| `--capacity-gpu`        | int     | autodetect                    | Override advertised GPU count.                   |
+| `--drain-timeout`       | dur     | `5m`                          | Grace period when draining the node.             |

--- a/examples/vector-os/content/reference/glossary.md
+++ b/examples/vector-os/content/reference/glossary.md
@@ -1,0 +1,47 @@
++++
+title = "03.03 — Glossary"
+description = "Terms used in this documentation."
+weight = 3
+
+[extra]
+section_label = "03 · Reference"
+section_number = "03.03"
++++
+
+Terms used across the documentation. Where a term has a precise meaning inside
+Vector OS that differs from common usage, the entry calls that out.
+
+## Terms
+
+**Catalog.** The typed inventory of resources the scheduler reasons about.
+The catalog is materialized from the event log and refreshed on every write.
+
+**Control plane.** The set of nodes running with `--role=control`. The
+control plane elects a leader, accepts client writes, and schedules tasks. The
+term refers to the cluster of replicas, not any single replica.
+
+**Event log.** The append-only log of every state change in the cluster. The
+log is the system's source of truth. Snapshots compact older entries.
+
+**Fence.** To revoke a worker's leases and forbid it from accepting new
+placements. Fencing is irreversible; a fenced worker must re-register from
+scratch.
+
+**Grace window.** The period during which a disconnected worker can
+re-register without losing its tasks. The default is sixty seconds.
+
+**Lease.** A time-bound claim on a resource. Tasks acquire leases on the
+resources they need; the scheduler revokes leases when a task exceeds its
+deadline.
+
+**Overlay.** The optional WireGuard-based mesh network that lets nodes in
+different L2 domains communicate as if local.
+
+**Placement.** A decision by the scheduler that a task should run on a
+specific node. Placements are advisory until the worker accepts them.
+
+**Token.** A short-lived bearer credential used to join a cluster. Tokens
+have a role and a TTL and are single-use.
+
+**Zone.** A failure domain label attached to a node. The scheduler spreads
+replicas across zones when a task requests anti-affinity.

--- a/examples/vector-os/static/css/style.css
+++ b/examples/vector-os/static/css/style.css
@@ -1,0 +1,670 @@
+/* =============================================================================
+   Vector OS — Swiss-precision dark documentation
+   Solid colors only. No gradients. No shadows. Hairline borders.
+   ============================================================================= */
+
+:root {
+  --bg: #0a0a0a;
+  --surface: #141414;
+  --surface-2: #1a1a1a;
+  --text: #e8e8e8;
+  --text-dim: #8a8a8a;
+  --text-faint: #5a5a5a;
+  --hairline: #262626;
+  --hairline-strong: #333333;
+  --accent: #5e72ff;
+  --accent-dim: #3a48a8;
+
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+
+  --content-max: 720px;
+  --sidebar-w: 240px;
+  --toc-w: 220px;
+  --shell-max: 1280px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+::selection { background: var(--accent); color: #fff; }
+
+/* =============================================================================
+   Top bar
+   ============================================================================= */
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--bg);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.topbar-inner {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: 0.01em;
+}
+
+.brand:hover { text-decoration: none; color: var(--text); }
+
+.brand-mark {
+  width: 14px;
+  height: 14px;
+  background: var(--accent);
+  display: inline-block;
+}
+
+.version-pill {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  border: 1px solid var(--hairline-strong);
+  padding: 2px 6px;
+  letter-spacing: 0.02em;
+}
+
+.topnav {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.topnav a {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.topnav a:hover { color: var(--text); text-decoration: none; }
+
+/* =============================================================================
+   Layout shell
+   ============================================================================= */
+
+.shell {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr var(--toc-w);
+  gap: 3rem;
+  align-items: start;
+}
+
+.shell-content { min-width: 0; padding: 3rem 0 4rem; }
+
+/* =============================================================================
+   Sidebar
+   ============================================================================= */
+
+.sidebar {
+  position: sticky;
+  top: 56px;
+  align-self: start;
+  max-height: calc(100vh - 56px);
+  overflow-y: auto;
+  padding: 2.5rem 0 3rem;
+  border-right: 1px solid var(--hairline);
+  padding-right: 1.5rem;
+}
+
+.sidebar-section { margin-bottom: 2rem; }
+
+.sidebar-heading {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin: 0 0 0.75rem;
+  padding-left: 0.6rem;
+}
+
+.sidebar-list { list-style: none; margin: 0; padding: 0; }
+
+.sidebar-list li { margin: 0; }
+
+.sidebar-list a {
+  display: block;
+  padding: 0.3rem 0.6rem;
+  font-size: 13px;
+  color: var(--text-dim);
+  border-left: 2px solid transparent;
+  line-height: 1.5;
+}
+
+.sidebar-list a:hover {
+  color: var(--text);
+  text-decoration: none;
+  background: var(--surface);
+}
+
+.sidebar-list a.is-active {
+  color: var(--text);
+  border-left-color: var(--accent);
+  background: var(--surface);
+}
+
+.sidebar-list a .num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+  margin-right: 0.5rem;
+}
+
+/* =============================================================================
+   TOC right rail
+   ============================================================================= */
+
+.toc-rail {
+  position: sticky;
+  top: 56px;
+  align-self: start;
+  max-height: calc(100vh - 56px);
+  overflow-y: auto;
+  padding: 3rem 0;
+  font-size: 13px;
+}
+
+.toc-heading {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin: 0 0 0.75rem;
+}
+
+.toc-rail ul { list-style: none; margin: 0; padding: 0; }
+
+.toc-rail li { margin: 0; }
+
+.toc-rail a {
+  display: block;
+  padding: 0.25rem 0;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.toc-rail a:hover { color: var(--text); text-decoration: none; }
+
+.toc-rail ul ul { padding-left: 0.85rem; }
+
+/* =============================================================================
+   Article
+   ============================================================================= */
+
+.article { max-width: var(--content-max); }
+
+.crumbs {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.crumbs a { color: var(--text-dim); }
+.crumbs a:hover { color: var(--text); text-decoration: none; }
+.crumbs .sep { color: var(--text-faint); }
+
+.crumbs-right {
+  margin-left: auto;
+}
+
+.crumbs-right a {
+  color: var(--text-dim);
+}
+
+.section-marker {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  margin-bottom: 0.5rem;
+}
+
+.article h1 {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 36px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin: 0 0 1.5rem;
+  color: #fff;
+}
+
+.article h2 {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  margin: 2.75rem 0 1rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--hairline);
+  color: #fff;
+}
+
+.article h3 {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 17px;
+  margin: 2rem 0 0.75rem;
+  color: #fff;
+}
+
+.article p { margin: 0 0 1rem; }
+
+.article ul, .article ol { margin: 0 0 1rem; padding-left: 1.25rem; }
+.article li { margin: 0.25rem 0; }
+
+.article hr { border: 0; border-top: 1px solid var(--hairline); margin: 2rem 0; }
+
+.article strong { color: #fff; font-weight: 600; }
+
+.article code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  padding: 1px 5px;
+  color: #d4d4d4;
+}
+
+.article pre {
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  margin: 1.25rem 0;
+}
+
+.article pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+.article blockquote {
+  margin: 1.25rem 0;
+  padding: 0.25rem 1rem;
+  border-left: 2px solid var(--accent);
+  color: var(--text-dim);
+}
+
+.article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.25rem 0;
+  font-size: 13px;
+}
+
+.article th, .article td {
+  text-align: left;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--hairline);
+  vertical-align: top;
+}
+
+.article th {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  font-weight: 500;
+  background: var(--surface);
+}
+
+.article td code {
+  white-space: nowrap;
+}
+
+/* =============================================================================
+   Prev/Next pager
+   ============================================================================= */
+
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--hairline);
+}
+
+.pager a {
+  display: block;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--hairline);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.pager a:hover { border-color: var(--hairline-strong); text-decoration: none; background: var(--surface); }
+
+.pager .label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin-bottom: 0.25rem;
+}
+
+.pager .pager-next { text-align: right; }
+
+.pager .title { font-size: 14px; color: var(--text); }
+
+/* =============================================================================
+   Home page
+   ============================================================================= */
+
+.home {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: 0 1.5rem 5rem;
+}
+
+.hero {
+  padding: 5rem 0 4rem;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.hero-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: clamp(56px, 9vw, 112px);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  margin: 0 0 1.5rem;
+  color: #fff;
+}
+
+.hero-deck {
+  max-width: 640px;
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--text-dim);
+  margin: 0 0 2rem;
+}
+
+.cta-row { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+
+.cta {
+  display: inline-block;
+  padding: 0.7rem 1.1rem;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid var(--hairline-strong);
+  color: var(--text);
+  background: var(--bg);
+}
+
+.cta:hover { background: var(--surface); text-decoration: none; }
+
+.cta-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.cta-primary:hover { background: var(--accent-dim); border-color: var(--accent-dim); }
+
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--hairline);
+  border: 1px solid var(--hairline);
+  margin: 4rem 0;
+}
+
+.home-card {
+  background: var(--bg);
+  padding: 1.75rem 1.5rem;
+}
+
+.home-card-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.home-card h2 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  color: #fff;
+  letter-spacing: -0.01em;
+}
+
+.home-card p {
+  color: var(--text-dim);
+  font-size: 13.5px;
+  margin: 0 0 1rem;
+}
+
+.home-card ul { list-style: none; margin: 0; padding: 0; }
+.home-card li { padding: 0.25rem 0; font-size: 13px; border-top: 1px solid var(--hairline); }
+.home-card li:first-child { border-top: 0; }
+.home-card li a { color: var(--text-dim); display: flex; gap: 0.5rem; }
+.home-card li a:hover { color: var(--text); text-decoration: none; }
+.home-card li .num { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); }
+
+.home-section { margin: 4rem 0; }
+
+.home-section-title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin: 0 0 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.recent { list-style: none; margin: 0; padding: 0; }
+.recent li {
+  display: grid;
+  grid-template-columns: 90px 1fr auto;
+  gap: 1rem;
+  align-items: baseline;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--hairline);
+}
+.recent li:last-child { border-bottom: 0; }
+.recent .num { font-family: var(--font-mono); font-size: 12px; color: var(--text-faint); }
+.recent .t { color: var(--text); }
+.recent .s { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.05em; }
+.recent a { color: var(--text); }
+.recent a:hover { color: var(--accent); text-decoration: none; }
+
+.adopters {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--hairline);
+  border: 1px solid var(--hairline);
+}
+
+.adopter {
+  background: var(--bg);
+  padding: 2rem 1rem;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  color: var(--text-dim);
+}
+
+/* =============================================================================
+   Section listing
+   ============================================================================= */
+
+.section-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--hairline);
+}
+
+.section-list li {
+  border-bottom: 1px solid var(--hairline);
+}
+
+.section-list a {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 1.5rem;
+  align-items: baseline;
+  padding: 1.25rem 0.5rem;
+  color: var(--text);
+}
+
+.section-list a:hover { background: var(--surface); text-decoration: none; }
+
+.section-list .num {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-faint);
+  letter-spacing: 0.02em;
+}
+
+.section-list .t { font-size: 16px; color: var(--text); }
+.section-list .d { font-size: 13px; color: var(--text-dim); margin-top: 0.25rem; }
+
+/* =============================================================================
+   Footer
+   ============================================================================= */
+
+.site-footer {
+  border-top: 1px solid var(--hairline);
+  margin-top: 4rem;
+}
+
+.site-footer-inner {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+  letter-spacing: 0.02em;
+  flex-wrap: wrap;
+}
+
+.site-footer-inner a { color: var(--text-dim); }
+.site-footer-inner a:hover { color: var(--text); text-decoration: none; }
+
+.site-footer-spacer { margin-left: auto; }
+
+/* =============================================================================
+   404
+   ============================================================================= */
+
+.fourohfour {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: 6rem 1.5rem;
+  font-family: var(--font-mono);
+}
+
+.fourohfour h1 {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--text);
+  margin: 0 0 1rem;
+}
+
+.fourohfour p { color: var(--text-dim); font-size: 13px; }
+
+/* =============================================================================
+   Responsive
+   ============================================================================= */
+
+@media (max-width: 1100px) {
+  .shell { grid-template-columns: var(--sidebar-w) 1fr; gap: 2rem; }
+  .toc-rail { display: none; }
+}
+
+@media (max-width: 760px) {
+  .shell { grid-template-columns: 1fr; gap: 0; padding: 0 1.25rem; }
+  .sidebar {
+    position: static;
+    max-height: none;
+    border-right: 0;
+    border-bottom: 1px solid var(--hairline);
+    padding: 1.5rem 0;
+  }
+  .shell-content { padding: 2rem 0 3rem; }
+  .topnav { gap: 1rem; }
+  .topnav a:nth-child(n+3) { display: none; }
+  .home-grid { grid-template-columns: 1fr; }
+  .adopters { grid-template-columns: repeat(2, 1fr); }
+  .hero { padding: 3rem 0 2.5rem; }
+  .pager { grid-template-columns: 1fr; }
+  .recent li { grid-template-columns: 80px 1fr; }
+  .recent .s { grid-column: 2; }
+}

--- a/examples/vector-os/templates/404.html
+++ b/examples/vector-os/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<main class="fourohfour">
+  <h1>// 404 — file not found</h1>
+  <p>The requested resource does not exist in this version of the documentation.</p>
+  <p>
+    <a href="{{ base_url }}/">-&gt; return to home</a><br>
+    <a href="{{ base_url }}/docs/introduction/">-&gt; introduction</a><br>
+    <a href="{{ base_url }}/reference/cli/">-&gt; cli reference</a>
+  </p>
+</main>
+{% include "footer.html" %}

--- a/examples/vector-os/templates/_sidebar.html
+++ b/examples/vector-os/templates/_sidebar.html
@@ -1,0 +1,20 @@
+<aside class="sidebar" aria-label="Documentation navigation">
+  {% if site.sections is defined %}
+    {% for sec in site.sections %}
+      {% if sec.pages is defined and sec.pages | length > 0 %}
+        <div class="sidebar-section">
+          <div class="sidebar-heading">{{ sec.title }}</div>
+          <ul class="sidebar-list">
+            {% for p in sec.pages | sort(attribute="weight") %}
+              <li>
+                <a href="{{ base_url }}{{ p.url }}"{% if page.url is defined and page.url == p.url %} class="is-active"{% endif %}>
+                  <span>{{ p.title }}</span>
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+</aside>

--- a/examples/vector-os/templates/_toc.html
+++ b/examples/vector-os/templates/_toc.html
@@ -1,0 +1,10 @@
+<aside class="toc-rail" aria-label="On this page">
+  <div class="toc-heading">On this page</div>
+  {% if toc is defined and toc %}
+    {{ toc | safe }}
+  {% else %}
+    <ul>
+      <li><a href="#top">Top</a></li>
+    </ul>
+  {% endif %}
+</aside>

--- a/examples/vector-os/templates/footer.html
+++ b/examples/vector-os/templates/footer.html
@@ -1,0 +1,13 @@
+  <footer class="site-footer">
+    <div class="site-footer-inner">
+      <span>(c) 2026 Vector OS</span>
+      <span>Apache-2.0</span>
+      <a href="https://github.com/" rel="noopener">Edit this page -&gt;</a>
+      <span class="site-footer-spacer"></span>
+      <span>build 9f3a1c8</span>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/vector-os/templates/header.html
+++ b/examples/vector-os/templates/header.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="topbar">
+    <div class="topbar-inner">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <span>vector-os</span>
+      </a>
+      <span class="version-pill">v0.4.2</span>
+      <nav class="topnav">
+        <a href="{{ base_url }}/docs/introduction/">Docs</a>
+        <a href="{{ base_url }}/guides/">Guides</a>
+        <a href="{{ base_url }}/reference/cli/">Reference</a>
+        <a href="{{ base_url }}/docs/">Changelog</a>
+        <a href="https://github.com/" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </div>

--- a/examples/vector-os/templates/home.html
+++ b/examples/vector-os/templates/home.html
@@ -1,0 +1,68 @@
+{% include "header.html" %}
+<main class="home">
+  <section class="hero">
+    <div class="hero-eyebrow">VECTOR OS / v0.4.2 / DOCUMENTATION</div>
+    <h1>Compute,<br>structured.</h1>
+    <p class="hero-deck">{{ site.description }} A single declarative interface over heterogeneous machines, GPU pools, and storage fabrics. A small, predictable runtime that does not get in the way.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/introduction/" class="cta cta-primary">Read the docs &rarr;</a>
+      <a href="{{ base_url }}/docs/installation/" class="cta">Quickstart &rarr;</a>
+    </div>
+  </section>
+
+  <section class="home-grid" aria-label="Sections">
+    <div class="home-card">
+      <div class="home-card-label">01 / DOCS</div>
+      <h2>Documentation</h2>
+      <p>Concepts and the day-one experience. Read in order.</p>
+      <ul>
+        <li><a href="{{ base_url }}/docs/introduction/"><span class="num">01.01</span><span>Introduction</span></a></li>
+        <li><a href="{{ base_url }}/docs/installation/"><span class="num">01.02</span><span>Installation</span></a></li>
+        <li><a href="{{ base_url }}/docs/architecture/"><span class="num">01.03</span><span>Architecture</span></a></li>
+        <li><a href="{{ base_url }}/docs/configuration/"><span class="num">01.04</span><span>Configuration</span></a></li>
+      </ul>
+    </div>
+    <div class="home-card">
+      <div class="home-card-label">02 / GUIDES</div>
+      <h2>Guides</h2>
+      <p>Task-oriented walkthroughs from a clean checkout.</p>
+      <ul>
+        <li><a href="{{ base_url }}/guides/deploying-a-node/"><span class="num">02.01</span><span>Deploying a node</span></a></li>
+        <li><a href="{{ base_url }}/guides/cluster-bootstrap/"><span class="num">02.02</span><span>Cluster bootstrap</span></a></li>
+        <li><a href="{{ base_url }}/guides/network-overlays/"><span class="num">02.03</span><span>Network overlays</span></a></li>
+      </ul>
+    </div>
+    <div class="home-card">
+      <div class="home-card-label">03 / REFERENCE</div>
+      <h2>Reference</h2>
+      <p>Every flag, endpoint, and term, in alphabetical order.</p>
+      <ul>
+        <li><a href="{{ base_url }}/reference/cli/"><span class="num">03.01</span><span>CLI</span></a></li>
+        <li><a href="{{ base_url }}/reference/api/"><span class="num">03.02</span><span>HTTP API</span></a></li>
+        <li><a href="{{ base_url }}/reference/glossary/"><span class="num">03.03</span><span>Glossary</span></a></li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="home-section">
+    <h3 class="home-section-title">Recent</h3>
+    <ul class="recent">
+      <li><span class="num">01.04</span><a class="t" href="{{ base_url }}/docs/configuration/">Configuration</a><span class="s">DOCS</span></li>
+      <li><span class="num">02.03</span><a class="t" href="{{ base_url }}/guides/network-overlays/">Network overlays</a><span class="s">GUIDES</span></li>
+      <li><span class="num">03.02</span><a class="t" href="{{ base_url }}/reference/api/">HTTP API</a><span class="s">REFERENCE</span></li>
+      <li><span class="num">01.03</span><a class="t" href="{{ base_url }}/docs/architecture/">Architecture</a><span class="s">DOCS</span></li>
+      <li><span class="num">02.02</span><a class="t" href="{{ base_url }}/guides/cluster-bootstrap/">Cluster bootstrap</a><span class="s">GUIDES</span></li>
+    </ul>
+  </section>
+
+  <section class="home-section">
+    <h3 class="home-section-title">Adopters</h3>
+    <div class="adopters">
+      <div class="adopter">ATLAS LABS</div>
+      <div class="adopter">FERROUS DATA</div>
+      <div class="adopter">NORTHFIELD</div>
+      <div class="adopter">ORBIT HQ</div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/vector-os/templates/page.html
+++ b/examples/vector-os/templates/page.html
@@ -1,0 +1,43 @@
+{% include "header.html" %}
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="shell-content">
+    <article class="article" id="top">
+      <div class="crumbs">
+        <a href="{{ base_url }}/">Home</a>
+        <span class="sep">/</span>
+        {% if page.extra.section_label is defined %}
+          <span>{{ page.extra.section_label }}</span>
+        {% else %}
+          <span>{{ page.section }}</span>
+        {% endif %}
+        {% if page.extra.section_number is defined %}
+          <span class="sep">/</span>
+          <span>{{ page.extra.section_number }}</span>
+        {% endif %}
+        <span class="crumbs-right"><a href="https://github.com/" rel="noopener">Edit on GitHub -&gt;</a></span>
+      </div>
+      {% if page.extra.section_number is defined %}
+        <div class="section-marker">{{ page.extra.section_number }}</div>
+      {% endif %}
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      <nav class="pager" aria-label="Page navigation">
+        {% if page.lower is defined and page.lower %}
+          <a href="{{ base_url }}{{ page.lower.url }}" class="pager-prev">
+            <div class="label">&larr; Previous</div>
+            <div class="title">{{ page.lower.title }}</div>
+          </a>
+        {% else %}<span></span>{% endif %}
+        {% if page.higher is defined and page.higher %}
+          <a href="{{ base_url }}{{ page.higher.url }}" class="pager-next">
+            <div class="label">Next &rarr;</div>
+            <div class="title">{{ page.higher.title }}</div>
+          </a>
+        {% else %}<span></span>{% endif %}
+      </nav>
+    </article>
+  </main>
+  {% include "_toc.html" %}
+</div>
+{% include "footer.html" %}

--- a/examples/vector-os/templates/section.html
+++ b/examples/vector-os/templates/section.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="shell-content">
+    <article class="article" id="top">
+      <div class="crumbs">
+        <a href="{{ base_url }}/">Home</a>
+        <span class="sep">/</span>
+        {% if page.extra.section_label is defined %}
+          <span>{{ page.extra.section_label }}</span>
+        {% else %}
+          <span>{{ page.title }}</span>
+        {% endif %}
+      </div>
+      {% if page.extra.section_number is defined %}
+        <div class="section-marker">{{ page.extra.section_number }}</div>
+      {% endif %}
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      <ol class="section-list">
+        {% for p in section.pages | sort(attribute="weight") %}
+          <li>
+            <a href="{{ base_url }}{{ p.url }}">
+              <span class="num">{% if p.extra.section_number is defined %}{{ p.extra.section_number }}{% else %}--{% endif %}</span>
+              <span>
+                <span class="t">{{ p.title }}</span>
+                {% if p.description %}<div class="d">{{ p.description }}</div>{% endif %}
+              </span>
+            </a>
+          </li>
+        {% endfor %}
+      </ol>
+    </article>
+  </main>
+  {% include "_toc.html" %}
+</div>
+{% include "footer.html" %}

--- a/examples/vector-os/templates/shortcodes/alert.html
+++ b/examples/vector-os/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/vector-os/templates/taxonomy.html
+++ b/examples/vector-os/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="shell-content">
+    <article class="article">
+      <div class="crumbs">
+        <a href="{{ base_url }}/">Home</a>
+        <span class="sep">/</span>
+        <span>Tags</span>
+      </div>
+      <h1>{{ page.title }}</h1>
+      <p>All terms in this taxonomy.</p>
+      {{ content | safe }}
+    </article>
+  </main>
+  {% include "_toc.html" %}
+</div>
+{% include "footer.html" %}

--- a/examples/vector-os/templates/taxonomy_term.html
+++ b/examples/vector-os/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="shell-content">
+    <article class="article">
+      <div class="crumbs">
+        <a href="{{ base_url }}/">Home</a>
+        <span class="sep">/</span>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <span class="sep">/</span>
+        <span>{{ page.title }}</span>
+      </div>
+      <h1>{{ page.title }}</h1>
+      <p>Pages tagged with this term.</p>
+      {{ content | safe }}
+    </article>
+  </main>
+  {% include "_toc.html" %}
+</div>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,4 +1,99 @@
 {
+  "obsidian-press": [
+    "dark",
+    "blog",
+    "editorial"
+  ],
+  "luminal": [
+    "light",
+    "landing",
+    "minimal"
+  ],
+  "terra-folio": [
+    "light",
+    "portfolio",
+    "minimal"
+  ],
+  "vector-os": [
+    "dark",
+    "docs",
+    "sidebar"
+  ],
+  "slate-journal": [
+    "light",
+    "blog",
+    "editorial",
+    "minimal"
+  ],
+  "cement-type": [
+    "light",
+    "blog",
+    "brutalist",
+    "minimal"
+  ],
+  "dusk-portal": [
+    "dark",
+    "portfolio",
+    "sci-fi"
+  ],
+  "acid-zine": [
+    "dark",
+    "blog",
+    "zine",
+    "punk"
+  ],
+  "signal-white": [
+    "light",
+    "blog",
+    "minimal",
+    "swiss"
+  ],
+  "noir-dispatch": [
+    "dark",
+    "blog",
+    "editorial",
+    "retro"
+  ],
+  "marble-haus": [
+    "light",
+    "portfolio",
+    "minimal",
+    "elegant"
+  ],
+  "volt-terminal": [
+    "dark",
+    "blog",
+    "terminal",
+    "retro"
+  ],
+  "ink-press": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "chrome-folio": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "obsidian-grid": [
+    "dark",
+    "blog",
+    "minimal",
+    "grid"
+  ],
+  "cosmic-glass-chronicles": [
+    "dark",
+    "portfolio",
+    "cyberpunk",
+    "minimal"
+  ],
+  "aura": [
+    "dark",
+    "glassmorphism",
+    "neon",
+    "ambient"
+  ],
   "abacus-ref": [
     "calculation",
     "logical",
@@ -26,11 +121,6 @@
     "deep-sea",
     "immersive"
   ],
-  "abyssal-cipher": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
   "accordion-fold": [
     "book",
     "light",
@@ -42,12 +132,6 @@
     "dark",
     "blog",
     "cyberpunk"
-  ],
-  "acid-zine": [
-    "dark",
-    "blog",
-    "zine",
-    "punk"
   ],
   "acme-docs": [
     "light",
@@ -71,12 +155,6 @@
     "dashboard",
     "admin",
     "sidebar"
-  ],
-  "aegis-shield": [
-    "dark",
-    "landing",
-    "minimal",
-    "docs"
   ],
   "aether": [
     "dark",
@@ -280,13 +358,6 @@
     "landing",
     "minimal"
   ],
-  "apolo-luxe": [
-    "elegant",
-    "luxury",
-    "dark",
-    "serif",
-    "blog"
-  ],
   "apothecary": [
     "light",
     "blog",
@@ -421,11 +492,6 @@
     "glow",
     "portfolio"
   ],
-  "astral-resonance": [
-    "dark",
-    "elegant",
-    "blog"
-  ],
   "astral-symphony-glass": [
     "dark",
     "portfolio",
@@ -477,12 +543,6 @@
     "light",
     "navigation"
   ],
-  "aura": [
-    "dark",
-    "glassmorphism",
-    "neon",
-    "ambient"
-  ],
   "aurelia": [
     "elegant",
     "minimalist",
@@ -521,11 +581,6 @@
     "dark",
     "animation"
   ],
-  "aurora-nebula-vanguard": [
-    "dark",
-    "sci-fi",
-    "glassmorphism"
-  ],
   "aurum": [
     "elegant",
     "dark",
@@ -558,11 +613,6 @@
     "design-system",
     "geometric",
     "mathematical"
-  ],
-  "axiom-grid": [
-    "light",
-    "docs",
-    "bauhaus"
   ],
   "axiom-ref": [
     "formal",
@@ -1224,21 +1274,6 @@
     "cosmic",
     "portfolio"
   ],
-  "celestial-weaver": [
-    "celestial",
-    "weaver",
-    "loom",
-    "ethereal",
-    "dark",
-    "elegant",
-    "ui"
-  ],
-  "cement-type": [
-    "light",
-    "blog",
-    "brutalist",
-    "minimal"
-  ],
   "center-stage": [
     "event",
     "solo",
@@ -1401,14 +1436,6 @@
     "chromatic",
     "portfolio"
   ],
-  "chromatic-veil": [
-    "glassmorphism",
-    "gradient",
-    "vibrant",
-    "portfolio",
-    "creative",
-    "dark-mode"
-  ],
   "chromatic-wave": [
     "dark",
     "portfolio",
@@ -1425,11 +1452,6 @@
     "bold",
     "minimal",
     "creative"
-  ],
-  "chrome-folio": [
-    "dark",
-    "portfolio",
-    "minimal"
   ],
   "chrome-pulse": [
     "minimal",
@@ -1460,12 +1482,6 @@
     "dark",
     "steampunk",
     "retro-futuristic"
-  ],
-  "chronos-flux": [
-    "dark",
-    "blog",
-    "elegant",
-    "cyberpunk"
   ],
   "chronos-forge": [
     "dark",
@@ -1854,12 +1870,6 @@
     "errata",
     "formal"
   ],
-  "cosmic-glass-chronicles": [
-    "dark",
-    "portfolio",
-    "cyberpunk",
-    "minimal"
-  ],
   "cosmic-wave": [
     "cyberpunk",
     "dark",
@@ -1912,13 +1922,6 @@
     "glassmorphism",
     "crimson",
     "blog"
-  ],
-  "crimson-void-nexus": [
-    "dark",
-    "glassmorphism",
-    "crimson",
-    "void",
-    "elegant"
   ],
   "cross-sectional": [
     "paper",
@@ -2048,22 +2051,10 @@
     "nature",
     "digital"
   ],
-  "cyber-glade": [
-    "dark",
-    "neon",
-    "cyber",
-    "retro"
-  ],
   "cyber-glass": [
     "blog",
     "cyberpunk",
     "glassmorphism"
-  ],
-  "cyber-neo": [
-    "dark",
-    "cyberpunk",
-    "portfolio",
-    "neon"
   ],
   "cyber-prism": [
     "cyberpunk",
@@ -2386,11 +2377,6 @@
     "blog",
     "sunset"
   ],
-  "dusk-portal": [
-    "dark",
-    "portfolio",
-    "sci-fi"
-  ],
   "dust-jacket": [
     "book",
     "light",
@@ -2447,12 +2433,6 @@
     "blog",
     "metallic",
     "plating"
-  ],
-  "elegance-aura": [
-    "dark",
-    "blog",
-    "portfolio",
-    "elegant"
   ],
   "elevate": [
     "landing",
@@ -2602,37 +2582,12 @@
     "etching",
     "printmaking"
   ],
-  "ether-weave": [
-    "elegant",
-    "glassmorphism",
-    "portfolio"
-  ],
   "ethereal-canvas": [
     "blog",
     "dark",
     "elegant",
     "minimal",
     "portfolio"
-  ],
-  "ethereal-geometric-vault": [
-    "dark",
-    "minimal",
-    "portfolio",
-    "editorial"
-  ],
-  "ethereal-loom": [
-    "ethereal",
-    "elegant",
-    "dark-mode",
-    "glassmorphism",
-    "weaving"
-  ],
-  "ethereal-plasma-glass": [
-    "dark",
-    "glassmorphism",
-    "plasma",
-    "portfolio",
-    "elegant"
   ],
   "ethereal-shimmer": [
     "dark",
@@ -2936,12 +2891,6 @@
     "generative",
     "mathematical"
   ],
-  "fractal-pulse": [
-    "dark",
-    "creative",
-    "glow",
-    "geometric"
-  ],
   "frequency": [
     "dark",
     "blog",
@@ -3118,11 +3067,6 @@
     "light",
     "landing",
     "geometric"
-  ],
-  "geometric-aether-lattice": [
-    "dark",
-    "minimal",
-    "blog"
   ],
   "gilded": [
     "dark",
@@ -3602,13 +3546,6 @@
     "modern",
     "jakarta"
   ],
-  "holo-vista": [
-    "dark",
-    "glassmorphism",
-    "neon",
-    "cyberpunk",
-    "holographic"
-  ],
   "hologram": [
     "dark",
     "showcase",
@@ -3796,11 +3733,6 @@
     "elegant",
     "serif"
   ],
-  "ink-press": [
-    "light",
-    "blog",
-    "editorial"
-  ],
   "ink-seoul": [
     "light",
     "blog",
@@ -3941,11 +3873,6 @@
     "hub",
     "bridge",
     "horizontal-scroll"
-  ],
-  "ivory": [
-    "light",
-    "portfolio",
-    "minimal"
   ],
   "jackhammer": [
     "heavy",
@@ -4317,11 +4244,6 @@
     "minimal",
     "luminescent"
   ],
-  "lumin-sphere": [
-    "dark",
-    "portfolio",
-    "cyberpunk"
-  ],
   "lumina": [
     "dark",
     "portfolio",
@@ -4338,11 +4260,6 @@
     "elegant",
     "soft",
     "glassmorphism"
-  ],
-  "lumina-canvas": [
-    "elegant",
-    "gallery",
-    "dark-mode"
   ],
   "lumina-chroma": [
     "blog",
@@ -4380,11 +4297,6 @@
     "neon",
     "glow",
     "animation"
-  ],
-  "luminal": [
-    "light",
-    "landing",
-    "minimal"
   ],
   "luminal-glass": [
     "dark",
@@ -4479,12 +4391,6 @@
     "dark",
     "blog",
     "elegant",
-    "minimal"
-  ],
-  "lunar-monolith": [
-    "dark",
-    "elegant",
-    "monolith",
     "minimal"
   ],
   "lunar-tide": [
@@ -4612,12 +4518,6 @@
     "gallery",
     "luxury",
     "marble-texture"
-  ],
-  "marble-haus": [
-    "light",
-    "portfolio",
-    "minimal",
-    "elegant"
   ],
   "marble-slab": [
     "sophisticated",
@@ -4923,11 +4823,6 @@
     "gold",
     "trendy"
   ],
-  "mono-stack": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
   "monochrome": [
     "light",
     "photo-essay",
@@ -4991,13 +4886,6 @@
     "texture",
     "unity",
     "monospace"
-  ],
-  "moonlit-sakura": [
-    "moonlight",
-    "sakura",
-    "parallax",
-    "dark-mode",
-    "elegant"
   ],
   "moonrise": [
     "dark",
@@ -5136,12 +5024,6 @@
     "space",
     "ethereal"
   ],
-  "nebulous-enigma": [
-    "dark",
-    "cosmic",
-    "glassmorphism",
-    "portfolio"
-  ],
   "nebulous-void-glass": [
     "dark",
     "portfolio",
@@ -5233,31 +5115,11 @@
     "dark",
     "grid"
   ],
-  "neon-blossom": [
-    "cyberpunk",
-    "neon",
-    "dark-mode",
-    "elegant",
-    "creative"
-  ],
   "neon-cipher": [
     "blog",
     "cyberpunk",
     "dark",
     "minimal"
-  ],
-  "neon-crystal-forge": [
-    "neon",
-    "crystal",
-    "dark-mode",
-    "glassmorphism",
-    "portfolio",
-    "creative"
-  ],
-  "neon-drift": [
-    "cyberpunk",
-    "neon",
-    "dark"
   ],
   "neon-dusk": [
     "dark",
@@ -5438,11 +5300,6 @@
     "glassmorphism",
     "neon"
   ],
-  "noctura": [
-    "dark",
-    "portfolio",
-    "landing"
-  ],
   "nocturne": [
     "dark",
     "blog",
@@ -5453,12 +5310,6 @@
     "dark",
     "blog",
     "noir"
-  ],
-  "noir-dispatch": [
-    "dark",
-    "blog",
-    "editorial",
-    "retro"
   ],
   "noire-gazette": [
     "dark",
@@ -5545,13 +5396,6 @@
     "glass",
     "oled"
   ],
-  "obsidian-abyss": [
-    "dark",
-    "abyss",
-    "elegant",
-    "blog",
-    "obsidian"
-  ],
   "obsidian-docs": [
     "docs",
     "dark",
@@ -5582,17 +5426,6 @@
     "glow",
     "portfolio",
     "glassmorphism"
-  ],
-  "obsidian-grid": [
-    "dark",
-    "blog",
-    "minimal",
-    "grid"
-  ],
-  "obsidian-press": [
-    "dark",
-    "blog",
-    "editorial"
   ],
   "obsidian-whisper": [
     "dark",
@@ -6257,29 +6090,11 @@
     "translucency",
     "outfit"
   ],
-  "prism-grid": [
-    "light",
-    "blog",
-    "editorial",
-    "brutalist"
-  ],
   "prism-pulse": [
     "dark",
     "neon",
     "pulsing",
     "creative"
-  ],
-  "prism-tesserae": [
-    "portfolio",
-    "glassmorphism",
-    "dark"
-  ],
-  "prism-wave": [
-    "design",
-    "glassmorphism",
-    "vibrant",
-    "prism",
-    "wave"
   ],
   "prismatic-void": [
     "dark",
@@ -7067,24 +6882,6 @@
     "immersive",
     "jakarta"
   ],
-  "signal-white": [
-    "light",
-    "blog",
-    "minimal",
-    "swiss"
-  ],
-  "silent-obelisk": [
-    "dark",
-    "minimal",
-    "brutalist",
-    "architecture"
-  ],
-  "silent-tide": [
-    "dark",
-    "minimal",
-    "portfolio",
-    "blog"
-  ],
   "silhouette": [
     "dark",
     "landing",
@@ -7142,12 +6939,6 @@
     "blog",
     "skeuomorphic",
     "realistic"
-  ],
-  "slate-journal": [
-    "light",
-    "blog",
-    "editorial",
-    "minimal"
   ],
   "slate-tile": [
     "dark",
@@ -7327,13 +7118,6 @@
     "seasonal",
     "time-based"
   ],
-  "solstice-aurora-glass": [
-    "dark",
-    "glassmorphism",
-    "portfolio",
-    "creative",
-    "elegant"
-  ],
   "sonar": [
     "dark",
     "hub",
@@ -7464,17 +7248,6 @@
     "portfolio",
     "elegant",
     "minimal"
-  ],
-  "starlight-nebula": [
-    "dark",
-    "blog",
-    "sci-fi"
-  ],
-  "starlight-sonata": [
-    "dark",
-    "portfolio",
-    "elegant",
-    "cosmic"
   ],
   "starlight-synth-glass": [
     "dark",
@@ -7877,11 +7650,6 @@
     "docs",
     "jakarta"
   ],
-  "terra-folio": [
-    "light",
-    "portfolio",
-    "minimal"
-  ],
   "terrace": [
     "light",
     "blog",
@@ -8263,11 +8031,6 @@
     "industrial",
     "jakarta"
   ],
-  "vector-os": [
-    "dark",
-    "docs",
-    "sidebar"
-  ],
   "vellum": [
     "light",
     "blog",
@@ -8278,25 +8041,10 @@
     "dark",
     "saas"
   ],
-  "velour": [
-    "light",
-    "blog",
-    "minimal",
-    "editorial"
-  ],
   "velvet": [
     "dark",
     "landing",
     "luxury"
-  ],
-  "velvet-cyber-lotus": [
-    "velvet",
-    "cyber",
-    "lotus",
-    "pink",
-    "dark",
-    "neon",
-    "futuristic"
   ],
   "velvet-rope": [
     "event",
@@ -8418,12 +8166,6 @@
     "dark",
     "portfolio",
     "cyberpunk"
-  ],
-  "volt-terminal": [
-    "dark",
-    "blog",
-    "terminal",
-    "retro"
   ],
   "voltage": [
     "dark",
@@ -8623,20 +8365,6 @@
     "x-ray",
     "transparent"
   ],
-  "xeno-crystal-echo": [
-    "dark",
-    "neon",
-    "glassmorphism",
-    "cyberpunk",
-    "elegant"
-  ],
-  "xeno-vortex": [
-    "dark",
-    "glassmorphism",
-    "futuristic",
-    "neon",
-    "elegant"
-  ],
   "xerograph": [
     "dark",
     "blog",
@@ -8648,17 +8376,6 @@
     "cyber",
     "metallic",
     "retro"
-  ],
-  "z-mystic-nova": [
-    "mystic",
-    "nova",
-    "dark"
-  ],
-  "z-mystic-nova-plus": [
-    "mystic",
-    "dark",
-    "neon",
-    "elegant"
   ],
   "zen": [
     "light",
@@ -8703,11 +8420,294 @@
     "raw",
     "unconventional"
   ],
+  "chromatic-veil": [
+    "glassmorphism",
+    "gradient",
+    "vibrant",
+    "portfolio",
+    "creative",
+    "dark-mode"
+  ],
+  "neon-crystal-forge": [
+    "neon",
+    "crystal",
+    "dark-mode",
+    "glassmorphism",
+    "portfolio",
+    "creative"
+  ],
+  "neon-blossom": [
+    "cyberpunk",
+    "neon",
+    "dark-mode",
+    "elegant",
+    "creative"
+  ],
+  "ethereal-loom": [
+    "ethereal",
+    "elegant",
+    "dark-mode",
+    "glassmorphism",
+    "weaving"
+  ],
+  "moonlit-sakura": [
+    "moonlight",
+    "sakura",
+    "parallax",
+    "dark-mode",
+    "elegant"
+  ],
+  "cyber-neo": [
+    "dark",
+    "cyberpunk",
+    "portfolio",
+    "neon"
+  ],
+  "lumin-sphere": [
+    "dark",
+    "portfolio",
+    "cyberpunk"
+  ],
+  "celestial-weaver": [
+    "celestial",
+    "weaver",
+    "loom",
+    "ethereal",
+    "dark",
+    "elegant",
+    "ui"
+  ],
+  "prism-wave": [
+    "design",
+    "glassmorphism",
+    "vibrant",
+    "prism",
+    "wave"
+  ],
+  "z-mystic-nova": [
+    "mystic",
+    "nova",
+    "dark"
+  ],
+  "astral-resonance": [
+    "dark",
+    "elegant",
+    "blog"
+  ],
+  "chronos-flux": [
+    "dark",
+    "blog",
+    "elegant",
+    "cyberpunk"
+  ],
+  "holo-vista": [
+    "dark",
+    "glassmorphism",
+    "neon",
+    "cyberpunk",
+    "holographic"
+  ],
+  "lumina-canvas": [
+    "elegant",
+    "gallery",
+    "dark-mode"
+  ],
+  "obsidian-abyss": [
+    "dark",
+    "abyss",
+    "elegant",
+    "blog",
+    "obsidian"
+  ],
+  "ether-weave": [
+    "elegant",
+    "glassmorphism",
+    "portfolio"
+  ],
+  "xeno-crystal-echo": [
+    "dark",
+    "neon",
+    "glassmorphism",
+    "cyberpunk",
+    "elegant"
+  ],
+  "velvet-cyber-lotus": [
+    "velvet",
+    "cyber",
+    "lotus",
+    "pink",
+    "dark",
+    "neon",
+    "futuristic"
+  ],
+  "xeno-vortex": [
+    "dark",
+    "glassmorphism",
+    "futuristic",
+    "neon",
+    "elegant"
+  ],
   "zircon-matrix-ui": [
     "dark",
     "portfolio",
     "glassmorphism",
     "elegant",
     "cyberpunk"
+  ],
+  "cyber-glade": [
+    "dark",
+    "neon",
+    "cyber",
+    "retro"
+  ],
+  "crimson-void-nexus": [
+    "dark",
+    "glassmorphism",
+    "crimson",
+    "void",
+    "elegant"
+  ],
+  "ethereal-plasma-glass": [
+    "dark",
+    "glassmorphism",
+    "plasma",
+    "portfolio",
+    "elegant"
+  ],
+  "z-mystic-nova-plus": [
+    "mystic",
+    "dark",
+    "neon",
+    "elegant"
+  ],
+  "solstice-aurora-glass": [
+    "dark",
+    "glassmorphism",
+    "portfolio",
+    "creative",
+    "elegant"
+  ],
+  "apolo-luxe": [
+    "elegant",
+    "luxury",
+    "dark",
+    "serif",
+    "blog"
+  ],
+  "prism-tesserae": [
+    "portfolio",
+    "glassmorphism",
+    "dark"
+  ],
+  "starlight-nebula": [
+    "dark",
+    "blog",
+    "sci-fi"
+  ],
+  "fractal-pulse": [
+    "dark",
+    "creative",
+    "glow",
+    "geometric"
+  ],
+  "nebulous-enigma": [
+    "dark",
+    "cosmic",
+    "glassmorphism",
+    "portfolio"
+  ],
+  "starlight-sonata": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "cosmic"
+  ],
+  "neon-drift": [
+    "cyberpunk",
+    "neon",
+    "dark"
+  ],
+  "ivory": [
+    "light",
+    "portfolio",
+    "minimal"
+  ],
+  "aurora-nebula-vanguard": [
+    "dark",
+    "sci-fi",
+    "glassmorphism"
+  ],
+  "elegance-aura": [
+    "dark",
+    "blog",
+    "portfolio",
+    "elegant"
+  ],
+  "geometric-aether-lattice": [
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "silent-tide": [
+    "dark",
+    "minimal",
+    "portfolio",
+    "blog"
+  ],
+  "ethereal-geometric-vault": [
+    "dark",
+    "minimal",
+    "portfolio",
+    "editorial"
+  ],
+  "aegis-shield": [
+    "dark",
+    "landing",
+    "minimal",
+    "docs"
+  ],
+  "lunar-monolith": [
+    "dark",
+    "elegant",
+    "monolith",
+    "minimal"
+  ],
+  "silent-obelisk": [
+    "dark",
+    "minimal",
+    "brutalist",
+    "architecture"
+  ],
+  "abyssal-cipher": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "prism-grid": [
+    "light",
+    "blog",
+    "editorial",
+    "brutalist"
+  ],
+  "mono-stack": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "velour": [
+    "light",
+    "blog",
+    "minimal",
+    "editorial"
+  ],
+  "axiom-grid": [
+    "light",
+    "docs",
+    "bauhaus"
+  ],
+  "noctura": [
+    "dark",
+    "portfolio",
+    "landing"
   ]
 }

--- a/tags.json
+++ b/tags.json
@@ -1,73 +1,4 @@
 {
-  "cement-type": [
-    "light",
-    "blog",
-    "brutalist",
-    "minimal"
-  ],
-  "dusk-portal": [
-    "dark",
-    "portfolio",
-    "sci-fi"
-  ],
-  "acid-zine": [
-    "dark",
-    "blog",
-    "zine",
-    "punk"
-  ],
-  "signal-white": [
-    "light",
-    "blog",
-    "minimal",
-    "swiss"
-  ],
-  "noir-dispatch": [
-    "dark",
-    "blog",
-    "editorial",
-    "retro"
-  ],
-  "marble-haus": [
-    "light",
-    "portfolio",
-    "minimal",
-    "elegant"
-  ],
-  "volt-terminal": [
-    "dark",
-    "blog",
-    "terminal",
-    "retro"
-  ],
-  "ink-press": [
-    "light",
-    "blog",
-    "editorial"
-  ],
-  "chrome-folio": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
-  "obsidian-grid": [
-    "dark",
-    "blog",
-    "minimal",
-    "grid"
-  ],
-  "cosmic-glass-chronicles": [
-    "dark",
-    "portfolio",
-    "cyberpunk",
-    "minimal"
-  ],
-  "aura": [
-    "dark",
-    "glassmorphism",
-    "neon",
-    "ambient"
-  ],
   "abacus-ref": [
     "calculation",
     "logical",
@@ -95,6 +26,11 @@
     "deep-sea",
     "immersive"
   ],
+  "abyssal-cipher": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
   "accordion-fold": [
     "book",
     "light",
@@ -106,6 +42,12 @@
     "dark",
     "blog",
     "cyberpunk"
+  ],
+  "acid-zine": [
+    "dark",
+    "blog",
+    "zine",
+    "punk"
   ],
   "acme-docs": [
     "light",
@@ -129,6 +71,12 @@
     "dashboard",
     "admin",
     "sidebar"
+  ],
+  "aegis-shield": [
+    "dark",
+    "landing",
+    "minimal",
+    "docs"
   ],
   "aether": [
     "dark",
@@ -332,6 +280,13 @@
     "landing",
     "minimal"
   ],
+  "apolo-luxe": [
+    "elegant",
+    "luxury",
+    "dark",
+    "serif",
+    "blog"
+  ],
   "apothecary": [
     "light",
     "blog",
@@ -466,6 +421,11 @@
     "glow",
     "portfolio"
   ],
+  "astral-resonance": [
+    "dark",
+    "elegant",
+    "blog"
+  ],
   "astral-symphony-glass": [
     "dark",
     "portfolio",
@@ -517,6 +477,12 @@
     "light",
     "navigation"
   ],
+  "aura": [
+    "dark",
+    "glassmorphism",
+    "neon",
+    "ambient"
+  ],
   "aurelia": [
     "elegant",
     "minimalist",
@@ -555,6 +521,11 @@
     "dark",
     "animation"
   ],
+  "aurora-nebula-vanguard": [
+    "dark",
+    "sci-fi",
+    "glassmorphism"
+  ],
   "aurum": [
     "elegant",
     "dark",
@@ -587,6 +558,11 @@
     "design-system",
     "geometric",
     "mathematical"
+  ],
+  "axiom-grid": [
+    "light",
+    "docs",
+    "bauhaus"
   ],
   "axiom-ref": [
     "formal",
@@ -1248,6 +1224,21 @@
     "cosmic",
     "portfolio"
   ],
+  "celestial-weaver": [
+    "celestial",
+    "weaver",
+    "loom",
+    "ethereal",
+    "dark",
+    "elegant",
+    "ui"
+  ],
+  "cement-type": [
+    "light",
+    "blog",
+    "brutalist",
+    "minimal"
+  ],
   "center-stage": [
     "event",
     "solo",
@@ -1410,6 +1401,14 @@
     "chromatic",
     "portfolio"
   ],
+  "chromatic-veil": [
+    "glassmorphism",
+    "gradient",
+    "vibrant",
+    "portfolio",
+    "creative",
+    "dark-mode"
+  ],
   "chromatic-wave": [
     "dark",
     "portfolio",
@@ -1426,6 +1425,11 @@
     "bold",
     "minimal",
     "creative"
+  ],
+  "chrome-folio": [
+    "dark",
+    "portfolio",
+    "minimal"
   ],
   "chrome-pulse": [
     "minimal",
@@ -1456,6 +1460,12 @@
     "dark",
     "steampunk",
     "retro-futuristic"
+  ],
+  "chronos-flux": [
+    "dark",
+    "blog",
+    "elegant",
+    "cyberpunk"
   ],
   "chronos-forge": [
     "dark",
@@ -1844,6 +1854,12 @@
     "errata",
     "formal"
   ],
+  "cosmic-glass-chronicles": [
+    "dark",
+    "portfolio",
+    "cyberpunk",
+    "minimal"
+  ],
   "cosmic-wave": [
     "cyberpunk",
     "dark",
@@ -1896,6 +1912,13 @@
     "glassmorphism",
     "crimson",
     "blog"
+  ],
+  "crimson-void-nexus": [
+    "dark",
+    "glassmorphism",
+    "crimson",
+    "void",
+    "elegant"
   ],
   "cross-sectional": [
     "paper",
@@ -2025,10 +2048,22 @@
     "nature",
     "digital"
   ],
+  "cyber-glade": [
+    "dark",
+    "neon",
+    "cyber",
+    "retro"
+  ],
   "cyber-glass": [
     "blog",
     "cyberpunk",
     "glassmorphism"
+  ],
+  "cyber-neo": [
+    "dark",
+    "cyberpunk",
+    "portfolio",
+    "neon"
   ],
   "cyber-prism": [
     "cyberpunk",
@@ -2351,6 +2386,11 @@
     "blog",
     "sunset"
   ],
+  "dusk-portal": [
+    "dark",
+    "portfolio",
+    "sci-fi"
+  ],
   "dust-jacket": [
     "book",
     "light",
@@ -2407,6 +2447,12 @@
     "blog",
     "metallic",
     "plating"
+  ],
+  "elegance-aura": [
+    "dark",
+    "blog",
+    "portfolio",
+    "elegant"
   ],
   "elevate": [
     "landing",
@@ -2556,12 +2602,37 @@
     "etching",
     "printmaking"
   ],
+  "ether-weave": [
+    "elegant",
+    "glassmorphism",
+    "portfolio"
+  ],
   "ethereal-canvas": [
     "blog",
     "dark",
     "elegant",
     "minimal",
     "portfolio"
+  ],
+  "ethereal-geometric-vault": [
+    "dark",
+    "minimal",
+    "portfolio",
+    "editorial"
+  ],
+  "ethereal-loom": [
+    "ethereal",
+    "elegant",
+    "dark-mode",
+    "glassmorphism",
+    "weaving"
+  ],
+  "ethereal-plasma-glass": [
+    "dark",
+    "glassmorphism",
+    "plasma",
+    "portfolio",
+    "elegant"
   ],
   "ethereal-shimmer": [
     "dark",
@@ -2865,6 +2936,12 @@
     "generative",
     "mathematical"
   ],
+  "fractal-pulse": [
+    "dark",
+    "creative",
+    "glow",
+    "geometric"
+  ],
   "frequency": [
     "dark",
     "blog",
@@ -3041,6 +3118,11 @@
     "light",
     "landing",
     "geometric"
+  ],
+  "geometric-aether-lattice": [
+    "dark",
+    "minimal",
+    "blog"
   ],
   "gilded": [
     "dark",
@@ -3520,6 +3602,13 @@
     "modern",
     "jakarta"
   ],
+  "holo-vista": [
+    "dark",
+    "glassmorphism",
+    "neon",
+    "cyberpunk",
+    "holographic"
+  ],
   "hologram": [
     "dark",
     "showcase",
@@ -3707,6 +3796,11 @@
     "elegant",
     "serif"
   ],
+  "ink-press": [
+    "light",
+    "blog",
+    "editorial"
+  ],
   "ink-seoul": [
     "light",
     "blog",
@@ -3847,6 +3941,11 @@
     "hub",
     "bridge",
     "horizontal-scroll"
+  ],
+  "ivory": [
+    "light",
+    "portfolio",
+    "minimal"
   ],
   "jackhammer": [
     "heavy",
@@ -4218,6 +4317,11 @@
     "minimal",
     "luminescent"
   ],
+  "lumin-sphere": [
+    "dark",
+    "portfolio",
+    "cyberpunk"
+  ],
   "lumina": [
     "dark",
     "portfolio",
@@ -4234,6 +4338,11 @@
     "elegant",
     "soft",
     "glassmorphism"
+  ],
+  "lumina-canvas": [
+    "elegant",
+    "gallery",
+    "dark-mode"
   ],
   "lumina-chroma": [
     "blog",
@@ -4271,6 +4380,11 @@
     "neon",
     "glow",
     "animation"
+  ],
+  "luminal": [
+    "light",
+    "landing",
+    "minimal"
   ],
   "luminal-glass": [
     "dark",
@@ -4365,6 +4479,12 @@
     "dark",
     "blog",
     "elegant",
+    "minimal"
+  ],
+  "lunar-monolith": [
+    "dark",
+    "elegant",
+    "monolith",
     "minimal"
   ],
   "lunar-tide": [
@@ -4492,6 +4612,12 @@
     "gallery",
     "luxury",
     "marble-texture"
+  ],
+  "marble-haus": [
+    "light",
+    "portfolio",
+    "minimal",
+    "elegant"
   ],
   "marble-slab": [
     "sophisticated",
@@ -4797,6 +4923,11 @@
     "gold",
     "trendy"
   ],
+  "mono-stack": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
   "monochrome": [
     "light",
     "photo-essay",
@@ -4860,6 +4991,13 @@
     "texture",
     "unity",
     "monospace"
+  ],
+  "moonlit-sakura": [
+    "moonlight",
+    "sakura",
+    "parallax",
+    "dark-mode",
+    "elegant"
   ],
   "moonrise": [
     "dark",
@@ -4998,6 +5136,12 @@
     "space",
     "ethereal"
   ],
+  "nebulous-enigma": [
+    "dark",
+    "cosmic",
+    "glassmorphism",
+    "portfolio"
+  ],
   "nebulous-void-glass": [
     "dark",
     "portfolio",
@@ -5089,11 +5233,31 @@
     "dark",
     "grid"
   ],
+  "neon-blossom": [
+    "cyberpunk",
+    "neon",
+    "dark-mode",
+    "elegant",
+    "creative"
+  ],
   "neon-cipher": [
     "blog",
     "cyberpunk",
     "dark",
     "minimal"
+  ],
+  "neon-crystal-forge": [
+    "neon",
+    "crystal",
+    "dark-mode",
+    "glassmorphism",
+    "portfolio",
+    "creative"
+  ],
+  "neon-drift": [
+    "cyberpunk",
+    "neon",
+    "dark"
   ],
   "neon-dusk": [
     "dark",
@@ -5274,6 +5438,11 @@
     "glassmorphism",
     "neon"
   ],
+  "noctura": [
+    "dark",
+    "portfolio",
+    "landing"
+  ],
   "nocturne": [
     "dark",
     "blog",
@@ -5284,6 +5453,12 @@
     "dark",
     "blog",
     "noir"
+  ],
+  "noir-dispatch": [
+    "dark",
+    "blog",
+    "editorial",
+    "retro"
   ],
   "noire-gazette": [
     "dark",
@@ -5370,6 +5545,13 @@
     "glass",
     "oled"
   ],
+  "obsidian-abyss": [
+    "dark",
+    "abyss",
+    "elegant",
+    "blog",
+    "obsidian"
+  ],
   "obsidian-docs": [
     "docs",
     "dark",
@@ -5400,6 +5582,17 @@
     "glow",
     "portfolio",
     "glassmorphism"
+  ],
+  "obsidian-grid": [
+    "dark",
+    "blog",
+    "minimal",
+    "grid"
+  ],
+  "obsidian-press": [
+    "dark",
+    "blog",
+    "editorial"
   ],
   "obsidian-whisper": [
     "dark",
@@ -6064,11 +6257,29 @@
     "translucency",
     "outfit"
   ],
+  "prism-grid": [
+    "light",
+    "blog",
+    "editorial",
+    "brutalist"
+  ],
   "prism-pulse": [
     "dark",
     "neon",
     "pulsing",
     "creative"
+  ],
+  "prism-tesserae": [
+    "portfolio",
+    "glassmorphism",
+    "dark"
+  ],
+  "prism-wave": [
+    "design",
+    "glassmorphism",
+    "vibrant",
+    "prism",
+    "wave"
   ],
   "prismatic-void": [
     "dark",
@@ -6856,6 +7067,24 @@
     "immersive",
     "jakarta"
   ],
+  "signal-white": [
+    "light",
+    "blog",
+    "minimal",
+    "swiss"
+  ],
+  "silent-obelisk": [
+    "dark",
+    "minimal",
+    "brutalist",
+    "architecture"
+  ],
+  "silent-tide": [
+    "dark",
+    "minimal",
+    "portfolio",
+    "blog"
+  ],
   "silhouette": [
     "dark",
     "landing",
@@ -6913,6 +7142,12 @@
     "blog",
     "skeuomorphic",
     "realistic"
+  ],
+  "slate-journal": [
+    "light",
+    "blog",
+    "editorial",
+    "minimal"
   ],
   "slate-tile": [
     "dark",
@@ -7092,6 +7327,13 @@
     "seasonal",
     "time-based"
   ],
+  "solstice-aurora-glass": [
+    "dark",
+    "glassmorphism",
+    "portfolio",
+    "creative",
+    "elegant"
+  ],
   "sonar": [
     "dark",
     "hub",
@@ -7222,6 +7464,17 @@
     "portfolio",
     "elegant",
     "minimal"
+  ],
+  "starlight-nebula": [
+    "dark",
+    "blog",
+    "sci-fi"
+  ],
+  "starlight-sonata": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "cosmic"
   ],
   "starlight-synth-glass": [
     "dark",
@@ -7624,6 +7877,11 @@
     "docs",
     "jakarta"
   ],
+  "terra-folio": [
+    "light",
+    "portfolio",
+    "minimal"
+  ],
   "terrace": [
     "light",
     "blog",
@@ -8005,6 +8263,11 @@
     "industrial",
     "jakarta"
   ],
+  "vector-os": [
+    "dark",
+    "docs",
+    "sidebar"
+  ],
   "vellum": [
     "light",
     "blog",
@@ -8015,10 +8278,25 @@
     "dark",
     "saas"
   ],
+  "velour": [
+    "light",
+    "blog",
+    "minimal",
+    "editorial"
+  ],
   "velvet": [
     "dark",
     "landing",
     "luxury"
+  ],
+  "velvet-cyber-lotus": [
+    "velvet",
+    "cyber",
+    "lotus",
+    "pink",
+    "dark",
+    "neon",
+    "futuristic"
   ],
   "velvet-rope": [
     "event",
@@ -8140,6 +8418,12 @@
     "dark",
     "portfolio",
     "cyberpunk"
+  ],
+  "volt-terminal": [
+    "dark",
+    "blog",
+    "terminal",
+    "retro"
   ],
   "voltage": [
     "dark",
@@ -8339,6 +8623,20 @@
     "x-ray",
     "transparent"
   ],
+  "xeno-crystal-echo": [
+    "dark",
+    "neon",
+    "glassmorphism",
+    "cyberpunk",
+    "elegant"
+  ],
+  "xeno-vortex": [
+    "dark",
+    "glassmorphism",
+    "futuristic",
+    "neon",
+    "elegant"
+  ],
   "xerograph": [
     "dark",
     "blog",
@@ -8350,6 +8648,17 @@
     "cyber",
     "metallic",
     "retro"
+  ],
+  "z-mystic-nova": [
+    "mystic",
+    "nova",
+    "dark"
+  ],
+  "z-mystic-nova-plus": [
+    "mystic",
+    "dark",
+    "neon",
+    "elegant"
   ],
   "zen": [
     "light",
@@ -8394,294 +8703,11 @@
     "raw",
     "unconventional"
   ],
-  "chromatic-veil": [
-    "glassmorphism",
-    "gradient",
-    "vibrant",
-    "portfolio",
-    "creative",
-    "dark-mode"
-  ],
-  "neon-crystal-forge": [
-    "neon",
-    "crystal",
-    "dark-mode",
-    "glassmorphism",
-    "portfolio",
-    "creative"
-  ],
-  "neon-blossom": [
-    "cyberpunk",
-    "neon",
-    "dark-mode",
-    "elegant",
-    "creative"
-  ],
-  "ethereal-loom": [
-    "ethereal",
-    "elegant",
-    "dark-mode",
-    "glassmorphism",
-    "weaving"
-  ],
-  "moonlit-sakura": [
-    "moonlight",
-    "sakura",
-    "parallax",
-    "dark-mode",
-    "elegant"
-  ],
-  "cyber-neo": [
-    "dark",
-    "cyberpunk",
-    "portfolio",
-    "neon"
-  ],
-  "lumin-sphere": [
-    "dark",
-    "portfolio",
-    "cyberpunk"
-  ],
-  "celestial-weaver": [
-    "celestial",
-    "weaver",
-    "loom",
-    "ethereal",
-    "dark",
-    "elegant",
-    "ui"
-  ],
-  "prism-wave": [
-    "design",
-    "glassmorphism",
-    "vibrant",
-    "prism",
-    "wave"
-  ],
-  "z-mystic-nova": [
-    "mystic",
-    "nova",
-    "dark"
-  ],
-  "astral-resonance": [
-    "dark",
-    "elegant",
-    "blog"
-  ],
-  "chronos-flux": [
-    "dark",
-    "blog",
-    "elegant",
-    "cyberpunk"
-  ],
-  "holo-vista": [
-    "dark",
-    "glassmorphism",
-    "neon",
-    "cyberpunk",
-    "holographic"
-  ],
-  "lumina-canvas": [
-    "elegant",
-    "gallery",
-    "dark-mode"
-  ],
-  "obsidian-abyss": [
-    "dark",
-    "abyss",
-    "elegant",
-    "blog",
-    "obsidian"
-  ],
-  "ether-weave": [
-    "elegant",
-    "glassmorphism",
-    "portfolio"
-  ],
-  "xeno-crystal-echo": [
-    "dark",
-    "neon",
-    "glassmorphism",
-    "cyberpunk",
-    "elegant"
-  ],
-  "velvet-cyber-lotus": [
-    "velvet",
-    "cyber",
-    "lotus",
-    "pink",
-    "dark",
-    "neon",
-    "futuristic"
-  ],
-  "xeno-vortex": [
-    "dark",
-    "glassmorphism",
-    "futuristic",
-    "neon",
-    "elegant"
-  ],
   "zircon-matrix-ui": [
     "dark",
     "portfolio",
     "glassmorphism",
     "elegant",
     "cyberpunk"
-  ],
-  "cyber-glade": [
-    "dark",
-    "neon",
-    "cyber",
-    "retro"
-  ],
-  "crimson-void-nexus": [
-    "dark",
-    "glassmorphism",
-    "crimson",
-    "void",
-    "elegant"
-  ],
-  "ethereal-plasma-glass": [
-    "dark",
-    "glassmorphism",
-    "plasma",
-    "portfolio",
-    "elegant"
-  ],
-  "z-mystic-nova-plus": [
-    "mystic",
-    "dark",
-    "neon",
-    "elegant"
-  ],
-  "solstice-aurora-glass": [
-    "dark",
-    "glassmorphism",
-    "portfolio",
-    "creative",
-    "elegant"
-  ],
-  "apolo-luxe": [
-    "elegant",
-    "luxury",
-    "dark",
-    "serif",
-    "blog"
-  ],
-  "prism-tesserae": [
-    "portfolio",
-    "glassmorphism",
-    "dark"
-  ],
-  "starlight-nebula": [
-    "dark",
-    "blog",
-    "sci-fi"
-  ],
-  "fractal-pulse": [
-    "dark",
-    "creative",
-    "glow",
-    "geometric"
-  ],
-  "nebulous-enigma": [
-    "dark",
-    "cosmic",
-    "glassmorphism",
-    "portfolio"
-  ],
-  "starlight-sonata": [
-    "dark",
-    "portfolio",
-    "elegant",
-    "cosmic"
-  ],
-  "neon-drift": [
-    "cyberpunk",
-    "neon",
-    "dark"
-  ],
-  "ivory": [
-    "light",
-    "portfolio",
-    "minimal"
-  ],
-  "aurora-nebula-vanguard": [
-    "dark",
-    "sci-fi",
-    "glassmorphism"
-  ],
-  "elegance-aura": [
-    "dark",
-    "blog",
-    "portfolio",
-    "elegant"
-  ],
-  "geometric-aether-lattice": [
-    "dark",
-    "minimal",
-    "blog"
-  ],
-  "silent-tide": [
-    "dark",
-    "minimal",
-    "portfolio",
-    "blog"
-  ],
-  "ethereal-geometric-vault": [
-    "dark",
-    "minimal",
-    "portfolio",
-    "editorial"
-  ],
-  "aegis-shield": [
-    "dark",
-    "landing",
-    "minimal",
-    "docs"
-  ],
-  "lunar-monolith": [
-    "dark",
-    "elegant",
-    "monolith",
-    "minimal"
-  ],
-  "silent-obelisk": [
-    "dark",
-    "minimal",
-    "brutalist",
-    "architecture"
-  ],
-  "abyssal-cipher": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
-  "prism-grid": [
-    "light",
-    "blog",
-    "editorial",
-    "brutalist"
-  ],
-  "mono-stack": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
-  "velour": [
-    "light",
-    "blog",
-    "minimal",
-    "editorial"
-  ],
-  "axiom-grid": [
-    "light",
-    "docs",
-    "bauhaus"
-  ],
-  "noctura": [
-    "dark",
-    "portfolio",
-    "landing"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds five new examples — `obsidian-press`, `luminal`, `terra-folio`, `vector-os`, `slate-journal` — each committed to a distinct contemporary aesthetic.
- No gradients or emojis anywhere, per the design brief.
- Registered in `tags.json` (alphabetical insert).

## The sites
| Name | Tags | Direction |
|---|---|---|
| `obsidian-press` | `dark`, `blog`, `editorial` | Dark editorial magazine — Fraunces display serif, brick-red accent, drop caps, `№` labels, asymmetric grid |
| `luminal` | `light`, `landing`, `minimal` | Bold light SaaS landing — Inter 700/800 hero, electric lime accent, 1px borders, KPI strip + changelog rail |
| `terra-folio` | `light`, `portfolio`, `minimal` | Warm cream portfolio for "Iris Voronova" — italic Fraunces, burnt sienna, flat color swatches per project |
| `vector-os` | `dark`, `docs`, `sidebar` | Swiss-precision dark technical docs — 3-col layout (sidebar / content / ToC), JetBrains Mono numerals, cool blue accent |
| `slate-journal` | `light`, `blog`, `editorial`, `minimal` | Light editorial journal — Fraunces body with italic emphasis, slate-blue accent, 8/4 asymmetric lead grid |

## Test plan
- [x] `hwaro build` clean on all 5 sites (8–14 pages each, zero warnings)
- [x] Repo-wide scan: no `linear-gradient` / `radial-gradient` / `conic-gradient`
- [x] Repo-wide scan: no emoji codepoints in content/templates/CSS
- [x] All asset/link references use `{{ base_url }}` prefix
- [x] `tags.json` resorted alphabetically (1403 entries)
- [ ] CI: index page deploys and tag filters surface the new entries