### PR TITLE
Add five modern docs example sites

### DIFF
--- a/examples/codex-mono/AGENTS.md
+++ b/examples/codex-mono/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/codex-mono/archetypes/default.md
+++ b/examples/codex-mono/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/codex-mono/config.toml
+++ b/examples/codex-mono/config.toml
@@ -1,0 +1,192 @@
+title = "Codex Mono"
+description = "A monospace-first technical reference. Grid, hairlines, and unembellished documentation."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/codex-mono/config.toml
+++ b/examples/codex-mono/config.toml
@@ -13,12 +13,6 @@ enabled = true
 theme = "github"
 use_cdn = true
 
-[search]
-enabled = true
-format = "fuse_json"
-fields = ["title", "content"]
-filename = "search.json"
-
 [pagination]
 enabled = false
 per_page = 10

--- a/examples/codex-mono/content/docs/01-installation.md
+++ b/examples/codex-mono/content/docs/01-installation.md
@@ -1,0 +1,50 @@
++++
+title = "Installation"
+description = "Get the toolchain on your machine."
+date = "2026-04-02"
+weight = 1
+tags = ["setup"]
++++
+
+## Requirements
+
+The runtime requires a POSIX-compatible shell and one of the following
+package managers. No additional system libraries are linked at runtime.
+
+- macOS 12 or newer (Homebrew)
+- Linux with `glibc` 2.31+ (apt, dnf, pacman)
+- Windows 10/11 via WSL2
+
+## Install via Homebrew
+
+```bash
+brew tap codex/mono
+brew install codex
+codex --version
+```
+
+The binary is statically linked and self-contained. Removing it is a single
+`brew uninstall codex` — there is no scattered state outside `~/.codex/`.
+
+## Install from source
+
+```bash
+git clone https://codex.example/runtime.git
+cd runtime
+make release
+sudo make install PREFIX=/usr/local
+```
+
+Build artifacts land in `./build/release/`. The default `make install` target
+copies the binary, shell completions, and a `man(1)` page.
+
+## Verifying the install
+
+```bash
+codex doctor
+# => runtime: 1.4.0
+# => config:  /Users/you/.codex/config.toml
+# => cache:   /Users/you/.codex/cache (12 entries, 2.1MB)
+```
+
+If `codex doctor` reports a clean state, you can proceed to the next chapter.

--- a/examples/codex-mono/content/docs/02-configuration.md
+++ b/examples/codex-mono/content/docs/02-configuration.md
@@ -1,0 +1,46 @@
++++
+title = "Configuration"
+description = "How the runtime locates and merges configuration sources."
+date = "2026-04-04"
+weight = 2
+tags = ["setup", "config"]
++++
+
+## Sources, in order of precedence
+
+1. Command-line flags
+2. Environment variables prefixed `CODEX_`
+3. `./codex.toml` in the current working directory
+4. `$XDG_CONFIG_HOME/codex/config.toml` (default `~/.config/codex/`)
+5. Compiled-in defaults
+
+Later sources override earlier ones field-by-field. The merge is non-destructive
+for nested tables — only the keys you set are replaced.
+
+## Reference
+
+```toml
+[runtime]
+log_level = "info"      # trace | debug | info | warn | error
+color     = "auto"      # auto | always | never
+workers   = 0            # 0 = match available cores
+
+[cache]
+path     = "~/.codex/cache"
+max_size = "256MB"
+ttl      = "7d"
+
+[telemetry]
+enabled  = false
+endpoint = "https://telemetry.example/v1/events"
+```
+
+## Inspecting the resolved config
+
+```bash
+codex config dump
+codex config dump --format json
+codex config dump --source       # show which file set each key
+```
+
+The `--source` flag is the fastest way to debug an unexpected value.

--- a/examples/codex-mono/content/docs/03-commands.md
+++ b/examples/codex-mono/content/docs/03-commands.md
@@ -1,0 +1,49 @@
++++
+title = "Command Reference"
+description = "Every subcommand the runtime exposes."
+date = "2026-04-08"
+weight = 3
+tags = ["reference"]
++++
+
+## Synopsis
+
+```
+codex [GLOBAL_FLAGS] <command> [COMMAND_FLAGS] [ARGS...]
+```
+
+## Global flags
+
+| Flag                | Default  | Description                                   |
+|---------------------|----------|-----------------------------------------------|
+| `-c, --config PATH` | autodet. | Path to an alternate config file.             |
+| `--log-level LVL`   | `info`   | One of `trace`, `debug`, `info`, `warn`.      |
+| `--no-color`        | off      | Disable ANSI escapes regardless of TTY.       |
+| `--cwd PATH`        | `.`      | Run as if invoked from this directory.        |
+
+## Subcommands
+
+### `codex build`
+
+Compile the project in the current directory. Output is placed under `./out/`.
+
+```
+codex build [--release] [--target TRIPLE] [--features LIST]
+```
+
+### `codex run`
+
+Build, then execute the resulting binary with the supplied arguments.
+
+```
+codex run [--release] -- arg1 arg2 ...
+```
+
+### `codex test`
+
+Run the test suite. Recognises `-p PACKAGE` to scope to a single package, and
+`--filter PATTERN` to select tests by name.
+
+### `codex doctor`
+
+Print a diagnostic report. Use this before opening a bug.

--- a/examples/codex-mono/content/docs/04-faq.md
+++ b/examples/codex-mono/content/docs/04-faq.md
@@ -1,0 +1,33 @@
++++
+title = "FAQ"
+description = "Questions that come up often enough to deserve an entry."
+date = "2026-04-12"
+weight = 4
+tags = ["reference"]
++++
+
+## Why is everything monospaced?
+
+Because tables, code, and prose all read better when they share a column grid.
+Variable-width fonts are well suited to magazines; they are not well suited to
+shell transcripts and configuration listings.
+
+## Can I theme this?
+
+The visual surface is intentionally fixed. Three things are tunable: column
+count, line height, and the accent ink. Look for the `--codex-*` custom
+properties in `style.css`.
+
+## How do I report a problem?
+
+Open an issue at `codex.example/issues` and attach the output of
+`codex doctor --json`. The diagnostic report contains the runtime version,
+resolved configuration paths, and the platform triple — enough information
+for a maintainer to reproduce most defects without further back-and-forth.
+
+## Is there a stable API?
+
+The CLI surface is covered by semantic versioning. Library bindings exposed
+through `lib/codex.h` are stable across minor versions; the embedded
+scripting host is explicitly unstable and may change between any two
+releases.

--- a/examples/codex-mono/content/docs/_index.md
+++ b/examples/codex-mono/content/docs/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Reference"
+description = "All documentation pages, sorted by chapter weight."
+sort_by = "weight"
+template = "section"
++++
+
+The Codex is organised as a sequence of numbered chapters. Each chapter is
+self-contained but assumes familiarity with the chapters that precede it.

--- a/examples/codex-mono/content/index.md
+++ b/examples/codex-mono/content/index.md
@@ -1,0 +1,9 @@
++++
+title = "Codex Mono"
+description = "A monospace-first technical reference."
+template = "home"
++++
+
+A precise, unembellished documentation surface built around a fixed-width grid.
+Codex Mono is for engineers who would rather read a man page than a marketing
+brochure. Every line snaps to a column. Nothing moves that does not need to.

