### PR TITLE
Fix broken post links in radiolaria template

### DIFF
--- a/examples/radiolaria/templates/section.html
+++ b/examples/radiolaria/templates/section.html
@@ -13,7 +13,7 @@
     <ul class="post-list">
         {% for post in section.pages %}
         <li class="post-item">
-            <h2 class="post-title"><a href="{{ post.permalink }}">{{ post.title }}</a></h2>
+            <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
             {% if post.date %}
                 <div class="post-meta">{{ post.date | date(format="%Y.%m.%d") }}</div>
             {% endif %}
@@ -23,7 +23,7 @@
                 <p style="font-size: 0.9rem;">{{ post.description }}</p>
             {% endif %}
             <div style="margin-top: 1rem;">
-                <a href="{{ post.permalink }}" style="font-size: 0.8rem; letter-spacing: 0.1em; text-transform: uppercase; border: 1px solid var(--accent); padding: 0.3rem 0.6rem;">Examine</a>
+                <a href="{{ base_url }}{{ post.url }}" style="font-size: 0.8rem; letter-spacing: 0.1em; text-transform: uppercase; border: 1px solid var(--accent); padding: 0.3rem 0.6rem;">Examine</a>
             </div>
         </li>
         {% endfor %}


### PR DESCRIPTION
This PR fixes broken post links in the `radiolaria` example site's index page (`/posts/`).

Previously, the `templates/section.html` template was using `{{ post.permalink }}` to generate links. In Hwaro, `permalink` is not a valid attribute and evaluates to empty, resulting in `href=""`. The template has been updated to use `{{ base_url }}{{ post.url }}`, which correctly generates absolute paths (e.g., `<a href="http://localhost:3000/posts/spicule-architecture/">`).

---
*PR created automatically by Jules for task [10047143139829160323](https://jules.google.com/task/10047143139829160323) started by @hahwul*