### PR TITLE
Add five modern dashboard example sites

### DIFF
--- a/examples/kepler-grid/AGENTS.md
+++ b/examples/kepler-grid/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/kepler-grid/archetypes/default.md
+++ b/examples/kepler-grid/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/kepler-grid/config.toml
+++ b/examples/kepler-grid/config.toml
@@ -1,0 +1,217 @@
+title = "Kepler Grid"
+description = "Mission control telemetry for orbital data systems."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "systems"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["logbook"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/kepler-grid/content/about.md
+++ b/examples/kepler-grid/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "Manual"
+description = "Reading guide for the Kepler Grid console."
++++
+
+Kepler Grid is a ground console for a small commercial constellation in low-Earth orbit. The display you just stepped away from is the working surface for two flight directors, four payload engineers and a rotating night shift of three.
+
+## What you are looking at
+
+Every panel in the console is a working board, not a summary. The numbers update on every telemetry tick — sixteen ticks per minute on the s-band, two per minute on the high-rate X-band downlink. When a panel goes dim the source has stopped reporting, not the page.
+
+> Treat the bright sliver. Anything outside the bright sliver was already true ten minutes ago.
+
+The orange marker means *attention without alarm*. A red dot is an alarm; an alarm has always been acknowledged by the time you see it here. The yellow square is operator-defined and survives between shifts.
+
+## What we promise
+
+- The console will be honest. If a stream is stale we show *stale*, not the last value.
+- We will publish a logbook entry within an hour of any anomaly leaving safe-mode rehearsal.
+- We will not invent a number to fill a panel. An empty panel is a real panel.
+
+## The team
+
+The grid is run jointly by the spacecraft and ground software groups. New shift members read the **Logbook** front to back before they pick up a handover.

--- a/examples/kepler-grid/content/index.md
+++ b/examples/kepler-grid/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Console"
+description = "Kepler Grid mission control telemetry, transcribed on the ground."
+template = "home"
++++

--- a/examples/kepler-grid/content/logbook/_index.md
+++ b/examples/kepler-grid/content/logbook/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Logbook"
+description = "Flight-director entries kept across shifts. Most recent first."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/kepler-grid/content/logbook/kep-09-watchdog.md
+++ b/examples/kepler-grid/content/logbook/kep-09-watchdog.md
@@ -1,0 +1,18 @@
++++
+title = "KEP-09 watchdog walk-out"
+date = "2026-05-12"
+description = "How a single missed scheduler tick walked KEP-09 into a safe-mode rehearsal — and the small instrumentation fix that closes the gap."
+tags = ["anomaly", "scheduler", "safe-mode"]
+systems = ["bus", "scheduler"]
++++
+
+KEP-09 entered safe-mode rehearsal at 03:41:09 UTC after the on-board scheduler missed three consecutive ticks on the bus housekeeping board. The watchdog did what it was supposed to do; the recovery sequence cleared in 9 minutes; nothing was at risk.
+
+The interesting bit is *why* it took us almost a full pass to notice that the rehearsal had run. The downlink event was emitted, but the ground decoder was tagging it as a level-3 ("informational") log rather than a level-1 ("alarm") because the OBC schema bumped the field in firmware revision r3.41 and the decoder still maps it to the r3.40 enum.
+
+## Fix landed
+
+- `groundsw/decoder/obc_events.toml`: add r3.41 enum, retire r3.40 once the fleet is flashed.
+- Decoder version is now reported in the heartbeat. Mismatch raises a yellow on the **Event Log** panel.
+
+> The bird did the right thing. The console did the wrong thing in a quiet way. Quiet wrong is what we are most afraid of.

--- a/examples/kepler-grid/content/logbook/orbit-determination.md
+++ b/examples/kepler-grid/content/logbook/orbit-determination.md
@@ -1,0 +1,18 @@
++++
+title = "Orbit determination converged in 12 ticks"
+date = "2026-05-01"
+description = "We re-tuned the OD filter to handle the new GPS receiver firmware. Convergence dropped from 41 to 12 ticks."
+tags = ["orbit-determination", "filter", "gnss"]
+systems = ["bus", "gnss"]
++++
+
+Earlier this season we flashed a new GNSS receiver firmware on KEP-04 → KEP-08. The new firmware emits position fixes at 20 Hz instead of 10 Hz, with a slightly different covariance structure. The old orbit determination filter was happy to consume the extra rate but it was *also* happy to converge slowly while it learned the new noise model.
+
+We retuned the process-noise matrix on the ground side and re-baselined the initial covariance.
+
+- **Before:** 41 ticks to converge after a maneuver.
+- **After:** 12 ticks to converge after a maneuver.
+
+The same filter is now running on all 17 birds. Nothing changed on the flight side; this is a ground-only improvement.
+
+> The flight team's nicest property is that good ground work makes the spacecraft look smarter without any of them having to wake up.

--- a/examples/kepler-grid/content/logbook/payload-sar-commit.md
+++ b/examples/kepler-grid/content/logbook/payload-sar-commit.md
@@ -1,0 +1,18 @@
++++
+title = "Payload SAR · commit 0a91f3"
+date = "2026-05-06"
+description = "Synthetic-aperture radar firmware bump rolls out across the constellation in three orbital passes."
+tags = ["payload", "firmware", "rollout"]
+systems = ["payload"]
++++
+
+The SAR firmware bump (`0a91f3`) lands on the constellation tonight. The change is small — a 38-line patch to the chirp generator that lowers transmit power during the calibration sweep — but the rollout still goes through the staged process.
+
+| Pass | Window (UTC)    | Birds          | Result   |
+|------|-----------------|----------------|----------|
+| 1    | 22:14 → 22:31   | KEP-01, KEP-02 | nominal  |
+| 2    | 23:48 → 00:04   | KEP-03 → KEP-06 | nominal  |
+| 3    | 01:22 → 01:38   | KEP-07 → KEP-12 | nominal  |
+| 4    | 02:54 → 03:11   | KEP-13 → KEP-17 | pending  |
+
+If pass 4 reports green at 03:11, we will close the rollout and the calibration board will hand control back to the science team at 06:00.

--- a/examples/kepler-grid/content/logbook/punta-arenas-weather.md
+++ b/examples/kepler-grid/content/logbook/punta-arenas-weather.md
@@ -1,0 +1,17 @@
++++
+title = "Punta Arenas downgraded for the storm window"
+date = "2026-05-09"
+description = "Antenna PUQ runs at 12 Mb/s through a 36-hour weather cell. Scheduling shifted to SVL and HBK."
+tags = ["ground", "weather", "schedule"]
+systems = ["ground-network"]
++++
+
+A deep low pressure system is parked over Magellan straits for the next 36 hours. Wind speed at PUQ is at 92 km/h gust and rising; the dish is held at 30° from vertical with the radome under load. We have voluntarily dropped to the 12 Mb/s emergency-only profile.
+
+## Schedule changes
+
+- All high-rate dumps for KEP-04, KEP-08, KEP-11 routed to **SVL** (Svalbard) for the next 6 passes.
+- HBK takes the redundancy slot for KEP-13 → 17.
+- The PUQ-only experimental link for KEP-09 is paused until the watchdog rehearsal closes (see entry of 2026-05-12).
+
+We are not behind on data volume. We are using the slack we deliberately built into the schedule.

--- a/examples/kepler-grid/static/css/style.css
+++ b/examples/kepler-grid/static/css/style.css
@@ -1,0 +1,202 @@
+:root {
+  --bg: #0c0d10;
+  --panel: #14161b;
+  --panel-2: #1b1e25;
+  --line: #262a33;
+  --line-2: #353a45;
+  --ink: #f5ebd6;
+  --ink-mute: #8a8f9b;
+  --ink-dim: #5b6070;
+  --accent: #ff3a20;
+  --accent-2: #ffcb45;
+  --good: #66d28a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "IBM Plex Sans", "Inter", system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  background-image:
+    linear-gradient(transparent 95%, rgba(255,255,255,0.025) 95%),
+    linear-gradient(90deg, transparent 95%, rgba(255,255,255,0.025) 95%);
+  background-size: 32px 32px;
+}
+
+a { color: var(--ink); text-decoration: none; border-bottom: 1px solid var(--line-2); }
+a:hover { color: var(--accent); border-color: var(--accent); }
+
+.mono, code, pre { font-family: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; }
+
+.frame {
+  max-width: 1340px;
+  margin: 0 auto;
+  padding: 24px 32px 80px;
+}
+
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 14px 0 28px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 28px;
+}
+.topbar .brand {
+  display: flex; align-items: center; gap: 14px;
+  font-family: "IBM Plex Mono", monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: var(--ink-mute);
+  border: 0;
+}
+.topbar .brand .mark {
+  width: 26px; height: 26px;
+  background: var(--accent);
+  display: inline-block;
+  position: relative;
+}
+.topbar .brand .mark::after {
+  content: ""; position: absolute; left: 6px; top: 6px;
+  width: 14px; height: 14px; background: var(--bg);
+}
+.topbar .brand b { color: var(--ink); font-weight: 600; letter-spacing: 0.16em; }
+.topbar .ticker {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  text-align: center;
+  color: var(--ink-dim);
+}
+.topbar .ticker span { color: var(--accent-2); margin-right: 6px; }
+.topbar nav { justify-self: end; display: flex; gap: 22px; }
+.topbar nav a {
+  border: 0;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.topbar nav a:hover { color: var(--ink); }
+
+.hero {
+  display: grid;
+  grid-template-columns: 7fr 5fr;
+  gap: 0;
+  border: 1px solid var(--line);
+  margin-bottom: 28px;
+}
+.hero .lead { padding: 44px 48px; border-right: 1px solid var(--line); }
+.hero .lead .crumb { font-family: "IBM Plex Mono", monospace; font-size: 11px; color: var(--ink-dim); letter-spacing: 0.18em; margin-bottom: 22px; text-transform: uppercase; }
+.hero .lead h1 { font-size: clamp(2.4rem, 4.4vw, 3.6rem); line-height: 0.98; letter-spacing: -0.02em; margin: 0 0 24px; font-weight: 700; }
+.hero .lead h1 em { font-style: normal; color: var(--accent); }
+.hero .lead p { color: var(--ink-mute); max-width: 52ch; font-size: 0.98rem; }
+.hero .stat-stack { display: grid; grid-template-rows: repeat(3, 1fr); }
+.hero .stat-stack .row { padding: 28px 32px; border-bottom: 1px solid var(--line); display: flex; align-items: baseline; justify-content: space-between; }
+.hero .stat-stack .row:last-child { border-bottom: 0; }
+.hero .stat-stack .label { font-family: "IBM Plex Mono", monospace; font-size: 11px; color: var(--ink-dim); letter-spacing: 0.18em; text-transform: uppercase; }
+.hero .stat-stack .value { font-family: "IBM Plex Mono", monospace; font-size: 2rem; color: var(--ink); font-feature-settings: "tnum"; }
+.hero .stat-stack .value.up::before { content: "▲ "; color: var(--good); font-size: 0.7em; }
+.hero .stat-stack .value.dn::before { content: "▼ "; color: var(--accent); font-size: 0.7em; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 16px;
+}
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 20px 22px;
+  position: relative;
+}
+.panel header.head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 0 0 14px; margin-bottom: 16px;
+  border-bottom: 1px solid var(--line);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-dim);
+}
+.panel header.head .id { color: var(--accent); }
+
+.col-4 { grid-column: span 4; }
+.col-6 { grid-column: span 6; }
+.col-8 { grid-column: span 8; }
+.col-12 { grid-column: span 12; }
+
+.kpi { font-family: "IBM Plex Mono", monospace; }
+.kpi .big { font-size: 2.6rem; color: var(--ink); line-height: 1; letter-spacing: -0.02em; }
+.kpi .delta { display: inline-block; margin-left: 10px; font-size: 0.85rem; color: var(--good); }
+.kpi .delta.neg { color: var(--accent); }
+.kpi .sub { color: var(--ink-mute); font-size: 12px; margin-top: 12px; }
+
+.bars { display: flex; align-items: flex-end; gap: 6px; height: 110px; margin-top: 6px; }
+.bars span { flex: 1; background: var(--line-2); position: relative; }
+.bars span::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; background: var(--accent); height: var(--h, 30%); }
+.bars span.alt::after { background: var(--accent-2); }
+.bars + .axis { display: flex; gap: 6px; margin-top: 8px; font-family: "IBM Plex Mono", monospace; font-size: 10px; color: var(--ink-dim); }
+.bars + .axis span { flex: 1; text-align: center; }
+
+.station-list { list-style: none; padding: 0; margin: 0; }
+.station-list li { display: grid; grid-template-columns: 26px 1fr auto auto; gap: 14px; align-items: center; padding: 10px 0; border-bottom: 1px dashed var(--line); font-family: "IBM Plex Mono", monospace; font-size: 13px; }
+.station-list li:last-child { border-bottom: 0; }
+.station-list .dot { width: 10px; height: 10px; background: var(--good); display: inline-block; }
+.station-list .dot.warn { background: var(--accent-2); }
+.station-list .dot.err { background: var(--accent); }
+.station-list .meta { color: var(--ink-mute); font-size: 11px; }
+
+.log { font-family: "IBM Plex Mono", monospace; font-size: 12.5px; line-height: 1.8; color: var(--ink-mute); margin: 0; }
+.log .t { color: var(--ink-dim); margin-right: 12px; }
+.log .ok { color: var(--good); }
+.log .wn { color: var(--accent-2); }
+.log .er { color: var(--accent); }
+
+.divider {
+  border: 0;
+  border-top: 1px solid var(--line);
+  margin: 36px 0;
+}
+
+article.prose { max-width: 78ch; }
+article.prose h2 { font-size: 1.6rem; letter-spacing: -0.01em; margin: 1.6em 0 0.5em; }
+article.prose h3 { font-size: 1.15rem; color: var(--ink); margin: 1.4em 0 0.4em; }
+article.prose p { color: var(--ink); }
+article.prose blockquote { border-left: 3px solid var(--accent); padding: 4px 18px; margin: 1.4em 0; color: var(--ink-mute); font-style: italic; }
+article.prose ul li::marker { color: var(--accent); }
+
+ul.section-list { list-style: none; padding: 0; }
+ul.section-list li { padding: 18px 0; border-top: 1px solid var(--line); display: flex; justify-content: space-between; align-items: baseline; }
+ul.section-list li:last-child { border-bottom: 1px solid var(--line); }
+ul.section-list li a { border: 0; font-size: 1.15rem; }
+ul.section-list li time { font-family: "IBM Plex Mono", monospace; font-size: 11px; color: var(--ink-dim); letter-spacing: 0.14em; text-transform: uppercase; }
+
+footer.foot {
+  margin-top: 60px;
+  border-top: 1px solid var(--line);
+  padding-top: 28px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 30px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+footer.foot strong { color: var(--ink); letter-spacing: 0.18em; display: block; margin-bottom: 10px; }
+
+@media (max-width: 900px) {
+  .hero { grid-template-columns: 1fr; }
+  .hero .lead { border-right: 0; border-bottom: 1px solid var(--line); }
+  .col-4, .col-6, .col-8 { grid-column: span 12; }
+  .topbar { grid-template-columns: 1fr auto; }
+  .topbar .ticker { display: none; }
+}

--- a/examples/kepler-grid/static/favicon.svg
+++ b/examples/kepler-grid/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/kepler-grid/templates/404.html
+++ b/examples/kepler-grid/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/kepler-grid/templates/footer.html
+++ b/examples/kepler-grid/templates/footer.html
@@ -1,0 +1,20 @@
+    <footer class="foot">
+      <div>
+        <strong>{{ site.title }}</strong>
+        Orbital telemetry, transcribed for the ground team. Built with Hwaro on Crystal.
+      </div>
+      <div>
+        <strong>Sections</strong>
+        <a href="{{ base_url }}/">Console</a> ·
+        <a href="{{ base_url }}/logbook/">Logbook</a> ·
+        <a href="{{ base_url }}/about/">Manual</a>
+      </div>
+      <div>
+        <strong>Ground · {{ current_year }}</strong>
+        Last sync {{ current_date }} · build 06.{{ current_year }}.r2
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/kepler-grid/templates/header.html
+++ b/examples/kepler-grid/templates/header.html
@@ -20,7 +20,7 @@
         <span class="mark" aria-hidden="true"></span>
         <span><b>KEPLER</b> · GRID/06</span>
       </a>
-      <div class="ticker"><span>SYS·NOM</span> orbit 412 km · slew −0.12° · downlink 1.2 Gb/s · ground link YGW · {{ current_year }}.{{ current_date }}</div>
+      <div class="ticker"><span>SYS·NOM</span> orbit 412 km · slew −0.12° · downlink 1.2 Gb/s · ground link YGW · {{ current_date }}</div>
       <nav>
         <a href="{{ base_url }}/">Console</a>
         <a href="{{ base_url }}/logbook/">Logbook</a>

--- a/examples/kepler-grid/templates/header.html
+++ b/examples/kepler-grid/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="frame">
+    <header class="topbar">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="mark" aria-hidden="true"></span>
+        <span><b>KEPLER</b> · GRID/06</span>
+      </a>
+      <div class="ticker"><span>SYS·NOM</span> orbit 412 km · slew −0.12° · downlink 1.2 Gb/s · ground link YGW · {{ current_year }}.{{ current_date }}</div>
+      <nav>
+        <a href="{{ base_url }}/">Console</a>
+        <a href="{{ base_url }}/logbook/">Logbook</a>
+        <a href="{{ base_url }}/about/">Manual</a>
+      </nav>
+    </header>

--- a/examples/kepler-grid/templates/home.html
+++ b/examples/kepler-grid/templates/home.html
@@ -1,0 +1,126 @@
+{% include "header.html" %}
+  <main>
+    <section class="hero">
+      <div class="lead">
+        <div class="crumb">Console · 06 · {{ current_date }}</div>
+        <h1>Watching the <em>bright sliver</em><br>between data and dark.</h1>
+        <p>Kepler Grid is mission control for orbital data systems: thirty-two payload streams, a constellation of seventeen, and a ground network that never blinks. Every digit on this console is fresh.</p>
+      </div>
+      <div class="stat-stack">
+        <div class="row"><span class="label">Orbit</span><span class="value">412.6 km</span></div>
+        <div class="row"><span class="label">Downlink</span><span class="value up">1.24 Gb/s</span></div>
+        <div class="row"><span class="label">Anomalies</span><span class="value dn">02</span></div>
+      </div>
+    </section>
+
+    <section class="grid" style="margin-bottom:28px;">
+      <div class="panel col-4">
+        <header class="head"><span><span class="id">01</span> · Power Budget</span><span>watts</span></header>
+        <div class="kpi">
+          <div class="big">2,418</div>
+          <div class="sub">+4.2% vs. prior orbit · margin 312W</div>
+        </div>
+        <div class="bars" style="margin-top:22px;">
+          <span style="--h:42%"></span><span style="--h:56%"></span><span style="--h:38%"></span>
+          <span style="--h:71%"></span><span style="--h:62%"></span><span style="--h:80%"></span>
+          <span style="--h:55%"></span><span style="--h:74%"></span><span style="--h:48%"></span>
+          <span class="alt" style="--h:90%"></span><span style="--h:64%"></span><span style="--h:58%"></span>
+        </div>
+        <div class="axis"><span>00</span><span>02</span><span>04</span><span>06</span><span>08</span><span>10</span><span>12</span><span>14</span><span>16</span><span>18</span><span>20</span><span>22</span></div>
+      </div>
+
+      <div class="panel col-4">
+        <header class="head"><span><span class="id">02</span> · Thermal</span><span>°C</span></header>
+        <div class="kpi">
+          <div class="big">−18.4</div>
+          <div class="sub">cabin nominal · radiator b3 within tol.</div>
+        </div>
+        <ul class="station-list" style="margin-top:18px;">
+          <li><span class="dot"></span><span>Bus A</span><span>−18.0</span><span class="meta">stable</span></li>
+          <li><span class="dot"></span><span>Bus B</span><span>−21.3</span><span class="meta">stable</span></li>
+          <li><span class="dot warn"></span><span>Sensor pod</span><span>+04.1</span><span class="meta">drift 0.08</span></li>
+          <li><span class="dot"></span><span>Solar yoke</span><span>+62.7</span><span class="meta">in sun</span></li>
+        </ul>
+      </div>
+
+      <div class="panel col-4">
+        <header class="head"><span><span class="id">03</span> · Constellation</span><span>17 sats</span></header>
+        <div class="kpi">
+          <div class="big">16/17<span class="delta">+1 acquired</span></div>
+          <div class="sub">KEP-09 in safe-mode rehearsal</div>
+        </div>
+        <ul class="station-list" style="margin-top:18px;">
+          <li><span class="dot"></span><span>KEP-01 → 06</span><span>nominal</span><span class="meta">412 km</span></li>
+          <li><span class="dot"></span><span>KEP-07 → 12</span><span>nominal</span><span class="meta">408 km</span></li>
+          <li><span class="dot err"></span><span>KEP-09</span><span>safe</span><span class="meta">rehearsal</span></li>
+          <li><span class="dot"></span><span>KEP-13 → 17</span><span>nominal</span><span class="meta">414 km</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="panel col-8">
+        <header class="head"><span><span class="id">04</span> · Downlink throughput</span><span>72 h window</span></header>
+        <div class="bars" style="height:160px; margin-top:8px;">
+          <span style="--h:34%"></span><span style="--h:40%"></span><span style="--h:38%"></span>
+          <span style="--h:52%"></span><span style="--h:48%"></span><span style="--h:58%"></span>
+          <span style="--h:64%"></span><span class="alt" style="--h:82%"></span><span style="--h:70%"></span>
+          <span style="--h:74%"></span><span style="--h:80%"></span><span style="--h:92%"></span>
+          <span class="alt" style="--h:100%"></span><span style="--h:88%"></span><span style="--h:76%"></span>
+          <span style="--h:60%"></span><span style="--h:54%"></span><span style="--h:48%"></span>
+          <span style="--h:62%"></span><span style="--h:68%"></span><span style="--h:78%"></span>
+          <span style="--h:82%"></span><span class="alt" style="--h:90%"></span><span style="--h:84%"></span>
+        </div>
+        <div class="axis">
+          <span>−72h</span><span></span><span></span><span></span><span></span><span></span>
+          <span>−48h</span><span></span><span></span><span></span><span></span><span></span>
+          <span>−24h</span><span></span><span></span><span></span><span></span><span></span>
+          <span>now</span><span></span><span></span><span></span><span></span><span></span>
+        </div>
+      </div>
+      <div class="panel col-4">
+        <header class="head"><span><span class="id">05</span> · Event Log</span><span>tail −12</span></header>
+        <pre class="log">
+<span class="t">04:18:02</span> <span class="ok">OK</span>  groundstation YGW acquired KEP-04
+<span class="t">04:14:55</span> <span class="ok">OK</span>  payload·SAR commit 0a91f3
+<span class="t">04:09:31</span> <span class="wn">WN</span>  sensor pod drift 0.08°/s
+<span class="t">04:02:10</span> <span class="ok">OK</span>  reaction wheel 2 reseat
+<span class="t">03:54:48</span> <span class="ok">OK</span>  orbit determination converged
+<span class="t">03:41:09</span> <span class="er">ER</span>  KEP-09 watchdog → safe
+<span class="t">03:33:18</span> <span class="ok">OK</span>  uplink window ENC closed
+<span class="t">03:21:02</span> <span class="ok">OK</span>  battery cycle 1,402 complete
+<span class="t">03:11:44</span> <span class="ok">OK</span>  scheduler tick · 86,400
+<span class="t">02:58:09</span> <span class="ok">OK</span>  comms s-band passive sweep
+<span class="t">02:42:30</span> <span class="wn">WN</span>  solar yoke +62.7° (limit 70)
+<span class="t">02:30:00</span> <span class="ok">OK</span>  midnight integrity check</pre>
+      </div>
+    </section>
+
+    <hr class="divider">
+
+    <section class="grid">
+      <div class="panel col-6">
+        <header class="head"><span><span class="id">06</span> · Ground Network</span><span>4 sites</span></header>
+        <ul class="station-list">
+          <li><span class="dot"></span><span>Yongin · YGW</span><span>uplink 84 Mb/s</span><span class="meta">contact +04:12</span></li>
+          <li><span class="dot"></span><span>Svalbard · SVL</span><span>uplink 220 Mb/s</span><span class="meta">contact −00:18</span></li>
+          <li><span class="dot warn"></span><span>Punta Arenas · PUQ</span><span>uplink 12 Mb/s</span><span class="meta">weather</span></li>
+          <li><span class="dot"></span><span>Hartebeesthoek · HBK</span><span>standby</span><span class="meta">contact +01:44</span></li>
+        </ul>
+      </div>
+      <div class="panel col-6">
+        <header class="head"><span><span class="id">07</span> · Most recent logbook</span><span>last 4</span></header>
+        <ul class="section-list" style="margin:0;">
+          {% for post in site.pages | where("section", "logbook") | sort_by("date", reverse=true) %}
+            {% if loop.index <= 4 %}
+            <li>
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/kepler-grid/templates/page.html
+++ b/examples/kepler-grid/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 style="font-size:2.2rem; letter-spacing:-0.02em; margin:0 0 28px;">{{ page.title | e }}</h1>{% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/kepler-grid/templates/section.html
+++ b/examples/kepler-grid/templates/section.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 style="font-size:2.4rem; letter-spacing:-0.02em; margin:0 0 16px;">{{ page.title | e }}</h1>{% endif %}
+    {% if page.description %}<p style="color:#8a8f9b; max-width:60ch; margin:0 0 36px;">{{ page.description }}</p>{% endif %}
+    {{ content }}
+    <ul class="section-list">
+      {% for post in section.pages %}
+        <li>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          <time>{{ post.date | date("%Y.%m.%d") }}</time>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/kepler-grid/templates/shortcodes/alert.html
+++ b/examples/kepler-grid/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/kepler-grid/templates/taxonomy.html
+++ b/examples/kepler-grid/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/kepler-grid/templates/taxonomy_term.html
+++ b/examples/kepler-grid/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-analytics/AGENTS.md
+++ b/examples/monolith-analytics/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/monolith-analytics/archetypes/default.md
+++ b/examples/monolith-analytics/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/monolith-analytics/config.toml
+++ b/examples/monolith-analytics/config.toml
@@ -1,0 +1,217 @@
+title = "Monolith Analytics"
+description = "A weekly editorial dashboard for revenue intelligence."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "article"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "desks"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["briefings"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/monolith-analytics/content/about.md
+++ b/examples/monolith-analytics/content/about.md
@@ -1,0 +1,34 @@
++++
+title = "Masthead"
+description = "Who files what, on what cadence."
+date = "2026-05-12"
++++
+
+*Monolith Analytics* is the standing weekly revenue briefing for a 280-person company. It exists because the company kept printing the same five numbers in five different decks, and the same five numbers kept drifting.
+
+## What this publication is, and is not
+
+It is a single page, refreshed every Monday at 09:00 New York / 14:00 London. The numbers on the page are exactly the numbers any executive — sales, finance, customer success — should be quoting in the next seven days. There is no other revenue page. We will not produce one for your team.
+
+It is not a real-time dashboard. The warehouse refreshes at 06:00 every weekday morning; the briefing is filed on the Monday refresh. Mid-week movements live in the slack channel `#rev-desk-tape`, not on this page.
+
+## The desk
+
+- **Lia Becker** — desk editor. Revenue cuts, ARR close, the lede.
+- **Sora Han** — pricing desk. Churn, segment cuts, the watch.
+- **Mateo Iyer** — sales desk. Pipeline, stage moves, the setup.
+
+The desk rotates the byline weekly. Approval to file is two signatures.
+
+## The standing methodology
+
+- ARR is measured at the **close of business Friday** in each customer's local time zone.
+- A customer counts as **churned** when they have either explicitly cancelled or their plan has been zero-valued for 30 days.
+- Expansion is **net of contraction within the same account** for the rolling quarter.
+- We do not bucket multi-product accounts; we report them in the largest product band.
+
+> The numbers should be boring. If the desk is making the numbers interesting, the desk is doing something wrong.
+
+## Reading the page
+
+The page has seven blocks, numbered I through VII. Read them in order on a Monday morning. The Lede tells you what changed, The Read tells you why, The Watch tells you what to watch for, and the tables let you check the desk's work.

--- a/examples/monolith-analytics/content/briefings/_index.md
+++ b/examples/monolith-analytics/content/briefings/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Briefings"
+description = "The full archive of Monday filings, in order. The newest at the top."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/monolith-analytics/content/briefings/churn-drift.md
+++ b/examples/monolith-analytics/content/briefings/churn-drift.md
@@ -1,0 +1,31 @@
++++
+title = "Why a 0.18-point churn drift matters"
+date = "2026-05-04"
+description = "Gross churn ticked up to 1.42% on the rolling-30. The drift is in the under-20-seat segment, and the calendar lines up with the April 4 price-card refresh."
+tags = ["churn", "pricing", "smb"]
+desks = ["pricing"]
++++
+
+Gross churn (trailing 30 days, paid customers only) closed at **1.42%** for the week. The reading is 0.18 points above the same-window reading at the end of last quarter. On its own, the drift is small. The desk is raising it because the *shape* of the drift is unusual.
+
+## The shape
+
+- The drift is **entirely** inside the under-20-seat segment. Above 20 seats, the trailing-30 figure is unchanged within noise.
+- Three cancellation reasons are responsible for almost the entire move: "price too high" (+0.09 pts), "found a free tool" (+0.06 pts), and "switched product" (+0.03 pts). The other reasons are flat.
+- The drift starts on April 7, three days after the April 4 price-card refresh.
+
+## What we think
+
+The price-card refresh moved the under-20 band by an average of $4/seat/month, with a steeper move on annual plans renewing in the second quarter. The drift is consistent with the smallest accounts re-evaluating at renewal — exactly the behaviour the refresh was designed to encourage in the *larger* bands. The smaller bands were not the target.
+
+## What we are doing
+
+- Holding the under-20 band's pricing for the next 30 days, while we observe the second cohort.
+- Re-priced renewal quotes are still going out, but with a short-term hold available without an approval.
+- The desk will file a second briefing in three weeks with the second-cohort reading.
+
+## What we are not doing
+
+We are not pulling the refresh. The targeted bands (50-to-500 seats) are performing as planned, and the structural mid-market lift in this morning's lede is partly the result of the refresh.
+
+*— S. Han, pricing desk*

--- a/examples/monolith-analytics/content/briefings/methodology-note.md
+++ b/examples/monolith-analytics/content/briefings/methodology-note.md
@@ -1,0 +1,35 @@
++++
+title = "Methodology note · how the desk reads ARR"
+date = "2026-04-20"
+description = "A standing note on how we measure ARR, what we exclude, and why we file the briefing on Mondays."
+tags = ["methodology"]
+desks = ["editorial"]
++++
+
+This briefing is filed every Monday on the same set of definitions. New readers asked for a single page they could read once and consult later. Here it is.
+
+## The numbers
+
+- **ARR** is the annualized contract value of every active paid subscription at the close of business on the previous Friday, expressed in USD at the WSJ closing rate of the same day.
+- **Net new ARR** is the period's new-business plus expansion, less contraction and churn. Reactivations within 90 days net against the prior period's churn.
+- **Gross churn** is the dollar value of cancellations divided by the starting ARR for the rolling 30-day window.
+- **Pipeline coverage** is the unweighted open pipe divided by the period's quota.
+
+## The exclusions
+
+- **Trials, paused, and zero-valued plans** are not counted in ARR.
+- **One-time services and professional services revenue** are not counted in ARR.
+- **Reseller-booked ARR** is counted at the *net* value to the company, not the gross customer-paid value.
+
+## The cadence
+
+- The warehouse refreshes at 06:00 New York every weekday.
+- The desk reads the Monday 06:00 refresh and files at 09:00 New York / 14:00 London.
+- The page is not refreshed mid-week. Mid-week reads live in `#rev-desk-tape`.
+- Addenda are filed at the top of the next briefing, not mid-week.
+
+## Why Mondays
+
+The desk used to file Fridays. We moved to Mondays in Q1 because the Friday briefing kept missing the actual Friday close — the warehouse Friday read isn't available until Saturday morning. Filing Monday means we read the *actual* close of business Friday, not a 4 p.m. snapshot.
+
+*— editorial standing note*

--- a/examples/monolith-analytics/content/briefings/mid-market-engine.md
+++ b/examples/monolith-analytics/content/briefings/mid-market-engine.md
@@ -1,0 +1,33 @@
++++
+title = "Mid-market expansion is the engine, not the wave"
+date = "2026-05-11"
+description = "Expansion in the 50–500 seat band accounts for 64% of net new ARR this quarter. The pattern is structural; we are not yet calling it durable past Q3."
+tags = ["expansion", "segment", "qoq"]
+desks = ["revenue"]
++++
+
+Net new ARR for the quarter is $1.46M. Of that, **$932,000 — 64% — comes from the 50-to-500 seat band**. SMB (under 50 seats) contributed $268k, down 6% on the previous quarter. Enterprise (500+ seats) was flat at $214k.
+
+The mid-market band has been the largest single contributor for three consecutive quarters. The desk now considers the pattern *structural* rather than *promotional*: the lift is not concentrated in a campaign window, and it is not concentrated in a single customer (the top mid-market customer is responsible for 4% of the band's net new).
+
+## Why this matters
+
+Structural beats promotional. A promotional lift requires a re-promotion to repeat; a structural lift requires the same product and the same go-to-market motion to keep operating. Both are good news, but they reach different parts of the income statement.
+
+## Why we are not calling it durable
+
+The desk is **not** calling it durable past Q3, for three reasons.
+
+1. The mid-market band sees the largest absolute share of summer churn historically. Q3 will tell us whether the structural lift survives.
+2. The seat-band definition is owned by RevOps; the band's lower edge was raised from 40 to 50 seats in Q4. We have re-stated history, but the optical break is still there.
+3. We have not yet seen a full price-card cycle. The April 4 refresh affects renewals starting in October.
+
+## What we are watching next week
+
+- The July renewal cohort in the 50–250 seat sub-band.
+- Any acceleration in the "moved-up-from-SMB" flow, which should fade as the cohort matures.
+- The first wave of accounts that experience the April 4 price card at renewal time.
+
+> The desk wants to call this durable. The desk will not call this durable for at least another quarter.
+
+*— L. Becker, revenue desk*

--- a/examples/monolith-analytics/content/briefings/pipeline-coverage.md
+++ b/examples/monolith-analytics/content/briefings/pipeline-coverage.md
@@ -1,0 +1,33 @@
++++
+title = "Pipeline coverage at 2.4× for Q3"
+date = "2026-04-27"
+description = "Sales has built the cleanest Q3 pipeline in two years on a flat quota. The concentration risk is the headline."
+tags = ["pipeline", "sales", "concentration"]
+desks = ["sales"]
++++
+
+The sales team enters Q3 with **2.4×** pipeline coverage against a flat quota — the cleanest Q3 setup the desk has seen in two years. The total open pipe is $58.2M. The desk's note this morning is not on the size; it is on the **concentration**.
+
+## Three deals, 38% of the pipe
+
+Three opportunities account for $22.1M of the $58.2M pipe.
+
+| Account              | Stage    | ARR     | Forecast probability |
+|----------------------|----------|---------|----------------------|
+| Northwind Logistics  | Verbal   | $9.4M   | 70%                  |
+| Atrium Health        | Verbal   | $7.1M   | 65%                  |
+| Marais Bank          | Proposal | $5.6M   | 40%                  |
+
+The combined weighted contribution is about $15.0M, which is exactly Q3's quota target. If one of the three slips, the team still makes plan. If two slip, the team is materially behind.
+
+## What we are watching
+
+- Northwind has two procurement reviews remaining. The desk has flagged the second review (security) as the higher-risk one.
+- Atrium has had a leadership change at the buying group. The new VP has asked for a re-presentation.
+- Marais's proposal is in the legal review window we underwrote at signing. The window expires May 30.
+
+## How this reads on the page
+
+The figure column on this morning's page reads **$58M pipe**. The pipe column is doing its job. The desk's job is the read underneath.
+
+*— M. Iyer, sales desk*

--- a/examples/monolith-analytics/content/index.md
+++ b/examples/monolith-analytics/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "The Lede"
+description = "Weekly revenue intelligence, filed Monday."
+template = "home"
++++

--- a/examples/monolith-analytics/static/css/style.css
+++ b/examples/monolith-analytics/static/css/style.css
@@ -1,0 +1,213 @@
+:root {
+  --paper: #131210;
+  --paper-2: #1a1814;
+  --ink: #f1e9d5;
+  --ink-2: #e2d6b9;
+  --mute: #9a8e76;
+  --dim: #5b5346;
+  --rule: #312c25;
+  --rule-2: #46402f;
+  --accent: #c1392b;
+  --accent-2: #e7b647;
+  --good: #6aa66a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Newsreader", "Cormorant Garamond", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.sans { font-family: "Inter", system-ui, sans-serif; }
+.mono, code, pre, time, .num { font-family: "JetBrains Mono", ui-monospace, monospace; }
+
+a { color: var(--ink); text-decoration: none; border-bottom: 1px solid var(--rule-2); }
+a:hover { color: var(--accent-2); border-color: var(--accent-2); }
+
+.paper {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 28px 38px 90px;
+}
+
+.mast {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  border-bottom: 1px solid var(--rule);
+  padding: 8px 0 24px;
+  margin-bottom: 22px;
+}
+.mast .left, .mast .right {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+.mast .right { text-align: right; }
+.mast .left b, .mast .right b { color: var(--ink); }
+.mast .title {
+  text-align: center;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  font-style: italic;
+  border: 0;
+}
+.mast .title a { border: 0; color: var(--ink); }
+.mast .title sup { font-family: "JetBrains Mono", monospace; font-style: normal; font-size: 11px; color: var(--accent); margin-left: 6px; vertical-align: super; }
+
+.subbar {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 0 0 20px;
+  border-bottom: 2px solid var(--ink-2);
+  margin-bottom: 26px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+.subbar nav { display: flex; gap: 28px; }
+.subbar nav a { border: 0; color: var(--mute); }
+.subbar nav a:hover { color: var(--ink); }
+.subbar .ticker b { color: var(--accent-2); }
+
+.lede {
+  display: grid;
+  grid-template-columns: 7fr 5fr;
+  gap: 48px;
+  padding-bottom: 36px;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 32px;
+}
+.lede .deck { font-family: "JetBrains Mono", monospace; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin-bottom: 14px; }
+.lede h1 {
+  font-size: clamp(2.6rem, 4.4vw, 4rem);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  margin: 0 0 22px;
+  font-weight: 600;
+}
+.lede h1 em { font-style: italic; color: var(--accent-2); }
+.lede .standfirst { font-size: 1.12rem; color: var(--ink-2); max-width: 56ch; line-height: 1.55; }
+.lede .byline { margin-top: 26px; font-family: "JetBrains Mono", monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mute); }
+.lede .byline b { color: var(--ink); }
+
+.figure {
+  padding: 26px;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+}
+.figure .figlabel { font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--mute); margin-bottom: 14px; }
+.figure .figval { font-family: "JetBrains Mono", monospace; font-size: 3rem; line-height: 1; letter-spacing: -0.03em; color: var(--ink); }
+.figure .figval em { color: var(--accent); font-style: normal; }
+.figure .figdelta { font-family: "JetBrains Mono", monospace; font-size: 13px; color: var(--good); margin-top: 8px; }
+.figure .figdelta.neg { color: var(--accent); }
+.figure .figdelta::before { content: "▲ "; }
+.figure .figdelta.neg::before { content: "▼ "; }
+.figure svg { width: 100%; height: 64px; margin-top: 14px; }
+.figure svg polyline { fill: none; stroke: var(--accent-2); stroke-width: 1.5; }
+.figure svg .base { stroke: var(--rule-2); stroke-dasharray: 2 3; }
+
+.cols {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 28px;
+}
+.c-4 { grid-column: span 4; }
+.c-6 { grid-column: span 6; }
+.c-8 { grid-column: span 8; }
+.c-12 { grid-column: span 12; }
+
+.column {
+  border-left: 1px solid var(--rule);
+  padding: 0 0 0 22px;
+}
+.column.first { border-left: 0; padding-left: 0; }
+
+.section-h {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin: 0 0 18px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--rule);
+}
+.section-h b { color: var(--ink); letter-spacing: 0.2em; }
+.section-h em { font-family: "Newsreader", serif; font-size: 14px; font-style: italic; color: var(--accent-2); text-transform: none; letter-spacing: 0; }
+
+.hl { font-family: "Newsreader", serif; font-size: 1.45rem; line-height: 1.18; letter-spacing: -0.01em; margin: 0 0 8px; font-weight: 500; }
+.hl a { border: 0; color: var(--ink); }
+.hl a:hover { color: var(--accent-2); }
+.dek { font-size: 0.95rem; color: var(--mute); line-height: 1.55; }
+.byline-small { font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--dim); margin-top: 10px; }
+
+.bar-table { width: 100%; border-collapse: collapse; font-family: "JetBrains Mono", monospace; font-size: 13px; }
+.bar-table th, .bar-table td { padding: 10px 0; text-align: left; border-bottom: 1px dashed var(--rule); }
+.bar-table th { color: var(--mute); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; font-weight: 500; }
+.bar-table .b { background: var(--rule-2); height: 6px; position: relative; }
+.bar-table .b::after { content: ""; position: absolute; left: 0; top: 0; height: 100%; background: var(--accent); width: var(--w, 40%); }
+.bar-table td.right { text-align: right; color: var(--ink-2); }
+.bar-table .neg::after { background: var(--accent-2); }
+
+.tab {
+  width: 100%; border-collapse: collapse;
+  font-family: "JetBrains Mono", monospace; font-size: 13px;
+}
+.tab th, .tab td { padding: 12px 0; border-bottom: 1px solid var(--rule); }
+.tab th { font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em; color: var(--mute); text-align: left; font-weight: 500; }
+.tab td { color: var(--ink-2); }
+.tab td.right { text-align: right; }
+.tab td .gain { color: var(--good); }
+.tab td .loss { color: var(--accent); }
+
+.divider { border: 0; height: 1px; background: var(--rule); margin: 40px 0; }
+
+article.prose { max-width: 64ch; }
+article.prose h2 { font-family: "Newsreader", serif; font-size: 1.8rem; font-style: italic; margin-top: 1.6em; }
+article.prose h3 { font-family: "Newsreader", serif; font-size: 1.3rem; margin-top: 1.4em; }
+article.prose blockquote { border-left: 3px solid var(--accent); padding: 4px 18px; margin: 1.4em 0; color: var(--ink-2); font-style: italic; font-size: 1.2rem; }
+article.prose code { background: var(--paper-2); padding: 2px 6px; border-radius: 3px; font-size: 0.85em; }
+
+ul.section-list { list-style: none; padding: 0; }
+ul.section-list li {
+  padding: 22px 0;
+  border-bottom: 1px solid var(--rule);
+  display: grid; grid-template-columns: 1fr 120px; gap: 24px; align-items: baseline;
+}
+ul.section-list li a { border: 0; font-family: "Newsreader", serif; font-size: 1.3rem; font-style: italic; }
+ul.section-list li a:hover { color: var(--accent-2); }
+ul.section-list li time { font-family: "JetBrains Mono", monospace; font-size: 11px; color: var(--mute); letter-spacing: 0.12em; text-transform: uppercase; }
+
+footer.foot {
+  margin-top: 70px;
+  padding: 30px 0 0;
+  border-top: 1px solid var(--rule);
+  display: grid; grid-template-columns: 2fr 1fr 1fr;
+  gap: 30px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+footer.foot strong { display: block; margin-bottom: 8px; letter-spacing: 0.2em; color: var(--ink); }
+footer.foot em { font-style: italic; color: var(--accent-2); font-family: "Newsreader", serif; font-size: 13px; text-transform: none; letter-spacing: 0; }
+
+@media (max-width: 900px) {
+  .lede, .cols { grid-template-columns: 1fr; }
+  .column { border-left: 0; padding-left: 0; padding-top: 22px; border-top: 1px solid var(--rule); }
+  .column.first { border-top: 0; padding-top: 0; }
+  .c-4, .c-6, .c-8 { grid-column: span 12; }
+  .mast { grid-template-columns: 1fr; gap: 10px; text-align: center; }
+  .mast .right { text-align: center; }
+}

--- a/examples/monolith-analytics/static/favicon.svg
+++ b/examples/monolith-analytics/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/monolith-analytics/templates/404.html
+++ b/examples/monolith-analytics/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-analytics/templates/footer.html
+++ b/examples/monolith-analytics/templates/footer.html
@@ -1,0 +1,21 @@
+    <footer class="foot">
+      <div>
+        <strong>Monolith Analytics</strong>
+        <em>Revenue intelligence, one steady page a week.</em><br>
+        Built with Hwaro on Crystal · &copy; {{ current_year }}
+      </div>
+      <div>
+        <strong>Desks</strong>
+        <a href="{{ base_url }}/briefings/">Briefings</a><br>
+        <a href="{{ base_url }}/about/">Masthead</a>
+      </div>
+      <div>
+        <strong>Filed</strong>
+        Last filed {{ current_date }}<br>
+        Next file Mon 09:00 NA · 14:00 GMT
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/monolith-analytics/templates/header.html
+++ b/examples/monolith-analytics/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} · {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper">
+    <header class="mast">
+      <div class="left"><b>VOL XVII</b> · ISSUE 19 · WEEKLY</div>
+      <div class="title"><a href="{{ base_url }}/">Monolith Analytics<sup>·MA·</sup></a></div>
+      <div class="right">{{ current_date }} · <b>NA · EMEA · APAC</b></div>
+    </header>
+    <div class="subbar">
+      <nav>
+        <a href="{{ base_url }}/">Lede</a>
+        <a href="{{ base_url }}/briefings/">Briefings</a>
+        <a href="{{ base_url }}/about/">Masthead</a>
+      </nav>
+      <div class="ticker">Revenue desk · <b>$24.18M</b> arr · <b>+6.4%</b> qoq · churn <b>1.42%</b> · pipeline <b>$58M</b></div>
+    </div>

--- a/examples/monolith-analytics/templates/home.html
+++ b/examples/monolith-analytics/templates/home.html
@@ -1,0 +1,115 @@
+{% include "header.html" %}
+  <main>
+    <section class="lede">
+      <div>
+        <div class="deck">The Lede · Week 19 · Filed {{ current_date }}</div>
+        <h1>The quiet quarter is producing the <em>loud number</em>.</h1>
+        <div class="standfirst">Annual recurring revenue closed the week at $24.18M, up 6.4% on the quarter — the second-best three months on record. The chase, this morning, is whether mid-market expansion is durable past the summer.</div>
+        <div class="byline">Filed by the revenue desk · <b>L. Becker, S. Han, M. Iyer</b> · 11 min read</div>
+      </div>
+      <aside style="display:grid; grid-template-rows: 1fr 1fr; gap:18px;">
+        <div class="figure">
+          <div class="figlabel">ARR · weekly close</div>
+          <div class="figval"><em>$24.18</em>M</div>
+          <div class="figdelta">+$1.46M qoq</div>
+          <svg viewBox="0 0 200 64" preserveAspectRatio="none" aria-hidden="true">
+            <line class="base" x1="0" y1="42" x2="200" y2="42"></line>
+            <polyline points="0,52 20,50 40,48 60,46 80,42 100,40 120,36 140,30 160,28 180,22 200,18" />
+          </svg>
+        </div>
+        <div class="figure">
+          <div class="figlabel">Gross churn · trailing 30</div>
+          <div class="figval">1.42<em>%</em></div>
+          <div class="figdelta neg">+0.18 pts qoq</div>
+          <svg viewBox="0 0 200 64" preserveAspectRatio="none" aria-hidden="true">
+            <line class="base" x1="0" y1="32" x2="200" y2="32"></line>
+            <polyline points="0,40 20,38 40,36 60,38 80,34 100,32 120,30 140,28 160,30 180,24 200,18" />
+          </svg>
+        </div>
+      </aside>
+    </section>
+
+    <section class="cols" style="margin-bottom:36px;">
+      <div class="column first c-4">
+        <div class="section-h"><span><b>I</b> · The Read</span><em>this week</em></div>
+        <h2 class="hl"><a href="{{ base_url }}/briefings/">Mid-market expansion is the engine, not the wave.</a></h2>
+        <p class="dek">Expansion revenue from the 50–500 seat band accounted for 64% of net new ARR for the quarter. The pattern looks structural; the desk is not yet calling it durable past Q3.</p>
+        <div class="byline-small">L. Becker · revenue desk</div>
+      </div>
+      <div class="column c-4">
+        <div class="section-h"><span><b>II</b> · The Watch</span><em>five days</em></div>
+        <h2 class="hl"><a href="{{ base_url }}/briefings/">Why a 0.18-point churn drift matters.</a></h2>
+        <p class="dek">Gross churn ticked up to 1.42%. The drift is concentrated in the under-20-seat segment and follows the price-card refresh on April 4. It is not yet material, but it is no longer noise.</p>
+        <div class="byline-small">S. Han · pricing desk</div>
+      </div>
+      <div class="column c-4">
+        <div class="section-h"><span><b>III</b> · The Setup</span><em>next week</em></div>
+        <h2 class="hl"><a href="{{ base_url }}/briefings/">Pipeline coverage at 2.4× for Q3.</a></h2>
+        <p class="dek">Sales has built the cleanest Q3 pipeline in two years — 2.4× coverage on a flat quota. The risk is concentration: three accounts represent 38% of the open pipe value.</p>
+        <div class="byline-small">M. Iyer · sales desk</div>
+      </div>
+    </section>
+
+    <hr class="divider">
+
+    <section class="cols">
+      <div class="column first c-8">
+        <div class="section-h"><span><b>IV</b> · Tables · Revenue by segment</span><em>quarter to date</em></div>
+        <table class="bar-table">
+          <thead>
+            <tr><th>Segment</th><th>Net new ARR</th><th>Share</th><th></th><th class="right">QoQ</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Mid-market · 50–500 seats</td><td>$932k</td><td>64%</td><td style="width:240px;"><div class="b" style="--w: 64%;"></div></td><td class="right">+18%</td></tr>
+            <tr><td>SMB · &lt;50 seats</td><td>$268k</td><td>18%</td><td><div class="b" style="--w: 18%;"></div></td><td class="right">−6%</td></tr>
+            <tr><td>Enterprise · 500+ seats</td><td>$214k</td><td>15%</td><td><div class="b" style="--w: 15%;"></div></td><td class="right">+2%</td></tr>
+            <tr><td>Startup grants</td><td>$46k</td><td>3%</td><td><div class="b" style="--w: 3%;"></div></td><td class="right">+12%</td></tr>
+          </tbody>
+        </table>
+        <div class="byline-small" style="margin-top:14px;">Source · revenue.warehouse · table arr.fact_week · week of {{ current_date }}</div>
+      </div>
+      <div class="column c-4">
+        <div class="section-h"><span><b>V</b> · Pipeline</span><em>top 5</em></div>
+        <table class="tab">
+          <thead>
+            <tr><th>Account</th><th class="right">ARR</th><th class="right">Stage</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Northwind Logistics</td><td class="right">$420k</td><td class="right"><span class="gain">VL</span></td></tr>
+            <tr><td>Atrium Health</td><td class="right">$310k</td><td class="right"><span class="gain">VL</span></td></tr>
+            <tr><td>Marais Bank</td><td class="right">$278k</td><td class="right">PROP</td></tr>
+            <tr><td>Vela Aerospace</td><td class="right">$224k</td><td class="right">PROP</td></tr>
+            <tr><td>Aurelius Retail</td><td class="right">$190k</td><td class="right"><span class="loss">DLY</span></td></tr>
+          </tbody>
+        </table>
+        <div class="byline-small" style="margin-top:14px;">VL · verbal · PROP · proposal sent · DLY · delayed.</div>
+      </div>
+    </section>
+
+    <hr class="divider">
+
+    <section class="cols">
+      <div class="column first c-6">
+        <div class="section-h"><span><b>VI</b> · Briefings filed</span><em>latest</em></div>
+        {% for post in site.pages | where("section", "briefings") | sort_by("date", reverse=true) %}
+          {% if loop.index <= 4 %}
+          <div style="padding:18px 0; border-bottom:1px solid var(--rule);">
+            <h2 class="hl"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <p class="dek">{{ post.description | strip_html | truncate_words(28) }}</p>
+            <div class="byline-small">{{ post.date | date("%a · %b %d") }}{% if post.tags %} · {{ post.tags | first }}{% endif %}</div>
+          </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+      <div class="column c-6">
+        <div class="section-h"><span><b>VII</b> · From the masthead</span><em>standing</em></div>
+        <p class="dek" style="font-size:1.05rem; color:var(--ink-2);">
+          <em>Monolith Analytics</em> files one issue a week, every Monday at 09:00 New York / 14:00 London. The desk does not file mid-week corrections; we file an addendum the following Monday. Every chart on this page is reproducible from the warehouse query published in the briefing footnotes.
+        </p>
+        <p class="dek" style="margin-top:14px;">
+          Read the <a href="{{ base_url }}/about/">masthead</a> for the desk roster, the publication calendar, and the standing methodology notes.
+        </p>
+      </div>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-analytics/templates/page.html
+++ b/examples/monolith-analytics/templates/page.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}
+    <section class="lede" style="grid-template-columns: 1fr; padding-bottom:32px;">
+      <div>
+        <div class="deck">{% if page.date %}{{ page.date | date("%A · %B %d, %Y") }}{% else %}Page{% endif %}</div>
+        <h1>{{ page.title | e }}</h1>
+        {% if page.description %}<div class="standfirst">{{ page.description | e }}</div>{% endif %}
+      </div>
+    </section>
+    {% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-analytics/templates/section.html
+++ b/examples/monolith-analytics/templates/section.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+  <main>
+    <section class="lede" style="grid-template-columns: 1fr; padding-bottom:32px;">
+      <div>
+        <div class="deck">Desk</div>
+        <h1>{{ page.title | e }}</h1>
+        {% if page.description %}<div class="standfirst">{{ page.description | e }}</div>{% endif %}
+      </div>
+    </section>
+    <ul class="section-list">
+      {% for post in section.pages %}
+        <li>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          <time>{{ post.date | date("%Y · %b %d") }}</time>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-analytics/templates/shortcodes/alert.html
+++ b/examples/monolith-analytics/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/monolith-analytics/templates/taxonomy.html
+++ b/examples/monolith-analytics/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/monolith-analytics/templates/taxonomy_term.html
+++ b/examples/monolith-analytics/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-stack/AGENTS.md
+++ b/examples/prism-stack/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/prism-stack/archetypes/default.md
+++ b/examples/prism-stack/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/prism-stack/config.toml
+++ b/examples/prism-stack/config.toml
@@ -1,0 +1,217 @@
+title = "Prism Stack"
+description = "A bright, calm dashboard for product teams."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "squads"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["updates"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/prism-stack/content/about.md
+++ b/examples/prism-stack/content/about.md
@@ -1,0 +1,38 @@
++++
+title = "Workspace"
+description = "Who works in Prism Stack, and how we use it."
+date = "2026-05-14"
++++
+
+Prism Stack is the working surface for a six-person product group inside a mid-size SaaS company. We are not a metrics team; we are a product team that decided the metrics should live somewhere we already look every day.
+
+## How we use this page
+
+The **Console** is the home view. It is the first thing we open when a meeting starts. It is intentionally calm — the room should feel like a quiet morning, not a launch.
+
+We update the active workstreams table at the end of every workweek. The confidence column is set by the owner, not by an algorithm. If the owner does not update it, the row goes pale; we do not let confidence quietly age in place.
+
+## What we measure
+
+- **Weekly active** users — our most important growth signal.
+- **Activation rate** — first-seven-days behaviour for new accounts.
+- **Net revenue retention** — the long arrow.
+
+That is it. Everything else is a leading indicator we look at when one of those three moves.
+
+> Three numbers can fit in your head. Twelve numbers fit in a spreadsheet. Choose three.
+
+## Who is who
+
+- **Hannah Park** — group product manager, owner of onboarding.
+- **Mateo Iyer** — staff product manager, owner of activation.
+- **Lia Becker** — engineering lead, owner of the retention pilot.
+- **Daniel Okafor** — design lead, owner of mobile beta.
+- **Sora Han** — product manager, owner of pricing v3.
+- **Ren Adachi** — growth, owner of outbound experiments.
+
+## What is missing
+
+- A board for the support backlog. Coming after the pricing v3 launch.
+- A view that overlays release calendar with the goal-progress chart. Designed; not implemented.
+- A view for the people side of the team — utilization, vacation, on-call. Deliberately omitted.

--- a/examples/prism-stack/content/index.md
+++ b/examples/prism-stack/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Console"
+description = "A bright product dashboard"
+template = "home"
++++

--- a/examples/prism-stack/content/updates/_index.md
+++ b/examples/prism-stack/content/updates/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Weekly updates"
+description = "What moved this week, in roughly one screen each. Most recent first."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/prism-stack/content/updates/week-17.md
+++ b/examples/prism-stack/content/updates/week-17.md
@@ -1,0 +1,19 @@
++++
+title = "Week 17 — Mobile beta paused for App Review"
+date = "2026-04-24"
+description = "App Review flagged a permission prompt. We are addressing it, then resuming wave 2. No impact on the desktop experience."
+tags = ["mobile", "release"]
+squads = ["mobile"]
++++
+
+Apple's App Review flagged the wave 2 build for an in-app prompt that asks for contact access without a clear in-flow reason. The flag is fair. We are addressing it by removing the prompt from the onboarding sequence entirely and moving it to the *invite teammates* screen, where the reason is obvious.
+
+## Schedule
+
+- Patched build submitted **Mon, Apr 28**.
+- Expected re-review by **Wed, Apr 30**.
+- Wave 2 resumed by **Mon, May 5** if re-review is clean.
+
+## Why this is on the board
+
+We want the **Mobile** chip on the Console to stay yellow ("on hold") for as long as App Review has the build. The chip turns green only when the build is in the hands of beta users again.

--- a/examples/prism-stack/content/updates/week-18.md
+++ b/examples/prism-stack/content/updates/week-18.md
@@ -1,0 +1,19 @@
++++
+title = "Week 18 — Pricing calculator embedded on marketing site"
+date = "2026-05-01"
+description = "The pricing calculator now lives on the marketing site instead of behind the sign-in wall. Early signal is positive but small."
+tags = ["pricing", "marketing"]
+squads = ["growth"]
++++
+
+The pricing calculator we shipped behind the sign-in wall in January is now embedded on the marketing site. The marketing team owns the placement and the copy around it; we own the calculator and the events it emits.
+
+## Early signal
+
+- Sessions that interact with the calculator have a **4.7%** higher sign-up rate this week vs. the rolling baseline.
+- The lift is concentrated in the "20–50 seats" range. Above and below, there is no signal yet.
+- Bounce on the pricing page is down two points.
+
+## Why we are not declaring yet
+
+The marketing team launched at the same time as a content campaign on pricing transparency. We cannot cleanly separate the two effects. We will rerun the regression in two weeks, once the campaign tail has cleared.

--- a/examples/prism-stack/content/updates/week-19.md
+++ b/examples/prism-stack/content/updates/week-19.md
@@ -1,0 +1,22 @@
++++
+title = "Week 19 — Retention pilot cohort B is lagging"
+date = "2026-05-08"
+description = "Cohort B for the retention pricing pilot is two points behind cohort A on the seven-day mark. We are not pulling the experiment; we are extending the window."
+tags = ["retention", "pricing", "experiment"]
+squads = ["product"]
++++
+
+The retention pricing pilot has two cohorts in flight. Cohort A reached the seven-day mark on Friday at **42.1%** retention. Cohort B reached the same mark this morning at **39.8%** — two points behind A, on a window where we expected parity.
+
+## What we know
+
+- The cohort assignment looks clean. We sampled 1% manually; nothing surprising.
+- Cohort B has a slightly higher share of accounts that joined through a referral. We expect a small *positive* delta from this, not a negative one. So this is not "referral mix".
+- Two specific account segments inside cohort B (sub-50-seat plans on monthly billing) are responsible for almost all of the gap.
+
+## What we are doing
+
+- Extending the seven-day window to a fourteen-day window for both cohorts. We will publish a second snapshot on May 22.
+- Lia is reading every conversion event from those two segments by hand. No automation, no rollup; we suspect the issue is in the in-app messaging on day 4.
+
+> When two cohorts diverge, the right next step is usually to look at the events with your own eyes for an hour. The dashboard already told you they differ — the dashboard is not going to tell you why.

--- a/examples/prism-stack/content/updates/week-20.md
+++ b/examples/prism-stack/content/updates/week-20.md
@@ -1,0 +1,24 @@
++++
+title = "Week 20 — Onboarding pre-fill is live for everyone"
+date = "2026-05-15"
+description = "Pre-fill went to 100% of new accounts on Wednesday. Day-1 activation already up 4.2 points; we will hold for two cohorts before we declare."
+tags = ["onboarding", "activation", "ship"]
+squads = ["growth"]
++++
+
+The onboarding pre-fill experiment graduated to 100% of new accounts on Wednesday at 14:00 UTC. Day-1 activation for the first cohort is up **4.2 points** vs. the previous two weeks. We will hold the change for two more cohorts (about ten days) before we call it.
+
+## What changed
+
+- New signups have their workspace name, region and team size pre-filled from the marketing form.
+- The first task in the onboarding tour is now a no-op (an *acknowledgment*) rather than a setup step. The setup step moved to a banner that disappears once any teammate is invited.
+
+## What we are watching
+
+- Day-7 retention for the May 13 cohort, which lands on Tuesday.
+- Sign-up to first-invite time, where we saw a 14-minute drop in early data.
+- Whether the support team sees any new "I didn't ask for that" tickets.
+
+## What's next
+
+Mateo is starting on the activation funnel pass. The pre-fill is the first half of the change he wants to make; the nudge sequence is the second half.

--- a/examples/prism-stack/static/css/style.css
+++ b/examples/prism-stack/static/css/style.css
@@ -1,0 +1,239 @@
+:root {
+  --bg: #eef0f4;
+  --bg-2: #e6e9ee;
+  --surface: #ffffff;
+  --ink: #0d1220;
+  --ink-2: #2a3147;
+  --ink-mute: #6b7287;
+  --line: #e3e6ec;
+  --line-2: #d6dae3;
+  --accent: #2b3aff;
+  --mint: #c7efe1;
+  --mint-ink: #157457;
+  --lav: #e0dcff;
+  --lav-ink: #4530b5;
+  --peach: #ffd9c7;
+  --peach-ink: #a3471e;
+  --rose: #ffd3df;
+  --rose-ink: #b62454;
+  --butter: #faecb8;
+  --butter-ink: #8a6a14;
+  --sky: #cfe3ff;
+  --sky-ink: #1c4d99;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01" 1, "cv11" 1;
+}
+.mono, code, pre { font-family: "JetBrains Mono", ui-monospace, monospace; }
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.shell {
+  max-width: 1340px;
+  margin: 0 auto;
+  padding: 22px 28px 80px;
+}
+
+.topbar {
+  background: var(--surface);
+  border-radius: 18px;
+  padding: 14px 22px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 28px;
+  box-shadow: 0 1px 0 var(--line-2), 0 12px 28px -22px rgba(13, 18, 32, 0.18);
+  margin-bottom: 22px;
+}
+.topbar .brand {
+  display: flex; align-items: center; gap: 12px;
+  font-weight: 700; font-size: 16px; letter-spacing: -0.01em;
+}
+.topbar .brand .logo {
+  width: 28px; height: 28px; border-radius: 9px;
+  background: var(--ink); position: relative;
+}
+.topbar .brand .logo::after {
+  content: ""; position: absolute; left: 6px; top: 6px;
+  width: 16px; height: 16px; background: var(--surface);
+  border-radius: 4px;
+}
+.topbar .brand .logo::before {
+  content: ""; position: absolute; left: 14px; top: 14px;
+  width: 8px; height: 8px; background: var(--accent);
+  border-radius: 2px;
+  z-index: 1;
+}
+.topbar .search {
+  background: var(--bg);
+  border-radius: 10px;
+  height: 36px;
+  display: flex; align-items: center; padding: 0 14px;
+  font-size: 14px; color: var(--ink-mute);
+  border: 1px solid var(--line);
+}
+.topbar .search kbd {
+  margin-left: auto; font-family: "JetBrains Mono", monospace;
+  font-size: 11px; padding: 2px 6px; border-radius: 5px;
+  background: var(--surface); border: 1px solid var(--line-2);
+  color: var(--ink-mute);
+}
+.topbar .actions { display: flex; gap: 10px; align-items: center; }
+.topbar .actions a { font-size: 13px; color: var(--ink-mute); }
+.topbar .actions a:hover { color: var(--ink); }
+.topbar .actions .pill { padding: 6px 12px; border-radius: 999px; background: var(--ink); color: var(--surface); font-weight: 600; font-size: 13px; }
+.topbar .actions .pill:hover { background: var(--accent); }
+.topbar .avatar { width: 32px; height: 32px; border-radius: 50%; background: var(--lav); display: inline-flex; align-items: center; justify-content: center; font-weight: 700; color: var(--lav-ink); font-size: 12px; }
+
+.greet {
+  background: var(--surface);
+  border-radius: 22px;
+  padding: 36px 38px 30px;
+  margin-bottom: 22px;
+  box-shadow: 0 1px 0 var(--line-2), 0 20px 50px -36px rgba(13,18,32,0.16);
+}
+.greet .day { font-family: "JetBrains Mono", monospace; font-size: 12px; color: var(--ink-mute); letter-spacing: 0.06em; text-transform: uppercase; margin-bottom: 14px; }
+.greet h1 { font-size: clamp(2rem, 3.6vw, 2.7rem); letter-spacing: -0.025em; line-height: 1.06; margin: 0 0 16px; font-weight: 700; }
+.greet h1 span { color: var(--ink-mute); font-weight: 400; }
+.greet .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 22px; }
+.chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px; border-radius: 999px;
+  font-size: 12.5px; font-weight: 500;
+  background: var(--bg); color: var(--ink-2);
+  border: 1px solid var(--line);
+}
+.chip .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; opacity: 0.6; }
+.chip.mint { background: var(--mint); color: var(--mint-ink); border-color: transparent; }
+.chip.lav  { background: var(--lav);  color: var(--lav-ink);  border-color: transparent; }
+.chip.peach{ background: var(--peach);color: var(--peach-ink);border-color: transparent; }
+.chip.rose { background: var(--rose); color: var(--rose-ink); border-color: transparent; }
+.chip.butter{background:var(--butter);color:var(--butter-ink);border-color: transparent; }
+.chip.sky  { background: var(--sky);  color: var(--sky-ink);  border-color: transparent; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 18px;
+}
+.card {
+  background: var(--surface);
+  border-radius: 18px;
+  padding: 22px 24px;
+  box-shadow: 0 1px 0 var(--line-2), 0 18px 40px -30px rgba(13,18,32,0.16);
+}
+.card .head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 16px; }
+.card .head h3 { font-size: 0.92rem; margin: 0; color: var(--ink-mute); font-weight: 500; letter-spacing: 0.02em; }
+.card .head .meta { font-family: "JetBrains Mono", monospace; font-size: 11px; color: var(--ink-mute); }
+
+.col-4 { grid-column: span 4; }
+.col-6 { grid-column: span 6; }
+.col-8 { grid-column: span 8; }
+.col-12 { grid-column: span 12; }
+
+.kpi .v { font-size: 2.3rem; letter-spacing: -0.02em; font-weight: 700; line-height: 1; }
+.kpi .v small { font-size: 1rem; color: var(--ink-mute); font-weight: 500; margin-left: 2px; }
+.kpi .delta { font-family: "JetBrains Mono", monospace; font-size: 12px; margin-top: 12px; color: var(--mint-ink); }
+.kpi .delta.neg { color: var(--rose-ink); }
+.kpi .delta.flat { color: var(--ink-mute); }
+.kpi .delta::before { content: "↑ "; }
+.kpi .delta.neg::before { content: "↓ "; }
+.kpi .delta.flat::before { content: "→ "; }
+
+.bars { display: flex; align-items: flex-end; gap: 4px; height: 64px; margin-top: 14px; }
+.bars span { flex: 1; background: var(--bg); border-radius: 3px 3px 0 0; position: relative; }
+.bars span::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; border-radius: 3px 3px 0 0; background: var(--ink); height: var(--h, 30%); }
+.bars span.acc::after { background: var(--accent); }
+.bars + .axis { display: flex; gap: 4px; margin-top: 8px; font-family: "JetBrains Mono", monospace; font-size: 10px; color: var(--ink-mute); }
+.bars + .axis span { flex: 1; text-align: center; }
+
+.list { list-style: none; padding: 0; margin: 0; }
+.list li {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  gap: 14px; align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+}
+.list li:last-child { border-bottom: 0; }
+.list .icon {
+  width: 36px; height: 36px; border-radius: 11px;
+  background: var(--bg); display: flex; align-items: center; justify-content: center;
+  font-family: "JetBrains Mono", monospace; font-size: 13px; font-weight: 700;
+}
+.list .icon.mint { background: var(--mint); color: var(--mint-ink); }
+.list .icon.lav  { background: var(--lav);  color: var(--lav-ink); }
+.list .icon.peach{ background: var(--peach);color: var(--peach-ink); }
+.list .icon.sky  { background: var(--sky);  color: var(--sky-ink); }
+.list .icon.rose { background: var(--rose); color: var(--rose-ink); }
+.list .name { font-weight: 600; font-size: 0.95rem; }
+.list .sub { font-size: 12.5px; color: var(--ink-mute); margin-top: 2px; }
+.list .val { font-family: "JetBrains Mono", monospace; font-size: 13px; color: var(--ink-2); }
+
+.donut { position: relative; width: 130px; height: 130px; margin: 8px auto; }
+.donut svg { width: 100%; height: 100%; transform: rotate(-90deg); }
+.donut circle { fill: none; stroke-width: 14; }
+.donut .track { stroke: var(--bg); }
+.donut .seg-a { stroke: var(--accent); }
+.donut .seg-b { stroke: var(--mint-ink); }
+.donut .seg-c { stroke: var(--peach-ink); }
+.donut .center { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; }
+.donut .center b { font-size: 1.6rem; letter-spacing: -0.02em; }
+.donut .center span { font-size: 11px; color: var(--ink-mute); font-family: "JetBrains Mono", monospace; }
+
+.legend { list-style: none; padding: 0; margin: 8px 0 0; font-size: 12.5px; }
+.legend li { display: flex; align-items: center; justify-content: space-between; padding: 6px 0; }
+.legend li::before {
+  content: ""; width: 9px; height: 9px; border-radius: 3px; margin-right: 10px;
+  background: var(--bg);
+}
+.legend li.a::before { background: var(--accent); }
+.legend li.b::before { background: var(--mint-ink); }
+.legend li.c::before { background: var(--peach-ink); }
+.legend li span { font-family: "JetBrains Mono", monospace; color: var(--ink-mute); }
+.legend li .name { color: var(--ink-2); }
+
+table.t { width: 100%; border-collapse: collapse; }
+table.t th, table.t td { text-align: left; padding: 12px 0; border-bottom: 1px solid var(--line); font-size: 14px; }
+table.t th { font-weight: 500; color: var(--ink-mute); font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; }
+table.t td.right { text-align: right; font-family: "JetBrains Mono", monospace; color: var(--ink-2); }
+
+article.prose { max-width: 70ch; }
+article.prose h2 { letter-spacing: -0.015em; margin-top: 1.6em; }
+article.prose blockquote { border-left: 3px solid var(--accent); padding: 6px 18px; margin: 1.4em 0; color: var(--ink-mute); }
+
+ul.section-list { list-style: none; padding: 0; }
+ul.section-list li { padding: 18px 0; border-bottom: 1px solid var(--line); display: flex; justify-content: space-between; align-items: baseline; }
+ul.section-list li a { font-size: 1.08rem; font-weight: 600; }
+ul.section-list li time { font-family: "JetBrains Mono", monospace; font-size: 12px; color: var(--ink-mute); }
+
+footer.foot {
+  margin-top: 50px;
+  padding: 30px 28px;
+  background: var(--surface);
+  border-radius: 18px;
+  box-shadow: 0 1px 0 var(--line-2);
+  display: grid; grid-template-columns: 1.5fr 1fr 1fr;
+  gap: 30px;
+  font-size: 13px;
+  color: var(--ink-mute);
+}
+footer.foot strong { color: var(--ink); display: block; margin-bottom: 8px; font-weight: 600; }
+footer.foot a { color: var(--ink-mute); }
+footer.foot a:hover { color: var(--accent); }
+
+@media (max-width: 980px) {
+  .col-4, .col-6, .col-8 { grid-column: span 12; }
+  .topbar { grid-template-columns: 1fr; }
+  .topbar .search { width: 100%; }
+}