--- a/examples/codex-mono/static/css/style.css
+++ b/examples/codex-mono/static/css/style.css
@@ -1,0 +1,287 @@
+:root {
+  --ink: #0c0c0d;
+  --ink-2: #2a2a2e;
+  --ink-3: #5a5a60;
+  --rule: #d8d8d4;
+  --rule-faint: #ececea;
+  --paper: #f5f4ef;
+  --paper-2: #ecebe4;
+  --accent: #cc3a1a;
+  --col: 11rem;
+}
+
+* { box-sizing: border-box; }
+
+html { font-size: 15px; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "JetBrains Mono", "IBM Plex Mono", "SF Mono", ui-monospace, monospace;
+  font-feature-settings: "calt" 0;
+  line-height: 1.55;
+}
+
+a { color: var(--ink); text-decoration: none; border-bottom: 1px solid var(--rule); }
+a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+.site {
+  max-width: 84rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+  display: grid;
+  grid-template-columns: 16rem 1fr;
+  gap: 3rem;
+  min-height: 100vh;
+}
+
+.topbar {
+  grid-column: 1 / -1;
+  border-bottom: 1px solid var(--ink);
+  padding: 1.25rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  letter-spacing: 0.02em;
+}
+
+.topbar .brand {
+  font-weight: 700;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  border-bottom: none;
+}
+.topbar .brand .dot {
+  display: inline-block;
+  width: 0.55rem; height: 0.55rem;
+  background: var(--accent);
+  margin-right: 0.55rem;
+  vertical-align: middle;
+}
+.topbar nav { display: flex; gap: 1.5rem; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.14em; }
+.topbar nav a { border-bottom: none; color: var(--ink-3); }
+.topbar nav a:hover { color: var(--ink); }
+.topbar .ver { font-size: 0.75rem; color: var(--ink-3); }
+
+aside.sidebar {
+  border-right: 1px solid var(--rule);
+  padding: 2.5rem 1rem 4rem 0;
+  font-size: 0.82rem;
+  position: sticky;
+  top: 0;
+  align-self: start;
+  max-height: 100vh;
+  overflow-y: auto;
+}
+
+.sidebar h4 {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ink-3);
+  margin: 1.6rem 0 0.6rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+.sidebar ol { list-style: none; padding: 0; margin: 0; counter-reset: chap; }
+.sidebar ol li { counter-increment: chap; padding: 0.2rem 0; display: flex; gap: 0.6rem; }
+.sidebar ol li::before {
+  content: counter(chap, decimal-leading-zero);
+  color: var(--ink-3);
+  font-variant-numeric: tabular-nums;
+}
+.sidebar a { border-bottom: none; color: var(--ink-2); }
+.sidebar a:hover, .sidebar a.active { color: var(--accent); }
+
+main.content {
+  padding: 2.5rem 0 5rem;
+  max-width: 56rem;
+}
+
+.crumbs {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+  margin-bottom: 1.5rem;
+}
+.crumbs a { border-bottom: none; color: var(--ink-3); }
+.crumbs a:hover { color: var(--ink); }
+
+article h1, .hero h1 {
+  font-size: 2.6rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  margin: 0 0 1rem;
+}
+
+.hero {
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding: 3rem 0;
+  margin-bottom: 3rem;
+  display: grid;
+  grid-template-columns: 5rem 1fr;
+  gap: 2rem;
+}
+.hero .marker {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  border-top: 2px solid var(--accent);
+  padding-top: 0.5rem;
+}
+.hero p { font-size: 1.05rem; color: var(--ink-2); max-width: 42rem; margin: 0 0 1.2rem; }
+
+.kbd {
+  display: inline-block;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--ink);
+  background: var(--paper);
+  font-size: 0.85rem;
+  margin-right: 0.4rem;
+}
+
+.meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  margin: 0 0 2.5rem;
+}
+.meta-row span b { color: var(--ink); font-weight: 700; }
+
+article h2 {
+  font-size: 1.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 3rem 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--ink);
+  position: relative;
+}
+article h2::before {
+  content: "§";
+  color: var(--accent);
+  margin-right: 0.6rem;
+}
+article h3 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.1em; margin-top: 2rem; color: var(--ink-2); }
+article p, article li { font-size: 0.92rem; color: var(--ink-2); }
+article ul, article ol { padding-left: 1.4rem; }
+article li { padding: 0.15rem 0; }
+article strong { color: var(--ink); }
+
+article pre, pre[class*="language-"] {
+  background: var(--ink) !important;
+  color: #f5f4ef !important;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid var(--ink);
+  overflow-x: auto;
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+article pre code, pre code { background: transparent !important; color: inherit !important; padding: 0; }
+article code {
+  background: var(--paper-2);
+  padding: 0.05rem 0.35rem;
+  border: 1px solid var(--rule);
+  font-size: 0.88em;
+}
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  margin: 1.5rem 0;
+}
+article th, article td {
+  text-align: left;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+article th {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-3);
+  border-bottom: 1px solid var(--ink);
+}
+article tr:last-child td { border-bottom: 1px solid var(--ink); }
+
+article blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 1.5rem 0;
+  padding: 0.4rem 1rem;
+  color: var(--ink-2);
+  background: var(--paper-2);
+}
+
+.section-list { display: grid; gap: 1px; background: var(--rule); border: 1px solid var(--ink); }
+.section-list .item {
+  background: var(--paper);
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  gap: 1.5rem;
+  align-items: baseline;
+}
+.section-list .item .num {
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  font-variant-numeric: tabular-nums;
+}
+.section-list .item h3 { margin: 0; font-size: 1.1rem; letter-spacing: 0; text-transform: none; color: var(--ink); }
+.section-list .item p { margin: 0.3rem 0 0; color: var(--ink-3); font-size: 0.85rem; }
+.section-list .item a { border-bottom: none; }
+.section-list .item .date { font-size: 0.75rem; color: var(--ink-3); }
+
+.foot {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--ink);
+  margin-top: 4rem;
+  padding: 1.5rem 0 2rem;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-3);
+}
+
+.tag-pill {
+  display: inline-block;
+  border: 1px solid var(--ink);
+  padding: 0.1rem 0.55rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-right: 0.4rem;
+  color: var(--ink);
+}
+.tag-pill:hover { background: var(--ink); color: var(--paper); border-bottom-color: var(--ink); }
+
+.notfound {
+  text-align: center;
+  padding: 6rem 0;
+}
+.notfound h1 { font-size: 6rem; margin: 0; letter-spacing: 0; }
+.notfound p { color: var(--ink-3); }
+
+@media (max-width: 880px) {
+  .site { grid-template-columns: 1fr; gap: 1rem; padding: 0 1rem; }
+  aside.sidebar { position: static; border-right: none; border-bottom: 1px solid var(--rule); padding: 1rem 0; max-height: none; }
+  .hero { grid-template-columns: 1fr; padding: 2rem 0; }
+  .topbar { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+  .foot { flex-direction: column; gap: 0.5rem; }
+}

--- a/examples/codex-mono/static/favicon.svg
+++ b/examples/codex-mono/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/codex-mono/templates/404.html
+++ b/examples/codex-mono/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p style="text-transform:uppercase;letter-spacing:0.2em;font-size:0.8rem;">SEGMENT NOT FOUND IN CODEX</p>
+  <p><a class="kbd" href="{{ base_url }}/">go to /</a> <a class="kbd" href="{{ base_url }}/docs/">go to /docs/</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/codex-mono/templates/footer.html
+++ b/examples/codex-mono/templates/footer.html
@@ -1,0 +1,8 @@
+  </main>
+  <footer class="foot">
+    <span>{{ site_title }} · v1.4.0</span>
+    <span>BUILT WITH HWARO · {{ current_year }}</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/codex-mono/templates/header.html
+++ b/examples/codex-mono/templates/header.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="site">
+  <header class="topbar">
+    <a class="brand" href="{{ base_url }}/"><span class="dot"></span>CODEX·MONO</a>
+    <nav>
+      <a href="{{ base_url }}/docs/">Reference</a>
+      <a href="{{ base_url }}/tags/">Tags</a>
+      <a href="https://github.com/hahwul/hwaro">Source</a>
+    </nav>
+    <span class="ver">v1.4.0 · stable</span>
+  </header>
+  <aside class="sidebar">
+    <h4>Reference</h4>
+    <ol>
+      <li><a href="{{ base_url }}/docs/01-installation/">Installation</a></li>
+      <li><a href="{{ base_url }}/docs/02-configuration/">Configuration</a></li>
+      <li><a href="{{ base_url }}/docs/03-commands/">Command Reference</a></li>
+      <li><a href="{{ base_url }}/docs/04-faq/">FAQ</a></li>
+    </ol>
+    <h4>Meta</h4>
+    <ol style="list-style:none;padding:0;counter-reset:none;">
+      <li style="padding:0.2rem 0;"><a href="{{ base_url }}/tags/">All tags</a></li>
+      <li style="padding:0.2rem 0;"><a href="{{ base_url }}/categories/">Categories</a></li>
+      <li style="padding:0.2rem 0;"><a href="{{ base_url }}/docs/">Section index</a></li>
+    </ol>
+  </aside>
+  <main class="content">

--- a/examples/codex-mono/templates/home.html
+++ b/examples/codex-mono/templates/home.html
@@ -1,0 +1,68 @@
+{% include "header.html" %}
+<div class="hero">
+  <div class="marker">PRELUDE<br/>v1.4.0</div>
+  <div>
+    <h1>The Codex.<br/>Mono-typed reference.</h1>
+    <p>{{ site.description }}</p>
+    <a href="{{ base_url }}/docs/" class="kbd">read the reference →</a>
+    <a href="https://github.com/hahwul/hwaro" class="kbd">view source</a>
+  </div>
+</div>
+
+<article>
+  {{ content | safe }}
+
+  <h2>Where to start</h2>
+  <div class="section-list">
+    <div class="item">
+      <span class="num">§ 01</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/01-installation/">Installation</a></h3>
+        <p>Get the toolchain on your machine. macOS, Linux, WSL2.</p>
+      </div>
+      <span class="date">2026-04-02</span>
+    </div>
+    <div class="item">
+      <span class="num">§ 02</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/02-configuration/">Configuration</a></h3>
+        <p>How the runtime locates and merges configuration sources.</p>
+      </div>
+      <span class="date">2026-04-04</span>
+    </div>
+    <div class="item">
+      <span class="num">§ 03</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/03-commands/">Command Reference</a></h3>
+        <p>Every subcommand the runtime exposes.</p>
+      </div>
+      <span class="date">2026-04-08</span>
+    </div>
+    <div class="item">
+      <span class="num">§ 04</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/04-faq/">FAQ</a></h3>
+        <p>Questions that come up often enough to deserve an entry.</p>
+      </div>
+      <span class="date">2026-04-12</span>
+    </div>
+  </div>
+
+  <h2>Design notes</h2>
+  <p>
+    Codex Mono is built around one premise: documentation that is read more
+    than once should look the same the second time as it did the first. The
+    page is anchored to an 8 rem column grid. The accent ink is reserved
+    for navigational signal — section markers, active links — and never used
+    for decoration.
+  </p>
+
+  <h3>Typography</h3>
+  <p>
+    Body, headings, tables, code, and labels all use the same JetBrains Mono
+    family at three weights. The only variation is uppercase setting and
+    letter-spacing for short labels, which preserves rhythm without breaking
+    the column.
+  </p>
+</article>
+{% include "footer.html" %}

--- a/examples/codex-mono/templates/page.html
+++ b/examples/codex-mono/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">Codex</a> / <a href="{{ base_url }}/docs/">Reference</a> / {{ page.title | e }}
+</nav>
+<article>
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p style="font-size:1.05rem;color:var(--ink-2);max-width:48rem;margin:-0.3rem 0 1.4rem;">{{ page.description | e }}</p>{% endif %}
+  <div class="meta-row">
+    {% if page.date %}<span>DATE · <b>{{ page.date | date(format="%Y-%m-%d") }}</b></span>{% endif %}
+    {% if page.reading_time %}<span>READ · <b>{{ page.reading_time }} min</b></span>{% endif %}
+    {% if page.word_count %}<span>WORDS · <b>{{ page.word_count }}</b></span>{% endif %}
+    {% if page.tags %}<span>TAGS · {% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/codex-mono/templates/section.html
+++ b/examples/codex-mono/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">Codex</a> / {{ page.title | e }}
+</nav>
+<div class="hero">
+  <div class="marker">§ /{{ page.title | lower }}</div>
+  <div>
+    <h1>{{ page.title | e }}</h1>
+    {% if content %}<p>{{ content | striptags | trim }}</p>{% endif %}
+    <span class="kbd">codex docs</span><span class="kbd">--all</span>
+  </div>
+</div>
+
+<div class="section-list">
+  {% for p in section.pages %}
+  <div class="item">
+    <span class="num">§ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <div>
+      <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+      {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+    </div>
+    <span class="date">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+  </div>
+  {% endfor %}
+</div>
+{% include "footer.html" %}

--- a/examples/codex-mono/templates/shortcodes/alert.html
+++ b/examples/codex-mono/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/codex-mono/templates/taxonomy.html
+++ b/examples/codex-mono/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<nav class="crumbs"><a href="{{ base_url }}/">Codex</a> / {{ taxonomy_name | default(value="Tags") | upper }}</nav>
+<article>
+  <h1>{{ taxonomy_name | default(value="Tags") | capitalize }}</h1>
+  <p style="color:var(--ink-3);">All terms in the <strong>{{ taxonomy_name }}</strong> taxonomy.</p>
+  <div class="section-list" style="margin-top:2rem;">
+    {% for term in taxonomy_terms %}
+    <div class="item">
+      <span class="num">§ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <h3><a href="{{ term.url }}">{{ term.name }}</a></h3>
+        <p>{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %}</p>
+      </div>
+      <span class="date">/{{ taxonomy_name }}/{{ term.slug }}/</span>
+    </div>
+    {% endfor %}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/codex-mono/templates/taxonomy_term.html
+++ b/examples/codex-mono/templates/taxonomy_term.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<nav class="crumbs"><a href="{{ base_url }}/">Codex</a> / <a href="{{ base_url }}/{{ taxonomy_name }}/">{{ taxonomy_name | upper }}</a> / {{ page.title | upper }}</nav>
+<article>
+  <h1>#{{ page.title }}</h1>
+  <p style="color:var(--ink-3);">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} tagged <strong>{{ page.title }}</strong>.</p>
+  <div class="section-list" style="margin-top:2rem;">
+    {% for p in taxonomy_pages %}
+    <div class="item">
+      <span class="num">§ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+      </div>
+      <span class="date">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+    </div>
+    {% endfor %}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/prism-shift/AGENTS.md
+++ b/examples/prism-shift/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/prism-shift/archetypes/default.md
+++ b/examples/prism-shift/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/prism-shift/config.toml
+++ b/examples/prism-shift/config.toml
@@ -1,0 +1,192 @@
+title = "Prism / Shift"
+description = "Sharp dark documentation with high-contrast geometric typography and decisive accent ink."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/prism-shift/config.toml
+++ b/examples/prism-shift/config.toml
@@ -13,12 +13,6 @@ enabled = true
 theme = "monokai"
 use_cdn = true
 
-[search]
-enabled = true
-format = "fuse_json"
-fields = ["title", "content"]
-filename = "search.json"
-
 [pagination]
 enabled = false
 per_page = 10

--- a/examples/prism-shift/content/docs/01-quickstart.md
+++ b/examples/prism-shift/content/docs/01-quickstart.md
@@ -1,0 +1,44 @@
++++
+title = "Quickstart"
+description = "From zero to a running node in under two minutes."
+date = "2026-02-01"
+weight = 1
+tags = ["getting-started"]
++++
+
+## Two-minute install
+
+The fastest way to get a node up. Suitable for a development machine. Not
+suitable for production — see chapter 04 for that.
+
+```bash
+curl -fsSL https://prism.example/install.sh | sh -
+prism init ./scratch
+cd scratch && prism start
+```
+
+The default configuration listens on `:8400` and persists state to `./data`.
+Both are tuneable.
+
+## Verify
+
+```bash
+prism ping
+# nodes:      1
+# leader:     localhost:8400
+# status:     ready
+# build:      2.7.1 (revision a8c1f29)
+```
+
+## Stop, start, and the lifecycle
+
+```bash
+prism start          # foreground
+prism start --daemon # background, writes pid to ./prism.pid
+prism stop           # graceful, fsyncs the journal
+prism stop --hard    # immediate, journal must replay on next start
+```
+
+A graceful stop is always preferable. The hard stop is reserved for the
+rare case where the process is wedged and a stack dump is more valuable
+than a clean shutdown.

--- a/examples/prism-shift/content/docs/02-api.md
+++ b/examples/prism-shift/content/docs/02-api.md
@@ -1,0 +1,46 @@
++++
+title = "API Surface"
+description = "The HTTP and gRPC interfaces, request shapes, and authentication."
+date = "2026-02-04"
+weight = 2
+tags = ["api", "reference"]
++++
+
+## Endpoints, in brief
+
+The node exposes two parallel interfaces. They are functionally equivalent;
+the choice is operational.
+
+| Surface | Address               | Use for                                |
+|---------|-----------------------|----------------------------------------|
+| HTTP    | `:8400/v1/*`          | Browsers, scripts, debugging.          |
+| gRPC    | `:8401/prism.v1.*`    | Service-to-service, high throughput.   |
+
+## Authentication
+
+All requests carry a bearer token issued by `prism auth`. Tokens are scoped:
+read tokens cannot mutate state, write tokens cannot enrol new peers, and
+operator tokens can do anything but cannot be issued by another operator.
+
+```http
+GET /v1/keys HTTP/1.1
+Host: node-01.prism.local:8400
+Authorization: Bearer ps_rw_aF8j2c...
+```
+
+## A worked example
+
+```bash
+TOKEN=$(prism auth mint --scope write)
+
+curl -sSf -H "Authorization: Bearer $TOKEN" \
+  -X PUT "http://localhost:8400/v1/keys/example" \
+  -d '{"value":"hello","ttl_seconds":3600}'
+
+curl -sSf -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8400/v1/keys/example"
+# => {"value":"hello","expires_at":"2026-02-04T13:00:00Z"}
+```
+
+The `TTL` is advisory at the protocol layer; expired keys are reaped during
+the next compaction cycle, not at the instant of expiry.

--- a/examples/prism-shift/content/docs/03-clustering.md
+++ b/examples/prism-shift/content/docs/03-clustering.md
@@ -1,0 +1,49 @@
++++
+title = "Clustering"
+description = "Peer discovery, the consensus protocol, and partition handling."
+date = "2026-02-08"
+weight = 3
+tags = ["distributed", "reference"]
++++
+
+## Three-node consensus
+
+A cluster of three identically-provisioned nodes is the smallest production
+configuration. The cluster elects a leader through a single-round protocol;
+the two followers maintain a synchronous replica of the leader's journal.
+
+```
+        ┌─────────┐
+        │ leader  │
+        └────┬────┘
+       ┌─────┴─────┐
+   ┌───┴───┐   ┌───┴───┐
+   │ peer1 │   │ peer2 │
+   └───────┘   └───────┘
+```
+
+Writes succeed once two of three nodes have durably accepted them. A single
+node failure does not block writes; two simultaneous failures do.
+
+## Joining a cluster
+
+```bash
+# on the new node
+prism join --leader node-01.prism.local:8400 \
+           --token $(cat /etc/prism/join.token)
+```
+
+The leader streams its current journal to the joining node, then transitions
+the new node into the active replica set. The procedure is hands-off and
+typically completes inside ten seconds on a quiet cluster.
+
+## Partition handling
+
+If the cluster splits, the side containing a majority of nodes continues
+serving writes; the minority side becomes read-only until the partition
+heals. The runtime never serves stale writes — a read against a partitioned
+follower returns `STALE` rather than an outdated value.
+
+> **Note** — partition recovery is automatic but not instantaneous. Plan
+> for up to thirty seconds of write unavailability following a partition
+> event.

--- a/examples/prism-shift/content/docs/04-tuning.md
+++ b/examples/prism-shift/content/docs/04-tuning.md
@@ -1,0 +1,51 @@
++++
+title = "Tuning"
+description = "Configuration knobs, what they do, and when to touch them."
+date = "2026-02-12"
+weight = 4
+tags = ["ops"]
++++
+
+## Cardinal rule
+
+Do not tune what you have not measured. The defaults are chosen for a
+mid-sized workload and are almost always the right starting point. The
+runtime ships a built-in profiler; use it before you touch the config.
+
+```bash
+prism profile --duration 5m --output prof.json
+prism profile inspect prof.json
+```
+
+## Knobs that matter
+
+These five settings account for the majority of useful tuning. Everything
+else is either a debugging aid or an escape hatch for a pathological
+workload.
+
+```toml
+[runtime]
+workers          = 0          # 0 = auto, one per core
+journal_buffer   = "16MiB"    # in-memory journal staging area
+
+[storage]
+segment_size_max = "64MiB"    # journal rollover threshold
+compact_after    = "7d"       # retention before compaction
+fsync_policy     = "always"   # always | batched | none
+```
+
+## When to touch them
+
+- **workers**: bump only if you have measured contention on the worker
+  queue. Adding workers past the core count almost always hurts.
+- **journal_buffer**: enlarge if `journal.spill_count` is non-zero in
+  the profiler output.
+- **segment_size_max**: lower for very small workloads (faster compaction);
+  do not raise above 256 MiB.
+- **fsync_policy**: never use `none` outside of a benchmark. `batched`
+  trades a window of unrecoverable writes for ≈3× throughput; you must
+  accept that trade in writing before enabling it.
+
+> **Warning** — `fsync_policy = "none"` is a knob for benchmark
+> reproducibility. Engaging it in production is a way to lose data, full
+> stop.

--- a/examples/prism-shift/content/docs/_index.md
+++ b/examples/prism-shift/content/docs/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Documentation"
+description = "All chapters of the Prism / Shift reference."
+sort_by = "weight"
+template = "section"
++++
+
+The reference covers everything from a clean install through high-throughput
+production deployment. Read in order, or jump to the chapter that addresses
+your immediate concern.

--- a/examples/prism-shift/content/index.md
+++ b/examples/prism-shift/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Prism / Shift"
+description = "Sharp dark documentation with decisive accent ink."
+template = "home"
++++
+
+A documentation surface engineered for high-contrast environments. Prism /
+Shift uses an austere two-tone palette and a single accent — applied
+sparingly, never decoratively — to keep the reader's attention on the
+material rather than the chrome.

--- a/examples/prism-shift/static/css/style.css
+++ b/examples/prism-shift/static/css/style.css
@@ -1,0 +1,521 @@
+:root {
+  --bg: #050507;
+  --bg-1: #0d0d11;
+  --bg-2: #15151a;
+  --bg-3: #1d1d24;
+  --ink: #f4f4f7;
+  --ink-2: #b8b8c4;
+  --ink-3: #74747f;
+  --ink-4: #46464e;
+  --rule: #25252d;
+  --rule-2: #3a3a44;
+  --accent: #00ffae;
+  --accent-2: #ff3672;
+  --warn: #ffb02e;
+  --sans: "Space Grotesk", "Inter", -apple-system, system-ui, sans-serif;
+  --mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 16px; -webkit-font-smoothing: antialiased; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+  line-height: 1.6;
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: -1;
+}
+
+::selection { background: var(--accent); color: var(--bg); }
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.frame {
+  max-width: 88rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.bar {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.2rem 0;
+  border-bottom: 1px solid var(--rule);
+  font-size: 0.85rem;
+}
+.bar .logo {
+  font-family: var(--mono);
+  font-weight: 500;
+  font-size: 0.92rem;
+  text-decoration: none;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.bar .logo .slash { color: var(--accent); }
+.bar .logo::before {
+  content: "";
+  width: 0.55rem; height: 0.55rem;
+  background: var(--accent);
+  display: inline-block;
+  margin-right: 0.55rem;
+  transform: rotate(45deg);
+}
+.bar .menu {
+  display: flex;
+  gap: 1.5rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-2);
+}
+.bar .menu a:hover { color: var(--accent); }
+.bar .status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-3);
+}
+.bar .status .dot {
+  width: 0.5rem; height: 0.5rem;
+  background: var(--accent);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--accent);
+}
+.bar .cta {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 0.55rem 1rem;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+  background: transparent;
+}
+.bar .cta:hover { background: var(--accent); border-color: var(--accent); color: var(--bg); }
+
+.grid {
+  display: grid;
+  grid-template-columns: 17rem 1fr;
+  gap: 3.5rem;
+  padding: 3rem 0 5rem;
+}
+.grid.solo { grid-template-columns: 1fr; }
+
+aside.rail {
+  position: sticky;
+  top: 2rem;
+  align-self: start;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+}
+.rail .group { padding: 1rem 0; border-bottom: 1px solid var(--rule); }
+.rail .group:last-child { border-bottom: none; }
+.rail h6 {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+  margin: 0 0 0.7rem;
+  font-weight: 500;
+}
+.rail ol, .rail ul { list-style: none; padding: 0; margin: 0; }
+.rail ol li, .rail ul li { padding: 0; }
+.rail ol li a, .rail ul li a {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 0;
+  color: var(--ink-2);
+  transition: color 0.15s, padding-left 0.15s;
+  position: relative;
+}
+.rail ol li a::before {
+  content: "";
+  display: inline-block;
+  width: 6px; height: 6px;
+  background: var(--ink-4);
+  margin-right: 0.7rem;
+  transform: rotate(45deg);
+  transition: background 0.15s;
+}
+.rail ol li a:hover, .rail ul li a:hover { color: var(--ink); }
+.rail ol li a:hover::before { background: var(--accent); }
+.rail ol li a.active { color: var(--accent); }
+.rail ol li a.active::before { background: var(--accent); }
+.rail ol li a .ix {
+  font-size: 0.7rem;
+  color: var(--ink-4);
+  letter-spacing: 0.08em;
+}
+
+main.view { min-width: 0; }
+
+.hero {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 3rem;
+  align-items: end;
+  padding: 1rem 0 3rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 3rem;
+}
+.hero .badges {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.2rem;
+}
+.hero .badge {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--rule-2);
+  color: var(--ink-2);
+}
+.hero .badge.live { border-color: var(--accent); color: var(--accent); }
+.hero h1 {
+  font-family: var(--sans);
+  font-size: clamp(2.6rem, 5vw, 4.6rem);
+  line-height: 1.02;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  margin: 0 0 1rem;
+}
+.hero h1 .accent { color: var(--accent); }
+.hero h1 .slash { color: var(--accent); font-weight: 400; }
+.hero .lede {
+  font-size: 1.15rem;
+  color: var(--ink-2);
+  max-width: 38rem;
+  margin: 0 0 1.4rem;
+}
+.hero .corner {
+  border: 1px solid var(--rule-2);
+  padding: 1.4rem 1.6rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--ink-2);
+  text-align: right;
+  background: var(--bg-1);
+  position: relative;
+  min-width: 14rem;
+}
+.hero .corner::before {
+  content: "";
+  position: absolute;
+  top: -1px; right: -1px;
+  width: 12px; height: 12px;
+  border-top: 2px solid var(--accent);
+  border-right: 2px solid var(--accent);
+}
+.hero .corner::after {
+  content: "";
+  position: absolute;
+  bottom: -1px; left: -1px;
+  width: 12px; height: 12px;
+  border-bottom: 2px solid var(--accent);
+  border-left: 2px solid var(--accent);
+}
+.hero .corner .k { color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.7rem; }
+.hero .corner .v { font-size: 1.6rem; color: var(--ink); font-weight: 500; line-height: 1.1; }
+.hero .corner .row { display: flex; justify-content: space-between; gap: 0.8rem; padding: 0.3rem 0; align-items: baseline; }
+.hero .corner .row:not(:last-child) { border-bottom: 1px solid var(--rule); }
+
+.crumbs {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  margin-bottom: 1.5rem;
+}
+.crumbs a { color: var(--ink-3); }
+.crumbs a:hover { color: var(--accent); }
+.crumbs .sep { color: var(--rule-2); margin: 0 0.5rem; }
+
+.meta-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border: 1px solid var(--rule);
+  margin: 0 0 2.5rem;
+  background: var(--bg-1);
+}
+.meta-strip .cell {
+  padding: 1rem 1.2rem;
+  border-right: 1px solid var(--rule);
+}
+.meta-strip .cell:last-child { border-right: none; }
+.meta-strip .cell .k {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+  display: block;
+  margin-bottom: 0.3rem;
+}
+.meta-strip .cell .v { font-family: var(--mono); font-size: 0.92rem; color: var(--ink); }
+
+article { max-width: 50rem; }
+article h2 {
+  font-size: 1.7rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  margin: 3.2rem 0 1rem;
+  padding-top: 1.8rem;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  align-items: baseline;
+  gap: 0.8rem;
+}
+article h2::before {
+  content: counter(h2) ".";
+  counter-increment: h2;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  color: var(--accent);
+  font-weight: 400;
+}
+article { counter-reset: h2; font-size: 1rem; color: var(--ink-2); line-height: 1.75; }
+article h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  margin: 2rem 0 0.7rem;
+  color: var(--ink);
+}
+article p, article li { color: var(--ink-2); }
+article ul, article ol { padding-left: 1.4rem; }
+article strong { color: var(--ink); font-weight: 600; }
+article em { color: var(--accent); font-style: normal; }
+article a { color: var(--accent); border-bottom: 1px dashed var(--accent); }
+article a:hover { background: var(--accent); color: var(--bg); border-bottom-style: solid; }
+
+article pre, pre[class*="language-"] {
+  background: var(--bg-1) !important;
+  border: 1px solid var(--rule);
+  border-left: 2px solid var(--accent);
+  padding: 1.2rem 1.4rem;
+  font-family: var(--mono);
+  font-size: 0.84rem;
+  line-height: 1.7;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  color: var(--ink) !important;
+  position: relative;
+}
+article pre::before {
+  content: "// shell";
+  position: absolute;
+  top: 0.4rem;
+  right: 0.8rem;
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  color: var(--ink-4);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+article code {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--bg-2);
+  padding: 0.1rem 0.45rem;
+  border: 1px solid var(--rule);
+  color: var(--accent);
+}
+article pre code { background: transparent; border: none; padding: 0; color: inherit; }
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  margin: 1.5rem 0;
+  border: 1px solid var(--rule);
+  background: var(--bg-1);
+}
+article th {
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--rule);
+  font-weight: 500;
+  background: var(--bg-2);
+}
+article td {
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+  vertical-align: top;
+}
+article tr:last-child td { border-bottom: none; }
+
+article blockquote {
+  border: 1px solid var(--warn);
+  border-left: 3px solid var(--warn);
+  margin: 1.5rem 0;
+  padding: 1rem 1.3rem;
+  background: rgba(255, 176, 46, 0.06);
+  color: var(--ink);
+}
+article blockquote strong { color: var(--warn); }
+
+.section-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-top: 2rem;
+}
+.section-grid a {
+  display: block;
+  padding: 1.6rem;
+  border: 1px solid var(--rule);
+  background: var(--bg-1);
+  transition: border-color 0.15s, transform 0.15s;
+  position: relative;
+}
+.section-grid a:hover {
+  border-color: var(--accent);
+  transform: translate(-2px, -2px);
+  box-shadow: 4px 4px 0 var(--accent);
+}
+.section-grid a .ix {
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-bottom: 0.7rem;
+}
+.section-grid a h3 {
+  font-family: var(--sans);
+  font-size: 1.35rem;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  margin: 0 0 0.4rem;
+  color: var(--ink);
+}
+.section-grid a p {
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0 0 0.6rem;
+  line-height: 1.55;
+}
+.section-grid a .date {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-3);
+}
+
+.tile-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin: 3rem 0;
+}
+.tile {
+  border: 1px solid var(--rule);
+  background: var(--bg-1);
+  padding: 1.6rem;
+  position: relative;
+}
+.tile::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0;
+  width: 12px; height: 12px;
+  border-top: 2px solid var(--accent);
+  border-left: 2px solid var(--accent);
+}
+.tile .ix {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin-bottom: 0.7rem;
+}
+.tile h4 { font-size: 1.25rem; margin: 0 0 0.5rem; font-weight: 500; letter-spacing: -0.01em; color: var(--ink); }
+.tile p { font-size: 0.92rem; color: var(--ink-2); margin: 0; line-height: 1.6; }
+
+.tag-pill {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  padding: 0.15rem 0.55rem;
+  border: 1px solid var(--rule-2);
+  margin-right: 0.4rem;
+  color: var(--ink-2);
+}
+.tag-pill::before { content: "#"; color: var(--accent); margin-right: 0.15rem; }
+.tag-pill:hover { border-color: var(--accent); color: var(--accent); }
+
+footer.bottom {
+  border-top: 1px solid var(--rule);
+  padding: 2.5rem 0;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 2rem;
+  font-size: 0.85rem;
+  font-family: var(--sans);
+}
+footer.bottom h6 {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  margin: 0 0 0.7rem;
+}
+footer.bottom ul { list-style: none; padding: 0; margin: 0; }
+footer.bottom ul li { padding: 0.2rem 0; }
+footer.bottom ul li a { color: var(--ink); }
+footer.bottom ul li a:hover { color: var(--accent); }
+footer.bottom .note { color: var(--ink-3); font-size: 0.78rem; font-family: var(--mono); }
+
+.notfound { text-align: center; padding: 6rem 0; }
+.notfound h1 { font-family: var(--mono); font-size: 8rem; font-weight: 500; margin: 0; color: var(--accent); letter-spacing: -0.02em; line-height: 1; }
+.notfound .lede { color: var(--ink-2); margin: 1rem 0 2rem; font-size: 1.1rem; }
+
+@media (max-width: 1000px) {
+  .frame { padding: 0 1.2rem; }
+  body { background-size: 2rem 2rem; }
+  .grid { grid-template-columns: 1fr; gap: 1.5rem; }
+  aside.rail { position: static; max-height: none; border-bottom: 1px solid var(--rule); padding-bottom: 1rem; }
+  .hero { grid-template-columns: 1fr; gap: 1.5rem; }
+  .meta-strip { grid-template-columns: repeat(2, 1fr); }
+  .meta-strip .cell:nth-child(2) { border-right: none; }
+  .section-grid, .tile-row { grid-template-columns: 1fr; }
+  footer.bottom { grid-template-columns: 1fr; }
+  .bar { grid-template-columns: 1fr; gap: 0.6rem; }
+}

