### PR TITLE
Fix 404 errors in anaglyph example

### DIFF
--- a/examples/anaglyph/templates/header.html
+++ b/examples/anaglyph/templates/header.html
@@ -15,9 +15,9 @@
         <header>
             <h1 class="anaglyph-text glitch"><a href="{{ base_url }}">{{ site.title }}</a></h1>
             <nav class="nav-links">
-                <a href="{{ base_url }}/posts" class="anaglyph-text-sub">Posts</a>
-                <a href="{{ base_url }}/about" class="anaglyph-text-sub">About</a>
-                <a href="{{ base_url }}/tags" class="anaglyph-text-sub">Tags</a>
+                <a href="{{ base_url }}/posts/" class="anaglyph-text-sub">Posts</a>
+                <a href="{{ base_url }}/about/" class="anaglyph-text-sub">About</a>
+                <a href="{{ base_url }}/tags/" class="anaglyph-text-sub">Tags</a>
             </nav>
         </header>
         <main>


### PR DESCRIPTION
Fix 404 errors in anaglyph example by appending trailing slashes to the navigation links (`/posts/`, `/about/`, `/tags/`) in `templates/header.html`. This ensures that the generated static sites correctly route to the `index.html` file within the generated output directories instead of returning 404.

---
*PR created automatically by Jules for task [16850076095839594615](https://jules.google.com/task/16850076095839594615) started by @chei-l*