--- a/examples/prism-stack/static/favicon.svg
+++ b/examples/prism-stack/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/prism-stack/templates/404.html
+++ b/examples/prism-stack/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-stack/templates/footer.html
+++ b/examples/prism-stack/templates/footer.html
@@ -1,0 +1,21 @@
+    <footer class="foot">
+      <div>
+        <strong>Prism Stack</strong>
+        A bright, calm dashboard for product teams. Built with Hwaro · {{ current_year }}.
+      </div>
+      <div>
+        <strong>Boards</strong>
+        <a href="{{ base_url }}/">Console</a><br>
+        <a href="{{ base_url }}/updates/">Weekly updates</a><br>
+        <a href="{{ base_url }}/about/">Workspace</a>
+      </div>
+      <div>
+        <strong>Synced</strong>
+        Last refresh {{ current_date }}<br>
+        v.{{ current_year }}.05 · region us-east-1
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/prism-stack/templates/header.html
+++ b/examples/prism-stack/templates/header.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} · {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="topbar">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="logo" aria-hidden="true"></span>
+        Prism Stack
+      </a>
+      <div class="search">
+        <span>Jump to a board, owner, or KPI…</span>
+        <kbd>⌘K</kbd>
+      </div>
+      <div class="actions">
+        <a href="{{ base_url }}/updates/">Updates</a>
+        <a href="{{ base_url }}/about/">Workspace</a>
+        <a class="pill" href="{{ base_url }}/">+ New board</a>
+        <span class="avatar" aria-label="Hannah Park">HP</span>
+      </div>
+    </header>

--- a/examples/prism-stack/templates/home.html
+++ b/examples/prism-stack/templates/home.html
@@ -1,0 +1,137 @@
+{% include "header.html" %}
+  <main>
+    <section class="greet">
+      <div class="day">{{ current_date }} · Console</div>
+      <h1>Good afternoon, Hannah. <span>Three boards moved this week.</span></h1>
+      <div class="chips">
+        <span class="chip mint"><span class="dot"></span>Onboarding · on track</span>
+        <span class="chip lav"><span class="dot"></span>Activation · ahead</span>
+        <span class="chip peach"><span class="dot"></span>Retention · at risk</span>
+        <span class="chip sky"><span class="dot"></span>Pricing · waiting</span>
+        <span class="chip butter"><span class="dot"></span>Mobile · on hold</span>
+      </div>
+    </section>
+
+    <section class="grid" style="margin-bottom:22px;">
+      <div class="card col-4 kpi">
+        <div class="head"><h3>Weekly active</h3><span class="meta">7 d</span></div>
+        <div class="v">182.4k</div>
+        <div class="delta">+6.2% vs last week</div>
+        <div class="bars" style="margin-top:18px;">
+          <span style="--h:42%"></span><span style="--h:48%"></span>
+          <span style="--h:55%"></span><span style="--h:60%"></span>
+          <span style="--h:68%"></span><span class="acc" style="--h:82%"></span>
+          <span class="acc" style="--h:88%"></span>
+        </div>
+        <div class="axis"><span>M</span><span>T</span><span>W</span><span>T</span><span>F</span><span>S</span><span>S</span></div>
+      </div>
+      <div class="card col-4 kpi">
+        <div class="head"><h3>Activation rate</h3><span class="meta">7 d cohort</span></div>
+        <div class="v">38.1<small>%</small></div>
+        <div class="delta">+2.4 pts vs last week</div>
+        <ul class="legend" style="margin-top:18px;">
+          <li class="a"><span class="name">Day 1 → 7</span><span>38.1%</span></li>
+          <li class="b"><span class="name">Day 7 → 30</span><span>62.4%</span></li>
+          <li class="c"><span class="name">Day 30 → 90</span><span>48.0%</span></li>
+        </ul>
+      </div>
+      <div class="card col-4 kpi">
+        <div class="head"><h3>Net revenue retention</h3><span class="meta">12 mo</span></div>
+        <div class="v">112<small>%</small></div>
+        <div class="delta neg">−3 pts vs last week</div>
+        <div class="donut" style="margin-top:6px;">
+          <svg viewBox="0 0 100 100" aria-hidden="true">
+            <circle class="track" cx="50" cy="50" r="40"></circle>
+            <circle class="seg-a" cx="50" cy="50" r="40"
+                    stroke-dasharray="251.2" stroke-dashoffset="40" stroke-linecap="round"></circle>
+          </svg>
+          <div class="center"><b>112%</b><span>NRR</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid" style="margin-bottom:22px;">
+      <div class="card col-8">
+        <div class="head">
+          <h3>Active workstreams</h3>
+          <span class="meta">5 owners · 12 contributors</span>
+        </div>
+        <table class="t">
+          <thead>
+            <tr><th>Board</th><th>Owner</th><th>Status</th><th>Cycle</th><th class="right">Confidence</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Onboarding refresh</td><td>Hannah Park</td><td><span class="chip mint">on track</span></td><td>Week 3 / 4</td><td class="right">82%</td></tr>
+            <tr><td>Activation funnel</td><td>Mateo Iyer</td><td><span class="chip lav">ahead</span></td><td>Week 2 / 3</td><td class="right">91%</td></tr>
+            <tr><td>Retention pricing pilot</td><td>Lia Becker</td><td><span class="chip peach">at risk</span></td><td>Week 4 / 4</td><td class="right">54%</td></tr>
+            <tr><td>Mobile beta wave 2</td><td>Daniel Okafor</td><td><span class="chip butter">on hold</span></td><td>Week — / 6</td><td class="right">—</td></tr>
+            <tr><td>Pricing v3</td><td>Sora Han</td><td><span class="chip sky">waiting</span></td><td>Week 1 / 4</td><td class="right">72%</td></tr>
+            <tr><td>Outbound experiments</td><td>Ren Adachi</td><td><span class="chip mint">on track</span></td><td>Week 1 / 2</td><td class="right">88%</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="card col-4">
+        <div class="head">
+          <h3>Top features this week</h3>
+          <span class="meta">events</span>
+        </div>
+        <ul class="list">
+          <li>
+            <span class="icon mint">OB</span>
+            <div><div class="name">Onboarding · pre-fill</div><div class="sub">enabled for all new plans</div></div>
+            <span class="val">+18.4%</span>
+          </li>
+          <li>
+            <span class="icon lav">AC</span>
+            <div><div class="name">Activation nudge v2</div><div class="sub">3-day cohort lift</div></div>
+            <span class="val">+9.1%</span>
+          </li>
+          <li>
+            <span class="icon sky">PR</span>
+            <div><div class="name">Pricing calculator</div><div class="sub">embedded on marketing site</div></div>
+            <span class="val">+4.7%</span>
+          </li>
+          <li>
+            <span class="icon peach">RT</span>
+            <div><div class="name">Retention pilot</div><div class="sub">cohort B is lagging</div></div>
+            <span class="val">−2.2%</span>
+          </li>
+          <li>
+            <span class="icon rose">MB</span>
+            <div><div class="name">Mobile beta</div><div class="sub">wave 2 paused for App Review</div></div>
+            <span class="val">—</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card col-6">
+        <div class="head"><h3>Latest updates</h3><span class="meta">last 4</span></div>
+        <ul class="list">
+          {% for post in site.pages | where("section", "updates") | sort_by("date", reverse=true) %}
+            {% if loop.index <= 4 %}
+            <li>
+              <span class="icon {% if loop.index == 1 %}mint{% elif loop.index == 2 %}lav{% elif loop.index == 3 %}sky{% else %}peach{% endif %}">{{ loop.index }}</span>
+              <div>
+                <div class="name"><a href="{{ post.url }}">{{ post.title }}</a></div>
+                <div class="sub">{{ post.description | strip_html | truncate_words(14) }}</div>
+              </div>
+              <span class="val">{{ post.date | date("%b %d") }}</span>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+      <div class="card col-6">
+        <div class="head"><h3>Goal progress</h3><span class="meta">Q2</span></div>
+        <ul class="list">
+          <li><span class="icon mint">A</span><div><div class="name">Reach 200k weekly active</div><div class="sub">currently 182.4k · +6.2% week</div></div><span class="val">91%</span></li>
+          <li><span class="icon lav">B</span><div><div class="name">Activation ≥ 40%</div><div class="sub">currently 38.1%</div></div><span class="val">95%</span></li>
+          <li><span class="icon peach">C</span><div><div class="name">NRR ≥ 115%</div><div class="sub">currently 112% (drop from 115%)</div></div><span class="val">97%</span></li>
+          <li><span class="icon sky">D</span><div><div class="name">Ship pricing v3 by Jun 30</div><div class="sub">scoping in progress</div></div><span class="val">42%</span></li>
+        </ul>
+      </div>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-stack/templates/page.html
+++ b/examples/prism-stack/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main>
+    <section class="greet">
+      <div class="day">{{ page.date | date("%A · %B %d, %Y") | default("Workspace") }}</div>
+      <h1>{{ page.title | e }}</h1>
+      {% if page.description %}<p style="color:var(--ink-mute); max-width:60ch;">{{ page.description }}</p>{% endif %}
+    </section>
+    <article class="card prose" style="padding: 38px 42px;">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-stack/templates/section.html
+++ b/examples/prism-stack/templates/section.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+  <main>
+    <section class="greet">
+      <div class="day">Section</div>
+      <h1>{{ page.title | e }}</h1>
+      {% if page.description %}<p style="color:var(--ink-mute); max-width:60ch;">{{ page.description }}</p>{% endif %}
+    </section>
+    <section class="card" style="padding:8px 28px;">
+      <ul class="section-list">
+        {% for post in section.pages %}
+          <li>
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            <time>{{ post.date | date("%b %d, %Y") }}</time>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-stack/templates/shortcodes/alert.html
+++ b/examples/prism-stack/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/prism-stack/templates/taxonomy.html
+++ b/examples/prism-stack/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/prism-stack/templates/taxonomy_term.html
+++ b/examples/prism-stack/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/stratum-bi/AGENTS.md
+++ b/examples/stratum-bi/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/stratum-bi/archetypes/default.md
+++ b/examples/stratum-bi/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/stratum-bi/config.toml
+++ b/examples/stratum-bi/config.toml
@@ -1,0 +1,217 @@
+title = "Stratum BI"
+description = "A high-density terminal for trading-desk style business intelligence."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "desks"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["notes"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/stratum-bi/content/about.md
+++ b/examples/stratum-bi/content/about.md
@@ -1,0 +1,34 @@
++++
+title = "Manual"
+description = "A short reading guide to the terminal."
+date = "2026-05-12"
++++
+
+Stratum BI is a single-screen working terminal for a revenue desk. It is dense on purpose. The team that uses it knows the shape of the screen the way a trader knows the shape of their layout — when something is in the wrong place, your eye notices before you do.
+
+## Reading the screen, top to bottom
+
+- **A1–A4** are the four headline numbers. A1 is the position; A2–A4 are the things that move it. If A1 is green and any of A2–A4 are red, you are walking into a meeting with a *current* answer and an *aging* risk.
+- **B1** is the segment breakdown. Sort it by the column you are about to defend. The default sort is the desk's chosen lead.
+- **B2** is the rolling six-week heatmap. It is the one panel on the screen that you read with your hand, not your head — the eye finds the dark or the bright square first.
+- **C1–C3** are the working columns. Watchlist, pipe stages, feed. C3 is the only panel that moves between refreshes; everything else is stable per refresh.
+- **D1–D2** are the analytical reads. D1 links to the desk's longer notes; D2 calls out concentration on the open pipe.
+
+## Refresh cadence
+
+The warehouse refreshes at **06:00 New York** weekdays. The terminal reads the refresh and re-renders at **06:05**. The numbers do not change during the day. If you see a number change without a refresh, the desk has filed a correction; the feed (C3) will say so.
+
+## Keyboard
+
+- `⌘K` — clear the command line
+- `↵` — run the current command
+- `F4` — switch layout profile (desk / sales / executive)
+- `?` — keyboard reference
+
+The terminal works without a keyboard. Most desk members never learn the shortcuts; the layout is meant to be read, not driven.
+
+## Profiles
+
+The terminal ships with three layout profiles. The **desk** profile is the one above. The **sales** profile rearranges C1/C2/D2 to lead with pipe stage and concentration. The **executive** profile drops the feed and replaces it with the goal-progress board.
+
+> The terminal exists to let the team have the same picture in their head at the same time. The shortcuts and the profiles are for after that goal is met.

--- a/examples/stratum-bi/content/index.md
+++ b/examples/stratum-bi/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Console"
+description = "Stratum BI terminal — the desk console."
+template = "home"
++++

--- a/examples/stratum-bi/content/notes/_index.md
+++ b/examples/stratum-bi/content/notes/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Desk notes"
+description = "Short notes filed by the revenue desk, in chronological order."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/stratum-bi/content/notes/concentration-read.md
+++ b/examples/stratum-bi/content/notes/concentration-read.md
@@ -1,0 +1,29 @@
++++
+title = "Concentration on the open pipe — the read"
+date = "2026-05-13"
+description = "Three accounts represent 37.9% of the open Q3 pipe. The desk's reading is structural, not new — we are tracking how the concentration unwinds."
+tags = ["pipeline", "concentration", "q3"]
+desks = ["sales"]
++++
+
+The terminal's **D2** panel is calling out concentration. The top three opportunities — `NORTH·LOG`, `ATRIUM·H`, `MARAIS·BK` — represent 37.9% of the open Q3 pipe. The desk is filing a short read on what we think this means and what to watch.
+
+## The shape
+
+Concentration at the top of pipe is not new. Q2 and Q4 typically run with a top-3 share between 30% and 40%. Q1 of this year was anomalous at 24%, because two enterprise deals closed early in Q4. The current 37.9% is well within the historical window.
+
+## What is new
+
+The new piece is that the bottom of pipe is **also** healthy. Pipe coverage is 2.4× on a flat quota. In quarters where concentration sits at the upper end of the range, the bottom of pipe is usually thin. This time it is not. The weighted contribution of the bottom 60% of pipe alone is enough to make Q3 plan.
+
+The desk's read is that we are in a quarter where we can carry one slip at the top without re-forecasting. We cannot carry two.
+
+## What we are watching
+
+- `NORTH·LOG` second security review — still scheduled for the week of May 20.
+- `ATRIUM·H` re-presentation under the new VP — scheduled for May 16.
+- `MARAIS·BK` legal review — window expires May 30.
+
+## Note for the executive layout
+
+When the executive profile loads, the D2 panel is replaced with the goal-progress board. Concentration data is still on the terminal — it lives one keystroke away via `/risk concentration` — but it is no longer on the home screen.

--- a/examples/stratum-bi/content/notes/profile-layouts.md
+++ b/examples/stratum-bi/content/notes/profile-layouts.md
@@ -1,0 +1,21 @@
++++
+title = "Three layouts, one terminal"
+date = "2026-04-30"
+description = "The terminal ships with desk, sales, and executive layouts. A short note on why we built three rather than letting people drag panels around."
+tags = ["product", "ux"]
+desks = ["editorial"]
++++
+
+We get asked once a quarter why the terminal doesn't let people rearrange panels. The reason is the same reason a trading firm doesn't let everyone rearrange their own keyboard — when something goes wrong, the team needs to be able to walk to any seat and read the screen instantly.
+
+## The three layouts
+
+- **Desk** — the working layout. Everything on the home page. Optimized for the people who *fill in* the numbers.
+- **Sales** — the customer-facing layout. Leads with pipe stage and concentration. Optimized for forecast calls.
+- **Executive** — the read-only layout. Drops the feed and replaces D2 with the goal-progress board. Optimized for the read, not the work.
+
+A user has one profile attached to their session. They can switch with `F4` but the switch is loud — the layout animates, the colour palette nudges, and the C3 feed publishes a "profile changed" entry. We do not hide the profile.
+
+## Why we are not adding "custom"
+
+We have shipped two custom-layout previews to the desk. Both times, individual layouts diverged within a quarter, the team stopped being able to read each other's screens, and the standing layouts won the next round. The lesson is in the bones of the product now.

--- a/examples/stratum-bi/content/notes/smb-eu-alert.md
+++ b/examples/stratum-bi/content/notes/smb-eu-alert.md
@@ -1,0 +1,21 @@
++++
+title = "SMB EU under-20 — alert, not action"
+date = "2026-05-10"
+description = "Churn for the EU SMB band under 20 seats is at 2.84%. The desk is flagging an alert; we are not yet recommending a price-card change."
+tags = ["churn", "eu", "smb"]
+desks = ["pricing"]
++++
+
+The terminal is flagging the EU SMB under-20 band as `ALERT` in panel B1. The 30-day churn for that band closed at **2.84%**, against a 12-month trailing average of 2.02%. The drift is consistent with the broader under-20 pattern we wrote up last week.
+
+## Why an alert, not a recommendation
+
+We could move the price card on EU SMB under-20 next week. The desk is not recommending it.
+
+- The cohort is small (~1,200 customers). A second-cohort read in three weeks will tell us whether the drift sustains.
+- Moving the price card mid-quarter creates a re-pricing event for renewals that are *already* in flight. Those renewals are an unrelated population.
+- We have a standing rule that price-card moves go to a 60-day comment window for any affected band. The clock starts on the desk's recommendation, not on the alert.
+
+## What the alert does
+
+The alert turns the row red in the terminal. The C3 feed publishes an entry. The watchlist is updated to track the band's *renewal* curve daily rather than weekly. That is enough to keep our eyes on it without making a move.

--- a/examples/stratum-bi/content/notes/warehouse-v3.md
+++ b/examples/stratum-bi/content/notes/warehouse-v3.md
@@ -1,0 +1,25 @@
++++
+title = "Warehouse v3 — feed switched"
+date = "2026-05-06"
+description = "The terminal's feed is now warehouse.v3. Read once if you wrote a saved query; everything else is automatic."
+tags = ["infra", "warehouse"]
+desks = ["data"]
++++
+
+The terminal's data feed is now `warehouse.v3`. The cut-over happened on Tuesday morning and the heartbeat on the terminal has been steady since.
+
+## What changed
+
+- The fact table for ARR moved from `arr.fact_day` to `arr.fact_week`. The terminal calls the week table now; the daily table is read-only and archived.
+- The seat-band definitions are read from a CRD instead of a CSV. The desk owns the CRD; pull requests go to `revenue-ops/seat-bands`.
+- Refresh time moved from 06:15 to **06:05** New York.
+
+## What did not change
+
+The numbers on the terminal. Every published number on this site is the same number it would have been against the old feed, to two decimal places. The desk re-ran the last twelve weeks against both feeds before we cut over.
+
+## Who needs to read this
+
+You only need to read this note if **you wrote a saved query** that the terminal references. The terminal's stock layout is automatic. Saved queries that reference `arr.fact_day` need to be ported by the end of the month.
+
+> If the heartbeat at the bottom of the terminal stops being green, page the on-call data engineer. Do not page the desk.

--- a/examples/stratum-bi/static/css/style.css
+++ b/examples/stratum-bi/static/css/style.css
@@ -1,0 +1,215 @@
+:root {
+  --bg: #fafaf7;
+  --bg-2: #f3f3ee;
+  --panel: #ffffff;
+  --ink: #0f1115;
+  --ink-2: #2a2e36;
+  --mute: #6b6f78;
+  --dim: #9a9ea7;
+  --line: #e2e2dc;
+  --line-2: #c9cac3;
+  --accent: #00777f;
+  --accent-2: #f59a23;
+  --up: #1a8f3c;
+  --dn: #c73b3b;
+  --warn: #c9890a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, "Menlo", monospace;
+  font-size: 13px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "tnum" 1;
+}
+.sans { font-family: "Inter", system-ui, -apple-system, sans-serif; }
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.terminal {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 8px 14px 60px;
+}
+
+.bar-top {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto auto;
+  align-items: center;
+  gap: 14px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--line-2);
+}
+.bar-top .ident {
+  font-weight: 700; letter-spacing: 0.04em;
+  font-size: 14px;
+  color: var(--ink);
+  padding-right: 14px; border-right: 1px solid var(--line);
+}
+.bar-top .ident span { color: var(--accent); }
+.bar-top .crumb { color: var(--mute); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; }
+.bar-top .scroll { overflow: hidden; white-space: nowrap; }
+.bar-top .scroll .tick { font-size: 12px; color: var(--ink-2); }
+.bar-top .scroll .tick b { color: var(--ink); }
+.bar-top .scroll .tick .up { color: var(--up); }
+.bar-top .scroll .tick .dn { color: var(--dn); }
+.bar-top .scroll .tick span { margin: 0 14px; }
+.bar-top .now { font-size: 11px; color: var(--mute); }
+.bar-top .now b { color: var(--ink); }
+.bar-top nav { display: flex; gap: 14px; }
+.bar-top nav a { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mute); padding: 4px 8px; border: 1px solid transparent; }
+.bar-top nav a:hover { color: var(--ink); border-color: var(--line); }
+.bar-top nav a.active { color: var(--ink); border: 1px solid var(--ink); }
+
+.bar-mid {
+  display: flex; align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 11px; color: var(--mute);
+  text-transform: uppercase; letter-spacing: 0.08em;
+}
+.bar-mid .cmd { background: var(--ink); color: var(--bg); padding: 2px 8px; letter-spacing: 0.1em; }
+.bar-mid .q { font-family: inherit; background: transparent; border: 0; outline: 0; flex: 1; font-size: 12px; color: var(--ink-2); letter-spacing: 0.02em; text-transform: none; }
+.bar-mid .hint { color: var(--dim); font-size: 10px; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1px;
+  background: var(--line);
+  margin: 12px 0 1px;
+}
+.cell {
+  background: var(--panel);
+  padding: 12px 14px;
+}
+.cell h3 {
+  margin: 0 0 8px;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mute);
+  display: flex; justify-content: space-between; align-items: baseline;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 6px;
+}
+.cell h3 b { color: var(--ink); }
+.cell h3 .id { color: var(--accent); font-weight: 700; }
+
+.c-2 { grid-column: span 2; }
+.c-3 { grid-column: span 3; }
+.c-4 { grid-column: span 4; }
+.c-5 { grid-column: span 5; }
+.c-6 { grid-column: span 6; }
+.c-7 { grid-column: span 7; }
+.c-8 { grid-column: span 8; }
+.c-12 { grid-column: span 12; }
+
+.k { display: flex; align-items: baseline; gap: 6px; }
+.k .v { font-size: 28px; letter-spacing: -0.02em; color: var(--ink); }
+.k .u { font-size: 11px; color: var(--mute); }
+.k .d { font-size: 11px; padding: 2px 6px; }
+.k .d.up { color: var(--up); }
+.k .d.dn { color: var(--dn); }
+.k .d::before { content: "+"; }
+.k .d.dn::before { content: ""; }
+.kpi-sub { font-size: 10px; color: var(--mute); margin-top: 6px; letter-spacing: 0.04em; }
+
+.sk { width: 100%; height: 36px; }
+.sk polyline { fill: none; stroke: var(--ink); stroke-width: 1.2; }
+.sk .a { stroke: var(--accent); }
+.sk .b { stroke: var(--accent-2); stroke-dasharray: 2 2; }
+.sk .baseline { stroke: var(--line-2); stroke-dasharray: 1 2; }
+
+table.dt { width: 100%; border-collapse: collapse; font-size: 12px; }
+table.dt th, table.dt td { padding: 4px 0; text-align: left; border-bottom: 1px solid var(--line); white-space: nowrap; }
+table.dt th { color: var(--mute); font-weight: 500; font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; }
+table.dt td.right { text-align: right; }
+table.dt td .up { color: var(--up); }
+table.dt td .dn { color: var(--dn); }
+table.dt td .flat { color: var(--mute); }
+table.dt tr:hover { background: var(--bg-2); }
+table.dt td .tag { display: inline-block; padding: 0 5px; border: 1px solid var(--line-2); font-size: 10px; color: var(--mute); letter-spacing: 0.08em; }
+table.dt td .tag.h { color: var(--accent); border-color: var(--accent); }
+table.dt td .tag.w { color: var(--warn); border-color: var(--warn); }
+table.dt td .tag.a { color: var(--dn); border-color: var(--dn); }
+
+.heat { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
+.heat span {
+  aspect-ratio: 1;
+  background: var(--bg-2);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 9px; color: var(--ink-2);
+}
+.heat span[data-l="1"] { background: #e7efe9; }
+.heat span[data-l="2"] { background: #cfe1d2; }
+.heat span[data-l="3"] { background: #b4ceb9; color: #08361a; }
+.heat span[data-l="4"] { background: #94bc9f; color: #08361a; }
+.heat span[data-l="5"] { background: #6da17b; color: #fafaf7; }
+.heat span.dn[data-l="2"] { background: #f1d6d6; color: var(--ink); }
+.heat span.dn[data-l="3"] { background: #e8bbbb; color: #45100f; }
+.heat span.dn[data-l="4"] { background: #d49494; color: #fafaf7; }
+
+.ticker-vert { list-style: none; padding: 0; margin: 0; }
+.ticker-vert li { display: grid; grid-template-columns: 1fr auto auto; gap: 8px; padding: 3px 0; font-size: 12px; border-bottom: 1px dashed var(--line); }
+.ticker-vert li:last-child { border-bottom: 0; }
+.ticker-vert .sym { font-weight: 700; }
+.ticker-vert .price { text-align: right; }
+.ticker-vert .chg.up { color: var(--up); }
+.ticker-vert .chg.dn { color: var(--dn); }
+
+.log { font-size: 11.5px; line-height: 1.7; color: var(--ink-2); margin: 0; padding: 0; }
+.log li { list-style: none; display: grid; grid-template-columns: 56px 36px 1fr; gap: 8px; padding: 1px 0; }
+.log .t { color: var(--mute); }
+.log .l { letter-spacing: 0.1em; }
+.log .l.i { color: var(--accent); }
+.log .l.w { color: var(--warn); }
+.log .l.e { color: var(--dn); }
+.log .l.o { color: var(--up); }
+
+.status { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; border-top: 1px solid var(--line-2); font-size: 11px; color: var(--mute); margin-top: 14px; letter-spacing: 0.06em; }
+.status .left b, .status .right b { color: var(--ink); }
+.status .right span { margin-left: 14px; }
+.status .ok { color: var(--up); }
+.status .er { color: var(--dn); }
+
+article.prose { font-family: "Inter", system-ui, sans-serif; font-size: 15px; line-height: 1.6; max-width: 70ch; padding: 28px 0; }
+article.prose h2 { font-size: 1.4rem; margin-top: 1.6em; letter-spacing: -0.01em; }
+article.prose h3 { font-size: 1.1rem; margin-top: 1.3em; }
+article.prose blockquote { border-left: 3px solid var(--accent); margin: 1.4em 0; padding: 4px 18px; color: var(--mute); font-style: italic; }
+article.prose code { background: var(--bg-2); padding: 2px 6px; font-size: 0.9em; font-family: "JetBrains Mono", monospace; }
+article.prose table { width: 100%; border-collapse: collapse; margin: 1.4em 0; font-family: "JetBrains Mono", monospace; font-size: 13px; }
+article.prose table th, article.prose table td { padding: 8px 12px; border-bottom: 1px solid var(--line); text-align: left; }
+article.prose table th { color: var(--mute); font-weight: 500; font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; }
+
+ul.section-list { list-style: none; padding: 0; font-family: "Inter", sans-serif; }
+ul.section-list li {
+  display: grid; grid-template-columns: 90px 1fr auto; gap: 18px;
+  padding: 14px 0; border-bottom: 1px solid var(--line); align-items: baseline;
+}
+ul.section-list li time { font-family: "JetBrains Mono", monospace; font-size: 11px; color: var(--mute); letter-spacing: 0.06em; }
+ul.section-list li a { font-size: 1rem; font-weight: 600; }
+
+footer.foot {
+  margin-top: 24px;
+  padding: 12px 0;
+  border-top: 1px solid var(--line-2);
+  display: grid; grid-template-columns: 1fr 1fr 1fr;
+  gap: 20px;
+  font-size: 10px;
+  color: var(--mute);
+  text-transform: uppercase; letter-spacing: 0.1em;
+}
+footer.foot b { color: var(--ink); }
+
+@media (max-width: 980px) {
+  .c-2, .c-3, .c-4, .c-5, .c-6, .c-7, .c-8 { grid-column: span 12; }
+  .bar-top { grid-template-columns: 1fr; gap: 6px; }
+  .bar-top .scroll { display: none; }
+}

--- a/examples/stratum-bi/static/favicon.svg
+++ b/examples/stratum-bi/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/stratum-bi/templates/404.html
+++ b/examples/stratum-bi/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/stratum-bi/templates/footer.html
+++ b/examples/stratum-bi/templates/footer.html
@@ -1,0 +1,19 @@
+    <div class="status">
+      <div class="left">
+        <b class="ok">●</b> connected · feed <b>warehouse.v3</b> · lag <b>00:00:14</b> · build <b>{{ current_year }}.05.r3</b>
+      </div>
+      <div class="right">
+        <span>{{ site.title }} · <b>v.{{ current_year }}.05</b></span>
+        <span>profile <b>desk:revenue</b></span>
+        <span>session <b>HP-2842</b></span>
+      </div>
+    </div>
+    <footer class="foot">
+      <div><b>{{ site.title | upper }}</b> · built with hwaro</div>
+      <div>boards · <a href="{{ base_url }}/">cons</a> · <a href="{{ base_url }}/notes/">note</a> · <a href="{{ base_url }}/about/">man</a></div>
+      <div>last sync <b>{{ current_date }}</b></div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/stratum-bi/templates/header.html
+++ b/examples/stratum-bi/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} · {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="terminal">
+    <header class="bar-top">
+      <a href="{{ base_url }}/" class="ident">STRAT<span>·</span>BI</a>
+      <span class="crumb">terminal // desk · revenue</span>
+      <div class="scroll">
+        <span class="tick"><b>NA</b> arr <span class="up">+0.42</span> · </span>
+        <span class="tick"><b>EU</b> arr <span class="up">+0.18</span> · </span>
+        <span class="tick"><b>APAC</b> arr <span class="dn">−0.06</span> · </span>
+        <span class="tick"><b>CHURN</b> <span class="dn">+0.18p</span> · </span>
+        <span class="tick"><b>PIPE</b> <span class="up">+2.1</span> · </span>
+        <span class="tick"><b>NRR</b> <span class="dn">−3p</span> · </span>
+        <span class="tick"><b>UTIL</b> 0.74</span>
+      </div>
+      <span class="now"><b>{{ current_date }}</b> · 14:32:09 UTC</span>
+      <nav>
+        <a href="{{ base_url }}/" class="active">CONS</a>
+        <a href="{{ base_url }}/notes/">NOTE</a>
+        <a href="{{ base_url }}/about/">MAN</a>
+      </nav>
+    </header>
+    <div class="bar-mid">
+      <span class="cmd">CMD</span>
+      <input class="q" type="text" value="/desk revenue · /from -7d · /group segment · /sort delta desc" readonly aria-label="terminal command line">
+      <span class="hint">↵ to run · ⌘k to clear · F4 to layout</span>
+    </div>

--- a/examples/stratum-bi/templates/home.html
+++ b/examples/stratum-bi/templates/home.html
@@ -1,0 +1,157 @@
+{% include "header.html" %}
+  <main>
+    <section class="grid">
+      <div class="cell c-3">
+        <h3><span><span class="id">A1</span> <b>ARR · 7D</b></span><span>USD</span></h3>
+        <div class="k"><span class="v">24.18</span><span class="u">M</span><span class="d up">0.42</span></div>
+        <div class="kpi-sub">+1.46M qoq · +6.4%</div>
+        <svg class="sk" viewBox="0 0 100 36" preserveAspectRatio="none" aria-hidden="true">
+          <polyline class="baseline" points="0,24 100,24"></polyline>
+          <polyline class="a" points="0,28 10,26 20,24 30,22 40,20 50,18 60,16 70,12 80,10 90,8 100,6"></polyline>
+        </svg>
+      </div>
+      <div class="cell c-3">
+        <h3><span><span class="id">A2</span> <b>CHURN · 30D</b></span><span>%</span></h3>
+        <div class="k"><span class="v">1.42</span><span class="u">%</span><span class="d dn">0.18</span></div>
+        <div class="kpi-sub">smb &lt;20 seats · +0.31p</div>
+        <svg class="sk" viewBox="0 0 100 36" preserveAspectRatio="none" aria-hidden="true">
+          <polyline class="baseline" points="0,18 100,18"></polyline>
+          <polyline class="a" points="0,16 10,15 20,17 30,16 40,18 50,17 60,19 70,18 80,20 90,22 100,24"></polyline>
+        </svg>
+      </div>
+      <div class="cell c-3">
+        <h3><span><span class="id">A3</span> <b>NRR · 12M</b></span><span>%</span></h3>
+        <div class="k"><span class="v">112</span><span class="u">%</span><span class="d dn">3.0</span></div>
+        <div class="kpi-sub">target 115 · -3p</div>
+        <svg class="sk" viewBox="0 0 100 36" preserveAspectRatio="none" aria-hidden="true">
+          <polyline class="baseline" points="0,12 100,12"></polyline>
+          <polyline class="a" points="0,10 10,9 20,10 30,11 40,10 50,12 60,14 70,13 80,15 90,17 100,18"></polyline>
+        </svg>
+      </div>
+      <div class="cell c-3">
+        <h3><span><span class="id">A4</span> <b>PIPE · Q3</b></span><span>USD</span></h3>
+        <div class="k"><span class="v">58.2</span><span class="u">M</span><span class="d up">2.1</span></div>
+        <div class="kpi-sub">cov 2.4× · conc 38%</div>
+        <svg class="sk" viewBox="0 0 100 36" preserveAspectRatio="none" aria-hidden="true">
+          <polyline class="baseline" points="0,20 100,20"></polyline>
+          <polyline class="a" points="0,22 10,21 20,22 30,20 40,19 50,16 60,15 70,14 80,12 90,10 100,8"></polyline>
+        </svg>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="cell c-7">
+        <h3><span><span class="id">B1</span> <b>SEGMENT · QTD DELTA</b></span><span>rank by net new</span></h3>
+        <table class="dt">
+          <thead>
+            <tr><th>SEGMENT</th><th>REGION</th><th class="right">NN·ARR</th><th class="right">QOQ</th><th class="right">CHURN</th><th class="right">PIPE</th><th class="right">FLAG</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>MM·50–250</td><td>NA</td><td class="right">$612k</td><td class="right"><span class="up">+19.1</span></td><td class="right">1.10</td><td class="right">$18.4M</td><td class="right"><span class="tag">▲</span></td></tr>
+            <tr><td>MM·250–500</td><td>EU</td><td class="right">$320k</td><td class="right"><span class="up">+12.6</span></td><td class="right">0.94</td><td class="right">$12.8M</td><td class="right"><span class="tag">▲</span></td></tr>
+            <tr><td>ENT·500+</td><td>NA</td><td class="right">$214k</td><td class="right"><span class="flat">+2.0</span></td><td class="right">0.40</td><td class="right">$22.1M</td><td class="right"><span class="tag h">CONC</span></td></tr>
+            <tr><td>SMB·&lt;50</td><td>NA</td><td class="right">$148k</td><td class="right"><span class="dn">−8.4</span></td><td class="right">2.21</td><td class="right">$2.4M</td><td class="right"><span class="tag w">WATCH</span></td></tr>
+            <tr><td>SMB·&lt;20</td><td>EU</td><td class="right">$96k</td><td class="right"><span class="dn">−12.1</span></td><td class="right">2.84</td><td class="right">$1.1M</td><td class="right"><span class="tag a">ALERT</span></td></tr>
+            <tr><td>MM·50–250</td><td>APAC</td><td class="right">$84k</td><td class="right"><span class="up">+6.2</span></td><td class="right">1.40</td><td class="right">$3.4M</td><td class="right"><span class="tag">▲</span></td></tr>
+            <tr><td>STARTUP</td><td>GLB</td><td class="right">$46k</td><td class="right"><span class="up">+12.0</span></td><td class="right">0.10</td><td class="right">$0.4M</td><td class="right"><span class="tag">▲</span></td></tr>
+            <tr><td>NPO</td><td>GLB</td><td class="right">$24k</td><td class="right"><span class="flat">0.0</span></td><td class="right">0.20</td><td class="right">$0.2M</td><td class="right"><span class="tag">·</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="cell c-5">
+        <h3><span><span class="id">B2</span> <b>HEAT · ARR DELTA · 6W × 7D</b></span><span>+%/day</span></h3>
+        <div class="heat" aria-hidden="true">
+          <span data-l="2">M</span><span data-l="3">T</span><span data-l="3">W</span><span data-l="2">T</span><span data-l="4">F</span><span data-l="1">S</span><span data-l="1">S</span>
+          <span data-l="3">·</span><span data-l="4">·</span><span data-l="2">·</span><span data-l="3">·</span><span data-l="5">·</span><span data-l="1">·</span><span data-l="1">·</span>
+          <span data-l="2">·</span><span data-l="3">·</span><span data-l="3">·</span><span data-l="2">·</span><span data-l="4">·</span><span data-l="1">·</span><span data-l="1">·</span>
+          <span class="dn" data-l="2">·</span><span data-l="2">·</span><span data-l="3">·</span><span data-l="4">·</span><span data-l="5">·</span><span data-l="1">·</span><span data-l="1">·</span>
+          <span data-l="3">·</span><span data-l="4">·</span><span data-l="4">·</span><span data-l="3">·</span><span data-l="5">·</span><span data-l="1">·</span><span data-l="1">·</span>
+          <span data-l="4">·</span><span data-l="5">·</span><span data-l="4">·</span><span data-l="4">·</span><span data-l="5">·</span><span data-l="1">·</span><span data-l="1">·</span>
+        </div>
+        <div class="kpi-sub" style="margin-top:12px;">rows · last 6 weeks · oldest top · weekday cols</div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="cell c-4">
+        <h3><span><span class="id">C1</span> <b>WATCHLIST · TOP 8</b></span><span>price · 7d chg</span></h3>
+        <ul class="ticker-vert">
+          <li><span class="sym">NORTH·LOG</span><span class="price">$9.40M</span><span class="chg up">+0.42</span></li>
+          <li><span class="sym">ATRIUM·H</span><span class="price">$7.10M</span><span class="chg up">+0.18</span></li>
+          <li><span class="sym">MARAIS·BK</span><span class="price">$5.60M</span><span class="chg dn">−0.06</span></li>
+          <li><span class="sym">VELA·AERO</span><span class="price">$4.20M</span><span class="chg up">+0.14</span></li>
+          <li><span class="sym">AUREL·RT</span><span class="price">$1.90M</span><span class="chg dn">−0.24</span></li>
+          <li><span class="sym">HELIX·BIO</span><span class="price">$1.40M</span><span class="chg up">+0.08</span></li>
+          <li><span class="sym">CASCADE·E</span><span class="price">$1.10M</span><span class="chg up">+0.02</span></li>
+          <li><span class="sym">SOMNI·LAB</span><span class="price">$0.92M</span><span class="chg dn">−0.10</span></li>
+        </ul>
+      </div>
+      <div class="cell c-4">
+        <h3><span><span class="id">C2</span> <b>PIPE · STAGE BREAKDOWN</b></span><span>q3 open</span></h3>
+        <table class="dt">
+          <thead>
+            <tr><th>STAGE</th><th class="right">N</th><th class="right">SUM</th><th class="right">CONV</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>DISC</td><td class="right">142</td><td class="right">$12.4M</td><td class="right">0.18</td></tr>
+            <tr><td>SCOPE</td><td class="right">96</td><td class="right">$14.8M</td><td class="right">0.31</td></tr>
+            <tr><td>PROP</td><td class="right">38</td><td class="right">$18.2M</td><td class="right">0.46</td></tr>
+            <tr><td>VERBAL</td><td class="right">14</td><td class="right">$10.4M</td><td class="right">0.68</td></tr>
+            <tr><td>LEGAL</td><td class="right">3</td><td class="right">$2.4M</td><td class="right">0.85</td></tr>
+          </tbody>
+        </table>
+        <div class="kpi-sub" style="margin-top:8px;">weighted total · ~$22.8M · target $15.0M</div>
+      </div>
+      <div class="cell c-4">
+        <h3><span><span class="id">C3</span> <b>FEED · LAST 12</b></span><span>tail −12</span></h3>
+        <ul class="log">
+          <li><span class="t">14:32:09</span><span class="l o">OK</span><span>arr.fact_week · refreshed · 0 err</span></li>
+          <li><span class="t">14:28:41</span><span class="l i">INF</span><span>watchlist NORTH·LOG advanced to LEGAL</span></li>
+          <li><span class="t">14:22:18</span><span class="l w">WRN</span><span>SMB·&lt;20 EU · churn 2.84 · alert</span></li>
+          <li><span class="t">14:14:02</span><span class="l o">OK</span><span>nightly cohort export · 14,210 rows</span></li>
+          <li><span class="t">14:08:50</span><span class="l i">INF</span><span>ATRIUM·H repush proposal · v3</span></li>
+          <li><span class="t">14:01:11</span><span class="l e">ERR</span><span>AURELIUS·RT pushed back 21 days</span></li>
+          <li><span class="t">13:54:34</span><span class="l o">OK</span><span>pricing.refresh hash a91c2 · steady</span></li>
+          <li><span class="t">13:42:08</span><span class="l i">INF</span><span>desk briefing · queued for 09:00 NY</span></li>
+          <li><span class="t">13:30:00</span><span class="l o">OK</span><span>warehouse heartbeat · t=14ms</span></li>
+          <li><span class="t">13:18:42</span><span class="l i">INF</span><span>VELA·AERO ARR confirmed · +$4.2M</span></li>
+          <li><span class="t">13:09:14</span><span class="l w">WRN</span><span>seat·band re-stated · oct 04</span></li>
+          <li><span class="t">12:58:00</span><span class="l o">OK</span><span>session HP-2842 · authenticated</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="cell c-6">
+        <h3><span><span class="id">D1</span> <b>LATEST DESK NOTES</b></span><span>last 4</span></h3>
+        <ul class="section-list" style="font-family:'Inter',sans-serif;">
+          {% for post in site.pages | where("section", "notes") | sort_by("date", reverse=true) %}
+            {% if loop.index <= 4 %}
+            <li>
+              <time>{{ post.date | date("%Y.%m.%d") }}</time>
+              <div><a href="{{ post.url }}">{{ post.title }}</a><div style="font-size:12.5px; color:var(--mute); margin-top:3px;">{{ post.description | strip_html | truncate_words(18) }}</div></div>
+              <span style="font-size:11px; color:var(--mute); font-family:'JetBrains Mono',monospace;">{% if post.tags %}{{ post.tags | first | upper }}{% endif %}</span>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+      <div class="cell c-6">
+        <h3><span><span class="id">D2</span> <b>CONCENTRATION RISK</b></span><span>pipe · top 5</span></h3>
+        <table class="dt">
+          <thead>
+            <tr><th>RANK</th><th>NAME</th><th class="right">ARR</th><th class="right">SHARE</th><th class="right">PROB</th><th class="right">FLAG</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>01</td><td>NORTH·LOG</td><td class="right">$9.40M</td><td class="right">16.1%</td><td class="right">0.70</td><td class="right"><span class="tag h">CONC</span></td></tr>
+            <tr><td>02</td><td>ATRIUM·H</td><td class="right">$7.10M</td><td class="right">12.2%</td><td class="right">0.65</td><td class="right"><span class="tag h">CONC</span></td></tr>
+            <tr><td>03</td><td>MARAIS·BK</td><td class="right">$5.60M</td><td class="right">9.6%</td><td class="right">0.40</td><td class="right"><span class="tag w">WATCH</span></td></tr>
+            <tr><td>04</td><td>VELA·AERO</td><td class="right">$4.20M</td><td class="right">7.2%</td><td class="right">0.55</td><td class="right"><span class="tag">·</span></td></tr>
+            <tr><td>05</td><td>AUREL·RT</td><td class="right">$1.90M</td><td class="right">3.3%</td><td class="right">0.30</td><td class="right"><span class="tag a">DELAY</span></td></tr>
+          </tbody>
+        </table>
+        <div class="kpi-sub" style="margin-top:8px;">top 5 · 48.4% of open pipe · top 3 · 37.9%</div>
+      </div>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/stratum-bi/templates/page.html
+++ b/examples/stratum-bi/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main>
+    <div class="cell" style="margin-top:12px;">
+      {% if page.title is present %}
+      <h3><span><span class="id">·</span> <b>{{ page.title | e | upper }}</b></span><span>{% if page.date %}{{ page.date | date("%Y.%m.%d") }}{% endif %}</span></h3>
+      {% endif %}
+      <article class="prose">{{ content }}</article>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/stratum-bi/templates/section.html
+++ b/examples/stratum-bi/templates/section.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main>
+    <div class="cell" style="margin-top:12px;">
+      <h3><span><span class="id">·</span> <b>{{ page.title | e | upper }}</b></span><span>{{ section.pages | length }} rec.</span></h3>
+      {% if page.description %}<p class="sans" style="color:var(--mute); font-size:13px; max-width:60ch; margin: 0 0 8px;">{{ page.description }}</p>{% endif %}
+      <ul class="section-list">
+        {% for post in section.pages %}
+          <li>
+            <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            <span style="font-size:11px; color:var(--mute);">{% if post.tags %}{{ post.tags | first | upper }}{% endif %}</span>
+          </li>
+        {% endfor %}
+      </ul>
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/stratum-bi/templates/shortcodes/alert.html
+++ b/examples/stratum-bi/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/stratum-bi/templates/taxonomy.html
+++ b/examples/stratum-bi/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/stratum-bi/templates/taxonomy_term.html
+++ b/examples/stratum-bi/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/vexel-ops/AGENTS.md
+++ b/examples/vexel-ops/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/vexel-ops/archetypes/default.md
+++ b/examples/vexel-ops/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/vexel-ops/config.toml
+++ b/examples/vexel-ops/config.toml
@@ -1,0 +1,217 @@
+title = "Vexel Ops"
+description = "An operations console for engineering teams who like sharp edges."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "owners"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["incidents"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/vexel-ops/content/about.md
+++ b/examples/vexel-ops/content/about.md
@@ -1,0 +1,27 @@
++++
+title = "Operating brief"
+description = "How this team runs its console, in seven short rules."
+tags = ["operating"]
++++
+
+Vexel/Ops is the console for a 22-person platform engineering group. We run twelve production services and four data pipelines for a mid-sized payments company. The display you just walked away from is the working surface, not a summary deck.
+
+## Seven rules
+
+1. **The number is real.** If a panel can't be honest, the panel goes blank.
+2. **No surprise green.** A service that has been on the warn list for ten days does not get to flip green without an explanation in the incident log.
+3. **Burn beats availability.** We watch the burn-rate column first. The SLO is a thirty-day promise.
+4. **Two pairs of eyes on every change.** Approvals are recorded by name, not handle.
+5. **Drill on the days you ship.** Chaos drills are scheduled the same week as significant releases — the team that ships should know exactly how its work fails.
+6. **The on-call rotation is sacred.** Six day cycle, handover Wednesday, no exceptions.
+7. **The brief survives the team.** Anyone joining the rotation reads this page; anyone leaving the rotation updates it.
+
+## Tools we use
+
+- **Hwaro** for this console (static, plain HTML, no framework)
+- **Loki + Tempo** for log and trace search
+- **Grafana** for ad-hoc dashboards
+- **PagerDuty** for paging the rotation
+- **A whiteboard** for the things tools can't help with
+
+> The console is a contract with the past version of yourself who set up the SLOs. Don't lie to that person.

--- a/examples/vexel-ops/content/incidents/_index.md
+++ b/examples/vexel-ops/content/incidents/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Incidents"
+description = "Postmortems, in chronological order. Most recent first. Names redacted, lessons not."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/vexel-ops/content/incidents/billing-warm-pool.md
+++ b/examples/vexel-ops/content/incidents/billing-warm-pool.md
@@ -1,0 +1,21 @@
++++
+title = "billing-api warm pool starves at 09:00"
+date = "2026-05-13"
+description = "A predictable spike was being treated as a surprise by the autoscaler. The warm pool was three nodes short of the steady-state."
+tags = ["p3", "billing", "autoscaler"]
+owners = ["payments"]
++++
+
+The morning spike for `billing-api` has been arriving at the same minute for nine months. The warm pool has been sized for the spike for eight months, but the autoscaler policy was rewritten in February to use the new platform CRD. The new policy sized the warm pool against the *median* of the previous hour rather than the *p95*. At 08:55 the median is low.
+
+## What broke
+
+Between 09:00:00 and 09:02:11 the warm pool was three nodes short of the steady-state for the morning spike. New connections to `billing-api` were placed onto cold nodes; cold nodes took about 11 seconds to enter the rotation. During those two minutes the p99 latency on the billing path climbed from 180ms to 1.2s, and 0.8% of requests retried.
+
+## The fix
+
+- `platform/autoscaling/policies/billing.yaml`: switch back to p95 over the previous 30 minutes.
+- Added a regression test in `chaos/morning-spike/` that replays the 09:00 traffic shape against a candidate policy.
+- Cleared the burn rate ratchet by 0.4× over the rolling 24 hours.
+
+The new policy CRD is fine. We sized the warm pool against the wrong statistic; that's all.

--- a/examples/vexel-ops/content/incidents/chaos-drill-auth.md
+++ b/examples/vexel-ops/content/incidents/chaos-drill-auth.md
@@ -1,0 +1,22 @@
++++
+title = "Chaos drill — auth-svc clean shutdown"
+date = "2026-05-08"
+description = "A clean shutdown drill on auth-svc finished 100/100, including the new token-cache hot replacement."
+tags = ["drill", "auth", "chaos"]
+owners = ["platform"]
++++
+
+We took `auth-svc` through a one-hundred-iteration clean-shutdown drill. The drill kills a randomly selected pod once every six seconds and measures how long the cluster takes to drain it from the rotation, plus the number of requests rejected during the window.
+
+## Numbers
+
+- 100/100 clean shutdowns.
+- 0 requests rejected during shutdown windows.
+- Median drain time: **2.1s** (was 3.4s last quarter).
+- Slowest drain: **3.8s** (was 5.6s last quarter).
+
+The improvement is from the new token-cache hot-replacement code (PR-1041). The cache no longer needs to be rebuilt on a fresh pod — it warms from a sibling.
+
+## Next drill
+
+Same shape against `billing-api` on Friday. The new warm-pool policy will be in production by then, and we want to know whether the warm-pool change *also* improved drain time.

--- a/examples/vexel-ops/content/incidents/edge-router-eu-west.md
+++ b/examples/vexel-ops/content/incidents/edge-router-eu-west.md
@@ -1,0 +1,19 @@
++++
+title = "edge-router eu-west-1 latency drift"
+date = "2026-05-04"
+description = "Two AZs in eu-west-1 added 12ms to the median because of a peering change at the upstream. We rerouted and notified the carrier."
+tags = ["p4", "edge", "network"]
+owners = ["platform"]
++++
+
+The upstream changed peering on a Sunday and forgot to tell us. We saw the drift on the **edge-router** panel by Monday 13:58, paged the network on-call, and shifted eu-west-1 traffic to the secondary peer at 14:18. The latency snapped back to the baseline at 14:22.
+
+## Why we saw it quickly
+
+The console now shows a per-region row on the edge-router panel during EU business hours. The new row is what surfaced the drift; before May we only had a global median.
+
+## What we are following up on
+
+- Carrier credit for the 36 minutes of degraded routing.
+- A signed change-window agreement: we expect 48h notice on peering rearrangements.
+- A panel that *also* shows the route-by-route p95 for the top ten paths in eu-west-1. The drift was hiding inside a small set of routes, not the median.

--- a/examples/vexel-ops/content/incidents/notify-retry-budget.md
+++ b/examples/vexel-ops/content/incidents/notify-retry-budget.md
@@ -1,0 +1,21 @@
++++
+title = "notify-svc retry budget exhausted at 14:12"
+date = "2026-05-10"
+description = "The SMS carrier rate-limited us for the third time this quarter. We routed non-critical notifies to email and stopped paying for the retries."
+tags = ["p4", "notify", "carrier"]
+owners = ["growth"]
++++
+
+`notify-svc` budgets retries per provider per hour. The SMS provider has been rate-limiting us since the carrier merger closed; every retry costs us a fraction of the budget and adds latency without delivery.
+
+## Decision
+
+- Non-critical notifies (marketing, low-priority transactional) → email only.
+- Critical notifies (two-factor codes, security alerts) → SMS first, email fallback.
+- The carrier is on notice for a 90-day re-evaluation.
+
+## What changes on the console
+
+The **error budget** panel for `notify-svc` will drop by ~1.8× burn over the next 48 hours as the queue drains. That is the expected shape, not an incident.
+
+> Pay the bill once. Do not pay the bill again on every retry.

--- a/examples/vexel-ops/content/index.md
+++ b/examples/vexel-ops/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Console"
+description = "A working operations console for an infrastructure team."
+template = "home"
++++

--- a/examples/vexel-ops/static/css/style.css
+++ b/examples/vexel-ops/static/css/style.css
@@ -1,0 +1,172 @@
+:root {
+  --bg: #f3f0ea;
+  --bg-2: #ffffff;
+  --ink: #0a0a0a;
+  --ink-mute: #5f5b54;
+  --rule: #0a0a0a;
+  --hair: #cbc6bd;
+  --accent: #ff5a1f;
+  --good: #2e7d32;
+  --warn: #b87b00;
+  --err: #c1322d;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+.mono, code, pre, time { font-family: "JetBrains Mono", ui-monospace, "Menlo", monospace; }
+
+a { color: var(--ink); text-underline-offset: 4px; text-decoration: underline; text-decoration-thickness: 1px; }
+a:hover { color: var(--accent); }
+
+.shell {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 28px 36px 80px;
+}
+
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-bottom: 22px; margin-bottom: 0;
+  border-bottom: 3px solid var(--ink);
+}
+.topbar .brand {
+  display: flex; align-items: baseline; gap: 14px;
+  text-decoration: none;
+  font-weight: 900; font-size: 18px; letter-spacing: -0.02em;
+}
+.topbar .brand .tag { font-family: "JetBrains Mono", monospace; font-size: 10px; padding: 3px 6px; background: var(--ink); color: var(--bg); letter-spacing: 0.18em; text-transform: uppercase; font-weight: 600; }
+.topbar nav { display: flex; gap: 26px; }
+.topbar nav a { font-family: "JetBrains Mono", monospace; font-size: 12px; text-transform: uppercase; letter-spacing: 0.12em; text-decoration: none; }
+.topbar nav a:hover { color: var(--accent); }
+
+.bar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 0 22px;
+  border-bottom: 1px solid var(--ink);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: var(--ink-mute);
+}
+.bar .now b { color: var(--ink); font-weight: 700; }
+
+.headline {
+  padding: 70px 0 60px;
+  border-bottom: 1px solid var(--ink);
+}
+.headline .num { font-family: "JetBrains Mono", monospace; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-mute); margin-bottom: 18px; }
+.headline h1 {
+  font-size: clamp(3.4rem, 7vw, 6.4rem);
+  line-height: 0.92;
+  letter-spacing: -0.04em;
+  font-weight: 900;
+  margin: 0 0 30px;
+}
+.headline h1 mark { background: var(--accent); color: var(--bg); padding: 0 0.16em 0.06em; }
+.headline p { max-width: 60ch; font-size: 1.05rem; color: var(--ink); margin: 0; }
+
+.row {
+  display: grid;
+  border-bottom: 1px solid var(--ink);
+}
+.row.r-3 { grid-template-columns: repeat(3, 1fr); }
+.row.r-4 { grid-template-columns: repeat(4, 1fr); }
+.row.r-asym { grid-template-columns: 2fr 1fr 1fr; }
+.row > * { padding: 26px 28px; border-left: 1px solid var(--ink); }
+.row > *:first-child { border-left: 0; padding-left: 0; }
+.row.no-rule { border-bottom: 0; }
+
+.metric .label { font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); margin-bottom: 14px; }
+.metric .num { font-family: "JetBrains Mono", monospace; font-size: 3rem; letter-spacing: -0.03em; line-height: 1; }
+.metric .delta { font-family: "JetBrains Mono", monospace; font-size: 12px; margin-top: 12px; color: var(--good); }
+.metric .delta.neg { color: var(--err); }
+.metric .delta.flat { color: var(--ink-mute); }
+
+.spark { height: 64px; width: 100%; }
+.spark line, .spark polyline { stroke: var(--ink); fill: none; stroke-width: 1.5; }
+.spark .acc { stroke: var(--accent); stroke-width: 2; }
+
+.block {
+  padding: 26px 28px;
+  border-left: 1px solid var(--ink);
+}
+.block:first-child { border-left: 0; padding-left: 0; }
+.block h3 {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin: 0 0 18px;
+  display: flex; justify-content: space-between; align-items: baseline;
+}
+.block h3 b { color: var(--ink); font-weight: 700; }
+
+table.ops { width: 100%; border-collapse: collapse; font-family: "JetBrains Mono", monospace; font-size: 13px; }
+table.ops th, table.ops td { text-align: left; padding: 10px 0; border-bottom: 1px dashed var(--hair); white-space: nowrap; }
+table.ops th { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-mute); font-weight: 500; }
+table.ops td .pill { display: inline-block; padding: 2px 8px; background: var(--ink); color: var(--bg); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; }
+table.ops td .pill.good { background: var(--good); }
+table.ops td .pill.warn { background: var(--warn); }
+table.ops td .pill.err { background: var(--err); }
+table.ops td.right { text-align: right; }
+
+.checklist { list-style: none; padding: 0; margin: 0; }
+.checklist li { display: flex; gap: 14px; padding: 12px 0; border-bottom: 1px dashed var(--hair); font-family: "JetBrains Mono", monospace; font-size: 13px; }
+.checklist li:last-child { border-bottom: 0; }
+.checklist li .box { width: 16px; height: 16px; border: 1.5px solid var(--ink); flex-shrink: 0; margin-top: 2px; position: relative; }
+.checklist li.done .box::after { content: ""; position: absolute; inset: 2px; background: var(--ink); }
+.checklist li.warn .box { border-color: var(--accent); }
+.checklist li.warn .box::after { content: ""; position: absolute; inset: 2px; background: var(--accent); }
+.checklist li small { display: block; color: var(--ink-mute); font-size: 11px; margin-top: 4px; }
+
+.runlog { list-style: none; padding: 0; margin: 0; font-family: "JetBrains Mono", monospace; font-size: 12.5px; line-height: 1.85; }
+.runlog li { display: grid; grid-template-columns: 64px 56px 1fr; gap: 12px; align-items: baseline; padding: 4px 0; }
+.runlog .ts { color: var(--ink-mute); }
+.runlog .lv { font-weight: 700; letter-spacing: 0.12em; }
+.runlog .lv.ok { color: var(--good); }
+.runlog .lv.warn { color: var(--accent); }
+.runlog .lv.err { color: var(--err); }
+
+article.prose { max-width: 70ch; padding: 50px 0; }
+article.prose h2 { font-size: 1.6rem; letter-spacing: -0.01em; margin-top: 1.8em; }
+article.prose h3 { font-size: 1.1rem; margin-top: 1.4em; }
+article.prose blockquote { border-left: 4px solid var(--accent); margin: 1.4em 0; padding: 6px 18px; color: var(--ink-mute); font-style: italic; }
+
+ul.section-list { list-style: none; padding: 0; }
+ul.section-list li {
+  display: grid; grid-template-columns: 80px 1fr auto; gap: 24px;
+  padding: 18px 0; border-bottom: 1px solid var(--hair);
+  font-family: "JetBrains Mono", monospace; font-size: 13px;
+  align-items: baseline;
+}
+ul.section-list li time { font-size: 11px; color: var(--ink-mute); letter-spacing: 0.1em; }
+ul.section-list li a { font-family: "Inter", sans-serif; font-size: 1.05rem; text-decoration: none; font-weight: 600; }
+ul.section-list li a:hover { color: var(--accent); }
+
+footer.foot {
+  margin-top: 80px;
+  padding: 28px 0;
+  border-top: 3px solid var(--ink);
+  display: grid; grid-template-columns: 1fr 2fr;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--ink-mute);
+}
+footer.foot b { color: var(--ink); }
+
+@media (max-width: 900px) {
+  .row.r-3, .row.r-4, .row.r-asym { grid-template-columns: 1fr; }
+  .row > * { border-left: 0; border-top: 1px solid var(--ink); padding-left: 0; }
+  .row > *:first-child { border-top: 0; padding-top: 0; }
+  .topbar nav { display: none; }
+  .headline { padding: 40px 0; }
+}

--- a/examples/vexel-ops/static/favicon.svg
+++ b/examples/vexel-ops/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/vexel-ops/templates/404.html
+++ b/examples/vexel-ops/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/vexel-ops/templates/footer.html
+++ b/examples/vexel-ops/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="foot">
+      <div><b>VEXEL/OPS</b> · {{ current_year }}</div>
+      <div>Built with Hwaro · <a href="{{ base_url }}/incidents/">Incidents</a> · <a href="{{ base_url }}/about/">Brief</a></div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/vexel-ops/templates/header.html
+++ b/examples/vexel-ops/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="topbar">
+      <a href="{{ base_url }}/" class="brand">
+        Vexel<span style="color:var(--accent);">/</span>Ops
+        <span class="tag">v.{{ current_year }}.05</span>
+      </a>
+      <nav>
+        <a href="{{ base_url }}/">Console</a>
+        <a href="{{ base_url }}/incidents/">Incidents</a>
+        <a href="{{ base_url }}/about/">Brief</a>
+      </nav>
+    </header>
+    <div class="bar">
+      <span>[ 01 ] Status — All quadrants reporting</span>
+      <span class="now">Now <b>{{ current_date }}</b> · synced 00:14 ago</span>
+    </div>

--- a/examples/vexel-ops/templates/home.html
+++ b/examples/vexel-ops/templates/home.html
@@ -1,0 +1,118 @@
+{% include "header.html" %}
+  <main>
+    <section class="headline">
+      <div class="num">[ 02 ] Today · The console at a glance</div>
+      <h1>The console is <mark>green</mark>.<br>The week is not.</h1>
+      <p>Three services are above their error budget for the rolling 30-day window. Nothing is on fire right now; the bill is just coming due. The next four working days are budget-burn days.</p>
+    </section>
+
+    <section class="row r-4">
+      <div class="metric">
+        <div class="label">[ A ] Request rate</div>
+        <div class="num">48.2k<span style="font-size:1.2rem; color:var(--ink-mute);">/s</span></div>
+        <div class="delta">+8.4% wow</div>
+      </div>
+      <div class="metric">
+        <div class="label">[ B ] p99 latency</div>
+        <div class="num">214<span style="font-size:1.2rem; color:var(--ink-mute);">ms</span></div>
+        <div class="delta neg">+19ms wow</div>
+      </div>
+      <div class="metric">
+        <div class="label">[ C ] Error budget</div>
+        <div class="num">61<span style="font-size:1.2rem; color:var(--ink-mute);">%</span></div>
+        <div class="delta neg">−14pts wow</div>
+      </div>
+      <div class="metric">
+        <div class="label">[ D ] Open incidents</div>
+        <div class="num">02</div>
+        <div class="delta flat">P3 + P4 · 0 active</div>
+      </div>
+    </section>
+
+    <section class="row r-asym">
+      <div class="block">
+        <h3><b>[ 03 ] Service health</b><span>30-day SLO</span></h3>
+        <table class="ops">
+          <thead>
+            <tr><th>service</th><th>tier</th><th>slo</th><th>burn</th><th class="right">status</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>edge-router</td><td>T0</td><td>99.95</td><td>0.4×</td><td class="right"><span class="pill good">ok</span></td></tr>
+            <tr><td>auth-svc</td><td>T0</td><td>99.95</td><td>1.1×</td><td class="right"><span class="pill warn">watch</span></td></tr>
+            <tr><td>billing-api</td><td>T1</td><td>99.9</td><td>2.4×</td><td class="right"><span class="pill err">burn</span></td></tr>
+            <tr><td>media-pipe</td><td>T1</td><td>99.9</td><td>1.6×</td><td class="right"><span class="pill warn">watch</span></td></tr>
+            <tr><td>notify-svc</td><td>T2</td><td>99.5</td><td>3.2×</td><td class="right"><span class="pill err">burn</span></td></tr>
+            <tr><td>search-svc</td><td>T1</td><td>99.9</td><td>0.6×</td><td class="right"><span class="pill good">ok</span></td></tr>
+            <tr><td>ledger-svc</td><td>T0</td><td>99.99</td><td>0.2×</td><td class="right"><span class="pill good">ok</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="block">
+        <h3><b>[ 04 ] Trend</b><span>p99 · 72h</span></h3>
+        <svg class="spark" viewBox="0 0 200 64" preserveAspectRatio="none" aria-hidden="true">
+          <line x1="0" y1="48" x2="200" y2="48" stroke="#cbc6bd" stroke-dasharray="2 3"></line>
+          <polyline points="0,40 14,38 28,42 42,36 56,34 70,38 84,30 98,32 112,28 126,30 140,24 154,20 168,22 182,16 196,12" />
+          <polyline class="acc" points="140,24 154,20 168,22 182,16 196,12" />
+        </svg>
+        <ul class="checklist" style="margin-top:18px;">
+          <li class="warn"><span class="box"></span><div><b>billing-api</b> warm-pool too small for 09:00 spike<small>likely cause of +14 pts burn this week</small></div></li>
+          <li class="warn"><span class="box"></span><div><b>notify-svc</b> retries are stacking<small>retry budget exhausted by 02:14 daily</small></div></li>
+        </ul>
+      </div>
+      <div class="block">
+        <h3><b>[ 05 ] On-call</b><span>this week</span></h3>
+        <table class="ops">
+          <tbody>
+            <tr><td>primary</td><td class="right">H. Park</td></tr>
+            <tr><td>secondary</td><td class="right">M. Iyer</td></tr>
+            <tr><td>incident commander</td><td class="right">L. Becker</td></tr>
+            <tr><td>shadow</td><td class="right">D. Okafor</td></tr>
+          </tbody>
+        </table>
+        <div style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--ink-mute); margin-top:16px; letter-spacing:0.06em;">
+          Rotation handover Wednesday 18:00 UTC · 6 day cycle
+        </div>
+      </div>
+    </section>
+
+    <section class="row r-asym no-rule" style="margin-top:36px; border-top:1px solid var(--ink);">
+      <div class="block">
+        <h3><b>[ 06 ] Last hour · all services</b><span>tail −24</span></h3>
+        <ul class="runlog">
+          <li><span class="ts">14:32:18</span><span class="lv ok">OK</span><span>deploy ledger-svc · v4.21.2 · 0 errors</span></li>
+          <li><span class="ts">14:28:04</span><span class="lv warn">WARN</span><span>billing-api · queue depth 412 (limit 600)</span></li>
+          <li><span class="ts">14:21:50</span><span class="lv ok">OK</span><span>cache eviction · media-pipe · 18,201 keys</span></li>
+          <li><span class="ts">14:18:33</span><span class="lv ok">OK</span><span>autoscaler · search-svc · 14 → 16 pods</span></li>
+          <li><span class="ts">14:12:07</span><span class="lv err">ERR</span><span>notify-svc · retry budget exhausted · downgrading SMS</span></li>
+          <li><span class="ts">14:04:21</span><span class="lv ok">OK</span><span>auth-svc · token cycle 04 complete</span></li>
+          <li><span class="ts">13:58:50</span><span class="lv warn">WARN</span><span>edge-router · region eu-west-1 latency drift +12ms</span></li>
+          <li><span class="ts">13:51:11</span><span class="lv ok">OK</span><span>chaos drill · auth-svc · clean shutdown 100/100</span></li>
+        </ul>
+      </div>
+      <div class="block">
+        <h3><b>[ 07 ] Recent incidents</b><span>last 4</span></h3>
+        <ul class="checklist">
+          {% for post in site.pages | where("section", "incidents") | sort_by("date", reverse=true) %}
+            {% if loop.index <= 4 %}
+            <li class="done"><span class="box"></span>
+              <div>
+                <a href="{{ post.url }}"><b>{{ post.title }}</b></a>
+                <small>{{ post.date | date("%Y.%m.%d") }} · {{ post.description | strip_html | truncate_words(12) }}</small>
+              </div>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+      <div class="block">
+        <h3><b>[ 08 ] Read this week</b></h3>
+        <p style="font-size:0.95rem; color:var(--ink);">
+          The team is rebuilding the warm-pool policy for billing-api so the 09:00 spike stops paying interest on the error budget every day. We are also rotating off SMS for non-critical notifies — the carrier is rate-limiting our retries below the budget we paid for.
+        </p>
+        <p style="font-family:'JetBrains Mono', monospace; font-size:11px; color:var(--ink-mute); letter-spacing:0.06em; text-transform:uppercase; margin-top:14px;">
+          → <a href="{{ base_url }}/about/">Read the operating brief</a>
+        </p>
+      </div>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/vexel-ops/templates/page.html
+++ b/examples/vexel-ops/templates/page.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}
+    <section class="headline">
+      <div class="num">[ Brief · {{ page.date | date("%Y.%m.%d") | default("") }} ]</div>
+      <h1>{{ page.title | e }}</h1>
+      {% if page.description %}<p>{{ page.description | e }}</p>{% endif %}
+    </section>
+    {% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/vexel-ops/templates/page.html
+++ b/examples/vexel-ops/templates/page.html
@@ -2,7 +2,7 @@
   <main>
     {% if page.title is present %}
     <section class="headline">
-      <div class="num">[ Brief · {{ page.date | date("%Y.%m.%d") | default("") }} ]</div>
+      <div class="num">[ Brief{% if page.date %} · {{ page.date | date("%Y.%m.%d") }}{% endif %} ]</div>
       <h1>{{ page.title | e }}</h1>
       {% if page.description %}<p>{{ page.description | e }}</p>{% endif %}
     </section>

--- a/examples/vexel-ops/templates/section.html
+++ b/examples/vexel-ops/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}
+    <section class="headline">
+      <div class="num">[ Section ]</div>
+      <h1>{{ page.title | e }}</h1>
+      {% if page.description %}<p>{{ page.description | e }}</p>{% endif %}
+    </section>
+    {% endif %}
+    <ul class="section-list">
+      {% for post in section.pages %}
+        <li>
+          <time>{{ post.date | date("%Y.%m.%d") }}</time>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          <span style="color:var(--ink-mute); font-family:'JetBrains Mono',monospace; font-size:11px;">{% if post.tags %}{{ post.tags | first }}{% endif %}</span>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/vexel-ops/templates/shortcodes/alert.html
+++ b/examples/vexel-ops/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/vexel-ops/templates/taxonomy.html
+++ b/examples/vexel-ops/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/vexel-ops/templates/taxonomy_term.html
+++ b/examples/vexel-ops/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,4 +1,29 @@
 {
+  "kepler-grid": [
+    "dark",
+    "dashboard",
+    "minimal"
+  ],
+  "vexel-ops": [
+    "light",
+    "dashboard",
+    "editorial"
+  ],
+  "prism-stack": [
+    "light",
+    "dashboard",
+    "minimal"
+  ],
+  "monolith-analytics": [
+    "dark",
+    "dashboard",
+    "editorial"
+  ],
+  "stratum-bi": [
+    "light",
+    "dashboard",
+    "minimal"
+  ],
   "obsidian-press": [
     "dark",
     "blog",


### PR DESCRIPTION
## Summary
- Adds **kepler-grid**, **vexel-ops**, **prism-stack**, **monolith-analytics**, and **stratum-bi** — five new dashboard-tagged examples exploring distinct modern aesthetics (dark Bauhaus mission control, light brutalist ops console, light pastel product console, dark editorial weekly briefing, dense light data terminal).
- Each site is fully content-populated: a custom homepage console, an about/manual page, and a four-post archive section.
- All five registered at the top of `tags.json` (matches the insertion pattern from #2660).

No gradients or emojis, per the design brief.

## Test plan
- [x] `hwaro build` is clean for all five sites (7 pages each, no warnings).
- [x] `hwaro serve` returns 200 for `/`, `/css/style.css`, the archive section, and `/about/`.
- [x] Each homepage uses a unique `home.html` template; no fallback warnings.
- [x] `tags.json` validates as JSON and registers `dashboard` plus one orientation tag and one style tag per site.