--- a/examples/prism-shift/static/favicon.svg
+++ b/examples/prism-shift/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/prism-shift/templates/404.html
+++ b/examples/prism-shift/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404<span style="color:var(--ink);">/</span></h1>
+  <p class="lede">No frame at the requested address. The wire returned <code style="color:var(--accent-2);">ERR_NOT_FOUND</code>.</p>
+  <p style="margin-top:1.5rem;">
+    <a class="cta" href="{{ base_url }}/" style="background:var(--accent);border-color:var(--accent);color:var(--bg);">RETURN HOME</a>
+    <a class="cta" href="{{ base_url }}/docs/" style="margin-left:0.5rem;">OPEN DOCS</a>
+  </p>
+</div>
+{% include "footer.html" %}

--- a/examples/prism-shift/templates/footer.html
+++ b/examples/prism-shift/templates/footer.html
@@ -1,0 +1,28 @@
+  <footer class="bottom">
+    <div>
+      <h6>{{ site_title }}</h6>
+      <p class="note">{{ site.description }}</p>
+      <p class="note" style="margin-top:1rem;">// Built with Hwaro · © {{ current_year }}</p>
+    </div>
+    <div>
+      <h6>Reference</h6>
+      <ul>
+        <li><a href="{{ base_url }}/docs/01-quickstart/">Quickstart</a></li>
+        <li><a href="{{ base_url }}/docs/02-api/">API surface</a></li>
+        <li><a href="{{ base_url }}/docs/03-clustering/">Clustering</a></li>
+        <li><a href="{{ base_url }}/docs/04-tuning/">Tuning</a></li>
+      </ul>
+    </div>
+    <div>
+      <h6>Meta</h6>
+      <ul>
+        <li><a href="{{ base_url }}/tags/">Tags</a></li>
+        <li><a href="{{ base_url }}/categories/">Categories</a></li>
+        <li><a href="{{ base_url }}/rss.xml">RSS feed</a></li>
+        <li><a href="https://github.com/hahwul/hwaro">GitHub</a></li>
+      </ul>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/prism-shift/templates/header.html
+++ b/examples/prism-shift/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="frame">
+  <header class="bar">
+    <a class="logo" href="{{ base_url }}/">PRISM<span class="slash">/</span>SHIFT</a>
+    <nav class="menu">
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/tags/">Tags</a>
+      <a href="{{ base_url }}/categories/">Categories</a>
+    </nav>
+    <span class="status"><span class="dot"></span>v2.7.1 / mainline</span>
+    <a class="cta" href="https://github.com/hahwul/hwaro">Source ↗</a>
+  </header>

--- a/examples/prism-shift/templates/home.html
+++ b/examples/prism-shift/templates/home.html
@@ -1,0 +1,77 @@
+{% include "header.html" %}
+<div class="grid solo">
+  <main class="view">
+    <header class="hero">
+      <div>
+        <div class="badges">
+          <span class="badge live">v2.7.1 LIVE</span>
+          <span class="badge">MIT LICENSED</span>
+          <span class="badge">EDGE READY</span>
+        </div>
+        <h1>Documentation<span class="slash">/</span><br/>built for <span class="accent">operators</span>.</h1>
+        <p class="lede">{{ site.description }}</p>
+        <p>
+          <a class="cta" href="{{ base_url }}/docs/01-quickstart/" style="background:var(--accent);border-color:var(--accent);color:var(--bg);">START THE QUICKSTART →</a>
+          <a class="cta" href="{{ base_url }}/docs/" style="margin-left:0.5rem;">BROWSE DOCS</a>
+        </p>
+      </div>
+      <div class="corner">
+        <div class="row"><span class="k">CLUSTER</span><span class="v">3 nodes</span></div>
+        <div class="row"><span class="k">RPS p50</span><span class="v">18.2k</span></div>
+        <div class="row"><span class="k">P99 LAT</span><span class="v">3.1ms</span></div>
+        <div class="row"><span class="k">UPTIME</span><span class="v" style="color:var(--accent);">99.99%</span></div>
+      </div>
+    </header>
+
+    <article>
+      {{ content | safe }}
+    </article>
+
+    <section class="tile-row">
+      <div class="tile">
+        <div class="ix">01 / PREDICTABLE</div>
+        <h4>No implicit globals.</h4>
+        <p>Every side-effect is named in the API. The runtime never touches state you did not hand it.</p>
+      </div>
+      <div class="tile">
+        <div class="ix">02 / DISTRIBUTED</div>
+        <h4>Single-writer, multi-reader.</h4>
+        <p>Wait-free reads. Synchronous journal replication. Three nodes are operationally identical to one.</p>
+      </div>
+      <div class="tile">
+        <div class="ix">03 / OBSERVABLE</div>
+        <h4>One binary, one profiler.</h4>
+        <p>The shipping artefact is a single statically-linked binary with a built-in profiler. No exporter needed.</p>
+      </div>
+    </section>
+
+    <h2 style="font-size:1.5rem;font-weight:500;letter-spacing:-0.02em;margin-top:3rem;padding-top:2rem;border-top:1px solid var(--rule);">Read the documentation</h2>
+    <div class="section-grid">
+      <a href="{{ base_url }}/docs/01-quickstart/">
+        <div class="ix">CH. 01 / GETTING-STARTED</div>
+        <h3>Quickstart</h3>
+        <p>From zero to a running node in under two minutes.</p>
+        <span class="date">2026.02.01</span>
+      </a>
+      <a href="{{ base_url }}/docs/02-api/">
+        <div class="ix">CH. 02 / REFERENCE</div>
+        <h3>API surface</h3>
+        <p>The HTTP and gRPC interfaces, request shapes, and authentication.</p>
+        <span class="date">2026.02.04</span>
+      </a>
+      <a href="{{ base_url }}/docs/03-clustering/">
+        <div class="ix">CH. 03 / DISTRIBUTED</div>
+        <h3>Clustering</h3>
+        <p>Peer discovery, consensus, and partition handling.</p>
+        <span class="date">2026.02.08</span>
+      </a>
+      <a href="{{ base_url }}/docs/04-tuning/">
+        <div class="ix">CH. 04 / OPS</div>
+        <h3>Tuning</h3>
+        <p>Configuration knobs, what they do, and when to touch them.</p>
+        <span class="date">2026.02.12</span>
+      </a>
+    </div>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/prism-shift/templates/page.html
+++ b/examples/prism-shift/templates/page.html
@@ -1,0 +1,47 @@
+{% include "header.html" %}
+<div class="grid">
+  <aside class="rail">
+    <div class="group">
+      <h6>Reference</h6>
+      <ol>
+        <li><a href="{{ base_url }}/docs/01-quickstart/"{% if page.url == "/docs/01-quickstart/" %} class="active"{% endif %}>Quickstart<span class="ix">01</span></a></li>
+        <li><a href="{{ base_url }}/docs/02-api/"{% if page.url == "/docs/02-api/" %} class="active"{% endif %}>API surface<span class="ix">02</span></a></li>
+        <li><a href="{{ base_url }}/docs/03-clustering/"{% if page.url == "/docs/03-clustering/" %} class="active"{% endif %}>Clustering<span class="ix">03</span></a></li>
+        <li><a href="{{ base_url }}/docs/04-tuning/"{% if page.url == "/docs/04-tuning/" %} class="active"{% endif %}>Tuning<span class="ix">04</span></a></li>
+      </ol>
+    </div>
+    <div class="group">
+      <h6>Resources</h6>
+      <ul>
+        <li><a href="{{ base_url }}/docs/">All chapters</a></li>
+        <li><a href="{{ base_url }}/tags/">Tag index</a></li>
+        <li><a href="{{ base_url }}/categories/">Categories</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="view">
+    <nav class="crumbs"><a href="{{ base_url }}/">prism</a><span class="sep">/</span><a href="{{ base_url }}/docs/">docs</a><span class="sep">/</span>{{ page.title }}</nav>
+    <header class="hero">
+      <div>
+        <div class="badges">
+          {% if page.weight %}<span class="badge live">CH. 0{{ page.weight }}</span>{% endif %}
+          {% if page.section %}<span class="badge">{{ page.section | upper }}</span>{% endif %}
+        </div>
+        <h1>{{ page.title | e }}<span class="accent">.</span></h1>
+        {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+      </div>
+    </header>
+
+    <div class="meta-strip">
+      <div class="cell"><span class="k">Published</span><span class="v">{% if page.date %}{{ page.date | date(format="%Y-%m-%d") }}{% else %}—{% endif %}</span></div>
+      <div class="cell"><span class="k">Read</span><span class="v">{% if page.reading_time %}{{ page.reading_time }} min{% else %}—{% endif %}</span></div>
+      <div class="cell"><span class="k">Words</span><span class="v">{% if page.word_count %}{{ page.word_count }}{% else %}—{% endif %}</span></div>
+      <div class="cell"><span class="k">Tags</span><span class="v">{% if page.tags %}{% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}{% else %}—{% endif %}</span></div>
+    </div>
+
+    <article>
+      {{ content | safe }}
+    </article>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/prism-shift/templates/section.html
+++ b/examples/prism-shift/templates/section.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+<div class="grid solo">
+  <main class="view">
+    <nav class="crumbs"><a href="{{ base_url }}/">prism</a><span class="sep">/</span>{{ page.title | lower }}</nav>
+    <header class="hero">
+      <div>
+        <div class="badges"><span class="badge live">SECTION INDEX</span></div>
+        <h1>{{ page.title | e }}<span class="accent">.</span></h1>
+        {% if content %}<p class="lede">{{ content | striptags | trim }}</p>{% endif %}
+      </div>
+      <div class="corner">
+        <div class="row"><span class="k">CHAPTERS</span><span class="v">{{ section.pages | length }}</span></div>
+        <div class="row"><span class="k">VERSION</span><span class="v">2.7.1</span></div>
+        <div class="row"><span class="k">STATUS</span><span class="v" style="color:var(--accent);">live</span></div>
+      </div>
+    </header>
+
+    <div class="section-grid">
+      {% for p in section.pages %}
+      <a href="{{ p.url }}">
+        <div class="ix">CH. 0{{ loop.index }} / {{ p.tags | first | default(value="ref") | upper }}</div>
+        <h3>{{ p.title | e }}</h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+        <span class="date">{% if p.date %}{{ p.date | date(format="%Y.%m.%d") }}{% endif %}</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/prism-shift/templates/shortcodes/alert.html
+++ b/examples/prism-shift/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/prism-shift/templates/taxonomy.html
+++ b/examples/prism-shift/templates/taxonomy.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<div class="grid solo">
+  <main class="view">
+    <nav class="crumbs"><a href="{{ base_url }}/">prism</a><span class="sep">/</span>{{ taxonomy_name | lower }}</nav>
+    <header class="hero">
+      <div>
+        <div class="badges"><span class="badge live">INDEX</span></div>
+        <h1>{{ taxonomy_name | default(value="Tags") | capitalize }}<span class="accent">.</span></h1>
+        <p class="lede">{{ taxonomy_terms | length }} term{% if taxonomy_terms | length != 1 %}s{% endif %} indexed across the documentation set.</p>
+      </div>
+    </header>
+    <div class="section-grid">
+      {% for term in taxonomy_terms %}
+      <a href="{{ term.url }}">
+        <div class="ix">/{{ taxonomy_name | upper }}/{{ term.slug | upper }}/</div>
+        <h3>{{ term.name }}</h3>
+        <p>{{ term.pages_count }} document{% if term.pages_count != 1 %}s{% endif %} filed.</p>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/prism-shift/templates/taxonomy_term.html
+++ b/examples/prism-shift/templates/taxonomy_term.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+<div class="grid solo">
+  <main class="view">
+    <nav class="crumbs"><a href="{{ base_url }}/">prism</a><span class="sep">/</span><a href="{{ base_url }}/{{ taxonomy_name }}/">{{ taxonomy_name }}</a><span class="sep">/</span>{{ page.title }}</nav>
+    <header class="hero">
+      <div>
+        <div class="badges"><span class="badge live">#{{ page.title | upper }}</span></div>
+        <h1>{{ page.title }}<span class="accent">.</span></h1>
+        <p class="lede">{{ taxonomy_pages | length }} document{% if taxonomy_pages | length != 1 %}s{% endif %} tagged with this term.</p>
+      </div>
+    </header>
+    <div class="section-grid">
+      {% for p in taxonomy_pages %}
+      <a href="{{ p.url }}">
+        <div class="ix">DOC 0{{ loop.index }} / {{ p.tags | first | default(value="ref") | upper }}</div>
+        <h3>{{ p.title | e }}</h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+        <span class="date">{% if p.date %}{{ p.date | date(format="%Y.%m.%d") }}{% endif %}</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/rune-archive/AGENTS.md
+++ b/examples/rune-archive/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/rune-archive/archetypes/default.md
+++ b/examples/rune-archive/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/rune-archive/config.toml
+++ b/examples/rune-archive/config.toml
@@ -13,12 +13,6 @@ enabled = true
 theme = "atom-one-dark"
 use_cdn = true
 
-[search]
-enabled = true
-format = "fuse_json"
-fields = ["title", "content"]
-filename = "search.json"
-
 [pagination]
 enabled = false
 per_page = 10

--- a/examples/rune-archive/config.toml
+++ b/examples/rune-archive/config.toml
@@ -1,0 +1,192 @@
+title = "Rune Archive"
+description = "An archival manuscript for engineering documentation. Dark vellum, warm ink, columned reading."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/rune-archive/content/docs/01-protocol.md
+++ b/examples/rune-archive/content/docs/01-protocol.md
@@ -1,0 +1,50 @@
++++
+title = "The Protocol"
+description = "Wire format, framing, and the lifecycle of a single request."
+date = "2026-03-01"
+weight = 1
+tags = ["spec", "protocol"]
++++
+
+## Wire format
+
+Every message on the wire is composed of a four-byte length prefix, a
+one-byte type discriminator, and a body of up to 65,531 bytes. Bodies that
+exceed this length are split across continuation frames.
+
+```
++-------------------+--------+-----------------------------+
+| length (uint32 BE)| type   | body                        |
++-------------------+--------+-----------------------------+
+```
+
+Length values are encoded big-endian to match the conventions of established
+internet protocols.[^1] Implementations MAY refuse messages whose declared
+length is less than five — the smallest possible valid frame.
+
+## Lifecycle of a request
+
+A request passes through four states:
+
+1. **Drafted.** The sender has constructed the frame but not yet committed
+   it to the wire.
+2. **In flight.** The frame has been transmitted, and the sender awaits
+   acknowledgement.
+3. **Settled.** The acknowledgement has been received and validated.
+4. **Sealed.** The settlement has been recorded in the local journal and
+   the corresponding draft has been discarded.
+
+Sealing is the only state transition that is irreversible. Implementations
+MUST NOT seal a request until the journal write has been fsynced.
+
+## Reserved type discriminators
+
+| Code | Name         | Meaning                                        |
+|------|--------------|------------------------------------------------|
+| 0x00 | `NOOP`       | Carrier wave; ignore.                          |
+| 0x01 | `REQUEST`    | Client-initiated, expects a response.          |
+| 0x02 | `RESPONSE`   | Reply to a prior request.                      |
+| 0x03 | `EVENT`      | Server-initiated; no response required.        |
+| 0x7F | `RESERVED`   | Forbidden; future protocol versions only.      |
+
+[^1]: See RFC 791 §3.1 for an analogous encoding decision.

--- a/examples/rune-archive/content/docs/02-storage.md
+++ b/examples/rune-archive/content/docs/02-storage.md
@@ -1,0 +1,51 @@
++++
+title = "Storage Layer"
+description = "On-disk layout, journal semantics, and the compaction loop."
+date = "2026-03-08"
+weight = 2
+tags = ["spec", "storage"]
++++
+
+## On-disk layout
+
+The data directory contains three kinds of file. Names are conventional; the
+runtime resolves files by their extension and ignores the basename.
+
+```
+data/
+├── 00000001.log    # journal segments, append-only
+├── 00000002.log
+├── 00000001.idx    # offset → record indices
+├── 00000002.idx
+└── snapshot.bin    # most recent compacted state
+```
+
+Segments are immutable once sealed. The runtime guarantees that a segment
+written by version N can be read by version N+1; the inverse is not
+guaranteed.
+
+## Journal semantics
+
+Writes are applied in two phases: first to the active log segment, then to
+the in-memory state. A crash between the two phases is recoverable by
+replaying the unrecovered tail of the segment at startup.
+
+```c
+int journal_append(journal_t *j, record_t *r) {
+    if (segment_full(j->head)) {
+        if (segment_seal(j->head) < 0) return -1;
+        if (segment_rotate(j) < 0)     return -1;
+    }
+    return segment_write(j->head, r);
+}
+```
+
+The default segment ceiling is 64 MiB. Operators may tune this with
+`storage.segment_size_max`, but should not lower it below 1 MiB; the index
+overhead grows quadratically as segments shrink.
+
+## Compaction
+
+A background loop coalesces sealed segments older than the configured
+retention window into a single snapshot. Compaction is opportunistic — it
+yields the CPU readily and never blocks foreground writes.

--- a/examples/rune-archive/content/docs/03-operations.md
+++ b/examples/rune-archive/content/docs/03-operations.md
@@ -1,0 +1,43 @@
++++
+title = "Operations"
+description = "Running a node in production: capacity, monitoring, and incident response."
+date = "2026-03-15"
+weight = 3
+tags = ["ops"]
++++
+
+## Capacity envelope
+
+A reference node, provisioned with eight cores, 32 GiB of memory, and an
+NVMe-backed data directory, sustains the following throughput under
+representative workloads.
+
+| Workload      | Throughput  | p50 latency | p99 latency |
+|---------------|-------------|-------------|-------------|
+| Read-only     | 18,200 rps  | 0.6 ms      | 3.1 ms      |
+| 90 / 10 mix   | 12,400 rps  | 1.1 ms      | 6.4 ms      |
+| Write-heavy   | 7,800 rps   | 2.3 ms      | 14.0 ms     |
+
+These figures are the lower envelope of a thirty-minute soak; instantaneous
+throughput is consistently higher.
+
+## What to watch
+
+Three metrics, taken together, are sufficient for most alerting.
+
+- `node.journal.fsync_p99` — sustained excursion above 25 ms is a leading
+  indicator of disk degradation.
+- `node.peer.replication_lag` — bounded growth is normal; unbounded growth
+  is a peer outage in disguise.
+- `node.errors.total` — any non-zero derivative warrants a look at the
+  structured log.
+
+## Incident response
+
+In the order listed:
+
+1. Confirm the alert is not a false positive by checking the dashboard.
+2. Capture the structured log window around the alert with `runic capture`.
+3. Open the relevant runbook in this Archive and follow it line for line.
+4. If no runbook exists for the failure mode, draft one once the incident
+   has resolved. The Archive grows by accretion.

--- a/examples/rune-archive/content/docs/04-glossary.md
+++ b/examples/rune-archive/content/docs/04-glossary.md
@@ -1,0 +1,35 @@
++++
+title = "Glossary"
+description = "Vocabulary used throughout the Archive."
+date = "2026-03-22"
+weight = 4
+tags = ["reference"]
++++
+
+## Terms of art
+
+**Folio.** A single chapter of the Archive. Folios are numbered, ordered,
+and self-contained.
+
+**Frame.** The smallest unit of data exchanged on the wire. See *The Protocol*.
+
+**Segment.** An append-only log file on disk. Segments are immutable once
+sealed.
+
+**Settlement.** Acknowledgement that a request has been received and
+validated by the peer. Distinct from *sealing*, which is durable.
+
+**Soak.** A representative workload sustained long enough for steady-state
+behaviour to emerge — typically thirty minutes.
+
+**Snapshot.** The compacted representation of all sealed segments older
+than the retention window.
+
+## Conventions
+
+Throughout the Archive, the words MUST, MUST NOT, SHOULD, SHOULD NOT, and
+MAY carry the meanings assigned to them in RFC 2119, and are typeset in
+small capitals so the reader cannot mistake them for ordinary emphasis.
+
+Code samples are presented in C wherever the runtime's reference
+implementation is unambiguous; otherwise pseudocode is used.

--- a/examples/rune-archive/content/docs/_index.md
+++ b/examples/rune-archive/content/docs/_index.md
@@ -1,0 +1,10 @@
++++
+title = "The Folios"
+description = "Each folio is a self-contained chapter of the Archive."
+sort_by = "weight"
+template = "section"
++++
+
+The Archive is bound in folios. Each folio addresses a single topic, runs no
+longer than is necessary, and assumes the reader has read the folios before
+it.

--- a/examples/rune-archive/content/index.md
+++ b/examples/rune-archive/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Rune Archive"
+description = "An archival manuscript for engineering documentation."
+template = "home"
++++
+
+Documentation that reads like a kept volume. Rune Archive is a dark editorial
+surface for protocols, specifications, and the kind of long-form technical
+prose that earns its keep over time. Warm ink on charcoal vellum; serif body
+text; columned, footnoted, indexed.

--- a/examples/rune-archive/static/css/style.css
+++ b/examples/rune-archive/static/css/style.css
@@ -1,0 +1,401 @@
+:root {
+  --bg: #14110f;
+  --bg-2: #1d1916;
+  --bg-3: #2a241f;
+  --vellum: #ebe1ce;
+  --vellum-2: #c8bda7;
+  --ink: #f4ead4;
+  --ink-2: #c8bda7;
+  --ink-3: #8a7e6a;
+  --rule: #3a322a;
+  --rule-faint: #2a241f;
+  --accent: #c69553;
+  --serif: "Spectral", "Source Serif Pro", "Cormorant Garamond", Georgia, serif;
+  --sans: "Inter", -apple-system, system-ui, sans-serif;
+  --mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 17px; -webkit-font-smoothing: antialiased; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--serif);
+  line-height: 1.7;
+  font-feature-settings: "liga", "calt", "kern";
+}
+
+::selection { background: var(--accent); color: var(--bg); }
+
+a { color: var(--ink); text-decoration: underline; text-decoration-color: var(--rule); text-underline-offset: 4px; }
+a:hover { text-decoration-color: var(--accent); color: var(--accent); }
+
+.shell {
+  max-width: 90rem;
+  margin: 0 auto;
+  padding: 0 3rem;
+}
+
+.masthead {
+  border-bottom: 1px solid var(--rule);
+  padding: 1.4rem 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 2rem;
+}
+.masthead .brand {
+  font-family: var(--serif);
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  color: var(--ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+.masthead .brand .sigil {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem; height: 1.8rem;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 0.85rem;
+}
+.masthead .center {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  font-family: var(--sans);
+  font-size: 0.65rem;
+  color: var(--ink-3);
+}
+.masthead nav {
+  justify-self: end;
+  display: flex;
+  gap: 1.6rem;
+  font-family: var(--sans);
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+}
+.masthead nav a { text-decoration: none; color: var(--ink-2); }
+.masthead nav a:hover { color: var(--accent); }
+
+.layout {
+  display: grid;
+  grid-template-columns: 18rem 1fr;
+  gap: 4rem;
+  padding: 3rem 0 5rem;
+}
+
+aside.toc {
+  position: sticky;
+  top: 2rem;
+  align-self: start;
+  font-family: var(--sans);
+  font-size: 0.84rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  padding-right: 1rem;
+}
+.toc h5 {
+  font-family: var(--sans);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.62rem;
+  color: var(--ink-3);
+  font-weight: 600;
+  margin: 1.6rem 0 0.6rem;
+}
+.toc ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-left: 1px solid var(--rule);
+}
+.toc ol li { padding: 0; }
+.toc ol li a {
+  display: block;
+  padding: 0.45rem 1rem;
+  text-decoration: none;
+  color: var(--ink-2);
+  border-left: 2px solid transparent;
+  margin-left: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.toc ol li a:hover { color: var(--ink); border-left-color: var(--rule); }
+.toc ol li a.active { color: var(--accent); border-left-color: var(--accent); }
+.toc ol li a small {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  margin-bottom: 0.1rem;
+}
+
+main.scroll {
+  max-width: 46rem;
+}
+
+.preamble {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2.4rem;
+  margin-bottom: 2.4rem;
+}
+.preamble .label {
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+.preamble h1 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(2.4rem, 4.5vw, 4rem);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  margin: 0 0 1.2rem;
+}
+.preamble h1 em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+}
+.preamble .lede {
+  font-size: 1.18rem;
+  color: var(--vellum-2);
+  font-family: var(--serif);
+  line-height: 1.6;
+  max-width: 36rem;
+  margin: 0 0 1.4rem;
+}
+.preamble .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+.preamble .meta strong { color: var(--ink); font-weight: 600; }
+
+article {
+  font-family: var(--serif);
+  font-size: 1.06rem;
+  color: var(--vellum);
+}
+article > p:first-of-type::first-letter {
+  font-family: var(--serif);
+  font-size: 4.2em;
+  line-height: 0.85;
+  float: left;
+  padding: 0.32rem 0.7rem 0 0;
+  color: var(--accent);
+  font-weight: 500;
+}
+article h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.85rem;
+  margin: 3.2rem 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--rule);
+  letter-spacing: -0.005em;
+}
+article h2::before {
+  content: "·  ";
+  color: var(--accent);
+  font-family: var(--mono);
+}
+article h3 {
+  font-family: var(--sans);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  margin: 2.4rem 0 0.8rem;
+  font-weight: 600;
+}
+article p, article li { line-height: 1.78; }
+article ul, article ol { padding-left: 1.5rem; }
+article strong { color: var(--ink); font-weight: 600; }
+article em { color: var(--accent); }
+
+article pre, pre[class*="language-"] {
+  background: var(--bg-2) !important;
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--accent);
+  padding: 1.1rem 1.3rem;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  line-height: 1.65;
+  color: var(--vellum) !important;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+article code {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 0.05rem 0.4rem;
+  color: var(--accent);
+}
+article pre code { background: transparent; border: none; padding: 0; color: inherit; font-size: 1em; }
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--sans);
+  font-size: 0.88rem;
+  margin: 1.5rem 0;
+}
+article th {
+  text-align: left;
+  font-family: var(--sans);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.68rem;
+  color: var(--ink-3);
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--accent);
+  font-weight: 600;
+}
+article td {
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--rule);
+  color: var(--vellum);
+  vertical-align: top;
+}
+
+article blockquote {
+  border-left: 2px solid var(--accent);
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.2rem;
+  font-style: italic;
+  color: var(--vellum-2);
+  font-family: var(--serif);
+}
+
+.footnotes {
+  margin-top: 4rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 1rem;
+  font-family: var(--sans);
+  font-size: 0.82rem;
+  color: var(--ink-3);
+}
+.footnotes ol { padding-left: 1.2rem; }
+.footnotes a { color: var(--accent); }
+
+.index-list { list-style: none; padding: 0; margin: 0; border-top: 1px solid var(--rule); }
+.index-list .row {
+  display: grid;
+  grid-template-columns: 5rem 1fr auto;
+  gap: 1.5rem;
+  padding: 1.3rem 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: baseline;
+  text-decoration: none;
+  color: var(--ink);
+}
+.index-list .row:hover { background: var(--bg-2); padding-left: 0.8rem; padding-right: 0.8rem; }
+.index-list .row .num {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--accent);
+  letter-spacing: 0.14em;
+}
+.index-list .row h3 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.4rem;
+  margin: 0 0 0.3rem;
+  letter-spacing: -0.01em;
+}
+.index-list .row p {
+  font-family: var(--serif);
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin: 0;
+}
+.index-list .row .date {
+  font-family: var(--sans);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+
+.btn-row { margin-top: 1.5rem; display: flex; gap: 0.7rem; flex-wrap: wrap; }
+.btn {
+  display: inline-block;
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  text-decoration: none;
+  padding: 0.7rem 1.2rem;
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  background: transparent;
+}
+.btn:hover { border-color: var(--accent); color: var(--accent); }
+.btn.solid { background: var(--accent); border-color: var(--accent); color: var(--bg); }
+.btn.solid:hover { background: transparent; color: var(--accent); }
+
+.tag-chip {
+  display: inline-block;
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-2);
+  border: 1px solid var(--rule);
+  padding: 0.1rem 0.55rem;
+  margin-right: 0.4rem;
+  text-decoration: none;
+}
+.tag-chip:hover { border-color: var(--accent); color: var(--accent); }
+
+footer.colophon {
+  border-top: 1px solid var(--rule);
+  padding: 1.6rem 0 2.4rem;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 1.5rem;
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ink-3);
+}
+footer.colophon .center { text-align: center; }
+footer.colophon .right { text-align: right; }
+
+.notfound { text-align: center; padding: 8rem 0; }
+.notfound h1 { font-family: var(--serif); font-size: 8rem; font-weight: 400; margin: 0; color: var(--accent); letter-spacing: -0.03em; }
+.notfound h1::before { content: ""; }
+.notfound .lede { color: var(--vellum-2); margin: 0.5rem 0 2rem; }
+
+@media (max-width: 1000px) {
+  .shell { padding: 0 1.5rem; }
+  .layout { grid-template-columns: 1fr; gap: 2rem; }
+  aside.toc { position: static; max-height: none; border-bottom: 1px solid var(--rule); padding-bottom: 1rem; }
+  .masthead { grid-template-columns: 1fr; gap: 0.8rem; }
+  .masthead nav { justify-self: start; }
+  .masthead .center { text-align: left; }
+  footer.colophon { grid-template-columns: 1fr; }
+  footer.colophon .right, footer.colophon .center { text-align: left; }
+}

--- a/examples/rune-archive/static/favicon.svg
+++ b/examples/rune-archive/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/rune-archive/templates/404.html
+++ b/examples/rune-archive/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p class="lede" style="font-family:var(--serif);font-style:italic;">This folio is not bound into the present volume.</p>
+  <div class="btn-row" style="justify-content:center;display:flex;">
+    <a class="btn solid" href="{{ base_url }}/">Return to the masthead</a>
+    <a class="btn" href="{{ base_url }}/docs/">Browse the folios</a>
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/rune-archive/templates/footer.html
+++ b/examples/rune-archive/templates/footer.html
@@ -1,0 +1,10 @@
+    </main>
+  </div>
+  <footer class="colophon">
+    <span>Rune Archive · Vol. I</span>
+    <span class="center">Set in Spectral, Inter, JetBrains Mono</span>
+    <span class="right">Built with Hwaro · {{ current_year }}</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/rune-archive/templates/header.html
+++ b/examples/rune-archive/templates/header.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;1,400;1,500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="shell">
+  <header class="masthead">
+    <a class="brand" href="{{ base_url }}/">
+      <span class="sigil">R</span>
+      <span>Rune Archive</span>
+    </a>
+    <div class="center">Vol. I · Folios 01–04 · Anno {{ current_year }}</div>
+    <nav>
+      <a href="{{ base_url }}/docs/">Folios</a>
+      <a href="{{ base_url }}/tags/">Index</a>
+      <a href="{{ base_url }}/categories/">Categories</a>
+    </nav>
+  </header>
+  <div class="layout">
+    <aside class="toc">
+      <h5>Folios</h5>
+      <ol>
+        <li><a href="{{ base_url }}/docs/01-protocol/"{% if page.url == "/docs/01-protocol/" %} class="active"{% endif %}><small>FOLIO I</small>The Protocol</a></li>
+        <li><a href="{{ base_url }}/docs/02-storage/"{% if page.url == "/docs/02-storage/" %} class="active"{% endif %}><small>FOLIO II</small>Storage Layer</a></li>
+        <li><a href="{{ base_url }}/docs/03-operations/"{% if page.url == "/docs/03-operations/" %} class="active"{% endif %}><small>FOLIO III</small>Operations</a></li>
+        <li><a href="{{ base_url }}/docs/04-glossary/"{% if page.url == "/docs/04-glossary/" %} class="active"{% endif %}><small>FOLIO IV</small>Glossary</a></li>
+      </ol>
+      <h5>Apparatus</h5>
+      <ol>
+        <li><a href="{{ base_url }}/docs/">All folios</a></li>
+        <li><a href="{{ base_url }}/tags/">Tag index</a></li>
+        <li><a href="{{ base_url }}/categories/">Categories</a></li>
+      </ol>
+    </aside>
+    <main class="scroll">

--- a/examples/rune-archive/templates/home.html
+++ b/examples/rune-archive/templates/home.html
@@ -1,0 +1,67 @@
+{% include "header.html" %}
+<header class="preamble">
+  <div class="label">Vol. I · Anno {{ current_year }}</div>
+  <h1>Long-form <em>documentation</em>,<br/>kept as a volume.</h1>
+  <p class="lede">{{ site.description }}</p>
+  <div class="btn-row">
+    <a class="btn solid" href="{{ base_url }}/docs/">Open the Folios</a>
+    <a class="btn" href="{{ base_url }}/docs/01-protocol/">Begin at Folio I</a>
+  </div>
+</header>
+
+<article style="font-size:1.04rem;">
+  {{ content | safe }}
+
+  <h2>The Folios</h2>
+  <ul class="index-list">
+    <li>
+      <a class="row" href="{{ base_url }}/docs/01-protocol/">
+        <span class="num">FOLIO 01</span>
+        <div>
+          <h3>The Protocol</h3>
+          <p>Wire format, framing, and the lifecycle of a single request.</p>
+        </div>
+        <span class="date">Mar 1, 2026</span>
+      </a>
+    </li>
+    <li>
+      <a class="row" href="{{ base_url }}/docs/02-storage/">
+        <span class="num">FOLIO 02</span>
+        <div>
+          <h3>Storage Layer</h3>
+          <p>On-disk layout, journal semantics, and the compaction loop.</p>
+        </div>
+        <span class="date">Mar 8, 2026</span>
+      </a>
+    </li>
+    <li>
+      <a class="row" href="{{ base_url }}/docs/03-operations/">
+        <span class="num">FOLIO 03</span>
+        <div>
+          <h3>Operations</h3>
+          <p>Running a node in production: capacity, monitoring, response.</p>
+        </div>
+        <span class="date">Mar 15, 2026</span>
+      </a>
+    </li>
+    <li>
+      <a class="row" href="{{ base_url }}/docs/04-glossary/">
+        <span class="num">FOLIO 04</span>
+        <div>
+          <h3>Glossary</h3>
+          <p>Vocabulary used throughout the Archive.</p>
+        </div>
+        <span class="date">Mar 22, 2026</span>
+      </a>
+    </li>
+  </ul>
+
+  <h2>A note on form</h2>
+  <p>
+    Each folio is bound to a single concern. The wire protocol does not
+    spill into the storage layer; operations do not anticipate the
+    glossary. This is deliberate: the Archive is intended to be read
+    out of order, returned to, and consulted — not skimmed end-to-end.
+  </p>
+</article>
+{% include "footer.html" %}

--- a/examples/rune-archive/templates/page.html
+++ b/examples/rune-archive/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<header class="preamble">
+  <div class="label">{% if page.section %}{{ page.section | upper }} · {% endif %}{% if page.weight %}Folio {{ page.weight }}{% else %}Reading{% endif %}</div>
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+  <div class="meta">
+    {% if page.date %}<span>Dated · <strong>{{ page.date | date(format="%B %e, %Y") }}</strong></span>{% endif %}
+    {% if page.reading_time %}<span>Reading · <strong>{{ page.reading_time }} min</strong></span>{% endif %}
+    {% if page.word_count %}<span>Length · <strong>{{ page.word_count }} words</strong></span>{% endif %}
+    {% if page.tags %}<span>Tags · {% for t in page.tags %}<a class="tag-chip" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</span>{% endif %}
+  </div>
+</header>
+<article>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/rune-archive/templates/section.html
+++ b/examples/rune-archive/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+<header class="preamble">
+  <div class="label">Section · {{ page.title | upper }}</div>
+  <h1>The <em>Folios</em></h1>
+  {% if content %}<div class="lede">{{ content | striptags | trim }}</div>{% endif %}
+  <div class="btn-row">
+    <a class="btn solid" href="{{ base_url }}/docs/01-protocol/">Begin reading</a>
+    <a class="btn" href="{{ base_url }}/tags/">Browse by topic</a>
+  </div>
+</header>
+
+<ul class="index-list">
+  {% for p in section.pages %}
+  <li>
+    <a class="row" href="{{ p.url }}">
+      <span class="num">FOLIO {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <h3>{{ p.title | e }}</h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+      </div>
+      <span class="date">{% if p.date %}{{ p.date | date(format="%b %e, %Y") }}{% endif %}</span>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% include "footer.html" %}

--- a/examples/rune-archive/templates/shortcodes/alert.html
+++ b/examples/rune-archive/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/rune-archive/templates/taxonomy.html
+++ b/examples/rune-archive/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<header class="preamble">
+  <div class="label">Apparatus</div>
+  <h1>{{ taxonomy_name | default(value="Tags") | capitalize }} <em>index</em></h1>
+  <p class="lede">All terms gathered from the corpus of folios.</p>
+</header>
+<ul class="index-list">
+  {% for term in taxonomy_terms %}
+  <li>
+    <a class="row" href="{{ term.url }}">
+      <span class="num">№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <h3>{{ term.name }}</h3>
+        <p>{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %} in the index</p>
+      </div>
+      <span class="date">/{{ taxonomy_name }}/{{ term.slug }}/</span>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% include "footer.html" %}

--- a/examples/rune-archive/templates/taxonomy_term.html
+++ b/examples/rune-archive/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<header class="preamble">
+  <div class="label">{{ taxonomy_name | default(value="Tags") | upper }} · INDEX</div>
+  <h1>Under <em>{{ page.title }}</em></h1>
+  <p class="lede">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} in the corpus filed under this term.</p>
+</header>
+<ul class="index-list">
+  {% for p in taxonomy_pages %}
+  <li>
+    <a class="row" href="{{ p.url }}">
+      <span class="num">№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <h3>{{ p.title | e }}</h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+      </div>
+      <span class="date">{% if p.date %}{{ p.date | date(format="%b %e, %Y") }}{% endif %}</span>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% include "footer.html" %}

--- a/examples/stratum-docs/AGENTS.md
+++ b/examples/stratum-docs/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/stratum-docs/archetypes/default.md
+++ b/examples/stratum-docs/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/stratum-docs/config.toml
+++ b/examples/stratum-docs/config.toml
@@ -13,12 +13,6 @@ enabled = true
 theme = "github"
 use_cdn = true
 
-[search]
-enabled = true
-format = "fuse_json"
-fields = ["title", "content"]
-filename = "search.json"
-
 [pagination]
 enabled = false
 per_page = 10

--- a/examples/stratum-docs/config.toml
+++ b/examples/stratum-docs/config.toml
@@ -1,0 +1,192 @@
+title = "Stratum"
+description = "A Swiss-aligned documentation system. Hairlines, generous whitespace, decisive numerals."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/stratum-docs/content/docs/01-overview.md
+++ b/examples/stratum-docs/content/docs/01-overview.md
@@ -1,0 +1,44 @@
++++
+title = "Overview"
+description = "How the system is shaped, and what it is not."
+date = "2026-05-04"
+weight = 1
+tags = ["intro"]
++++
+
+## In one paragraph
+
+Stratum is a layered runtime. The lowest layer is a small kernel of
+primitives — values, types, and effects. Each successive layer is built
+exclusively from the layers below it, never from the layers above. The
+result is a system in which any layer can be understood in isolation,
+without reaching for context that does not yet exist.
+
+## What you get
+
+- A predictable execution model with no implicit globals.
+- A single binary, statically linked, that runs on every host the team
+  has paid for.
+- Documentation that maps one-to-one with the source.
+
+## What it is not
+
+Stratum is **not** a framework, in the sense that it does not call your
+code. You call it, in the order you choose, and you decide what happens
+on either side of each call.
+
+It is also not a replacement for a database. It will hold a working set
+in memory and journal mutations to disk, but it expects a system of
+record to live elsewhere.
+
+## A small example
+
+```rust
+let stage = stratum::stage::open("./data")?;
+let txn   = stage.begin()?;
+txn.put(b"hello", b"world")?;
+txn.commit()?;
+```
+
+That is the smallest useful program. Every other example in the reference
+is an elaboration on this shape.

--- a/examples/stratum-docs/content/docs/02-primitives.md
+++ b/examples/stratum-docs/content/docs/02-primitives.md
@@ -1,0 +1,41 @@
++++
+title = "Primitives"
+description = "The values, types, and effects from which everything else is constructed."
+date = "2026-05-06"
+weight = 2
+tags = ["spec", "intro"]
++++
+
+## Values
+
+A *value* is an immutable sequence of bytes with a known length. The
+runtime makes no assumption about its interpretation; serialisation is
+the caller's responsibility.
+
+| Value kind     | Width        | Notes                                   |
+|----------------|--------------|-----------------------------------------|
+| Inline         | ≤ 248 bytes  | Stored alongside its key.               |
+| Page-backed    | ≤ 64 KiB     | Stored in a private page.               |
+| Extent-backed  | up to 1 GiB  | Stored in a multi-page extent.          |
+
+Values larger than 1 GiB are not addressable. The runtime will reject
+mutations that produce one, rather than silently truncate.
+
+## Types
+
+Types are advisory. They are recorded in the catalogue and used by the
+query planner, but they do not change how values are stored. A schema
+is the union of the type assignments for every key that has ever
+existed in a stage.
+
+## Effects
+
+An *effect* is anything that escapes the runtime. Three categories are
+recognised.
+
+1. **Journal effects** — append to the persistent log.
+2. **Network effects** — send or receive a frame on a peer connection.
+3. **Time effects** — read the host clock.
+
+Code that performs no effect is *pure*, and may be evaluated by the
+planner at compile time.

--- a/examples/stratum-docs/content/docs/03-runtime.md
+++ b/examples/stratum-docs/content/docs/03-runtime.md
@@ -1,0 +1,43 @@
++++
+title = "Runtime"
+description = "The execution model in detail."
+date = "2026-05-09"
+weight = 3
+tags = ["spec"]
++++
+
+## Phases of a call
+
+Every call passes through five phases. They are linear: a phase may not
+start until the previous phase has fully resolved.
+
+1. **Resolve.** Names are bound to objects in the catalogue.
+2. **Plan.** A plan is constructed from the bound objects.
+3. **Cost.** The plan is annotated with cost estimates.
+4. **Execute.** The plan is run.
+5. **Commit.** The journal is fsynced and the working set is updated.
+
+If any phase fails, no later phase runs and the call returns the error
+from the failing phase.
+
+## Concurrency
+
+The runtime is single-writer, multi-reader. Reads are wait-free with
+respect to writes. A writer holds an exclusive lock for the duration
+of its execute phase only — resolve, plan, cost, and commit are
+performed without holding the lock.
+
+```rust
+let plan = stage.plan(&query)?;        // no lock held
+{
+    let guard = stage.write()?;        // exclusive
+    guard.execute(plan)?;
+}                                       // released
+stage.commit()?;                       // no lock held
+```
+
+## Scheduling
+
+By default the runtime spawns one worker per available core, less one
+for the journal flush thread. The worker count is tunable but the
+journal flush thread is not optional.

--- a/examples/stratum-docs/content/docs/04-deployment.md
+++ b/examples/stratum-docs/content/docs/04-deployment.md
@@ -1,0 +1,44 @@
++++
+title = "Deployment"
+description = "Provisioning, packaging, and the upgrade path."
+date = "2026-05-12"
+weight = 4
+tags = ["ops"]
++++
+
+## A reference deployment
+
+A reference deployment of Stratum is three nodes of identical shape,
+each provisioned with eight cores, 32 GiB of memory, and a dedicated
+NVMe-class data volume. The three nodes elect a leader; the two
+followers replicate the leader's journal.
+
+```
+┌────────────┐    ┌────────────┐    ┌────────────┐
+│  node-01   │    │  node-02   │    │  node-03   │
+│  leader    │ ←→ │  follower  │ ←→ │  follower  │
+└────────────┘    └────────────┘    └────────────┘
+```
+
+A single-node deployment is supported for development, but the runtime
+will print a warning at startup and the warning cannot be silenced.
+
+## Packaging
+
+The runtime is distributed as a single statically linked binary. The
+binary has no runtime dependencies other than the platform's C library.
+A container image is also published, built `FROM scratch` and weighing
+less than 32 MiB.
+
+## Upgrade path
+
+Upgrades are performed rolling, one node at a time, followers first.
+The runtime guarantees that a journal written by version N is readable
+by version N+1; the inverse is not guaranteed. To downgrade, restore
+from a snapshot taken under the older version.
+
+| From    | To      | Method                                          |
+|---------|---------|-------------------------------------------------|
+| 1.0     | 1.1     | Rolling, no downtime.                           |
+| 1.0     | 1.2     | Rolling, no downtime.                           |
+| 1.x     | 2.0     | Snapshot + restore. Read the upgrade notes.     |

--- a/examples/stratum-docs/content/docs/_index.md
+++ b/examples/stratum-docs/content/docs/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Documentation"
+description = "All layers of the Stratum reference."
+sort_by = "weight"
+template = "section"
++++
+
+The reference is composed of four layers. Read top to bottom for orientation,
+or jump directly to the layer most relevant to your task.

--- a/examples/stratum-docs/content/index.md
+++ b/examples/stratum-docs/content/index.md
@@ -1,0 +1,9 @@
++++
+title = "Stratum"
+description = "A Swiss-aligned documentation system."
+template = "home"
++++
+
+Stratum is a documentation system arranged in layers. Each layer adds
+detail without disturbing the layers beneath it. The visual surface is
+typographic, decisive, and built on a strict baseline grid.

--- a/examples/stratum-docs/static/css/style.css
+++ b/examples/stratum-docs/static/css/style.css
@@ -1,0 +1,420 @@
+:root {
+  --ink: #0a0a0a;
+  --ink-2: #2c2c2c;
+  --ink-3: #6c6c6c;
+  --ink-4: #a8a8a8;
+  --paper: #fafaf7;
+  --paper-2: #f0efea;
+  --paper-3: #e5e4dd;
+  --rule: #d8d6cc;
+  --rule-faint: #ececea;
+  --accent: #2540ff;
+  --accent-2: #ff5430;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 16px; -webkit-font-smoothing: antialiased; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-feature-settings: "ss01", "cv11", "kern";
+  line-height: 1.55;
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.container {
+  max-width: 88rem;
+  margin: 0 auto;
+  padding: 0 2.5rem;
+}
+
+.nav {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.nav .brand {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  font-size: 1.1rem;
+}
+.nav .brand .v {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  font-weight: 400;
+  letter-spacing: 0;
+  padding: 0.1rem 0.45rem;
+  border: 1px solid var(--rule);
+}
+.nav .links {
+  display: flex;
+  gap: 2rem;
+  font-size: 0.85rem;
+  color: var(--ink-2);
+}
+.nav .links a { font-weight: 500; }
+.nav .right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+}
+.nav .right .pill {
+  border: 1px solid var(--ink);
+  padding: 0.35rem 0.75rem;
+  font-weight: 500;
+  color: var(--ink);
+}
+.nav .right .pill:hover { background: var(--ink); color: var(--paper); }
+.nav .right .pill.solid { background: var(--accent); border-color: var(--accent); color: white; }
+.nav .right .pill.solid:hover { background: var(--ink); border-color: var(--ink); }
+
+.layout {
+  display: grid;
+  grid-template-columns: 16rem 1fr;
+  gap: 4rem;
+  padding: 3rem 0 5rem;
+}
+.layout.full { grid-template-columns: 1fr; }
+
+aside.side {
+  position: sticky;
+  top: 2rem;
+  align-self: start;
+  font-size: 0.88rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+}
+.side h6 {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  margin: 1.6rem 0 0.6rem;
+  font-weight: 600;
+}
+.side .group { border-top: 1px solid var(--rule); padding-top: 1rem; }
+.side ol { list-style: none; padding: 0; margin: 0; counter-reset: layer; }
+.side ol li {
+  counter-increment: layer;
+  padding: 0;
+  margin-bottom: 0.1rem;
+}
+.side ol li a {
+  display: grid;
+  grid-template-columns: 2rem 1fr;
+  align-items: baseline;
+  padding: 0.45rem 0;
+  color: var(--ink-2);
+  font-weight: 500;
+}
+.side ol li a::before {
+  content: counter(layer, decimal-leading-zero);
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  color: var(--ink-4);
+  font-weight: 400;
+  letter-spacing: 0.05em;
+}
+.side ol li a:hover { color: var(--ink); }
+.side ol li a.active { color: var(--accent); }
+.side ol li a.active::before { color: var(--accent); }
+.side ul { list-style: none; padding: 0; margin: 0; }
+.side ul li a { display: block; padding: 0.4rem 0; color: var(--ink-2); }
+.side ul li a:hover { color: var(--ink); }
+
+main.body { max-width: 50rem; }
+
+.hero {
+  padding: 2.5rem 0 3rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 3rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 3rem;
+  align-items: end;
+}
+.hero .num {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.hero h1 {
+  font-size: clamp(2.6rem, 5vw, 4.6rem);
+  line-height: 1;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  margin: 1.2rem 0 1.2rem;
+}
+.hero h1 .accent { color: var(--accent); }
+.hero .lede {
+  font-size: 1.2rem;
+  color: var(--ink-2);
+  max-width: 38rem;
+  margin: 0 0 1.4rem;
+  line-height: 1.5;
+}
+.hero .big-num {
+  font-family: var(--sans);
+  font-size: clamp(7rem, 14vw, 12rem);
+  font-weight: 700;
+  line-height: 0.85;
+  color: var(--paper-3);
+  letter-spacing: -0.06em;
+  user-select: none;
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--rule);
+  margin: 0 0 2.5rem;
+}
+.meta-grid .cell {
+  padding: 1rem 1.2rem 1rem 0;
+  border-right: 1px solid var(--rule);
+}
+.meta-grid .cell:last-child { border-right: none; }
+.meta-grid .cell .k {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+  display: block;
+  margin-bottom: 0.35rem;
+}
+.meta-grid .cell .v { font-family: var(--mono); font-size: 0.9rem; color: var(--ink); font-weight: 500; }
+
+article h2 {
+  font-size: 1.65rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 3.2rem 0 1rem;
+  padding-top: 2.2rem;
+  border-top: 1px solid var(--rule);
+  position: relative;
+}
+article h2::before {
+  content: counter(h2, decimal-leading-zero);
+  counter-increment: h2;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.35rem;
+}
+article { counter-reset: h2; font-size: 1.02rem; color: var(--ink-2); line-height: 1.7; }
+article h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  margin: 2rem 0 0.6rem;
+  color: var(--ink);
+}
+article p, article li { color: var(--ink-2); }
+article ul, article ol { padding-left: 1.4rem; }
+article strong { color: var(--ink); font-weight: 600; }
+article a { color: var(--accent); border-bottom: 1px solid var(--accent); }
+article a:hover { background: var(--accent); color: var(--paper); }
+
+article pre, pre[class*="language-"] {
+  background: var(--ink) !important;
+  color: var(--paper) !important;
+  padding: 1.2rem 1.4rem;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  border: none;
+  margin: 1.5rem 0;
+}
+article code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  background: var(--paper-2);
+  padding: 0.05rem 0.4rem;
+  border-radius: 0;
+}
+article pre code { background: transparent; padding: 0; }
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  margin: 1.5rem 0;
+}
+article th {
+  text-align: left;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-3);
+  padding: 0.7rem 0.9rem 0.7rem 0;
+  border-bottom: 1px solid var(--ink);
+  font-weight: 600;
+}
+article td {
+  padding: 0.7rem 0.9rem 0.7rem 0;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+  vertical-align: top;
+}
+
+article blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.2rem;
+  color: var(--ink-2);
+  font-style: italic;
+}
+
+.feature-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  margin: 3rem 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--rule);
+}
+.feature-row .feat {
+  padding: 2rem 1.5rem 2rem 0;
+  border-right: 1px solid var(--rule);
+}
+.feature-row .feat:last-child { border-right: none; padding-right: 0; }
+.feature-row .feat .n {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin-bottom: 0.8rem;
+}
+.feature-row .feat h4 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.5rem;
+  line-height: 1.2;
+}
+.feature-row .feat p { font-size: 0.92rem; color: var(--ink-2); margin: 0; }
+
+.doc-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--ink);
+}
+.doc-grid a {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr;
+  gap: 1.2rem;
+  padding: 2rem 2rem 2rem 0;
+  border-bottom: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+}
+.doc-grid a:nth-child(2n) { border-right: none; padding-right: 0; }
+.doc-grid a:hover { background: var(--paper-2); padding-left: 1rem; }
+.doc-grid a .num {
+  font-family: var(--mono);
+  font-size: 2.2rem;
+  font-weight: 400;
+  color: var(--ink-4);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.doc-grid a:hover .num { color: var(--accent); }
+.doc-grid a h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.4rem;
+  color: var(--ink);
+}
+.doc-grid a p { font-size: 0.92rem; color: var(--ink-2); margin: 0; }
+.doc-grid a .date {
+  display: block;
+  margin-top: 0.7rem;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-4);
+}
+
+.tag-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.72rem;
+  padding: 0.18rem 0.55rem;
+  border: 1px solid var(--rule);
+  margin-right: 0.4rem;
+  color: var(--ink-2);
+  font-weight: 500;
+}
+.tag-pill:hover { border-color: var(--accent); color: var(--accent); }
+.tag-pill::before { content: "#"; color: var(--ink-4); }
+
+footer.site {
+  border-top: 1px solid var(--ink);
+  padding: 2rem 0 2.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 2rem;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+}
+footer.site h6 {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  margin: 0 0 0.7rem;
+  font-weight: 600;
+}
+footer.site ul { list-style: none; padding: 0; margin: 0; }
+footer.site ul li { padding: 0.2rem 0; }
+footer.site ul li a { color: var(--ink); font-weight: 500; }
+footer.site ul li a:hover { color: var(--accent); }
+footer.site .colophon { color: var(--ink-3); font-size: 0.78rem; }
+
+.notfound { text-align: center; padding: 8rem 0; }
+.notfound .num { font-family: var(--sans); font-size: 12rem; font-weight: 700; letter-spacing: -0.06em; line-height: 0.85; color: var(--paper-3); margin: 0; }
+.notfound h1 { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; margin: 1rem 0; }
+.notfound p { color: var(--ink-2); }
+
+@media (max-width: 980px) {
+  .container { padding: 0 1.5rem; }
+  .layout { grid-template-columns: 1fr; gap: 2rem; }
+  aside.side { position: static; max-height: none; border-bottom: 1px solid var(--rule); padding-bottom: 1rem; }
+  .hero { grid-template-columns: 1fr; gap: 1rem; }
+  .meta-grid { grid-template-columns: repeat(2, 1fr); }
+  .meta-grid .cell:nth-child(2) { border-right: none; }
+  .feature-row { grid-template-columns: 1fr; }
+  .feature-row .feat { border-right: none; border-bottom: 1px solid var(--rule); }
+  .doc-grid { grid-template-columns: 1fr; }
+  .doc-grid a, .doc-grid a:nth-child(2n) { border-right: none; padding-right: 0; }
+  footer.site { grid-template-columns: 1fr; }
+  .nav { grid-template-columns: 1fr; gap: 0.6rem; }
+  .nav .right { flex-wrap: wrap; }
+}

--- a/examples/stratum-docs/static/favicon.svg
+++ b/examples/stratum-docs/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/stratum-docs/templates/404.html
+++ b/examples/stratum-docs/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<div class="notfound">
+  <p class="num">404</p>
+  <h1>This stratum is not deposited.</h1>
+  <p>The page you requested is not part of this documentation set.</p>
+  <p style="margin-top:2rem;"><a class="pill solid" href="{{ base_url }}/" style="padding:0.7rem 1.4rem;display:inline-block;background:var(--ink);color:var(--paper);font-size:0.85rem;font-weight:500;">Return home</a> <a class="pill" href="{{ base_url }}/docs/" style="padding:0.7rem 1.4rem;display:inline-block;border:1px solid var(--ink);color:var(--ink);font-size:0.85rem;font-weight:500;margin-left:0.5rem;">Read the docs</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/stratum-docs/templates/footer.html
+++ b/examples/stratum-docs/templates/footer.html
@@ -1,0 +1,28 @@
+  <footer class="site">
+    <div>
+      <h6>{{ site_title }}</h6>
+      <p class="colophon">{{ site.description }}</p>
+    </div>
+    <div>
+      <h6>Documentation</h6>
+      <ul>
+        <li><a href="{{ base_url }}/docs/01-overview/">Overview</a></li>
+        <li><a href="{{ base_url }}/docs/02-primitives/">Primitives</a></li>
+        <li><a href="{{ base_url }}/docs/03-runtime/">Runtime</a></li>
+        <li><a href="{{ base_url }}/docs/04-deployment/">Deployment</a></li>
+      </ul>
+    </div>
+    <div>
+      <h6>Meta</h6>
+      <ul>
+        <li><a href="{{ base_url }}/tags/">Tags</a></li>
+        <li><a href="{{ base_url }}/categories/">Categories</a></li>
+        <li><a href="{{ base_url }}/rss.xml">RSS feed</a></li>
+        <li><a href="https://github.com/hahwul/hwaro">Source</a></li>
+      </ul>
+      <p class="colophon" style="margin-top:1.2rem;">© {{ current_year }} · Set in Inter & JetBrains Mono · Built with Hwaro</p>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/stratum-docs/templates/header.html
+++ b/examples/stratum-docs/templates/header.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="container">
+  <nav class="nav">
+    <a class="brand" href="{{ base_url }}/">Stratum<span class="v">v2.1</span></a>
+    <div class="links">
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/tags/">Topics</a>
+      <a href="{{ base_url }}/categories/">Categories</a>
+    </div>
+    <div class="right">
+      <span>SSR · Static · Edge</span>
+      <a class="pill" href="https://github.com/hahwul/hwaro">GitHub →</a>
+      <a class="pill solid" href="{{ base_url }}/docs/01-overview/">Read docs</a>
+    </div>
+  </nav>

--- a/examples/stratum-docs/templates/home.html
+++ b/examples/stratum-docs/templates/home.html
@@ -1,0 +1,75 @@
+{% include "header.html" %}
+<div class="layout full">
+  <main class="body" style="max-width:none;">
+    <header class="hero">
+      <div>
+        <span class="num">v2.1 · STABLE · MIT</span>
+        <h1>Documentation, in <span class="accent">layers</span>.</h1>
+        <p class="lede">{{ site.description }}</p>
+        <a class="pill solid" href="{{ base_url }}/docs/01-overview/" style="padding:0.7rem 1.4rem;display:inline-block;font-size:0.85rem;font-weight:500;background:var(--accent);color:white;text-decoration:none;border:1px solid var(--accent);">Start reading →</a>
+        <a class="pill" href="{{ base_url }}/docs/" style="padding:0.7rem 1.4rem;display:inline-block;font-size:0.85rem;font-weight:500;color:var(--ink);border:1px solid var(--ink);text-decoration:none;margin-left:0.5rem;">Browse all docs</a>
+      </div>
+      <div class="big-num">04</div>
+    </header>
+
+    <section class="feature-row">
+      <div class="feat">
+        <div class="n">01 · Predictable</div>
+        <h4>No implicit globals, no hidden side-effects.</h4>
+        <p>Every effect is named. Every call is traceable. The runtime never reaches for state you did not hand it.</p>
+      </div>
+      <div class="feat">
+        <div class="n">02 · Layered</div>
+        <h4>Each stratum depends only on the one below.</h4>
+        <p>A layered architecture means any layer can be understood, tested, and replaced in isolation.</p>
+      </div>
+      <div class="feat">
+        <div class="n">03 · Distributed</div>
+        <h4>Single-writer, multi-reader, all the way down.</h4>
+        <p>Wait-free reads. Journal-backed writes. A three-node deployment is operationally indistinguishable from one.</p>
+      </div>
+    </section>
+
+    <article>
+      {{ content | safe }}
+
+      <h2>Read the documentation</h2>
+    </article>
+
+    <div class="doc-grid">
+      <a href="{{ base_url }}/docs/01-overview/">
+        <span class="num">01</span>
+        <div>
+          <h3>Overview</h3>
+          <p>How the system is shaped, and what it is not.</p>
+          <span class="date">2026.05.04</span>
+        </div>
+      </a>
+      <a href="{{ base_url }}/docs/02-primitives/">
+        <span class="num">02</span>
+        <div>
+          <h3>Primitives</h3>
+          <p>The values, types, and effects from which everything else is constructed.</p>
+          <span class="date">2026.05.06</span>
+        </div>
+      </a>
+      <a href="{{ base_url }}/docs/03-runtime/">
+        <span class="num">03</span>
+        <div>
+          <h3>Runtime</h3>
+          <p>The execution model in detail.</p>
+          <span class="date">2026.05.09</span>
+        </div>
+      </a>
+      <a href="{{ base_url }}/docs/04-deployment/">
+        <span class="num">04</span>
+        <div>
+          <h3>Deployment</h3>
+          <p>Provisioning, packaging, and the upgrade path.</p>
+          <span class="date">2026.05.12</span>
+        </div>
+      </a>
+    </div>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/stratum-docs/templates/page.html
+++ b/examples/stratum-docs/templates/page.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+<div class="layout">
+  <aside class="side">
+    <h6>Reference</h6>
+    <ol>
+      <li><a href="{{ base_url }}/docs/01-overview/"{% if page.url == "/docs/01-overview/" %} class="active"{% endif %}>Overview</a></li>
+      <li><a href="{{ base_url }}/docs/02-primitives/"{% if page.url == "/docs/02-primitives/" %} class="active"{% endif %}>Primitives</a></li>
+      <li><a href="{{ base_url }}/docs/03-runtime/"{% if page.url == "/docs/03-runtime/" %} class="active"{% endif %}>Runtime</a></li>
+      <li><a href="{{ base_url }}/docs/04-deployment/"{% if page.url == "/docs/04-deployment/" %} class="active"{% endif %}>Deployment</a></li>
+    </ol>
+    <div class="group">
+      <h6>Resources</h6>
+      <ul>
+        <li><a href="{{ base_url }}/docs/">All documents</a></li>
+        <li><a href="{{ base_url }}/tags/">Topic index</a></li>
+        <li><a href="{{ base_url }}/categories/">Categories</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="body">
+    <header class="hero">
+      <div>
+        <span class="num">{% if page.weight %}LAYER 0{{ page.weight }} ·{% endif %} {{ page.section | default(value="DOCS") | upper }}</span>
+        <h1>{{ page.title | e }}</h1>
+        {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+      </div>
+      {% if page.weight %}<div class="big-num">0{{ page.weight }}</div>{% endif %}
+    </header>
+
+    <div class="meta-grid">
+      <div class="cell"><span class="k">Published</span><span class="v">{% if page.date %}{{ page.date | date(format="%Y.%m.%d") }}{% else %}—{% endif %}</span></div>
+      <div class="cell"><span class="k">Reading time</span><span class="v">{% if page.reading_time %}{{ page.reading_time }} min{% else %}—{% endif %}</span></div>
+      <div class="cell"><span class="k">Words</span><span class="v">{% if page.word_count %}{{ page.word_count }}{% else %}—{% endif %}</span></div>
+      <div class="cell"><span class="k">Tags</span><span class="v">{% if page.tags %}{% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}{% else %}—{% endif %}</span></div>
+    </div>
+
+    <article>
+      {{ content | safe }}
+    </article>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/stratum-docs/templates/section.html
+++ b/examples/stratum-docs/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+<div class="layout full">
+  <main class="body" style="max-width:none;">
+    <header class="hero">
+      <div>
+        <span class="num">SECTION · /DOCS/</span>
+        <h1>{{ page.title | e }}<span class="accent">.</span></h1>
+        {% if content %}<p class="lede">{{ content | striptags | trim }}</p>{% endif %}
+      </div>
+      <div class="big-num">{{ section.pages | length }}</div>
+    </header>
+
+    <div class="doc-grid">
+      {% for p in section.pages %}
+      <a href="{{ p.url }}">
+        <span class="num">0{{ loop.index }}</span>
+        <div>
+          <h3>{{ p.title | e }}</h3>
+          {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+          <span class="date">{% if p.date %}{{ p.date | date(format="%Y.%m.%d") }}{% endif %}</span>
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/stratum-docs/templates/shortcodes/alert.html
+++ b/examples/stratum-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/stratum-docs/templates/taxonomy.html
+++ b/examples/stratum-docs/templates/taxonomy.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+<div class="layout full">
+  <main class="body" style="max-width:none;">
+    <header class="hero">
+      <div>
+        <span class="num">INDEX · /{{ taxonomy_name | upper }}/</span>
+        <h1>{{ taxonomy_name | default(value="Tags") | capitalize }}<span class="accent">.</span></h1>
+        <p class="lede">{{ taxonomy_terms | length }} terms collected across the documentation set.</p>
+      </div>
+      <div class="big-num">{{ taxonomy_terms | length }}</div>
+    </header>
+    <div class="doc-grid">
+      {% for term in taxonomy_terms %}
+      <a href="{{ term.url }}">
+        <span class="num">0{{ loop.index }}</span>
+        <div>
+          <h3>{{ term.name }}</h3>
+          <p>{{ term.pages_count }} document{% if term.pages_count != 1 %}s{% endif %} filed under this term.</p>
+          <span class="date">/{{ taxonomy_name }}/{{ term.slug }}/</span>
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/stratum-docs/templates/taxonomy_term.html
+++ b/examples/stratum-docs/templates/taxonomy_term.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+<div class="layout full">
+  <main class="body" style="max-width:none;">
+    <header class="hero">
+      <div>
+        <span class="num">/{{ taxonomy_name | upper }}/{{ page.title | upper }}/</span>
+        <h1>#{{ page.title }}<span class="accent">.</span></h1>
+        <p class="lede">{{ taxonomy_pages | length }} document{% if taxonomy_pages | length != 1 %}s{% endif %} tagged <strong>{{ page.title }}</strong>.</p>
+      </div>
+      <div class="big-num">{{ taxonomy_pages | length }}</div>
+    </header>
+    <div class="doc-grid">
+      {% for p in taxonomy_pages %}
+      <a href="{{ p.url }}">
+        <span class="num">0{{ loop.index }}</span>
+        <div>
+          <h3>{{ p.title | e }}</h3>
+          {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+          <span class="date">{% if p.date %}{{ p.date | date(format="%Y.%m.%d") }}{% endif %}</span>
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/vellum-press/AGENTS.md
+++ b/examples/vellum-press/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/vellum-press/archetypes/default.md
+++ b/examples/vellum-press/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/vellum-press/config.toml
+++ b/examples/vellum-press/config.toml
@@ -13,12 +13,6 @@ enabled = true
 theme = "github"
 use_cdn = true
 
-[search]
-enabled = true
-format = "fuse_json"
-fields = ["title", "content"]
-filename = "search.json"
-
 [pagination]
 enabled = false
 per_page = 10

--- a/examples/vellum-press/config.toml
+++ b/examples/vellum-press/config.toml
@@ -1,0 +1,192 @@
+title = "Vellum Press"
+description = "Engineering documentation as a printed manual. Cream paper, classical serif body, footnoted margins."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/vellum-press/content/docs/01-preface.md
+++ b/examples/vellum-press/content/docs/01-preface.md
@@ -1,0 +1,42 @@
++++
+title = "Preface"
+description = "On the form of the manual and the conventions that govern it."
+date = "2026-01-04"
+weight = 1
+tags = ["intro"]
++++
+
+## On the manual
+
+This manual concerns itself with the design and operation of a small,
+well-understood system. It is written for the engineer who will inherit
+the system once its current authors have moved on, and so it errs on the
+side of explaining why rather than what.[^1]
+
+The form is the printed manual, not the website. Pages are intended to be
+read top-to-bottom, in roughly the order they are numbered, with the reader
+returning to any chapter as often as is necessary. There are no animations,
+no interactive widgets, and no expanding panels — only paragraphs, tables,
+and the occasional figure.
+
+## Typographic conventions
+
+- Body text is set in a transitional serif at 18 pixels, with generous
+  leading. The line length is held to roughly sixty-five characters, the
+  width at which prose is most easily read.
+- Code, output, and command lines are set in a monospace face,
+  inline `like this` or as displayed blocks.
+- Defined terms, where they first appear, are *italicised*. Subsequent
+  appearances are not.
+- Footnotes are gathered at the foot of each page (or, on the web, of
+  each section), numbered consecutively.
+
+## A note to the casual reader
+
+You are welcome to skim. The chapter heads are descriptive and the table
+of contents is genuine — neither was written to entice you to read
+further than your interest carries you. If chapter three is what you
+need, please proceed directly to chapter three.
+
+[^1]: The author has, in twenty years of writing such manuals, never once
+regretted explaining why too much.

--- a/examples/vellum-press/content/docs/02-architecture.md
+++ b/examples/vellum-press/content/docs/02-architecture.md
@@ -1,0 +1,55 @@
++++
+title = "Architecture"
+description = "The shape of the system, and the reasoning behind that shape."
+date = "2026-01-09"
+weight = 2
+tags = ["spec"]
++++
+
+## The shape of the system
+
+The system is composed of three processes, each of which performs one
+duty and no other. The processes communicate by means of a shared
+journal on disk and a pair of named pipes; no process holds a network
+socket open to any other process within the same host.[^1]
+
+| Process     | Duty                                       |
+|-------------|--------------------------------------------|
+| `ingest`    | Accepts new entries from the outside.      |
+| `journal`   | Records accepted entries to durable media. |
+| `egress`    | Serves entries to clients on request.      |
+
+The separation is intentional. A failure in the ingress path — for
+instance, a malformed entry, or a sudden surge of traffic — cannot
+prevent the egress path from serving entries that have already been
+journalled.
+
+## Why three, and not one
+
+A single process would be simpler to operate but harder to reason
+about. The three-process arrangement makes the dependencies explicit
+in the process table: at any moment, an operator running `ps` can see
+which duties are healthy and which are not.
+
+```
+USER       PID   STAT  COMMAND
+press      4101  Ss    /usr/local/bin/press-ingest
+press      4102  Ss    /usr/local/bin/press-journal
+press      4103  Ss    /usr/local/bin/press-egress
+```
+
+The cost of the additional fork-and-pipe is small: in the worst case
+observed, less than two hundred microseconds of latency on the ingress
+path.
+
+## What is *not* in the diagram
+
+The diagram above omits two things on purpose. There is no cache and
+there is no message queue. Both were considered during the design and
+both were rejected: the cache because the underlying journal is fast
+enough, the queue because pipes already suffice. The author has
+observed too many systems where a cache or a queue was added once and
+never removed.
+
+[^1]: A single host. Cross-host communication is described in chapter
+four, which addresses the protocol on the wire.

--- a/examples/vellum-press/content/docs/03-operations.md
+++ b/examples/vellum-press/content/docs/03-operations.md
@@ -1,0 +1,49 @@
++++
+title = "Operations"
+description = "Provisioning, monitoring, and the discipline of running the system in production."
+date = "2026-01-15"
+weight = 3
+tags = ["ops"]
++++
+
+## Provisioning
+
+A reference deployment of the Press is a single host, provisioned with
+four cores, sixteen gibibytes of memory, and a hundred gibibytes of
+NVMe-class storage allocated to the journal. The cores need not be
+fast; the storage must be local and must be NVMe-class. Both
+constraints are bounded by the journal's behaviour on the synchronous
+write path.
+
+## Monitoring
+
+Three metrics are sufficient for ordinary alerting. They are listed
+here in declining order of importance.
+
+1. **`press.journal.fsync_p99`.** Sustained excursion above twenty-five
+   milliseconds is the leading indicator of disk degradation.
+2. **`press.ingest.queue_depth`.** A healthy depth is bounded; an
+   unbounded depth means the journal cannot keep pace with ingress.
+3. **`press.egress.errors_total`.** The derivative should be zero. Any
+   non-zero value warrants reading the structured log.
+
+A fourth metric, `press.host.load_avg`, is sometimes useful but is
+prone to noise; it should not be used for alerting without a window
+of at least five minutes.
+
+## The discipline of operating
+
+The Press is a system that punishes carelessness. Two practices, taken
+together, have eliminated most of the incidents seen in production
+over the last three years.
+
+- **Always read the journal tail before restarting the service.** A
+  restart that loses the last write is a worse outcome than a five-minute
+  outage.
+- **Never disable the fsync policy.** It is tempting to do so during
+  bulk-loads; the temptation should be resisted. The bulk-load path is
+  the path where a crash hurts most.
+
+> **Note** — Operators new to the Press are encouraged to read chapter
+> two before touching production. The architecture chapter is short and
+> the architecture is, in part, the operational interface.

--- a/examples/vellum-press/content/docs/04-appendix.md
+++ b/examples/vellum-press/content/docs/04-appendix.md
@@ -1,0 +1,43 @@
++++
+title = "Appendix"
+description = "Errata, the bibliography, and a colophon."
+date = "2026-01-22"
+weight = 4
+tags = ["reference"]
++++
+
+## Errata
+
+The first printing of this manual contained two errors of substance.
+Both have been corrected in subsequent printings, but are recorded
+here for the benefit of readers consulting older copies.
+
+1. In chapter two, the diagram of the three processes initially showed
+   the journal communicating with egress by means of a socket. This
+   has been corrected to a named pipe, in line with the prose.
+2. In chapter three, the monitoring section listed the metric
+   `press.egress.error_total` in the singular. The metric is, and has
+   always been, `errors_total` — plural.
+
+## Bibliography
+
+The following works informed the design of the Press, and are
+recommended further reading.
+
+- Lampson, B. (1983). *Hints for Computer System Design.* Operating
+  Systems Review, 17(5).
+- Liskov, B. (1988). *Distributed Programming in Argus.*
+  Communications of the ACM, 31(3).
+- Stevens, W. R. (1992). *Advanced Programming in the UNIX Environment.*
+  Addison-Wesley.
+
+## Colophon
+
+This manual is set in *Spectral* for the body, *Inter* for the heading
+hierarchy, and *JetBrains Mono* for the displayed code. The page colour
+is a warm cream. The accent ink is a brick red, chosen for legibility
+on the chosen ground and used only for the chapter rule and the heading
+ornaments.
+
+The manual was written in plain text, rendered with Hwaro, and intended
+to be readable both on screen and in print without modification.

--- a/examples/vellum-press/content/docs/_index.md
+++ b/examples/vellum-press/content/docs/_index.md
@@ -1,0 +1,9 @@
++++
+title = "The Manual"
+description = "Chapters of the Vellum Press engineering manual."
+sort_by = "weight"
+template = "section"
++++
+
+The chapters are intended to be read in the order printed, though each is
+self-contained should a reader wish to consult only one.

--- a/examples/vellum-press/content/index.md
+++ b/examples/vellum-press/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Vellum Press"
+description = "Engineering documentation as a printed manual."
+template = "home"
++++
+
+Vellum Press is documentation, presented as a printed manual would be. The
+page is cream rather than glaring white. The body is a serif of long
+descenders. The margins carry footnotes; the spine carries the chapter
+number; the cover carries nothing it does not need to.

--- a/examples/vellum-press/static/css/style.css
+++ b/examples/vellum-press/static/css/style.css
@@ -1,0 +1,466 @@
+:root {
+  --paper: #f4eddc;
+  --paper-2: #ece4cf;
+  --paper-3: #e0d6bb;
+  --ink: #1c1714;
+  --ink-2: #3a3127;
+  --ink-3: #6d5d4b;
+  --ink-4: #968671;
+  --rule: #c8b994;
+  --rule-faint: #ddd0aa;
+  --accent: #a52a1a;
+  --serif: "Spectral", "Source Serif Pro", Georgia, serif;
+  --sans: "Inter", -apple-system, system-ui, sans-serif;
+  --mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 17px; -webkit-font-smoothing: antialiased; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--serif);
+  line-height: 1.72;
+  font-feature-settings: "kern", "liga", "calt", "onum";
+}
+
+::selection { background: var(--accent); color: var(--paper); }
+a { color: var(--ink); text-decoration: underline; text-decoration-color: var(--ink-4); text-underline-offset: 3px; text-decoration-thickness: 1px; }
+a:hover { color: var(--accent); text-decoration-color: var(--accent); }
+
+.book {
+  max-width: 78rem;
+  margin: 0 auto;
+  padding: 0 3rem;
+}
+
+.spine {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 2rem;
+  padding: 1.6rem 0 1.2rem;
+  border-bottom: 1px solid var(--ink);
+  position: relative;
+}
+.spine::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -4px;
+  height: 1px;
+  background: var(--ink);
+}
+.spine .pressmark {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.6rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+.spine .pressmark .amp { color: var(--accent); font-style: italic; font-weight: 400; }
+.spine .center {
+  text-align: center;
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: var(--ink-3);
+}
+.spine nav {
+  display: flex;
+  gap: 1.6rem;
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+.spine nav a { text-decoration: none; color: var(--ink-2); }
+.spine nav a:hover { color: var(--accent); }
+
+.layout {
+  display: grid;
+  grid-template-columns: 17rem 1fr;
+  gap: 4rem;
+  padding: 3rem 0 5rem;
+}
+.layout.full { grid-template-columns: 1fr; }
+
+aside.contents {
+  position: sticky;
+  top: 2rem;
+  align-self: start;
+  font-family: var(--sans);
+  font-size: 0.86rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  padding-right: 1rem;
+}
+.contents h5 {
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+  margin: 1.6rem 0 0.8rem;
+  font-weight: 600;
+}
+.contents .group { border-top: 1px solid var(--rule); padding-top: 0.5rem; }
+.contents ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.contents ol li a {
+  display: grid;
+  grid-template-columns: 2.4rem 1fr;
+  gap: 0.6rem;
+  align-items: baseline;
+  padding: 0.55rem 0;
+  text-decoration: none;
+  color: var(--ink-2);
+  border-bottom: 1px dotted var(--rule-faint);
+}
+.contents ol li:last-child a { border-bottom: none; }
+.contents ol li a .roman {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-4);
+}
+.contents ol li a .ttl { font-family: var(--serif); font-size: 0.95rem; line-height: 1.3; color: var(--ink); font-weight: 500; }
+.contents ol li a:hover .ttl { color: var(--accent); }
+.contents ol li a.active .ttl { color: var(--accent); }
+.contents ol li a.active .roman { color: var(--accent); }
+.contents ul { list-style: none; padding: 0; margin: 0; }
+.contents ul li { padding: 0.35rem 0; }
+.contents ul li a { color: var(--ink-2); text-decoration: none; }
+.contents ul li a:hover { color: var(--accent); }
+
+main.leaf {
+  max-width: 38rem;
+  margin: 0 auto;
+}
+
+.chapterhead {
+  text-align: center;
+  margin: 0 0 3rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--ink);
+  position: relative;
+}
+.chapterhead::after {
+  content: "";
+  position: absolute;
+  left: 50%; bottom: -7px;
+  width: 12px; height: 12px;
+  background: var(--paper);
+  border: 1px solid var(--ink);
+  transform: translateX(-50%) rotate(45deg);
+}
+.chapterhead .ix {
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.34em;
+  color: var(--accent);
+  margin-bottom: 1.2rem;
+}
+.chapterhead h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.2rem, 4.5vw, 3.6rem);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+}
+.chapterhead h1 em { font-style: italic; color: var(--accent); }
+.chapterhead .lede {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.12rem;
+  color: var(--ink-2);
+  max-width: 32rem;
+  margin: 0 auto 1.4rem;
+}
+.chapterhead .meta {
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+.chapterhead .meta strong { color: var(--ink); font-weight: 600; }
+
+article {
+  font-family: var(--serif);
+  font-size: 1.08rem;
+  color: var(--ink);
+}
+article > p:first-of-type::first-letter {
+  font-family: var(--serif);
+  font-size: 4em;
+  line-height: 0.85;
+  float: left;
+  padding: 0.3rem 0.55rem 0 0;
+  color: var(--accent);
+  font-weight: 400;
+}
+article h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.7rem;
+  margin: 3rem 0 0.8rem;
+  letter-spacing: -0.01em;
+  text-align: center;
+  position: relative;
+  padding-top: 2.5rem;
+}
+article h2::before {
+  content: "";
+  display: block;
+  width: 3.5rem; height: 1px;
+  background: var(--accent);
+  margin: 0 auto 2rem;
+}
+article h3 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1.2rem;
+  margin: 2.2rem 0 0.7rem;
+  color: var(--ink);
+}
+article p { line-height: 1.78; margin: 1.2rem 0; }
+article ul, article ol { padding-left: 1.6rem; line-height: 1.78; }
+article ul li, article ol li { margin: 0.4rem 0; }
+article strong { color: var(--ink); font-weight: 600; }
+article em { color: var(--accent); }
+
+article pre, pre[class*="language-"] {
+  background: var(--paper-2) !important;
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--accent);
+  padding: 1rem 1.2rem;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  color: var(--ink) !important;
+}
+article code {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--paper-2);
+  padding: 0.05rem 0.4rem;
+  border: 1px solid var(--rule-faint);
+  color: var(--accent);
+}
+article pre code { background: transparent; border: none; padding: 0; color: inherit; }
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--serif);
+  font-size: 0.98rem;
+  margin: 1.8rem 0;
+}
+article th {
+  text-align: left;
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1.5px solid var(--ink);
+  border-top: 1.5px solid var(--ink);
+  font-weight: 600;
+}
+article td {
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--rule-faint);
+  color: var(--ink-2);
+  vertical-align: top;
+}
+article tr:last-child td { border-bottom: 1.5px solid var(--ink); }
+
+article blockquote {
+  border-left: 2px solid var(--accent);
+  margin: 1.5rem 0;
+  padding: 0.4rem 1.2rem;
+  font-style: italic;
+  color: var(--ink-2);
+  font-family: var(--serif);
+}
+
+.footnotes {
+  margin-top: 4rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 1rem;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  font-family: var(--serif);
+}
+.footnotes ol { padding-left: 1.3rem; }
+.footnotes a { color: var(--accent); }
+
+.tag-chip {
+  display: inline-block;
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.5rem;
+  margin: 0 0.3rem 0 0;
+  color: var(--ink-2);
+  border: 1px solid var(--rule);
+  text-decoration: none;
+  background: var(--paper);
+}
+.tag-chip:hover { color: var(--accent); border-color: var(--accent); }
+
+.chapter-list { list-style: none; padding: 0; margin: 2.5rem auto; max-width: 44rem; }
+.chapter-list li {
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  gap: 1.5rem;
+  align-items: baseline;
+  padding: 1.4rem 0;
+  border-bottom: 1px dotted var(--rule);
+}
+.chapter-list li:first-child { border-top: 1px solid var(--ink); }
+.chapter-list li:last-child { border-bottom: 1px solid var(--ink); }
+.chapter-list li .roman {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.4rem;
+  color: var(--accent);
+  text-align: center;
+}
+.chapter-list li h3 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.35rem;
+  letter-spacing: -0.005em;
+  margin: 0 0 0.3rem;
+}
+.chapter-list li h3 a { text-decoration: none; }
+.chapter-list li p {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-2);
+  font-size: 0.98rem;
+  margin: 0;
+  line-height: 1.55;
+}
+.chapter-list li .pageno {
+  font-family: var(--serif);
+  font-size: 0.88rem;
+  color: var(--ink-3);
+  letter-spacing: 0.04em;
+}
+
+.dot-leader {
+  display: inline-block;
+  flex: 1;
+  border-bottom: 1px dotted var(--ink-4);
+  position: relative;
+  top: -0.35rem;
+  margin: 0 0.5rem;
+  min-width: 1rem;
+}
+
+.btn {
+  display: inline-block;
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  padding: 0.7rem 1.3rem;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+  text-decoration: none;
+  background: transparent;
+}
+.btn:hover { background: var(--ink); color: var(--paper); }
+.btn.solid { background: var(--accent); border-color: var(--accent); color: var(--paper); }
+.btn.solid:hover { background: var(--ink); border-color: var(--ink); }
+
+footer.imprint {
+  border-top: 1px solid var(--ink);
+  padding: 1.6rem 0 2.4rem;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 2rem;
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ink-3);
+  align-items: center;
+}
+footer.imprint .center { text-align: center; font-style: normal; }
+footer.imprint .center .pagemark {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: var(--ink-2);
+}
+footer.imprint .right { text-align: right; }
+
+.notfound {
+  text-align: center;
+  padding: 6rem 0;
+  max-width: 32rem;
+  margin: 0 auto;
+}
+.notfound .ix {
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.34em;
+  color: var(--accent);
+  margin-bottom: 1.2rem;
+}
+.notfound h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 5rem;
+  margin: 0;
+  color: var(--ink);
+  letter-spacing: -0.02em;
+}
+.notfound h1 em { font-style: italic; color: var(--accent); }
+.notfound p {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-2);
+  font-size: 1.1rem;
+  margin: 1rem 0 2rem;
+}
+
+@media (max-width: 980px) {
+  .book { padding: 0 1.5rem; }
+  .spine { grid-template-columns: 1fr; gap: 0.5rem; text-align: left; }
+  .spine nav { flex-wrap: wrap; gap: 1rem; }
+  .spine .center { text-align: left; }
+  .layout { grid-template-columns: 1fr; gap: 2rem; }
+  aside.contents { position: static; max-height: none; border-bottom: 1px solid var(--rule); padding-bottom: 1rem; }
+  main.leaf { max-width: 100%; }
+  footer.imprint { grid-template-columns: 1fr; }
+  footer.imprint .center, footer.imprint .right { text-align: left; }
+  .chapter-list li { grid-template-columns: 3rem 1fr; }
+  .chapter-list li .pageno { grid-column: 2; }
+}

--- a/examples/vellum-press/static/favicon.svg
+++ b/examples/vellum-press/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/vellum-press/templates/404.html
+++ b/examples/vellum-press/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<div class="notfound">
+  <div class="ix">Errata · Not Bound</div>
+  <h1>Page <em>missing</em>.</h1>
+  <p>The chapter you requested is not part of the present edition.</p>
+  <p>
+    <a class="btn solid" href="{{ base_url }}/">Return to the spine</a>
+    <a class="btn" href="{{ base_url }}/docs/" style="margin-left:0.6rem;">Open the manual</a>
+  </p>
+</div>
+{% include "footer.html" %}

--- a/examples/vellum-press/templates/footer.html
+++ b/examples/vellum-press/templates/footer.html
@@ -1,0 +1,10 @@
+  <footer class="imprint">
+    <span>Vellum &amp; Press · Edition I</span>
+    <div class="center">
+      <span class="pagemark">— Set in Spectral &amp; Inter —</span>
+    </div>
+    <span class="right">Built with Hwaro · © {{ current_year }}</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/vellum-press/templates/header.html
+++ b/examples/vellum-press/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;1,400;1,500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="book">
+  <header class="spine">
+    <a class="pressmark" href="{{ base_url }}/">Vellum <span class="amp">&amp;</span> Press</a>
+    <div class="center">Manual № 14 · Edition I · Anno {{ current_year }}</div>
+    <nav>
+      <a href="{{ base_url }}/docs/">Contents</a>
+      <a href="{{ base_url }}/tags/">Index</a>
+      <a href="{{ base_url }}/categories/">Categories</a>
+    </nav>
+  </header>

--- a/examples/vellum-press/templates/home.html
+++ b/examples/vellum-press/templates/home.html
@@ -1,0 +1,67 @@
+{% include "header.html" %}
+<div class="layout full">
+  <main class="leaf" style="max-width:42rem;">
+    <header class="chapterhead">
+      <div class="ix">Manual № 14 · First Edition</div>
+      <h1>The <em>Engineering</em><br/>Manual.</h1>
+      <p class="lede">{{ site.description }}</p>
+      <div class="meta">
+        <span><strong>4</strong> chapters</span>
+        <span><strong>·</strong></span>
+        <span>printed <strong>Anno {{ current_year }}</strong></span>
+      </div>
+    </header>
+
+    <article style="max-width:36rem;margin:0 auto;">
+      {{ content | safe }}
+    </article>
+
+    <h2 style="text-align:center;font-family:var(--serif);font-weight:400;font-size:1.8rem;margin:4rem 0 0.5rem;padding-top:3rem;border-top:1px solid var(--rule);">
+      <em>Table of Contents</em>
+    </h2>
+    <p style="text-align:center;font-family:var(--sans);font-size:0.72rem;text-transform:uppercase;letter-spacing:0.32em;color:var(--ink-3);margin:0 0 0;">
+      Four chapters
+    </p>
+
+    <ul class="chapter-list">
+      <li>
+        <span class="roman">I.</span>
+        <div>
+          <h3><a href="{{ base_url }}/docs/01-preface/">Preface</a></h3>
+          <p>On the form of the manual and the conventions that govern it.</p>
+        </div>
+        <span class="pageno">p. 11</span>
+      </li>
+      <li>
+        <span class="roman">II.</span>
+        <div>
+          <h3><a href="{{ base_url }}/docs/02-architecture/">Architecture</a></h3>
+          <p>The shape of the system, and the reasoning behind that shape.</p>
+        </div>
+        <span class="pageno">p. 25</span>
+      </li>
+      <li>
+        <span class="roman">III.</span>
+        <div>
+          <h3><a href="{{ base_url }}/docs/03-operations/">Operations</a></h3>
+          <p>Provisioning, monitoring, and the discipline of production.</p>
+        </div>
+        <span class="pageno">p. 39</span>
+      </li>
+      <li>
+        <span class="roman">IV.</span>
+        <div>
+          <h3><a href="{{ base_url }}/docs/04-appendix/">Appendix</a></h3>
+          <p>Errata, the bibliography, and a colophon.</p>
+        </div>
+        <span class="pageno">p. 53</span>
+      </li>
+    </ul>
+
+    <p style="text-align:center;margin-top:3rem;">
+      <a class="btn solid" href="{{ base_url }}/docs/01-preface/">Begin at Chapter I</a>
+      <a class="btn" href="{{ base_url }}/docs/" style="margin-left:0.6rem;">All chapters</a>
+    </p>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/vellum-press/templates/page.html
+++ b/examples/vellum-press/templates/page.html
@@ -1,0 +1,41 @@
+{% include "header.html" %}
+<div class="layout">
+  <aside class="contents">
+    <h5>Table of Contents</h5>
+    <ol>
+      <li><a href="{{ base_url }}/docs/01-preface/"{% if page.url == "/docs/01-preface/" %} class="active"{% endif %}><span class="roman">I.</span><span class="ttl">Preface</span></a></li>
+      <li><a href="{{ base_url }}/docs/02-architecture/"{% if page.url == "/docs/02-architecture/" %} class="active"{% endif %}><span class="roman">II.</span><span class="ttl">Architecture</span></a></li>
+      <li><a href="{{ base_url }}/docs/03-operations/"{% if page.url == "/docs/03-operations/" %} class="active"{% endif %}><span class="roman">III.</span><span class="ttl">Operations</span></a></li>
+      <li><a href="{{ base_url }}/docs/04-appendix/"{% if page.url == "/docs/04-appendix/" %} class="active"{% endif %}><span class="roman">IV.</span><span class="ttl">Appendix</span></a></li>
+    </ol>
+    <div class="group">
+      <h5>Apparatus</h5>
+      <ul>
+        <li><a href="{{ base_url }}/docs/">All chapters</a></li>
+        <li><a href="{{ base_url }}/tags/">Index of terms</a></li>
+        <li><a href="{{ base_url }}/categories/">Categories</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="leaf">
+    <header class="chapterhead">
+      <div class="ix">{% if page.weight %}CHAPTER {% if page.weight == 1 %}I{% elif page.weight == 2 %}II{% elif page.weight == 3 %}III{% elif page.weight == 4 %}IV{% elif page.weight == 5 %}V{% else %}{{ page.weight }}{% endif %} ·{% endif %} {{ page.section | default(value="Manual") | upper }}</div>
+      <h1>{{ page.title | e }}</h1>
+      {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+      <div class="meta">
+        {% if page.date %}<span>Dated · <strong>{{ page.date | date(format="%e %B, %Y") }}</strong></span>{% endif %}
+        {% if page.reading_time %}<span>Reading · <strong>{{ page.reading_time }} min</strong></span>{% endif %}
+        {% if page.word_count %}<span>Length · <strong>{{ page.word_count }} words</strong></span>{% endif %}
+      </div>
+    </header>
+    <article>
+      {{ content | safe }}
+      {% if page.tags %}
+      <p style="margin-top:3rem;padding-top:1.2rem;border-top:1px solid var(--rule);font-family:var(--sans);font-size:0.78rem;text-transform:uppercase;letter-spacing:0.18em;color:var(--ink-3);">
+        Filed under: {% for t in page.tags %}<a class="tag-chip" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}
+      </p>
+      {% endif %}
+    </article>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/vellum-press/templates/section.html
+++ b/examples/vellum-press/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+<div class="layout full">
+  <main class="leaf" style="max-width:48rem;">
+    <header class="chapterhead">
+      <div class="ix">Table of Contents</div>
+      <h1>The <em>Manual</em></h1>
+      {% if content %}<p class="lede">{{ content | striptags | trim }}</p>{% endif %}
+    </header>
+
+    <ul class="chapter-list">
+      {% for p in section.pages %}
+      <li>
+        <span class="roman">{% if loop.index == 1 %}I.{% elif loop.index == 2 %}II.{% elif loop.index == 3 %}III.{% elif loop.index == 4 %}IV.{% elif loop.index == 5 %}V.{% else %}{{ loop.index }}.{% endif %}</span>
+        <div>
+          <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+          {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+        </div>
+        <span class="pageno">p. {{ loop.index * 14 - 3 }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/vellum-press/templates/shortcodes/alert.html
+++ b/examples/vellum-press/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/vellum-press/templates/taxonomy.html
+++ b/examples/vellum-press/templates/taxonomy.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<div class="layout full">
+  <main class="leaf" style="max-width:48rem;">
+    <header class="chapterhead">
+      <div class="ix">Index of {{ taxonomy_name | default(value="Terms") | capitalize }}</div>
+      <h1><em>Index</em></h1>
+      <p class="lede">{{ taxonomy_terms | length }} term{% if taxonomy_terms | length != 1 %}s{% endif %} gathered across the manual.</p>
+    </header>
+    <ul class="chapter-list">
+      {% for term in taxonomy_terms %}
+      <li>
+        <span class="roman">§</span>
+        <div>
+          <h3><a href="{{ term.url }}">{{ term.name }}</a></h3>
+          <p>{{ term.pages_count }} reference{% if term.pages_count != 1 %}s{% endif %} in the corpus</p>
+        </div>
+        <span class="pageno">/{{ taxonomy_name }}/{{ term.slug }}/</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/examples/vellum-press/templates/taxonomy_term.html
+++ b/examples/vellum-press/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<div class="layout full">
+  <main class="leaf" style="max-width:48rem;">
+    <header class="chapterhead">
+      <div class="ix">{{ taxonomy_name | upper }} · {{ page.title | upper }}</div>
+      <h1>Under <em>{{ page.title }}</em></h1>
+      <p class="lede">{{ taxonomy_pages | length }} reference{% if taxonomy_pages | length != 1 %}s{% endif %} filed under this term.</p>
+    </header>
+    <ul class="chapter-list">
+      {% for p in taxonomy_pages %}
+      <li>
+        <span class="roman">§</span>
+        <div>
+          <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+          {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+        </div>
+        <span class="pageno">{% if p.date %}{{ p.date | date(format="%e %b %Y") }}{% endif %}</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -8709,5 +8709,36 @@
     "dark",
     "portfolio",
     "landing"
+  ],
+  "codex-mono": [
+    "light",
+    "docs",
+    "minimal",
+    "sidebar"
+  ],
+  "rune-archive": [
+    "dark",
+    "docs",
+    "editorial",
+    "sidebar"
+  ],
+  "stratum-docs": [
+    "light",
+    "docs",
+    "minimal",
+    "swiss",
+    "sidebar"
+  ],
+  "prism-shift": [
+    "dark",
+    "docs",
+    "cyberpunk",
+    "sidebar"
+  ],
+  "vellum-press": [
+    "light",
+    "docs",
+    "editorial",
+    "traditional"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds five new docs-tagged example sites, each with a distinct modern aesthetic and bespoke templates/CSS.
- Each site ships a homepage, a section index, four chapter pages, custom 404, and taxonomy templates.
- `tags.json` updated with entries for all five.

| Site | Theme | Tags |
|---|---|---|
| `codex-mono` | Monospace-grid technical reference | light, docs, minimal, sidebar |
| `rune-archive` | Editorial serif manuscript archive | dark, docs, editorial, sidebar |
| `stratum-docs` | Swiss minimal hairline grid | light, docs, minimal, swiss, sidebar |
| `prism-shift` | Cyber-minimal with cyan accent | dark, docs, cyberpunk, sidebar |
| `vellum-press` | Classical book / printed manual | light, docs, editorial, traditional |

No gradients or emojis used anywhere in the new sources.

## Test plan
- [x] `hwaro build` succeeds for each of the five sites (6 pages each).
- [x] `hwaro doctor --fix` clean for each site.
- [x] Manual audit confirms no `linear/radial/conic-gradient` and no emoji glyphs in any new file.
- [ ] CI deploy preview renders all five at `examples.hwaro.hahwul.com/<name>/`.