### PR TITLE
Add five modern docs example sites

### DIFF
--- a/examples/circuit-ledger/AGENTS.md
+++ b/examples/circuit-ledger/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+The site is the reference specification for **Circuit Ledger**, a fictional embedded
+ledger runtime. The visual theme is dark, monospace-dominant, with neon-green
+accents and ASCII-art schematic decoration. No gradients. No emojis. Single-color
+borders only.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   └── docs/            # Spec chapters
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Visual Constraints (Hard Rules)
+
+- **No gradients**, anywhere — solid colors only.
+- **No emojis**, anywhere — ASCII art (`+`, `-`, `|`, box-drawing characters,
+  bullet `▌`) is fine and encouraged.
+- Background is near-black `#0d0d10`. Accent is neon green `#3aff8a`, used
+  sparingly for navigational signal, links, and key data.
+- JetBrains Mono is the dominant face. Inter is only used for display
+  headings (`h1` on hero and chapter cards).
+- Chapter and section cards are framed with `+` corner glyphs positioned with
+  CSS pseudo-elements; do not replace these with rounded boxes or shadows.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+- When adding a new chapter, give it a `weight` one higher than the current
+  last chapter and update the `templates/header.html` sidebar tree by hand.
+- Opcode tables in chapter 02 are the source of truth; update them before
+  changing any prose that references opcode counts or gas numbers.

--- a/examples/circuit-ledger/archetypes/default.md
+++ b/examples/circuit-ledger/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/circuit-ledger/config.toml
+++ b/examples/circuit-ledger/config.toml
@@ -1,0 +1,45 @@
+title = "Circuit Ledger"
+description = "Reference for the Circuit Ledger embedded runtime. Monospace, neon-green accents, schematic frames."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/circuit-ledger/content/docs/01-overview.md
+++ b/examples/circuit-ledger/content/docs/01-overview.md
@@ -1,0 +1,92 @@
++++
+title = "Overview"
+description = "What the runtime is, what it isn't, and the contract it makes with hosts."
+date = "2026-05-01"
+weight = 1
+tags = ["spec", "vm"]
++++
+
+## What it is
+
+Circuit Ledger is two artifacts shipped together:
+
+1. A deterministic stack-based virtual machine (the **VM**), with 128 opcodes
+   defined and 128 reserved for future revisions.
+2. An append-only, merkle-sealed record format (the **journal**), into which
+   every state mutation produced by the VM is written.
+
+The two are tied together by one rule, repeated frequently in this document:
+
+> Given identical inputs, every host running the same runtime version must
+> produce a byte-identical journal. There are no exceptions to this rule.
+
+## What it isn't
+
+Circuit Ledger is **not** a blockchain, **not** a database, **not** a consensus
+layer, and **not** an orchestration runtime. It does not gossip, it does not
+elect leaders, and it has no opinion on how transactions reach it. If you need
+those, wrap the runtime in something that provides them.
+
+## The host contract
+
+A host application gives the runtime three things:
+
+| Resource          | Provided by host          | Mutable by VM |
+| ----------------- | ------------------------- | ------------- |
+| Bytecode buffer   | `cl_bytes`                | no            |
+| Input record      | `cl_bytes`                | no            |
+| Scratch memory    | `cl_arena` (≤ 4 MiB)      | yes           |
+| Account store     | `cl_store` (callback set) | yes (via VM)  |
+
+The VM never allocates from the global heap, never reads a clock, never opens
+a file descriptor. Everything it needs must arrive through the host contract.
+
+## Execution shape
+
+A program runs to completion or it traps. There is no preemption, no thread
+of execution beyond the single VM frame, no async. Termination is one of:
+
+```text
++---------------------+-----------------------------------------+
+| outcome             | meaning                                 |
++---------------------+-----------------------------------------+
+| HALT (ok)           | program reached an explicit HALT opcode |
+| HALT (revert)       | program reverted; journal is rolled     |
+|                     | back, gas already burned is kept        |
+| TRAP (oog)          | gas counter reached zero                |
+| TRAP (badop)        | undefined or reserved opcode            |
+| TRAP (stack)        | underflow or overflow on the stack      |
++---------------------+-----------------------------------------+
+```
+
+## Gas model
+
+Every opcode declares a static gas cost. There are no dynamic costs that depend
+on values popped at runtime — only on bytecode shape. This makes the worst-case
+cost of any program calculable at load time.
+
+```rust
+// Reference cost lookup, taken from `src/vm/cost.rs`.
+pub const fn gas(op: Op) -> u64 {
+    match op {
+        Op::Nop      => 1,
+        Op::Push(_)  => 2,
+        Op::Add      => 3,
+        Op::Hash     => 32,
+        Op::Journal  => 64,
+        // ...
+        _            => panic!("undefined opcode"),
+    }
+}
+```
+
+The number 64 for `Journal` is not arbitrary: every journal write costs more
+than every non-journal opcode combined in a 64-instruction window. This biases
+programs toward computing first and writing last.
+
+## Determinism, restated
+
+The runtime forbids: floating point arithmetic, syscalls, threads,
+non-deterministic iteration order, system clocks, and any host callback that
+is not part of the documented store interface. Hosts that violate this lose
+the determinism guarantee and the journal becomes unverifiable.

--- a/examples/circuit-ledger/content/docs/02-vm-instructions.md
+++ b/examples/circuit-ledger/content/docs/02-vm-instructions.md
@@ -1,0 +1,109 @@
++++
+title = "VM Instructions"
+description = "The full opcode table, gas costs, stack effects, and trap conditions."
+date = "2026-05-04"
+weight = 2
+tags = ["spec", "vm", "opcodes"]
++++
+
+## Instruction format
+
+Every instruction is a single byte opcode optionally followed by an immediate.
+The longest instruction in the set is `PUSH32`, which carries a 32-byte immediate
+for a total of 33 bytes on the wire.
+
+```text
++--------+-------------------------+
+| opcode | immediate (0..32 bytes) |
++--------+-------------------------+
+   1 byte
+```
+
+## Stack notation
+
+The tables below use the convention `a b c -- x y` where the items to the left
+of `--` are popped (rightmost is on top) and items to the right are pushed
+(rightmost ends up on top after execution).
+
+## Arithmetic and logic
+
+| Op   | Hex  | Gas | Stack            | Notes                              |
+| ---- | ---- | --- | ---------------- | ---------------------------------- |
+| NOP  | 0x00 | 1   | --               | no effect                          |
+| ADD  | 0x10 | 3   | `a b -- a+b`     | wrapping `u256`                    |
+| SUB  | 0x11 | 3   | `a b -- a-b`     | wrapping `u256`                    |
+| MUL  | 0x12 | 5   | `a b -- a*b`     | wrapping `u256`                    |
+| DIV  | 0x13 | 5   | `a b -- a/b`     | `b == 0` pushes `0`, does not trap |
+| MOD  | 0x14 | 5   | `a b -- a%b`     | `b == 0` pushes `0`, does not trap |
+| AND  | 0x20 | 3   | `a b -- a&b`     | bitwise                            |
+| OR   | 0x21 | 3   | `a b -- a\|b`    | bitwise                            |
+| XOR  | 0x22 | 3   | `a b -- a^b`     | bitwise                            |
+| NOT  | 0x23 | 3   | `a -- ~a`        | bitwise                            |
+
+## Stack and memory
+
+| Op     | Hex  | Gas | Stack             | Notes                          |
+| ------ | ---- | --- | ----------------- | ------------------------------ |
+| PUSH1  | 0x30 | 2   | `-- imm`          | 1-byte immediate, zero-extended |
+| PUSH32 | 0x3F | 2   | `-- imm`          | 32-byte immediate              |
+| POP    | 0x40 | 2   | `a --`            | discard top                    |
+| DUP    | 0x41 | 2   | `a -- a a`        | duplicate top                  |
+| SWAP   | 0x42 | 2   | `a b -- b a`      | swap top two                   |
+| MLOAD  | 0x50 | 3   | `off -- v`        | read 32 bytes from arena       |
+| MSTORE | 0x51 | 3   | `off v --`        | write 32 bytes to arena        |
+
+## Crypto
+
+| Op    | Hex  | Gas | Stack            | Notes                                |
+| ----- | ---- | --- | ---------------- | ------------------------------------ |
+| HASH  | 0x60 | 32  | `off len -- h`   | blake3 hash over arena range         |
+| VERIF | 0x61 | 96  | `m sig pk -- 0/1` | ed25519 verify, pushes `1` on success |
+| RND   | 0x62 | --  | reserved          | reserved; traps if executed          |
+
+The `RND` opcode is reserved precisely so it cannot exist. A program that
+attempts non-determinism by reaching for it gets a `badop` trap and the
+journal is rolled back.
+
+## Ledger primitives
+
+| Op       | Hex  | Gas | Stack                   | Effect                            |
+| -------- | ---- | --- | ----------------------- | --------------------------------- |
+| READACC  | 0x80 | 8   | `id -- bal`             | look up account balance           |
+| ADJACC   | 0x81 | 16  | `id delta --`           | adjust balance, signed `i128`     |
+| JOURNAL  | 0x90 | 64  | `tag off len --`        | append journal record from arena  |
+| EPOCH    | 0x91 | 32  | `-- n`                  | current epoch number              |
+| SEAL     | 0xF0 | 128 | `--`                    | seal current epoch, derive merkle |
+| HALT     | 0xFE | 0   | `--`                    | terminate normally                |
+| REVERT   | 0xFF | 0   | `off len --`            | terminate with reason             |
+
+## Example: deposit
+
+A minimal deposit transaction that credits 100 units to an account, writes a
+journal record, and halts.
+
+```text
+PUSH32 <account_id>     ; -- id
+PUSH1  100              ; -- id 100
+ADJACC                  ; --        (balance += 100)
+PUSH32 <log_tag>        ; -- tag
+PUSH1  0                ; -- tag 0
+PUSH1  64               ; -- tag 0 64
+JOURNAL                 ; --        (append 64 bytes from arena[0..64])
+HALT
+```
+
+Worst-case static gas for the snippet above is `2 + 2 + 16 + 2 + 2 + 2 + 64 + 0 = 90`.
+
+## Trap conditions
+
+Any of the following raises a trap, rolls back the journal for the current
+transaction, and returns control to the host:
+
+- Undefined or reserved opcode (`badop`).
+- Pop from an empty stack (`stack`).
+- Push onto a full 1024-entry stack (`stack`).
+- Arena access outside `[0, 4 MiB)` (`mem`).
+- Gas counter would go negative (`oog`).
+
+There is no recoverable trap. A trapped frame is dead; the host must start
+a fresh frame to do anything further.

--- a/examples/circuit-ledger/content/docs/03-ledger-model.md
+++ b/examples/circuit-ledger/content/docs/03-ledger-model.md
@@ -1,0 +1,119 @@
++++
+title = "Ledger Model"
+description = "Accounts, balances, journals, and how state is sealed at epoch boundaries."
+date = "2026-05-08"
+weight = 3
+tags = ["spec", "ledger", "state"]
++++
+
+## State, in one diagram
+
+```text
+   ┌──────────────────────────────────────────────────────────┐
+   │                       LEDGER STATE                       │
+   │                                                          │
+   │   ┌──────────────┐     ┌──────────────┐                  │
+   │   │   accounts   │ ──▶ │   balances   │  (flat keyspace) │
+   │   └──────────────┘     └──────────────┘                  │
+   │           │                                              │
+   │           ▼                                              │
+   │   ┌──────────────┐     ┌──────────────┐     ┌─────────┐  │
+   │   │   journal    │ ──▶ │  epoch seal  │ ──▶ │  root   │  │
+   │   │ (append-only)│     │ (merkle, n)  │     │ (32 B)  │  │
+   │   └──────────────┘     └──────────────┘     └─────────┘  │
+   │                                                          │
+   └──────────────────────────────────────────────────────────┘
+```
+
+The three primitives are **accounts**, the **journal**, and **epoch seals**.
+Everything else in the runtime is bookkeeping on top of these.
+
+## Accounts
+
+An account is identified by a 32-byte id. The id is opaque to the runtime —
+how it is derived (public key hash, content hash, host-assigned) is a host
+decision. The runtime only requires that ids are stable and unique within
+a ledger.
+
+| Field         | Type    | Notes                                    |
+| ------------- | ------- | ---------------------------------------- |
+| `id`          | `[u8;32]` | host-assigned, opaque to VM            |
+| `balance`     | `i128`  | signed; negative balances are permitted  |
+| `nonce`       | `u64`   | host-managed counter, not used by VM     |
+| `extra`       | `[u8;32]` | host scratch; included in seal hash    |
+
+Balances are `i128` because the runtime takes no position on whether liabilities
+are first-class. A bookkeeping ledger uses negative balances heavily; a token
+runtime usually doesn't. Both are supported by the same primitive.
+
+## The journal
+
+The journal is an ordered sequence of records. Each record has the shape:
+
+```text
++--------+--------+----------+--------+
+| tag    | epoch  | payload  | digest |
+| 32 B   | 8 B    | n bytes  | 32 B   |
++--------+--------+----------+--------+
+```
+
+- `tag` is the journal namespace, written by the program via the `JOURNAL` opcode.
+- `epoch` is the epoch into which the record was written. It is filled by the
+  runtime, not by the program.
+- `payload` is the raw bytes the program asked to be journalled.
+- `digest` is `blake3(prev_digest || tag || epoch || payload)`. The first record
+  uses an all-zero `prev_digest`.
+
+Because each digest covers the previous digest, the journal is a tamper-evident
+hash chain. The final digest at the end of an epoch is the **epoch root**.
+
+## Epoch seals
+
+An epoch is a host-chosen interval. The runtime does not impose a duration; it
+only requires that the host calls `cl_seal_epoch()` at the boundary. The seal
+operation:
+
+1. Reads the last journal digest.
+2. Hashes it together with the current account merkle root.
+3. Writes the resulting `seal_root` into the journal under a reserved tag.
+
+```rust
+struct EpochSeal {
+    epoch: u64,
+    journal_tip: [u8; 32],
+    account_root: [u8; 32],
+    seal_root: [u8; 32],   // blake3(journal_tip || account_root)
+}
+```
+
+Two hosts that ran the same inputs against the same runtime version produce
+identical `seal_root` values. This is the verification primitive: ship the
+seal, replay the inputs, compare.
+
+## Replay
+
+Replaying a ledger from genesis is a single function in the reference
+implementation:
+
+```rust
+fn replay(genesis: State, inputs: &[Input]) -> EpochSeal {
+    let mut s = genesis;
+    for input in inputs {
+        s = vm::run(s, input).expect("transaction must not trap host");
+    }
+    s.seal_epoch()
+}
+```
+
+If your replay produces a different `seal_root` than the one the original host
+published, you have a determinism bug — either in the runtime, your bindings,
+or the bytecode you fed it. The runtime authors will be very interested in
+the first case.
+
+## What the model deliberately omits
+
+- **No tokens.** Balances are bare integers; semantics are a host concern.
+- **No transfers.** "Transfer" is just two `ADJACC` calls with opposite signs.
+- **No fees.** Gas is metered, but how it is charged or to whom is not in scope.
+- **No history queries.** The journal is append-only; reading historical state
+  means replaying from a checkpoint. This is intentional.

--- a/examples/circuit-ledger/content/docs/04-deploy.md
+++ b/examples/circuit-ledger/content/docs/04-deploy.md
@@ -1,0 +1,124 @@
++++
+title = "Deploy"
+description = "Embedding the runtime in a host application. C, Rust, and Crystal targets."
+date = "2026-05-12"
+weight = 4
+tags = ["spec", "embed", "host"]
++++
+
+## What "deploy" means here
+
+Circuit Ledger is not a service. You do not run it; you link it. "Deploy" in
+this chapter means **embedding the runtime as a library** inside an application
+that handles transport, persistence, authentication, and everything else that
+is not the VM or the journal.
+
+## Linkage
+
+The reference implementation ships three artifacts:
+
+| Artifact            | Target          | Notes                                       |
+| ------------------- | --------------- | ------------------------------------------- |
+| `libcircuit.a`      | static C lib    | no dynamic deps; `cl_*` C ABI               |
+| `circuit_ledger`    | Rust crate      | thin wrapper, re-exports `Vm`, `Store`      |
+| `circuit-ledger.cr` | Crystal shard   | wraps `libcircuit.a` via `lib LibCircuit`   |
+
+Everything goes through the same C ABI. The Rust crate and Crystal shard are
+convenience layers and add zero overhead beyond a function-pointer indirection.
+
+## The C ABI in eight functions
+
+```c
+// circuit_ledger.h — abridged
+typedef struct cl_vm cl_vm;
+typedef struct cl_store cl_store;
+
+cl_vm*  cl_vm_new(const cl_store* store, uint64_t gas_limit);
+void    cl_vm_free(cl_vm* vm);
+
+int     cl_vm_load(cl_vm* vm, const uint8_t* code, size_t code_len);
+int     cl_vm_input(cl_vm* vm, const uint8_t* data, size_t data_len);
+int     cl_vm_run(cl_vm* vm);                 /* 0 = halt, <0 = trap */
+
+int     cl_seal_epoch(cl_vm* vm, uint8_t out_root[32]);
+int     cl_journal_tip(const cl_vm* vm, uint8_t out_digest[32]);
+const char* cl_last_error(const cl_vm* vm);   /* never NULL */
+```
+
+The error string returned by `cl_last_error` is owned by the VM and stable
+until the next call. Copy it if you need it to outlive the next API call.
+
+## Rust embedding
+
+```rust
+use circuit_ledger::{Store, Vm};
+
+fn main() -> anyhow::Result<()> {
+    let store = Store::in_memory();
+    let mut vm = Vm::new(&store, /* gas_limit = */ 10_000);
+
+    vm.load(include_bytes!("../programs/deposit.bin"))?;
+    vm.input(&serialize_request())?;
+
+    match vm.run() {
+        Ok(()) => {
+            let root = vm.seal_epoch()?;
+            println!("sealed epoch root: {}", hex::encode(root));
+        }
+        Err(e) => eprintln!("vm trapped: {e}"),
+    }
+    Ok(())
+}
+```
+
+The `Store` trait is the only place the host wires in persistence. The default
+`Store::in_memory()` is suitable for tests and replay; production hosts
+implement the trait against rocksdb, lmdb, or a custom store.
+
+## Crystal embedding
+
+```crystal
+require "circuit_ledger"
+
+store = CircuitLedger::Store.in_memory
+vm    = CircuitLedger::Vm.new(store, gas_limit: 10_000)
+
+vm.load(File.read("programs/deposit.bin").to_slice)
+vm.input(request_bytes)
+
+case result = vm.run
+when CircuitLedger::Halt
+  root = vm.seal_epoch
+  puts "sealed: #{root.hexstring}"
+when CircuitLedger::Trap
+  STDERR.puts "trap: #{result.reason}"
+end
+```
+
+## Sizing
+
+The runtime has a fixed footprint. Numbers below are from the reference
+implementation built with `--release` on `x86_64-unknown-linux-gnu`.
+
+| Component        | Size    | Notes                                |
+| ---------------- | ------- | ------------------------------------ |
+| `libcircuit.a`   | 412 KiB | static, no syscalls                  |
+| VM stack         | 32 KiB  | 1024 entries × 32 bytes              |
+| Arena (per-frame)| 4 MiB   | cleared at frame start, host-owned   |
+| Worst-case heap  | 0 B     | runtime never allocates              |
+
+The "0 B heap" line is not a typo. The reference runtime calls `malloc` zero
+times after `cl_vm_new` returns. All scratch memory is bumped in the arena
+the host provides.
+
+## What you have to bring yourself
+
+- **Transport.** The runtime takes a byte slice; how it arrived is your problem.
+- **Identity.** The runtime verifies signatures via `VERIF`, but does not know
+  whose keys those are. Map ids to identities upstream.
+- **Persistence.** Implement `cl_store` against whatever store you like.
+- **Indexing.** The journal is append-only and unindexed. Build indices in
+  your host if you want historical queries.
+
+If you find yourself wanting any of these things to live inside the runtime,
+the answer is no, and the chapter you should reread is the [Overview](../01-overview/).

--- a/examples/circuit-ledger/content/docs/_index.md
+++ b/examples/circuit-ledger/content/docs/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Spec"
+description = "All chapters of the Circuit Ledger specification, in order."
+sort_by = "weight"
+template = "section"
++++
+
+The spec is read top-to-bottom. Each chapter builds on the previous one and assumes
+you have not skipped ahead. Code samples target the reference implementation at
+the version pinned in the topbar.

--- a/examples/circuit-ledger/content/index.md
+++ b/examples/circuit-ledger/content/index.md
@@ -1,0 +1,11 @@
++++
+title = "Circuit Ledger"
+description = "Reference for the Circuit Ledger embedded runtime."
+template = "home"
++++
+
+Circuit Ledger is a small, deterministic virtual machine and an append-only journal
+format, glued together with a host ABI you can fit in a single header file. It is
+designed to be embedded — not deployed, not orchestrated, not gossipped — embedded.
+The specification on this site is the source of truth: where the prose disagrees
+with the reference implementation, the prose wins and the implementation is wrong.

--- a/examples/circuit-ledger/static/css/style.css
+++ b/examples/circuit-ledger/static/css/style.css
@@ -1,0 +1,626 @@
+:root {
+  --bg: #0d0d10;
+  --panel: #15151a;
+  --panel-2: #1a1a20;
+  --rule: #1f1f24;
+  --rule-2: #2a2a31;
+  --ink: #d4d4d8;
+  --ink-2: #a8a8b0;
+  --ink-3: #8a8a92;
+  --accent: #3aff8a;
+  --accent-dim: #2cb868;
+  --warn: #ffb84a;
+  --err: #ff5a5a;
+}
+
+* { box-sizing: border-box; }
+
+html { font-size: 15px; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "JetBrains Mono", "IBM Plex Mono", "SF Mono", ui-monospace, monospace;
+  font-feature-settings: "calt" 0;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+a:hover { border-bottom-color: var(--accent); }
+
+::selection { background: var(--accent); color: var(--bg); }
+
+.site {
+  max-width: 90rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+  display: grid;
+  grid-template-columns: 16rem 1fr;
+  gap: 3rem;
+  min-height: 100vh;
+}
+
+/* ============== TOPBAR ============== */
+.topbar {
+  grid-column: 1 / -1;
+  border-bottom: 1px solid var(--rule-2);
+  padding: 1rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.82rem;
+}
+
+.topbar .brand {
+  font-weight: 700;
+  font-size: 0.92rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink);
+  border-bottom: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.topbar .brand .blip {
+  display: inline-block;
+  width: 0.55rem;
+  height: 0.55rem;
+  background: var(--accent);
+  box-shadow: 0 0 0 2px rgba(58, 255, 138, 0.18);
+}
+.topbar .brand .slash {
+  color: var(--accent);
+  margin: 0 0.1rem;
+}
+
+.topbar nav {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+.topbar nav a { color: var(--ink-3); border-bottom: none; }
+.topbar nav a:hover { color: var(--accent); }
+.topbar .ver {
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.topbar .ver .ok { color: var(--accent); }
+
+/* ============== SIDEBAR ============== */
+aside.sidebar {
+  border-right: 1px solid var(--rule);
+  padding: 2.5rem 1.25rem 4rem 0;
+  font-size: 0.8rem;
+  position: sticky;
+  top: 0;
+  align-self: start;
+  max-height: 100vh;
+  overflow-y: auto;
+}
+
+.sidebar h4 {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  margin: 1.6rem 0 0.6rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px dashed var(--rule-2);
+}
+.sidebar h4:first-child { margin-top: 0; }
+
+.sidebar .tree {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.82rem;
+}
+.sidebar .tree li {
+  padding: 0.18rem 0;
+  color: var(--ink-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar .tree li::before {
+  content: "├── ";
+  color: var(--rule-2);
+}
+.sidebar .tree li:last-child::before {
+  content: "└── ";
+}
+.sidebar .tree a {
+  color: var(--ink-2);
+  border-bottom: none;
+}
+.sidebar .tree a:hover { color: var(--accent); }
+
+.sidebar .root {
+  color: var(--ink-3);
+  font-size: 0.78rem;
+  padding-bottom: 0.4rem;
+}
+.sidebar .root::before {
+  content: "▌ ";
+  color: var(--accent);
+}
+
+/* ============== MAIN ============== */
+main.content {
+  padding: 2.2rem 0 5rem;
+  max-width: 60rem;
+}
+
+.crumbs {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  margin-bottom: 1.5rem;
+}
+.crumbs a { color: var(--ink-3); border-bottom: none; }
+.crumbs a:hover { color: var(--accent); }
+.crumbs .sep {
+  color: var(--accent-dim);
+  margin: 0 0.4rem;
+}
+
+/* ============== HEADINGS ============== */
+article h1, .hero h1 {
+  font-family: "Inter", "JetBrains Mono", ui-monospace, monospace;
+  font-size: 2.4rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.08;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+article h2 {
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin: 3rem 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--rule-2);
+  color: var(--ink);
+}
+article h2::before {
+  content: "// ";
+  color: var(--accent);
+}
+
+article h3 {
+  font-size: 0.92rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  margin-top: 2rem;
+  color: var(--ink-2);
+}
+article h3::before {
+  content: "› ";
+  color: var(--accent);
+}
+
+article p, article li {
+  font-size: 0.92rem;
+  color: var(--ink-2);
+}
+article ul, article ol { padding-left: 1.5rem; }
+article ul li::marker { color: var(--accent-dim); }
+article ol li::marker { color: var(--accent-dim); }
+article li { padding: 0.15rem 0; }
+article strong { color: var(--ink); font-weight: 700; }
+article em { color: var(--accent); font-style: normal; }
+
+/* ============== HERO ============== */
+.hero {
+  border: 1px solid var(--rule-2);
+  padding: 0;
+  margin-bottom: 3rem;
+  position: relative;
+  background: var(--panel);
+}
+.hero::before {
+  content: "+";
+  position: absolute;
+  top: -0.7rem;
+  left: -0.5rem;
+  color: var(--accent);
+  font-size: 1.1rem;
+  background: var(--bg);
+  padding: 0 0.2rem;
+}
+.hero::after {
+  content: "+";
+  position: absolute;
+  top: -0.7rem;
+  right: -0.5rem;
+  color: var(--accent);
+  font-size: 1.1rem;
+  background: var(--bg);
+  padding: 0 0.2rem;
+}
+.hero .hero-inner {
+  padding: 2.2rem 2.2rem 1.6rem;
+  position: relative;
+}
+.hero .hero-inner::before {
+  content: "+";
+  position: absolute;
+  bottom: -0.7rem;
+  left: -0.5rem;
+  color: var(--accent);
+  font-size: 1.1rem;
+  background: var(--bg);
+  padding: 0 0.2rem;
+}
+.hero .hero-inner::after {
+  content: "+";
+  position: absolute;
+  bottom: -0.7rem;
+  right: -0.5rem;
+  color: var(--accent);
+  font-size: 1.1rem;
+  background: var(--bg);
+  padding: 0 0.2rem;
+}
+.hero .marker {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  margin-bottom: 0.9rem;
+}
+.hero p {
+  font-size: 1.02rem;
+  color: var(--ink-2);
+  max-width: 44rem;
+  margin: 0 0 1.4rem;
+}
+.hero .actions { margin-top: 1.2rem; }
+
+/* Stat block */
+.statblock {
+  border-top: 1px dashed var(--rule-2);
+  padding: 1.1rem 2.2rem 1.6rem;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  font-variant-numeric: tabular-nums;
+  background: var(--panel-2);
+}
+.statblock .row {
+  display: grid;
+  grid-template-columns: 11rem 1fr;
+  gap: 1rem;
+  padding: 0.15rem 0;
+}
+.statblock .row .k { color: var(--ink-3); }
+.statblock .row .k::before { content: "› "; color: var(--accent-dim); }
+.statblock .row .v { color: var(--ink); }
+.statblock .row .v .green { color: var(--accent); }
+
+/* ============== KBD / BUTTON ============== */
+.kbd {
+  display: inline-block;
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--rule-2);
+  background: var(--panel-2);
+  color: var(--ink);
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  margin-right: 0.5rem;
+  border-bottom: 1px solid var(--rule-2);
+}
+.kbd:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.kbd.primary {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.kbd.primary:hover {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+/* ============== META ============== */
+.meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  padding: 0.65rem 0;
+  border-top: 1px solid var(--rule-2);
+  border-bottom: 1px solid var(--rule-2);
+  margin: 0 0 2.5rem;
+  font-variant-numeric: tabular-nums;
+}
+.meta-row span b { color: var(--accent); font-weight: 700; }
+
+/* ============== CODE ============== */
+article pre, pre[class*="language-"] {
+  background: #08080b !important;
+  color: #d4d4d8 !important;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid var(--rule-2);
+  border-left: 3px solid var(--accent);
+  overflow-x: auto;
+  font-size: 0.83rem;
+  line-height: 1.6;
+  position: relative;
+  margin: 1.2rem 0;
+}
+article pre::before {
+  content: attr(data-lang);
+  position: absolute;
+  top: 0.3rem;
+  right: 0.7rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+}
+article pre code, pre code {
+  background: transparent !important;
+  color: inherit !important;
+  padding: 0;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+article code {
+  background: var(--panel-2);
+  padding: 0.08rem 0.4rem;
+  border: 1px solid var(--rule-2);
+  font-size: 0.86em;
+  color: var(--accent);
+}
+article a code { color: var(--accent); }
+
+/* ============== TABLES ============== */
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.84rem;
+  margin: 1.5rem 0;
+  font-variant-numeric: tabular-nums;
+}
+article th, article td {
+  text-align: left;
+  padding: 0.55rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+  color: var(--ink-2);
+}
+article th {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  border-bottom: 1px solid var(--rule-2);
+  background: var(--panel);
+}
+article tr:last-child td { border-bottom: 1px solid var(--rule-2); }
+article td code { color: var(--accent); }
+
+/* ============== BLOCKQUOTE ============== */
+article blockquote {
+  border: 1px solid var(--rule-2);
+  border-left: 3px solid var(--accent);
+  margin: 1.5rem 0;
+  padding: 0.6rem 1rem 0.6rem 2.2rem;
+  color: var(--ink-2);
+  background: var(--panel);
+  position: relative;
+}
+article blockquote::before {
+  content: ">";
+  position: absolute;
+  left: 0.9rem;
+  top: 0.6rem;
+  color: var(--accent);
+  font-weight: 700;
+}
+article blockquote p { margin: 0.2rem 0; color: var(--ink-2); }
+
+/* ============== HORIZONTAL RULE ============== */
+article hr {
+  border: none;
+  border-top: 1px dashed var(--rule-2);
+  margin: 2rem 0;
+}
+
+/* ============== CHAPTER CARDS ============== */
+.section-list {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.section-list .item {
+  background: var(--panel);
+  border: 1px solid var(--rule-2);
+  padding: 1.1rem 1.3rem;
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  gap: 1.5rem;
+  align-items: baseline;
+  position: relative;
+}
+.section-list .item::before {
+  content: "+";
+  position: absolute;
+  top: -0.55rem;
+  left: -0.45rem;
+  color: var(--accent);
+  background: var(--bg);
+  padding: 0 0.15rem;
+  font-size: 0.95rem;
+  line-height: 1;
+}
+.section-list .item::after {
+  content: "+";
+  position: absolute;
+  bottom: -0.55rem;
+  right: -0.45rem;
+  color: var(--accent);
+  background: var(--bg);
+  padding: 0 0.15rem;
+  font-size: 0.95rem;
+  line-height: 1;
+}
+.section-list .item:hover { border-color: var(--accent-dim); }
+.section-list .item .num {
+  font-size: 0.82rem;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.06em;
+}
+.section-list .item h3 {
+  margin: 0;
+  font-size: 1.02rem;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink);
+  font-family: "Inter", "JetBrains Mono", monospace;
+}
+.section-list .item h3::before { content: ""; }
+.section-list .item h3 a { color: var(--ink); border-bottom: none; }
+.section-list .item h3 a:hover { color: var(--accent); }
+.section-list .item p {
+  margin: 0.3rem 0 0;
+  color: var(--ink-3);
+  font-size: 0.84rem;
+}
+.section-list .item .date {
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============== FOOTER ============== */
+.foot {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule-2);
+  margin-top: 4rem;
+  padding: 1.3rem 0 2rem;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+.foot .dot { color: var(--accent-dim); margin: 0 0.5rem; }
+
+/* ============== TAGS ============== */
+.tag-pill {
+  display: inline-block;
+  border: 1px solid var(--rule-2);
+  padding: 0.12rem 0.55rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-right: 0.4rem;
+  color: var(--accent);
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--rule-2);
+}
+.tag-pill:hover {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+
+/* ============== 404 ============== */
+.notfound {
+  text-align: center;
+  padding: 5rem 0;
+}
+.notfound pre {
+  display: inline-block;
+  background: transparent !important;
+  border: none !important;
+  color: var(--accent) !important;
+  font-size: 0.88rem;
+  line-height: 1.15;
+  padding: 0;
+  text-align: left;
+}
+.notfound p { color: var(--ink-3); }
+.notfound .errmsg {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.78rem;
+  margin: 1.4rem 0 2rem;
+}
+
+/* ============== ALERT SHORTCODE ============== */
+.alert-box {
+  border: 1px solid var(--rule-2);
+  border-left: 3px solid var(--accent);
+  background: var(--panel);
+  padding: 0.85rem 1rem 0.85rem 1rem;
+  margin: 1.4rem 0;
+  font-size: 0.86rem;
+  color: var(--ink-2);
+  position: relative;
+}
+.alert-box .alert-head {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.3rem;
+}
+.alert-box.warn { border-left-color: var(--warn); }
+.alert-box.warn .alert-head { color: var(--warn); }
+.alert-box.error { border-left-color: var(--err); }
+.alert-box.error .alert-head { color: var(--err); }
+
+/* ============== ASCII DECO ============== */
+.ascii-rule {
+  color: var(--rule-2);
+  font-size: 0.78rem;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  margin: 2rem 0 1rem;
+  overflow: hidden;
+  white-space: nowrap;
+  user-select: none;
+}
+
+/* ============== RESPONSIVE ============== */
+@media (max-width: 900px) {
+  .site {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    padding: 0 1rem;
+  }
+  aside.sidebar {
+    position: static;
+    border-right: none;
+    border-bottom: 1px solid var(--rule);
+    padding: 1rem 0;
+    max-height: none;
+  }
+  .topbar { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+  .foot { flex-direction: column; gap: 0.5rem; }
+  .statblock .row { grid-template-columns: 1fr; gap: 0.2rem; }
+  .section-list .item { grid-template-columns: 1fr; gap: 0.4rem; }
+  article h1, .hero h1 { font-size: 1.8rem; }
+}

--- a/examples/circuit-ledger/static/favicon.svg
+++ b/examples/circuit-ledger/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0d0d10"/>
+  <rect x="4" y="4" width="24" height="24" fill="none" stroke="#3aff8a" stroke-width="2"/>
+  <rect x="10" y="10" width="12" height="12" fill="none" stroke="#3aff8a" stroke-width="1"/>
+  <line x1="4" y1="16" x2="10" y2="16" stroke="#3aff8a" stroke-width="1"/>
+  <line x1="22" y1="16" x2="28" y2="16" stroke="#3aff8a" stroke-width="1"/>
+  <line x1="16" y1="4" x2="16" y2="10" stroke="#3aff8a" stroke-width="1"/>
+  <line x1="16" y1="22" x2="16" y2="28" stroke="#3aff8a" stroke-width="1"/>
+  <circle cx="16" cy="16" r="2" fill="#3aff8a"/>
+</svg>

--- a/examples/circuit-ledger/templates/404.html
+++ b/examples/circuit-ledger/templates/404.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<div class="notfound">
+<pre>
+  ┌─────────────────────────────────┐
+  │   ___   ___   ___               │
+  │  | | | | | | | | |              │
+  │  |_| | |_| | |_| |  TRAP        │
+  │   _| |  _| |  _| |              │
+  │  |___| |___| |___|              │
+  └─────────────────────────────────┘
+     opcode 0xFF · address not mapped
+</pre>
+  <p class="errmsg">segment not present in journal</p>
+  <p>
+    <a class="kbd primary" href="{{ base_url }}/">return to /</a>
+    <a class="kbd" href="{{ base_url }}/docs/">jump to /docs/</a>
+  </p>
+</div>
+{% include "footer.html" %}

--- a/examples/circuit-ledger/templates/footer.html
+++ b/examples/circuit-ledger/templates/footer.html
@@ -1,0 +1,8 @@
+  </main>
+  <footer class="foot">
+    <span>{{ site_title }} <span class="dot">·</span> runtime v0.7.3</span>
+    <span>BUILT WITH HWARO <span class="dot">·</span> {{ current_year }}</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/circuit-ledger/templates/header.html
+++ b/examples/circuit-ledger/templates/header.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="site">
+  <header class="topbar">
+    <a class="brand" href="{{ base_url }}/"><span class="blip"></span>CIRCUIT<span class="slash">/</span>LEDGER</a>
+    <nav>
+      <a href="{{ base_url }}/docs/">Spec</a>
+      <a href="{{ base_url }}/tags/">Tags</a>
+      <a href="{{ base_url }}/categories/">Categories</a>
+      <a href="https://github.com/hahwul/hwaro">Source</a>
+    </nav>
+    <span class="ver">runtime v0.7.3 · <span class="ok">▌</span> sealed</span>
+  </header>
+  <aside class="sidebar">
+    <div class="root">~/circuit-ledger/</div>
+    <h4>Spec</h4>
+    <ul class="tree">
+      <li><a href="{{ base_url }}/docs/01-overview/">01-overview</a></li>
+      <li><a href="{{ base_url }}/docs/02-vm-instructions/">02-vm-instructions</a></li>
+      <li><a href="{{ base_url }}/docs/03-ledger-model/">03-ledger-model</a></li>
+      <li><a href="{{ base_url }}/docs/04-deploy/">04-deploy</a></li>
+    </ul>
+    <h4>Meta</h4>
+    <ul class="tree">
+      <li><a href="{{ base_url }}/tags/">tags/</a></li>
+      <li><a href="{{ base_url }}/categories/">categories/</a></li>
+      <li><a href="{{ base_url }}/docs/">spec/index</a></li>
+    </ul>
+    <h4>Status</h4>
+    <ul class="tree">
+      <li>build: ok</li>
+      <li>seal: signed</li>
+      <li>gas-bench: stable</li>
+    </ul>
+  </aside>
+  <main class="content">

--- a/examples/circuit-ledger/templates/home.html
+++ b/examples/circuit-ledger/templates/home.html
@@ -1,0 +1,79 @@
+{% include "header.html" %}
+<div class="hero">
+  <div class="hero-inner">
+    <div class="marker">▌ CIRCUIT LEDGER · spec v0.7.3 · deterministic embedded vm</div>
+    <h1>An embedded ledger,<br/>traced like a circuit.</h1>
+    <p>{{ site.description }}</p>
+    <div class="actions">
+      <a href="{{ base_url }}/docs/" class="kbd primary">read the spec →</a>
+      <a href="{{ base_url }}/docs/04-deploy/" class="kbd">embed it</a>
+      <a href="https://github.com/hahwul/hwaro" class="kbd">source</a>
+    </div>
+  </div>
+  <div class="statblock">
+    <div class="row"><span class="k">runtime.version</span><span class="v"><span class="green">0.7.3</span> (sealed, 2026-05-12)</span></div>
+    <div class="row"><span class="k">vm.opcodes</span><span class="v">128 / 256 reserved</span></div>
+    <div class="row"><span class="k">vm.determinism</span><span class="v"><span class="green">total</span> (no FP, no syscalls)</span></div>
+    <div class="row"><span class="k">ledger.accounts</span><span class="v">flat keyspace, 32-byte ids</span></div>
+    <div class="row"><span class="k">ledger.journal</span><span class="v">append-only, merkle-sealed</span></div>
+    <div class="row"><span class="k">host.embed</span><span class="v">C ABI · Rust · Crystal bindings</span></div>
+    <div class="row"><span class="k">bench.tx_per_ms</span><span class="v"><span class="green">42</span> (median, m1 air, in-memory)</span></div>
+  </div>
+</div>
+
+<article>
+  {{ content | safe }}
+
+  <h2>Chapters</h2>
+  <div class="section-list">
+    <div class="item">
+      <span class="num">[ 01 ]</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/01-overview/">Overview</a></h3>
+        <p>What the runtime is, what it isn't, and the contract it makes with hosts.</p>
+      </div>
+      <span class="date">2026-05-01</span>
+    </div>
+    <div class="item">
+      <span class="num">[ 02 ]</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/02-vm-instructions/">VM Instructions</a></h3>
+        <p>The full opcode table, gas costs, stack effects, and trap conditions.</p>
+      </div>
+      <span class="date">2026-05-04</span>
+    </div>
+    <div class="item">
+      <span class="num">[ 03 ]</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/03-ledger-model/">Ledger Model</a></h3>
+        <p>Accounts, balances, journals, and how state is sealed at epoch boundaries.</p>
+      </div>
+      <span class="date">2026-05-08</span>
+    </div>
+    <div class="item">
+      <span class="num">[ 04 ]</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/04-deploy/">Deploy</a></h3>
+        <p>Embedding the runtime in a host application. C, Rust, and Crystal targets.</p>
+      </div>
+      <span class="date">2026-05-12</span>
+    </div>
+  </div>
+
+  <h2>Design axioms</h2>
+  <p>
+    Circuit Ledger is built on five non-negotiables: <strong>determinism</strong>,
+    <strong>seal-ability</strong>, <strong>embed-ability</strong>, <strong>auditability</strong>,
+    and <strong>silence</strong>. A program that runs on one host must produce a byte-identical
+    journal on every other host. There are no syscalls, no clocks, no floating point,
+    and no allocator surprises. The runtime is, by design, boring.
+  </p>
+
+  <h3>What it is not</h3>
+  <p>
+    This is not a blockchain. There is no consensus, no gossip layer, no native token.
+    The runtime is a deterministic VM and a journal format. What you wire around it is
+    your problem.
+  </p>
+</article>
+{% include "footer.html" %}

--- a/examples/circuit-ledger/templates/page.html
+++ b/examples/circuit-ledger/templates/page.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">~/circuit-ledger</a><span class="sep">/</span><a href="{{ base_url }}/docs/">spec</a><span class="sep">/</span>{{ page.title | e }}
+</nav>
+<article>
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p style="font-size:1.02rem;color:var(--ink-2);max-width:48rem;margin:-0.3rem 0 1.4rem;">{{ page.description | e }}</p>{% endif %}
+  <div class="meta-row">
+    {% if page.date %}<span>DATE · <b>{{ page.date | date(format="%Y-%m-%d") }}</b></span>{% endif %}
+    {% if page.reading_time %}<span>READ · <b>{{ page.reading_time }} min</b></span>{% endif %}
+    {% if page.word_count %}<span>WORDS · <b>{{ page.word_count }}</b></span>{% endif %}
+    {% if page.weight %}<span>CHAPTER · <b>{{ page.weight }}</b></span>{% endif %}
+    {% if page.tags %}<span>TAGS · {% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/circuit-ledger/templates/section.html
+++ b/examples/circuit-ledger/templates/section.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">~/circuit-ledger</a><span class="sep">/</span>{{ page.title | e }}
+</nav>
+<div class="hero">
+  <div class="hero-inner">
+    <div class="marker">▌ section · /{{ page.title | lower }}</div>
+    <h1>{{ page.title | e }}</h1>
+    {% if content %}<p>{{ content | striptags | trim }}</p>{% endif %}
+    <div class="actions">
+      <span class="kbd">circuit spec</span>
+      <span class="kbd">--all</span>
+      <span class="kbd">--sort=weight</span>
+    </div>
+  </div>
+</div>
+
+<div class="section-list">
+  {% for p in section.pages %}
+  <div class="item">
+    <span class="num">[ {% if loop.index < 10 %}0{% endif %}{{ loop.index }} ]</span>
+    <div>
+      <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+      {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+    </div>
+    <span class="date">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+  </div>
+  {% endfor %}
+</div>
+{% include "footer.html" %}

--- a/examples/circuit-ledger/templates/shortcodes/alert.html
+++ b/examples/circuit-ledger/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert-box {{ type | default(value='info') | lower }}">
+  <div class="alert-head">▌ {{ type | default(value="NOTE") | upper }}</div>
+  <div class="alert-body">{{ body }}</div>
+</div>

--- a/examples/circuit-ledger/templates/taxonomy.html
+++ b/examples/circuit-ledger/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">~/circuit-ledger</a><span class="sep">/</span>{{ taxonomy_name | default(value="tags") | lower }}
+</nav>
+<article>
+  <h1>{{ taxonomy_name | default(value="Tags") | capitalize }}</h1>
+  <p style="color:var(--ink-3);">All terms in the <strong>{{ taxonomy_name }}</strong> taxonomy.</p>
+  <div class="section-list" style="margin-top:2rem;">
+    {% for term in taxonomy_terms %}
+    <div class="item">
+      <span class="num">[ {% if loop.index < 10 %}0{% endif %}{{ loop.index }} ]</span>
+      <div>
+        <h3><a href="{{ term.url }}">#{{ term.name }}</a></h3>
+        <p>{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %} indexed under this term.</p>
+      </div>
+      <span class="date">/{{ taxonomy_name }}/{{ term.slug }}/</span>
+    </div>
+    {% endfor %}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/circuit-ledger/templates/taxonomy_term.html
+++ b/examples/circuit-ledger/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">~/circuit-ledger</a><span class="sep">/</span><a href="{{ base_url }}/{{ taxonomy_name }}/">{{ taxonomy_name | lower }}</a><span class="sep">/</span>{{ page.title | lower }}
+</nav>
+<article>
+  <h1>#{{ page.title }}</h1>
+  <p style="color:var(--ink-3);">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} tagged <strong>{{ page.title }}</strong>.</p>
+  <div class="section-list" style="margin-top:2rem;">
+    {% for p in taxonomy_pages %}
+    <div class="item">
+      <span class="num">[ {% if loop.index < 10 %}0{% endif %}{{ loop.index }} ]</span>
+      <div>
+        <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+      </div>
+      <span class="date">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+    </div>
+    {% endfor %}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/forma-docs/AGENTS.md
+++ b/examples/forma-docs/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md - AI Agent Instructions for Forma Docs
+
+This is a Hwaro static site. See [Hwaro Documentation](https://hwaro.hahwul.com)
+for full reference.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build to `public/` |
+| `hwaro serve` | Dev server on port 3000 |
+
+## Notes
+
+1. Front matter is TOML between `+++` delimiters.
+2. Rendered content is `{{ content | safe }}`.
+3. Custom metadata is `page.extra.field`.
+4. Use `{{ base_url }}` for all links and assets.
+5. CSS lives in `static/css/style.css`; do not inline.

--- a/examples/forma-docs/archetypes/default.md
+++ b/examples/forma-docs/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/forma-docs/config.toml
+++ b/examples/forma-docs/config.toml
@@ -1,0 +1,45 @@
+title = "Forma"
+description = "Documentation for Forma, a typed UI primitives framework. Modern light surface, oversized chapter numerals, narrow read column."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/forma-docs/content/docs/01-primitives.md
+++ b/examples/forma-docs/content/docs/01-primitives.md
@@ -1,0 +1,53 @@
++++
+title = "Primitives"
+description = "The eight components Forma exposes, with their full type signatures."
+date = "2026-05-03"
+weight = 1
+tags = ["api", "components"]
++++
+
+## The eight
+
+Forma exposes exactly eight primitives. Adding a ninth requires an RFC and
+unanimous approval from the maintainers. This is deliberate; the small
+surface is the product.
+
+| Primitive | Purpose                                  | Slots          |
+|-----------|------------------------------------------|----------------|
+| `Box`     | The unstyled rectangle                   | `children`     |
+| `Stack`   | One-dimensional flex layout              | `children`     |
+| `Grid`    | Two-dimensional grid layout              | `children`     |
+| `Text`    | Typographic block                        | —              |
+| `Field`   | Labelled form input                      | `label, hint`  |
+| `Button`  | Press-able control                       | `children`     |
+| `Sheet`   | Bordered surface                         | `children`     |
+| `Portal`  | Render escape hatch                      | `children`     |
+
+## Signature
+
+Every primitive shares the same prop conventions:
+
+```ts
+type FormaPrimitive<P> = {
+  as?: keyof JSX.IntrinsicElements
+  token?: TokenRef
+  policy?: PolicyRef
+  children?: ReactNode
+} & P
+```
+
+If a primitive does not use a convention (e.g. `Text` has no `children`),
+that prop is omitted from its specific signature.
+
+## Conventions
+
+Three conventions hold across every primitive:
+
+1. **`as` is structural.** It changes the HTML tag but never the visual.
+2. **`token` is decorative.** It changes the visual but never the structure.
+3. **`policy` is behavioural.** It changes interaction rules — focus,
+   keyboard, ARIA — but never the visual or the structure.
+
+This separation is what lets composition work without surprise. A page can
+be re-themed by swapping tokens, and re-skinned for accessibility by
+swapping policies, without touching the markup.

--- a/examples/forma-docs/content/docs/02-composition.md
+++ b/examples/forma-docs/content/docs/02-composition.md
@@ -1,0 +1,66 @@
++++
+title = "Composition"
+description = "How primitives combine into layouts. Slots, props, and policy types."
+date = "2026-05-06"
+weight = 2
+tags = ["composition", "patterns"]
++++
+
+## A typical composition
+
+A real-world Forma component is a tree of primitives. Each primitive is
+typed; the type checker enforces correct slot usage.
+
+```tsx
+<Sheet token="surface.elevated">
+  <Stack token="space.lg" as="section">
+    <Text token="heading.h2">Account settings</Text>
+    <Field label="Display name" hint="Visible to everyone.">
+      <Box as="input" type="text" />
+    </Field>
+    <Button policy="submit" token="action.primary">Save</Button>
+  </Stack>
+</Sheet>
+```
+
+## Slot typing
+
+Some primitives declare named slots. The type checker rejects children
+that do not match.
+
+```tsx
+<Field
+  label={<Text token="label">Email</Text>}
+  hint={<Text token="hint">We never share this.</Text>}
+>
+  <Box as="input" type="email" />
+</Field>
+```
+
+Passing a `Button` as the `label` slot is a compile error. The slot type
+is `ReactElement<typeof Text>`, not `ReactNode`.
+
+## Policy types
+
+Policies are first-class. A `Button` with `policy="submit"` activates the
+parent form on Enter; with `policy="link"` it announces itself as a link
+to assistive tech. The runtime checks for policy/primitive mismatches at
+mount time.
+
+| Primitive | Allowed policies                              |
+|-----------|-----------------------------------------------|
+| `Button`  | `default`, `submit`, `link`, `menuitem`       |
+| `Field`   | `default`, `inline`, `required`               |
+| `Sheet`   | `default`, `dialog`, `popover`                |
+
+## Anti-patterns
+
+A handful of compositions are technically possible but actively
+discouraged. The linter flags them with an `forma/discouraged` warning.
+
+- `Box` directly inside `Grid` without a `token`. Use `Sheet` or pass an
+  explicit grid-area token.
+- `Portal` inside a `Sheet` whose policy is `popover`. Portals already
+  escape their parent; double-escaping is a paper-cut waiting to happen.
+- Nested `Field`s. Forms with conditional rows should use a single
+  `Stack` of `Field`s instead.

--- a/examples/forma-docs/content/docs/03-tokens.md
+++ b/examples/forma-docs/content/docs/03-tokens.md
@@ -1,0 +1,78 @@
++++
+title = "Tokens"
+description = "The design token surface. Colours, spacing, type scale, motion."
+date = "2026-05-09"
+weight = 3
+tags = ["tokens", "design"]
++++
+
+## What a token is
+
+A token is a typed reference into the design surface. It is not a CSS
+custom property; the runtime resolves tokens at render time so values can
+change per-tree without a re-mount.
+
+```ts
+type TokenRef =
+  | `color.${keyof typeof color}`
+  | `space.${keyof typeof space}`
+  | `text.${keyof typeof text}`
+  | `radius.${keyof typeof radius}`
+```
+
+## The default set
+
+The default token set is intentionally narrow. Most applications use the
+defaults verbatim and override only the `color` namespace.
+
+```toml
+[color]
+ink   = "#09090b"
+paper = "#fafafa"
+soft  = "#f4f4f5"
+rule  = "#e4e4e7"
+
+[space]
+xs = "0.25rem"
+sm = "0.5rem"
+md = "1rem"
+lg = "1.5rem"
+xl = "2rem"
+
+[text]
+caption = { size = "0.78rem", weight = 500, line = 1.4 }
+body    = { size = "0.95rem", weight = 400, line = 1.6 }
+heading = { size = "1.8rem",  weight = 600, line = 1.1 }
+
+[radius]
+sm = "4px"
+md = "8px"
+lg = "12px"
+```
+
+## Overriding
+
+Token overrides are scoped to a subtree by the `TokenScope` component.
+
+```tsx
+<TokenScope tokens={{ color: { ink: "#fff", paper: "#000" } }}>
+  <Sheet>
+    <Text>Inverted theme, locally.</Text>
+  </Sheet>
+</TokenScope>
+```
+
+The override is shallow-merged with the parent scope. A child that asks
+for `color.ink` resolves to the nearest defined value walking up the tree,
+same as CSS cascade — but typed.
+
+## Motion
+
+Motion tokens are a separate namespace and are always opt-in. A primitive
+with no `motion` token is fully static; this is the default.
+
+| Token             | Duration | Easing              |
+|-------------------|----------|---------------------|
+| `motion.fast`     | 120ms    | `cubic-bezier(...)` |
+| `motion.normal`   | 200ms    | `cubic-bezier(...)` |
+| `motion.deliberate` | 360ms  | `cubic-bezier(...)` |

--- a/examples/forma-docs/content/docs/04-runtime.md
+++ b/examples/forma-docs/content/docs/04-runtime.md
@@ -1,0 +1,69 @@
++++
+title = "Runtime"
+description = "Server rendering, hydration, and the streaming render pipeline."
+date = "2026-05-13"
+weight = 4
+tags = ["runtime", "rendering"]
++++
+
+## The pipeline
+
+Forma's runtime renders in three discrete phases. Each phase has a
+well-defined input and output; you can stop after any phase and inspect
+the intermediate result.
+
+```text
+   ┌──────────┐    ┌──────────┐    ┌──────────┐
+   │ Resolve  ├───▶│  Layout  ├───▶│  Paint   │
+   └──────────┘    └──────────┘    └──────────┘
+        ▲              ▲                ▲
+        │              │                │
+     tokens         policies          markup
+```
+
+## Resolve
+
+The resolve phase walks the tree and replaces every `TokenRef` with its
+concrete value. The output of this phase is a token-free tree that the
+layout phase can process without dereferencing anything.
+
+```ts
+const resolved = resolve(tree, { tokens, scope })
+// All `token="color.ink"` are now real CSSValues.
+```
+
+## Layout
+
+The layout phase computes box positions and dimensions. It runs once on
+the server during SSR and a second time on the client only when the
+viewport changes class (mobile / tablet / desktop).
+
+## Paint
+
+Paint is the only browser-only phase. It writes the resolved tree to the
+DOM and attaches event handlers. Paint never recurses into descendants
+that have not changed; the runtime tracks a per-subtree dirty bit.
+
+## Streaming
+
+Forma supports streaming SSR. The server emits the resolved tree
+incrementally so the browser can begin painting before layout is complete
+for the full document.
+
+```ts
+import { renderStream } from "forma/server"
+
+for await (const chunk of renderStream(<App />, { tokens })) {
+  response.write(chunk)
+}
+```
+
+Streaming is on by default. Disabling it requires explicit configuration;
+this is the only place in the framework where we discourage the
+non-default path.
+
+## Hydration
+
+Hydration walks the existing DOM and attaches policies. Because policies
+are declared at compile time, hydration does not need a virtual diff —
+the server-emitted tree and the client-resolved tree are byte-identical.

--- a/examples/forma-docs/content/docs/_index.md
+++ b/examples/forma-docs/content/docs/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Documentation"
+description = "All Forma reference pages, in reading order."
+sort_by = "weight"
+template = "section"
++++
+
+The reference is intentionally short. Read it once, in order, and you'll
+have seen the entire surface area of the framework.

--- a/examples/forma-docs/content/index.md
+++ b/examples/forma-docs/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Forma"
+description = "Typed UI primitives, documented like a language reference."
+template = "home"
++++
+
+Forma is a small, opinionated UI library. The surface is eight primitives,
+nine tokens, and one runtime — nothing else. This site is the canonical
+documentation, kept in lock-step with the package version pinned in the
+header.

--- a/examples/forma-docs/static/css/style.css
+++ b/examples/forma-docs/static/css/style.css
@@ -1,0 +1,421 @@
+:root {
+  --bg: #fafafa;
+  --panel: #ffffff;
+  --ink: #09090b;
+  --ink-2: #27272a;
+  --ink-3: #52525b;
+  --ink-4: #71717a;
+  --rule: #e4e4e7;
+  --rule-2: #d4d4d8;
+  --soft: #f4f4f5;
+  --link: #0a0a0a;
+  --accent: #2563eb;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 15px; scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  line-height: 1.6;
+}
+
+a { color: var(--link); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+code, pre, .mono { font-family: "Geist Mono", "JetBrains Mono", ui-monospace, monospace; }
+
+.shell {
+  display: grid;
+  grid-template-columns: 16rem 1fr;
+  min-height: 100vh;
+}
+
+aside.side {
+  border-right: 1px solid var(--rule);
+  background: var(--panel);
+  padding: 1.5rem 1.25rem;
+  position: sticky;
+  top: 0;
+  align-self: start;
+  max-height: 100vh;
+  overflow-y: auto;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin-bottom: 1.6rem;
+  color: var(--ink);
+}
+.brand .glyph {
+  width: 1.6rem; height: 1.6rem;
+  background: var(--ink);
+  position: relative;
+  border-radius: 4px;
+}
+.brand .glyph::before, .brand .glyph::after {
+  content: "";
+  position: absolute;
+  background: var(--bg);
+}
+.brand .glyph::before { inset: 0.3rem 0.5rem; }
+.brand .glyph::after { inset: 0.5rem 0.3rem; }
+
+.search {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--rule);
+  background: var(--bg);
+  border-radius: 8px;
+  padding: 0.42rem 0.7rem;
+  font-size: 0.82rem;
+  color: var(--ink-4);
+  margin-bottom: 1.4rem;
+  gap: 0.5rem;
+}
+.search .key {
+  margin-left: auto;
+  font-family: "Geist Mono", "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  border: 1px solid var(--rule);
+  background: var(--panel);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+
+.side h5 {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--ink-3);
+  margin: 1.3rem 0 0.4rem;
+  text-transform: uppercase;
+}
+.side ul { list-style: none; padding: 0; margin: 0; }
+.side li a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.38rem 0.65rem;
+  font-size: 0.86rem;
+  color: var(--ink-2);
+  border-radius: 6px;
+  margin: 0.05rem 0;
+}
+.side li a:hover { background: var(--soft); color: var(--ink); }
+.side li a .chev { color: var(--ink-4); font-family: "Geist Mono", monospace; font-size: 0.78rem; }
+.side li a:hover .chev { color: var(--ink); }
+
+main {
+  min-width: 0;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2.5rem;
+  border-bottom: 1px solid var(--rule);
+  background: rgba(250, 250, 250, 0.8);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.topbar nav { display: flex; gap: 1.4rem; font-size: 0.86rem; color: var(--ink-3); }
+.topbar nav a:hover { color: var(--ink); }
+.topbar .right { display: flex; gap: 0.6rem; align-items: center; font-size: 0.78rem; color: var(--ink-4); }
+.topbar .ver-pill {
+  background: var(--soft);
+  border: 1px solid var(--rule);
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  font-family: "Geist Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-2);
+}
+
+.wrap {
+  padding: 3rem 2.5rem 6rem;
+  max-width: 50rem;
+}
+
+.crumbs {
+  font-size: 0.8rem;
+  color: var(--ink-4);
+  margin-bottom: 1.4rem;
+}
+.crumbs a { color: var(--ink-4); }
+.crumbs a:hover { color: var(--ink); }
+.crumbs .sep { margin: 0 0.4rem; color: var(--rule-2); }
+
+h1.page-title {
+  font-size: 3rem;
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.04;
+  margin: 0 0 0.7rem;
+}
+.lede {
+  font-size: 1.12rem;
+  color: var(--ink-3);
+  max-width: 38rem;
+  margin: 0 0 1.6rem;
+}
+
+.meta-strip {
+  display: flex;
+  gap: 1.2rem;
+  font-size: 0.78rem;
+  color: var(--ink-4);
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.4rem;
+  flex-wrap: wrap;
+}
+.meta-strip .v { color: var(--ink); font-weight: 500; margin-left: 0.3rem; }
+.tag {
+  display: inline-block;
+  background: var(--soft);
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  color: var(--ink-2);
+  margin-right: 0.3rem;
+}
+.tag:hover { background: var(--ink); color: var(--bg); }
+
+article h2 {
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 3rem 0 0.6rem;
+  scroll-margin-top: 5rem;
+}
+article h3 {
+  font-size: 1.12rem;
+  font-weight: 600;
+  margin-top: 2rem;
+}
+article p { color: var(--ink-2); }
+article ul, article ol { color: var(--ink-2); padding-left: 1.4rem; }
+article strong { color: var(--ink); }
+
+article pre, pre[class*="language-"] {
+  background: var(--ink) !important;
+  color: #e4e4e7 !important;
+  padding: 1rem 1.25rem;
+  border-radius: 10px;
+  overflow-x: auto;
+  font-size: 0.84rem;
+  margin: 1.4rem 0;
+}
+article pre code, pre code { background: transparent !important; color: inherit !important; padding: 0; }
+article code {
+  background: var(--soft);
+  padding: 0.05rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.88em;
+  color: var(--ink);
+  border: 1px solid var(--rule);
+}
+
+article table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 1.5rem 0;
+  font-size: 0.88rem;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  overflow: hidden;
+}
+article th, article td {
+  text-align: left;
+  padding: 0.65rem 0.9rem;
+  border-bottom: 1px solid var(--rule);
+}
+article th {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-4);
+  background: var(--soft);
+  font-weight: 600;
+}
+article tr:last-child td { border-bottom: none; }
+
+article blockquote {
+  margin: 1.4rem 0;
+  padding: 0.7rem 1.1rem;
+  background: var(--soft);
+  border-radius: 8px;
+  color: var(--ink-2);
+  border-left: 2px solid var(--ink);
+}
+
+/* HOME */
+.hero {
+  padding: 4rem 2.5rem 3rem;
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+  overflow: hidden;
+}
+.hero .bignum {
+  position: absolute;
+  font-size: 26rem;
+  font-weight: 700;
+  letter-spacing: -0.06em;
+  color: var(--rule);
+  right: -2.5rem;
+  top: -4rem;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+.hero-inner { position: relative; max-width: 38rem; }
+.hero .eyebrow {
+  font-family: "Geist Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--ink-4);
+  letter-spacing: 0.02em;
+  margin-bottom: 0.8rem;
+}
+.hero h1 {
+  font-size: 3.6rem;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  margin: 0 0 0.9rem;
+}
+.hero p {
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0 0 1.8rem;
+  max-width: 32rem;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1rem;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  border: 1px solid var(--rule);
+  background: var(--panel);
+  color: var(--ink);
+  margin-right: 0.4rem;
+}
+.btn:hover { background: var(--soft); }
+.btn.primary { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+.btn.primary:hover { background: var(--ink-2); color: var(--bg); }
+.btn .arrow { font-family: "Geist Mono", monospace; }
+
+.section-h {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-4);
+  font-weight: 600;
+  margin: 3rem 0 1.2rem;
+}
+
+.chap-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+  margin-bottom: 2rem;
+}
+.chap-list .row {
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  gap: 1.5rem;
+  align-items: center;
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  padding: 1.1rem 1.4rem;
+  transition: all 0.15s;
+}
+.chap-list .row:hover {
+  border-color: var(--ink-3);
+  transform: translateY(-1px);
+}
+.chap-list .row .num {
+  font-family: "Geist Mono", monospace;
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: var(--ink-4);
+  letter-spacing: -0.02em;
+}
+.chap-list .row h3 { margin: 0; font-size: 1.05rem; font-weight: 600; color: var(--ink); }
+.chap-list .row p { margin: 0.2rem 0 0; color: var(--ink-3); font-size: 0.86rem; }
+.chap-list .row .go {
+  font-family: "Geist Mono", monospace;
+  font-size: 0.85rem;
+  color: var(--ink-4);
+}
+.chap-list .row:hover .go { color: var(--ink); }
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+}
+.feature-grid .f {
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  padding: 1.2rem;
+}
+.feature-grid .f .glyph {
+  width: 2rem; height: 2rem;
+  background: var(--ink);
+  border-radius: 6px;
+  margin-bottom: 0.7rem;
+  position: relative;
+}
+.feature-grid .f .glyph::after {
+  content: "";
+  position: absolute;
+  inset: 0.5rem;
+  border: 1.5px solid var(--bg);
+  border-radius: 2px;
+}
+.feature-grid .f h4 { margin: 0 0 0.3rem; font-size: 0.96rem; font-weight: 600; }
+.feature-grid .f p { margin: 0; font-size: 0.84rem; color: var(--ink-3); }
+
+.foot {
+  border-top: 1px solid var(--rule);
+  padding: 2rem 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--ink-4);
+}
+
+.notfound { padding: 5rem 2.5rem; text-align: center; }
+.notfound h1 { font-size: 7rem; margin: 0; font-weight: 700; letter-spacing: -0.05em; color: var(--ink); }
+.notfound p { color: var(--ink-4); }
+
+@media (max-width: 900px) {
+  .shell { grid-template-columns: 1fr; }
+  aside.side { position: static; max-height: none; border-right: none; border-bottom: 1px solid var(--rule); }
+  .topbar, .wrap, .foot, .hero { padding-left: 1.25rem; padding-right: 1.25rem; }
+  .hero h1 { font-size: 2.6rem; }
+  .hero .bignum { font-size: 14rem; right: -1rem; top: -1rem; }
+  .feature-grid { grid-template-columns: 1fr; }
+  .chap-list .row { grid-template-columns: 3rem 1fr; }
+  .chap-list .row .go { display: none; }
+}

--- a/examples/forma-docs/static/favicon.svg
+++ b/examples/forma-docs/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="#09090b"/><rect x="8" y="8" width="16" height="16" rx="3" fill="#fafafa"/><rect x="11" y="11" width="10" height="10" rx="1" fill="#09090b"/></svg>

--- a/examples/forma-docs/templates/404.html
+++ b/examples/forma-docs/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p>That primitive does not exist in this composition.</p>
+  <p style="margin-top:1.4rem;">
+    <a class="btn primary" href="{{ base_url }}/">Home</a>
+    <a class="btn" href="{{ base_url }}/docs/">Docs</a>
+  </p>
+</div>
+{% include "footer.html" %}

--- a/examples/forma-docs/templates/footer.html
+++ b/examples/forma-docs/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="foot">
+      <span>{{ site_title }} · v0.18.0</span>
+      <span>BUILT WITH HWARO · {{ current_year }}</span>
+    </footer>
+  </main>
+</div>
+</body>
+</html>

--- a/examples/forma-docs/templates/header.html
+++ b/examples/forma-docs/templates/header.html
@@ -9,7 +9,7 @@
 <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 {{ og_all_tags | safe }}
 {{ canonical_tag | safe }}
 {{ highlight_tags | safe }}

--- a/examples/forma-docs/templates/header.html
+++ b/examples/forma-docs/templates/header.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="shell">
+  <aside class="side">
+    <a class="brand" href="{{ base_url }}/">
+      <span class="glyph"></span>
+      <span>Forma</span>
+    </a>
+    <div class="search">
+      <span class="mono">search</span>
+      <span class="key">⌘ K</span>
+    </div>
+    <h5>Reference</h5>
+    <ul>
+      <li><a href="{{ base_url }}/docs/01-primitives/"><span>Primitives</span><span class="chev">›</span></a></li>
+      <li><a href="{{ base_url }}/docs/02-composition/"><span>Composition</span><span class="chev">›</span></a></li>
+      <li><a href="{{ base_url }}/docs/03-tokens/"><span>Tokens</span><span class="chev">›</span></a></li>
+      <li><a href="{{ base_url }}/docs/04-runtime/"><span>Runtime</span><span class="chev">›</span></a></li>
+    </ul>
+    <h5>Meta</h5>
+    <ul>
+      <li><a href="{{ base_url }}/tags/"><span>All tags</span><span class="chev">›</span></a></li>
+      <li><a href="{{ base_url }}/categories/"><span>Categories</span><span class="chev">›</span></a></li>
+      <li><a href="{{ base_url }}/docs/"><span>Section index</span><span class="chev">›</span></a></li>
+    </ul>
+  </aside>
+  <main>
+    <header class="topbar">
+      <nav>
+        <a href="{{ base_url }}/docs/">Docs</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="https://github.com/hahwul/hwaro">Source</a>
+      </nav>
+      <div class="right">
+        <span class="ver-pill">v0.18.0</span>
+      </div>
+    </header>

--- a/examples/forma-docs/templates/home.html
+++ b/examples/forma-docs/templates/home.html
@@ -1,0 +1,71 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="bignum">01</div>
+  <div class="hero-inner">
+    <div class="eyebrow">Forma — v0.18.0 — stable</div>
+    <h1>Typed UI primitives, documented like a language reference.</h1>
+    <p>{{ site.description }}</p>
+    <a class="btn primary" href="{{ base_url }}/docs/01-primitives/">Read the docs <span class="arrow">→</span></a>
+    <a class="btn" href="{{ base_url }}/docs/">All chapters</a>
+  </div>
+</section>
+
+<div class="wrap" style="max-width:64rem;">
+  {{ content | safe }}
+
+  <h2 class="section-h">Chapters</h2>
+  <div class="chap-list">
+    <a class="row" href="{{ base_url }}/docs/01-primitives/">
+      <div class="num">01</div>
+      <div>
+        <h3>Primitives</h3>
+        <p>The eight components Forma exposes, with their full type signatures.</p>
+      </div>
+      <div class="go">→</div>
+    </a>
+    <a class="row" href="{{ base_url }}/docs/02-composition/">
+      <div class="num">02</div>
+      <div>
+        <h3>Composition</h3>
+        <p>How primitives combine into layouts. Slots, props, and policy types.</p>
+      </div>
+      <div class="go">→</div>
+    </a>
+    <a class="row" href="{{ base_url }}/docs/03-tokens/">
+      <div class="num">03</div>
+      <div>
+        <h3>Tokens</h3>
+        <p>The design token surface. Colours, spacing, type scale, motion.</p>
+      </div>
+      <div class="go">→</div>
+    </a>
+    <a class="row" href="{{ base_url }}/docs/04-runtime/">
+      <div class="num">04</div>
+      <div>
+        <h3>Runtime</h3>
+        <p>Server rendering, hydration, and the streaming render pipeline.</p>
+      </div>
+      <div class="go">→</div>
+    </a>
+  </div>
+
+  <h2 class="section-h">Why Forma</h2>
+  <div class="feature-grid">
+    <div class="f">
+      <div class="glyph"></div>
+      <h4>One contract</h4>
+      <p>Every primitive obeys the same prop conventions. Learn one, know them all.</p>
+    </div>
+    <div class="f">
+      <div class="glyph"></div>
+      <h4>Typed slots</h4>
+      <p>Children are typed by slot. Misuse fails at compile time, not at runtime.</p>
+    </div>
+    <div class="f">
+      <div class="glyph"></div>
+      <h4>Zero ambiguity</h4>
+      <p>No magic class names. Every visual change is reachable from a token.</p>
+    </div>
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/forma-docs/templates/page.html
+++ b/examples/forma-docs/templates/page.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<div class="wrap">
+  <nav class="crumbs">
+    <a href="{{ base_url }}/">Forma</a><span class="sep">/</span>
+    <a href="{{ base_url }}/docs/">Docs</a><span class="sep">/</span>
+    <span>{{ page.title | e }}</span>
+  </nav>
+  <article>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+    <div class="meta-strip">
+      {% if page.date %}<span>Published <span class="v">{{ page.date | date(format="%B %d, %Y") }}</span></span>{% endif %}
+      {% if page.reading_time %}<span>Read <span class="v">{{ page.reading_time }} min</span></span>{% endif %}
+      {% if page.tags %}<span>{% for t in page.tags %}<a class="tag" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</span>{% endif %}
+    </div>
+    {{ content | safe }}
+  </article>
+</div>
+{% include "footer.html" %}

--- a/examples/forma-docs/templates/section.html
+++ b/examples/forma-docs/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+<div class="wrap" style="max-width:64rem;">
+  <nav class="crumbs">
+    <a href="{{ base_url }}/">Forma</a><span class="sep">/</span>
+    <span>{{ page.title | e }}</span>
+  </nav>
+  <h1 class="page-title">{{ page.title | e }}</h1>
+  {% if content %}<p class="lede">{{ content | striptags | trim }}</p>{% endif %}
+
+  <h2 class="section-h">All chapters · {{ section.pages_count }}</h2>
+  <div class="chap-list">
+    {% for p in section.pages %}
+    <a class="row" href="{{ p.url }}">
+      <div class="num">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+      <div>
+        <h3>{{ p.title | e }}</h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+      </div>
+      <div class="go">→</div>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/forma-docs/templates/shortcodes/alert.html
+++ b/examples/forma-docs/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div style="background:var(--soft);border:1px solid var(--rule);border-left:3px solid var(--ink);border-radius:0 8px 8px 0;padding:0.8rem 1.1rem;margin:1.2rem 0;">
+  <div style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--ink-4);font-weight:600;margin-bottom:0.2rem;">{{ type | default(value="note") }}</div>
+  {{ body }}
+</div>

--- a/examples/forma-docs/templates/taxonomy.html
+++ b/examples/forma-docs/templates/taxonomy.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<div class="wrap" style="max-width:64rem;">
+  <nav class="crumbs">
+    <a href="{{ base_url }}/">Forma</a><span class="sep">/</span>
+    <span>{{ taxonomy_name | default(value="tags") }}</span>
+  </nav>
+  <h1 class="page-title">{{ taxonomy_name | default(value="tags") | capitalize }}</h1>
+  <p class="lede">All terms in the <strong>{{ taxonomy_name }}</strong> taxonomy.</p>
+  <div class="chap-list">
+    {% for term in taxonomy_terms %}
+    <a class="row" href="{{ term.url }}">
+      <div class="num">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+      <div>
+        <h3>{{ term.name }}</h3>
+        <p>{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %}</p>
+      </div>
+      <div class="go">→</div>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/forma-docs/templates/taxonomy_term.html
+++ b/examples/forma-docs/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<div class="wrap" style="max-width:64rem;">
+  <nav class="crumbs">
+    <a href="{{ base_url }}/">Forma</a><span class="sep">/</span>
+    <a href="{{ base_url }}/{{ taxonomy_name }}/">{{ taxonomy_name }}</a><span class="sep">/</span>
+    <span>{{ page.title }}</span>
+  </nav>
+  <h1 class="page-title">{{ page.title }}</h1>
+  <p class="lede">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} tagged <strong>{{ page.title }}</strong>.</p>
+  <div class="chap-list">
+    {% for p in taxonomy_pages %}
+    <a class="row" href="{{ p.url }}">
+      <div class="num">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+      <div>
+        <h3>{{ p.title | e }}</h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+      </div>
+      <div class="go">→</div>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/lattice-handbook/AGENTS.md
+++ b/examples/lattice-handbook/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md - AI Agent Instructions for Lattice Handbook
+
+This is a Hwaro static site. See [Hwaro Documentation](https://hwaro.hahwul.com)
+for full reference and [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt)
+for an AI-optimized version.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build to `public/` |
+| `hwaro serve` | Dev server on port 3000 |
+| `hwaro new docs/05-foo.md` | Create new content |
+
+## Notes
+
+1. Front matter is TOML between `+++` delimiters.
+2. Rendered content is `{{ content | safe }}`.
+3. Custom metadata is `page.extra.field`.
+4. Use `{{ base_url }}` for all links and assets.
+5. CSS lives in `static/css/style.css`; do not inline.

--- a/examples/lattice-handbook/archetypes/default.md
+++ b/examples/lattice-handbook/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/lattice-handbook/config.toml
+++ b/examples/lattice-handbook/config.toml
@@ -1,0 +1,45 @@
+title = "Lattice Handbook"
+description = "A modern reference for the Lattice graph engine. Hairline grid, mint accent, tabular data."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/lattice-handbook/content/docs/01-overview.md
+++ b/examples/lattice-handbook/content/docs/01-overview.md
@@ -1,0 +1,51 @@
++++
+title = "Overview"
+description = "What Lattice is, what it isn't, and the constraints that shaped it."
+date = "2026-05-02"
+weight = 1
+tags = ["intro", "architecture"]
++++
+
+## What Lattice is
+
+Lattice is a property-graph engine for read-heavy workloads where latency
+matters more than write throughput. The query layer is decoupled from
+storage so that planners can target either the embedded RocksDB backend or
+a cluster-mode shard set without changes to the user-facing API.
+
+A typical deployment looks like this:
+
+```text
+   ┌────────────┐    ┌────────────┐    ┌────────────┐
+   │  Gateway   ├───▶│  Planner   ├───▶│  Executor  │
+   └────────────┘    └────────────┘    └─────┬──────┘
+                                             ▼
+                                     ┌───────────────┐
+                                     │ Storage Shard │
+                                     └───────────────┘
+```
+
+## What Lattice is not
+
+Lattice does not attempt to be a general-purpose graph database. There is
+no ACID transaction guarantee across shards, no support for online schema
+migration, and no plan to add either. If you need those, use a different
+tool.
+
+## Design constraints
+
+| Constraint        | Value                            |
+|-------------------|----------------------------------|
+| p99 read latency  | ≤ 5 ms at 100k QPS               |
+| Max graph size    | 50B edges per cluster            |
+| Replication       | Asynchronous, log-shipped        |
+| Index types       | Property, edge-type, full-text   |
+
+The numbers above are not aspirational. They are the contract the engine
+holds. If a release misses them, the release is reverted.
+
+## Reading order
+
+1. **Graph Model** — the type system the planner depends on.
+2. **Query API** — how to express traversals.
+3. **Deployment** — how to run a cluster without paging at 3 a.m.

--- a/examples/lattice-handbook/content/docs/02-graph-model.md
+++ b/examples/lattice-handbook/content/docs/02-graph-model.md
@@ -1,0 +1,63 @@
++++
+title = "Graph Model"
+description = "Nodes, edges, properties, and the typing rules the planner depends on."
+date = "2026-05-05"
+weight = 2
+tags = ["model", "schema"]
++++
+
+## Nodes
+
+Every node has a stable 128-bit identifier and a typed label. Labels are
+immutable for the lifetime of a node; renaming a label requires inserting
+a new node and migrating edges.
+
+```toml
+[node]
+id = "01HW3K2N9A...XQ"
+label = "Account"
+
+[node.properties]
+created_at = 1714521600
+status      = "active"
+tier        = "pro"
+```
+
+## Edges
+
+Edges are directed and typed. A pair `(label, direction)` defines a unique
+adjacency list on the source node, which is what makes single-hop
+traversals constant-time.
+
+```toml
+[edge]
+type   = "OWNS"
+source = "01HW3K2N9A...XQ"
+target = "01HW3K8T1Q...AB"
+weight = 1.0
+```
+
+## Properties
+
+Properties are typed and indexed at write time. The supported scalar types
+are: `int64`, `float64`, `bool`, `string`, `bytes`, and `instant`. Lists of
+scalars are allowed; nested maps are not.
+
+| Type      | Indexable | Range scan |
+|-----------|-----------|------------|
+| `int64`   | •         | •          |
+| `float64` | •         | •          |
+| `bool`    | •         | —          |
+| `string`  | •         | prefix     |
+| `instant` | •         | •          |
+| `bytes`   | —         | —          |
+
+## Typing rules
+
+The planner relies on three invariants:
+
+1. **Label closure.** Every node has exactly one label, fixed at insert.
+2. **Edge constancy.** An edge's `(source_label, type, target_label)` tuple
+   is fixed at insert and cannot be redefined.
+3. **Property monotonicity.** Property types may only be widened
+   (`int64 → float64`), never narrowed.

--- a/examples/lattice-handbook/content/docs/03-query-api.md
+++ b/examples/lattice-handbook/content/docs/03-query-api.md
@@ -1,0 +1,71 @@
++++
+title = "Query API"
+description = "The traversal grammar, with examples drawn from production workloads."
+date = "2026-05-08"
+weight = 3
+tags = ["api", "traversal"]
++++
+
+## Surface
+
+The query API is a single endpoint. Queries are sent as a JSON envelope; the
+planner returns a streaming result set. There is no client library beyond
+the thin wrappers that ship with the runtime.
+
+```http
+POST /v3/query HTTP/1.1
+Host: lattice.internal
+Content-Type: application/json
+
+{
+  "trav": "g.V().has('Account','tier','pro').out('OWNS').values('region')",
+  "timeout_ms": 250
+}
+```
+
+## Traversal grammar
+
+Traversals are expressed in a Gremlin-compatible subset. The compatible
+operators are listed below. Steps not in this list will be rejected at
+parse time.
+
+| Step          | Cardinality | Notes                              |
+|---------------|-------------|------------------------------------|
+| `V()`         | many        | Entry into the vertex space        |
+| `has(...)`    | filter      | Property predicate                 |
+| `out(type)`   | many        | Outgoing edges of a type           |
+| `in(type)`    | many        | Incoming edges of a type           |
+| `values(k)`   | many        | Project a property to the stream   |
+| `count()`     | one         | Terminal aggregation               |
+| `limit(n)`    | many        | Bounded scan                       |
+
+## Planner hints
+
+```toml
+[hint]
+# Pin the plan to the property index even if cost says otherwise.
+index = "Account.tier"
+
+# Reject queries the planner estimates above this row budget.
+max_rows = 10_000_000
+```
+
+Hints are advisory in development and enforced in production. The same
+query, with the same hint, will either succeed or fail consistently across
+environments.
+
+## Errors
+
+The query API returns structured errors. The shape is stable across
+versions; new fields may be added but existing fields will not be removed.
+
+```json
+{
+  "error": {
+    "code": "PLAN_TIMEOUT",
+    "stage": "planner",
+    "detail": "exceeded 50ms budget",
+    "trace_id": "01HW3K9F4Z...PQ"
+  }
+}
+```

--- a/examples/lattice-handbook/content/docs/04-deployment.md
+++ b/examples/lattice-handbook/content/docs/04-deployment.md
@@ -1,0 +1,67 @@
++++
+title = "Deployment"
+description = "Topologies, resource sizing, and operational playbooks for SRE teams."
+date = "2026-05-12"
+weight = 4
+tags = ["ops", "deployment"]
++++
+
+## Topologies
+
+Lattice ships with two reference topologies. Both are first-class; the
+single-node topology is not a development-only mode.
+
+### Single node
+
+The single-node topology runs the gateway, planner, and storage in one
+process. It scales vertically to about 4B edges before the storage layer
+becomes the dominant bottleneck.
+
+```bash
+lattice serve \
+  --bind 0.0.0.0:7170 \
+  --data /var/lib/lattice \
+  --memory 32G
+```
+
+### Cluster
+
+The cluster topology shards the graph by source-vertex hash. Each shard is
+served by a triplet of replicas. The gateway is stateless and can be
+horizontally scaled independently.
+
+| Component | Replicas | CPU      | Memory | Disk      |
+|-----------|----------|----------|--------|-----------|
+| Gateway   | 3+       | 4 vCPU   | 8 GB   | —         |
+| Planner   | 3+       | 8 vCPU   | 16 GB  | —         |
+| Storage   | 3 / shard| 16 vCPU  | 64 GB  | NVMe SSD  |
+
+## Sizing
+
+A reasonable rule of thumb: one storage shard per 5B edges, plus 30%
+headroom. Past 50B edges per cluster, the operational complexity grows
+sharply; consider partitioning the graph at the application boundary.
+
+## Observability
+
+Every binary exposes a Prometheus endpoint on port 7180.
+
+```text
+lattice_query_p99_ms{shard="0"}        4.1
+lattice_query_p99_ms{shard="1"}        4.3
+lattice_storage_compaction_pending     2
+lattice_replication_lag_ms{shard="0"}  12
+```
+
+## On-call
+
+The on-call playbook is short by design.
+
+1. Check `lattice_query_p99_ms` per shard. Outliers usually mean a hot key.
+2. If a shard is hot, force a key-range split with `lattice admin split`.
+3. If the planner is busy, increase planner replicas. The planner is
+   stateless and rebalances in seconds.
+4. If storage compaction backs up, throttle writes with the gateway's
+   `write_quota` setting until the backlog drains.
+
+These four steps cover roughly 95% of pages the team sees in a quarter.

--- a/examples/lattice-handbook/content/docs/_index.md
+++ b/examples/lattice-handbook/content/docs/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Reference"
+description = "All Lattice documentation pages, sorted by chapter weight."
+sort_by = "weight"
+template = "section"
++++
+
+Each chapter is self-contained but the chapters are written in order. Readers
+new to Lattice should start with the overview before reaching for the API.

--- a/examples/lattice-handbook/content/index.md
+++ b/examples/lattice-handbook/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Lattice Handbook"
+description = "A modern reference for the Lattice graph engine."
+template = "home"
++++
+
+Lattice is a distributed property-graph engine designed for low-latency
+traversals over billion-edge workloads. This handbook is the canonical
+reference — the surface here matches the binary at the version pinned in
+the topbar, no more, no less.

--- a/examples/lattice-handbook/static/css/style.css
+++ b/examples/lattice-handbook/static/css/style.css
@@ -1,0 +1,437 @@
+:root {
+  --bg: #0a0c10;
+  --bg-2: #11141b;
+  --bg-3: #161a23;
+  --fg: #e8ecf2;
+  --fg-2: #b6bdcb;
+  --fg-3: #6e7787;
+  --rule: #1f2430;
+  --rule-2: #2a3142;
+  --mint: #6ee7d4;
+  --mint-2: #2dd4bf;
+  --warn: #fbbf24;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 15px; scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'><path d='M48 0H0V48' fill='none' stroke='%231f2430' stroke-width='1'/></svg>");
+  background-repeat: repeat;
+  color: var(--fg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+  font-feature-settings: "ss01", "cv11";
+}
+
+a { color: var(--fg); text-decoration: none; }
+a:hover { color: var(--mint); }
+
+code, pre, .mono { font-family: "JetBrains Mono", ui-monospace, monospace; }
+
+.shell {
+  max-width: 92rem;
+  margin: 0 auto;
+  padding: 0 1.75rem;
+  display: grid;
+  grid-template-columns: 16rem minmax(0, 1fr) 14rem;
+  gap: 2.5rem;
+  min-height: 100vh;
+}
+
+.topbar {
+  grid-column: 1 / -1;
+  border-bottom: 1px solid var(--rule);
+  padding: 1.1rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(10, 12, 16, 0.7);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: -0.01em;
+}
+.brand .glyph {
+  width: 1.5rem; height: 1.5rem;
+  border: 1px solid var(--mint);
+  position: relative;
+}
+.brand .glyph::after {
+  content: "";
+  position: absolute;
+  inset: 0.32rem;
+  background: var(--mint);
+}
+.brand .name { font-family: "JetBrains Mono", monospace; }
+.brand .name b { color: var(--mint); font-weight: 600; }
+
+.topbar nav {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.82rem;
+  color: var(--fg-2);
+  font-family: "JetBrains Mono", monospace;
+}
+.topbar nav a:hover { color: var(--fg); }
+
+.topbar .right {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 0.75rem;
+  color: var(--fg-3);
+  font-family: "JetBrains Mono", monospace;
+}
+.topbar .right .pill {
+  border: 1px solid var(--rule-2);
+  padding: 0.18rem 0.5rem;
+  border-radius: 999px;
+  color: var(--fg-2);
+}
+.topbar .right .pill .ok { color: var(--mint); }
+
+aside.nav-side {
+  padding: 2rem 0.5rem 4rem 0;
+  position: sticky;
+  top: 4rem;
+  align-self: start;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  font-size: 0.86rem;
+}
+.nav-side h5 {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  margin: 1.5rem 0 0.6rem;
+  font-weight: 500;
+}
+.nav-side ul { list-style: none; padding: 0; margin: 0; }
+.nav-side li { padding: 0.08rem 0; }
+.nav-side li a {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding: 0.32rem 0.55rem;
+  border-radius: 6px;
+  color: var(--fg-2);
+}
+.nav-side li a .idx {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  color: var(--fg-3);
+  letter-spacing: 0.05em;
+}
+.nav-side li a:hover {
+  background: var(--bg-2);
+  color: var(--fg);
+}
+
+aside.toc {
+  padding: 2rem 0 4rem 0;
+  position: sticky;
+  top: 4rem;
+  align-self: start;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  font-size: 0.78rem;
+  color: var(--fg-3);
+  border-left: 1px solid var(--rule);
+  padding-left: 1.2rem;
+}
+.toc h5 {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  margin: 0 0 0.6rem;
+  font-weight: 500;
+}
+.toc-line {
+  border-top: 1px dashed var(--rule-2);
+  margin: 0.6rem 0 0.8rem;
+}
+
+main.body {
+  padding: 2rem 0 5rem;
+  min-width: 0;
+}
+
+.crumbs {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--fg-3);
+  letter-spacing: 0.05em;
+  margin-bottom: 1.4rem;
+}
+.crumbs a { color: var(--fg-3); }
+.crumbs a:hover { color: var(--mint); }
+.crumbs .sep { color: var(--rule-2); margin: 0 0.4rem; }
+
+h1.page-title {
+  font-size: 2.8rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  margin: 0.3rem 0 0.8rem;
+}
+.lede {
+  font-size: 1.08rem;
+  color: var(--fg-2);
+  max-width: 42rem;
+  margin: 0 0 1.6rem;
+}
+
+.meta-strip {
+  display: flex;
+  gap: 1.6rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  padding: 0.8rem 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  color: var(--fg-3);
+  margin-bottom: 2.4rem;
+}
+.meta-strip .k { color: var(--fg-3); }
+.meta-strip .v { color: var(--fg); margin-left: 0.4rem; }
+.meta-strip .tag {
+  display: inline-block;
+  border: 1px solid var(--rule-2);
+  padding: 0.05rem 0.45rem;
+  border-radius: 3px;
+  color: var(--fg-2);
+  margin-right: 0.3rem;
+  font-size: 0.72rem;
+}
+
+article h2 {
+  font-size: 1.45rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 3rem 0 0.8rem;
+  padding-top: 1.6rem;
+  border-top: 1px solid var(--rule);
+  position: relative;
+}
+article h2::before {
+  content: attr(data-idx);
+  position: absolute;
+  top: 1.6rem;
+  left: -2.4rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--mint);
+}
+article h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-top: 2rem;
+  color: var(--fg);
+}
+article p { color: var(--fg-2); font-size: 0.96rem; }
+article ul, article ol { color: var(--fg-2); padding-left: 1.4rem; }
+article strong { color: var(--fg); }
+
+article pre, pre[class*="language-"] {
+  background: var(--bg-2) !important;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  position: relative;
+}
+article pre::before {
+  content: attr(data-lang);
+  position: absolute;
+  top: 0.55rem; right: 0.85rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+}
+article pre code, pre code { background: transparent !important; color: var(--fg) !important; padding: 0; }
+article code {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 0.05rem 0.42rem;
+  border-radius: 4px;
+  font-size: 0.88em;
+  color: var(--mint);
+}
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.88rem;
+}
+article th, article td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+}
+article th {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  border-bottom: 1px solid var(--rule-2);
+}
+article tr:last-child td { border-bottom: 1px solid var(--rule-2); }
+
+article blockquote {
+  margin: 1.4rem 0;
+  padding: 0.7rem 1.1rem;
+  border-left: 2px solid var(--mint);
+  background: var(--bg-2);
+  border-radius: 0 6px 6px 0;
+  color: var(--fg-2);
+}
+
+/* HOME */
+.hero {
+  padding: 3.5rem 0 3rem;
+  border-bottom: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2rem;
+  align-items: end;
+}
+.hero h1 {
+  font-size: 3.6rem;
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1;
+  margin: 0 0 0.8rem;
+}
+.hero h1 .accent { color: var(--mint); }
+.hero p { font-size: 1.1rem; color: var(--fg-2); max-width: 38rem; margin: 0 0 1.6rem; }
+.hero .ctas { display: flex; gap: 0.6rem; }
+.btn {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  padding: 0.6rem 1rem;
+  border-radius: 6px;
+  border: 1px solid var(--rule-2);
+  color: var(--fg);
+}
+.btn:hover { border-color: var(--mint); color: var(--mint); }
+.btn.primary {
+  background: var(--mint);
+  color: var(--bg);
+  border-color: var(--mint);
+  font-weight: 600;
+}
+.btn.primary:hover { background: var(--mint-2); color: var(--bg); border-color: var(--mint-2); }
+
+.stat-block {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--fg-3);
+  border: 1px solid var(--rule);
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  background: rgba(17, 20, 27, 0.65);
+  min-width: 14rem;
+}
+.stat-block .row { display: flex; justify-content: space-between; padding: 0.2rem 0; }
+.stat-block .row .v { color: var(--fg); }
+.stat-block .row .v.ok { color: var(--mint); }
+
+.chap-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 2.5rem 0;
+}
+.chap-grid .cell {
+  background: var(--bg);
+  padding: 1.4rem 1.5rem;
+  display: block;
+  transition: background 0.15s;
+}
+.chap-grid .cell:hover { background: var(--bg-2); }
+.chap-grid .cell .idx {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--mint);
+  letter-spacing: 0.1em;
+}
+.chap-grid .cell h3 {
+  margin: 0.3rem 0 0.4rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--fg);
+}
+.chap-grid .cell p { margin: 0; color: var(--fg-3); font-size: 0.86rem; }
+
+h2.section-h {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  margin: 3rem 0 1rem;
+  font-weight: 500;
+}
+
+.foot {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule);
+  margin-top: 3rem;
+  padding: 1.5rem 0 2rem;
+  display: flex;
+  justify-content: space-between;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  color: var(--fg-3);
+}
+
+.notfound {
+  padding: 5rem 0;
+  text-align: center;
+}
+.notfound h1 {
+  font-size: 6rem;
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: -0.05em;
+  color: var(--mint);
+}
+.notfound p { color: var(--fg-3); }
+
+@media (max-width: 1100px) {
+  .shell { grid-template-columns: 14rem minmax(0, 1fr); }
+  aside.toc { display: none; }
+}
+@media (max-width: 760px) {
+  .shell { grid-template-columns: 1fr; gap: 0.5rem; padding: 0 1rem; }
+  aside.nav-side { position: static; max-height: none; padding: 1rem 0; border-bottom: 1px solid var(--rule); }
+  .topbar { flex-direction: column; gap: 0.6rem; align-items: flex-start; }
+  .hero { grid-template-columns: 1fr; }
+  .hero h1 { font-size: 2.6rem; }
+  .chap-grid { grid-template-columns: 1fr; }
+}

--- a/examples/lattice-handbook/static/css/style.css
+++ b/examples/lattice-handbook/static/css/style.css
@@ -388,6 +388,15 @@ article blockquote {
 }
 .chap-grid .cell p { margin: 0; color: var(--fg-3); font-size: 0.86rem; }
 
+.eyebrow {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  color: var(--fg-3);
+  letter-spacing: 0.1em;
+  margin-bottom: 0.8rem;
+}
+.eyebrow--tight { margin-bottom: 0.6rem; }
+
 h2.section-h {
   font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;

--- a/examples/lattice-handbook/static/favicon.svg
+++ b/examples/lattice-handbook/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#0a0c10"/><rect x="6" y="6" width="20" height="20" fill="none" stroke="#6ee7d4" stroke-width="2"/><rect x="12" y="12" width="8" height="8" fill="#6ee7d4"/></svg>

--- a/examples/lattice-handbook/templates/404.html
+++ b/examples/lattice-handbook/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p style="font-family:'JetBrains Mono',monospace;letter-spacing:0.18em;font-size:0.8rem;color:var(--fg-3);text-transform:uppercase;">node not present in lattice</p>
+  <div style="margin-top:1.5rem;display:flex;gap:0.6rem;justify-content:center;">
+    <a class="btn primary" href="{{ base_url }}/">home</a>
+    <a class="btn" href="{{ base_url }}/docs/">docs</a>
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/lattice-handbook/templates/footer.html
+++ b/examples/lattice-handbook/templates/footer.html
@@ -1,0 +1,23 @@
+  </main>
+
+  <aside class="toc">
+    <h5>On this page</h5>
+    <div class="toc-line"></div>
+    <div style="font-family:'JetBrains Mono',monospace;color:var(--fg-3);font-size:0.74rem;">
+      Section headings are auto-anchored. Scroll the page to track context.
+    </div>
+    <h5 style="margin-top:2rem;">Links</h5>
+    <div style="font-size:0.78rem;">
+      <a href="{{ base_url }}/docs/" style="display:block;padding:0.18rem 0;color:var(--fg-2);">→ Reference index</a>
+      <a href="{{ base_url }}/tags/" style="display:block;padding:0.18rem 0;color:var(--fg-2);">→ Tag cloud</a>
+      <a href="https://github.com/hahwul/hwaro" style="display:block;padding:0.18rem 0;color:var(--fg-2);">→ Hwaro source</a>
+    </div>
+  </aside>
+
+  <footer class="foot">
+    <span>{{ site_title }} · v2.6.1</span>
+    <span>BUILT WITH HWARO · {{ current_year }}</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/lattice-handbook/templates/header.html
+++ b/examples/lattice-handbook/templates/header.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="shell">
+  <header class="topbar">
+    <a class="brand" href="{{ base_url }}/">
+      <span class="glyph"></span>
+      <span class="name">lattice<b>/</b>handbook</span>
+    </a>
+    <nav>
+      <a href="{{ base_url }}/docs/">docs</a>
+      <a href="{{ base_url }}/tags/">tags</a>
+      <a href="https://github.com/hahwul/hwaro">source</a>
+    </nav>
+    <div class="right">
+      <span class="pill">build <span class="ok">passing</span></span>
+      <span>v2.6.1</span>
+    </div>
+  </header>
+
+  <aside class="nav-side">
+    <h5>Reference</h5>
+    <ul>
+      <li><a href="{{ base_url }}/docs/01-overview/"><span class="idx">01</span><span>Overview</span></a></li>
+      <li><a href="{{ base_url }}/docs/02-graph-model/"><span class="idx">02</span><span>Graph Model</span></a></li>
+      <li><a href="{{ base_url }}/docs/03-query-api/"><span class="idx">03</span><span>Query API</span></a></li>
+      <li><a href="{{ base_url }}/docs/04-deployment/"><span class="idx">04</span><span>Deployment</span></a></li>
+    </ul>
+    <h5>Meta</h5>
+    <ul>
+      <li><a href="{{ base_url }}/tags/"><span class="idx">⌗</span><span>All tags</span></a></li>
+      <li><a href="{{ base_url }}/categories/"><span class="idx">⌗</span><span>Categories</span></a></li>
+      <li><a href="{{ base_url }}/docs/"><span class="idx">⌗</span><span>Section index</span></a></li>
+    </ul>
+  </aside>
+
+  <main class="body">

--- a/examples/lattice-handbook/templates/home.html
+++ b/examples/lattice-handbook/templates/home.html
@@ -1,0 +1,59 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div style="font-family:'JetBrains Mono',monospace;font-size:0.75rem;color:var(--fg-3);letter-spacing:0.1em;margin-bottom:0.8rem;">REFERENCE · v2.6.1 · STABLE</div>
+    <h1>The graph engine,<br/><span class="accent">documented end to end.</span></h1>
+    <p>{{ site.description }}</p>
+    <div class="ctas">
+      <a class="btn primary" href="{{ base_url }}/docs/01-overview/">read overview →</a>
+      <a class="btn" href="{{ base_url }}/docs/">browse all chapters</a>
+    </div>
+  </div>
+  <div class="stat-block">
+    <div class="row"><span>release</span><span class="v">2.6.1</span></div>
+    <div class="row"><span>cluster api</span><span class="v">v3</span></div>
+    <div class="row"><span>storage</span><span class="v">rocksdb</span></div>
+    <div class="row"><span>latency p99</span><span class="v ok">4.2 ms</span></div>
+    <div class="row"><span>status</span><span class="v ok">operational</span></div>
+  </div>
+</section>
+
+<article>
+  {{ content | safe }}
+
+  <h2 class="section-h">CHAPTERS</h2>
+  <div class="chap-grid">
+    <a class="cell" href="{{ base_url }}/docs/01-overview/">
+      <span class="idx">CH 01</span>
+      <h3>Overview</h3>
+      <p>What Lattice is, what it isn't, and the constraints that drove its shape.</p>
+    </a>
+    <a class="cell" href="{{ base_url }}/docs/02-graph-model/">
+      <span class="idx">CH 02</span>
+      <h3>Graph Model</h3>
+      <p>Nodes, edges, properties, and the typing rules the planner depends on.</p>
+    </a>
+    <a class="cell" href="{{ base_url }}/docs/03-query-api/">
+      <span class="idx">CH 03</span>
+      <h3>Query API</h3>
+      <p>The traversal grammar, with examples drawn from production workloads.</p>
+    </a>
+    <a class="cell" href="{{ base_url }}/docs/04-deployment/">
+      <span class="idx">CH 04</span>
+      <h3>Deployment</h3>
+      <p>Topologies, resource sizing, and operational playbooks for SRE teams.</p>
+    </a>
+  </div>
+
+  <h2 class="section-h">PHILOSOPHY</h2>
+  <p>
+    Lattice is read documentation, not marketed documentation. Every page assumes
+    you have already decided to use the engine and now need to understand it.
+    No comparison tables. No badges. No content engineered for skim.
+  </p>
+  <p>
+    The hairline grid behind every page is the same grid the planner uses to
+    align its plan trees. It is intentional, not decoration.
+  </p>
+</article>
+{% include "footer.html" %}

--- a/examples/lattice-handbook/templates/home.html
+++ b/examples/lattice-handbook/templates/home.html
@@ -1,7 +1,7 @@
 {% include "header.html" %}
 <section class="hero">
   <div>
-    <div style="font-family:'JetBrains Mono',monospace;font-size:0.75rem;color:var(--fg-3);letter-spacing:0.1em;margin-bottom:0.8rem;">REFERENCE · v2.6.1 · STABLE</div>
+    <div class="eyebrow">REFERENCE · v2.6.1 · STABLE</div>
     <h1>The graph engine,<br/><span class="accent">documented end to end.</span></h1>
     <p>{{ site.description }}</p>
     <div class="ctas">

--- a/examples/lattice-handbook/templates/page.html
+++ b/examples/lattice-handbook/templates/page.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">lattice</a><span class="sep">/</span>
+  <a href="{{ base_url }}/docs/">docs</a><span class="sep">/</span>
+  <span>{{ page.title | e }}</span>
+</nav>
+<article>
+  <h1 class="page-title">{{ page.title | e }}</h1>
+  {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+  <div class="meta-strip">
+    {% if page.date %}<span><span class="k">DATE</span><span class="v">{{ page.date | date(format="%Y-%m-%d") }}</span></span>{% endif %}
+    {% if page.reading_time %}<span><span class="k">READ</span><span class="v">{{ page.reading_time }} min</span></span>{% endif %}
+    {% if page.word_count %}<span><span class="k">WORDS</span><span class="v">{{ page.word_count }}</span></span>{% endif %}
+    {% if page.tags %}<span><span class="k">TAGS</span>{% for t in page.tags %}<a class="tag" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/lattice-handbook/templates/section.html
+++ b/examples/lattice-handbook/templates/section.html
@@ -4,7 +4,7 @@
   <span>{{ page.title | e }}</span>
 </nav>
 <div style="padding:2rem 0 1rem;">
-  <div style="font-family:'JetBrains Mono',monospace;font-size:0.75rem;color:var(--fg-3);letter-spacing:0.1em;margin-bottom:0.6rem;">SECTION · {{ section.pages_count }} CHAPTERS</div>
+  <div class="eyebrow eyebrow--tight">SECTION · {{ section.pages_count }} CHAPTERS</div>
   <h1 class="page-title">{{ page.title | e }}</h1>
   {% if content %}<p class="lede">{{ content | striptags | trim }}</p>{% endif %}
 </div>

--- a/examples/lattice-handbook/templates/section.html
+++ b/examples/lattice-handbook/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">lattice</a><span class="sep">/</span>
+  <span>{{ page.title | e }}</span>
+</nav>
+<div style="padding:2rem 0 1rem;">
+  <div style="font-family:'JetBrains Mono',monospace;font-size:0.75rem;color:var(--fg-3);letter-spacing:0.1em;margin-bottom:0.6rem;">SECTION · {{ section.pages_count }} CHAPTERS</div>
+  <h1 class="page-title">{{ page.title | e }}</h1>
+  {% if content %}<p class="lede">{{ content | striptags | trim }}</p>{% endif %}
+</div>
+
+<div class="chap-grid">
+  {% for p in section.pages %}
+  <a class="cell" href="{{ p.url }}">
+    <span class="idx">CH {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <h3>{{ p.title | e }}</h3>
+    {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+  </a>
+  {% endfor %}
+</div>
+{% include "footer.html" %}

--- a/examples/lattice-handbook/templates/shortcodes/alert.html
+++ b/examples/lattice-handbook/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div style="border:1px solid var(--rule);border-left:2px solid var(--mint);background:var(--bg-2);border-radius:0 6px 6px 0;padding:0.8rem 1rem;margin:1.2rem 0;color:var(--fg-2);">
+  <div style="font-family:'JetBrains Mono',monospace;font-size:0.7rem;letter-spacing:0.16em;text-transform:uppercase;color:var(--mint);margin-bottom:0.2rem;">{{ type | default(value="note") }}</div>
+  {{ body }}
+</div>

--- a/examples/lattice-handbook/templates/taxonomy.html
+++ b/examples/lattice-handbook/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">lattice</a><span class="sep">/</span>
+  <span>{{ taxonomy_name | default(value="tags") }}</span>
+</nav>
+<article>
+  <h1 class="page-title">{{ taxonomy_name | default(value="tags") | capitalize }}</h1>
+  <p class="lede">All terms in the <strong>{{ taxonomy_name }}</strong> taxonomy.</p>
+  <div class="chap-grid">
+    {% for term in taxonomy_terms %}
+    <a class="cell" href="{{ term.url }}">
+      <span class="idx">#{{ loop.index }}</span>
+      <h3>{{ term.name }}</h3>
+      <p>{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %}</p>
+    </a>
+    {% endfor %}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/lattice-handbook/templates/taxonomy_term.html
+++ b/examples/lattice-handbook/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">lattice</a><span class="sep">/</span>
+  <a href="{{ base_url }}/{{ taxonomy_name }}/">{{ taxonomy_name }}</a><span class="sep">/</span>
+  <span>{{ page.title }}</span>
+</nav>
+<article>
+  <h1 class="page-title">#{{ page.title }}</h1>
+  <p class="lede">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} tagged <strong>{{ page.title }}</strong>.</p>
+  <div class="chap-grid">
+    {% for p in taxonomy_pages %}
+    <a class="cell" href="{{ p.url }}">
+      <span class="idx">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+      <h3>{{ p.title | e }}</h3>
+      {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+    </a>
+    {% endfor %}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/noctis-runtime/AGENTS.md
+++ b/examples/noctis-runtime/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md - AI Agent Instructions for Noctis Runtime
+
+This is a Hwaro static site. See [Hwaro Documentation](https://hwaro.hahwul.com)
+for full reference.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build to `public/` |
+| `hwaro serve` | Dev server on port 3000 |
+
+## Notes
+
+1. Front matter is TOML between `+++` delimiters.
+2. Rendered content is `{{ content | safe }}`.
+3. Custom metadata is `page.extra.field`.
+4. Use `{{ base_url }}` for all links and assets.
+5. CSS lives in `static/css/style.css`; do not inline.

--- a/examples/noctis-runtime/archetypes/default.md
+++ b/examples/noctis-runtime/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/noctis-runtime/config.toml
+++ b/examples/noctis-runtime/config.toml
@@ -1,0 +1,45 @@
+title = "Noctis Runtime"
+description = "Reference for the Noctis streaming runtime. Neo-brutalist surface, single accent, sharp corners."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/noctis-runtime/content/docs/01-architecture.md
+++ b/examples/noctis-runtime/content/docs/01-architecture.md
@@ -1,0 +1,63 @@
++++
+title = "Architecture"
+description = "How the runtime is wired. Loops, queues, and the single mutator rule."
+date = "2026-04-22"
+weight = 1
+tags = ["architecture", "internals"]
++++
+
+## Single mutator
+
+Noctis runs one mutator thread per core. Operators are scheduled onto
+mutators by a work-stealing dispatcher; each operator's state is owned by
+exactly one mutator at a time. There is no cross-thread sharing of
+operator state and no lock contention on the hot path.
+
+```text
+   core 0          core 1          core 2          core 3
+  ┌──────┐       ┌──────┐        ┌──────┐        ┌──────┐
+  │ MUT  │       │ MUT  │        │ MUT  │        │ MUT  │
+  └──┬───┘       └──┬───┘        └──┬───┘        └──┬───┘
+     │              │               │               │
+     └──── shared work queue ──── dispatcher ──── steal ────
+```
+
+## Event loop
+
+Each mutator runs a simple loop. There is no scheduler hierarchy, no
+fairness logic, and no priority inversion. Operators are first-come,
+first-served from the local queue.
+
+```text
+loop:
+  ev = local.pop_or_steal()
+  if ev is None:
+    park(64us)
+    continue
+  op = registry[ev.op_id]
+  op.tick(ev)
+```
+
+## Backpressure
+
+Backpressure is enforced at the queue boundary. A mutator's local queue
+has a fixed depth (default 16,384 events). When the queue is full, the
+upstream producer is blocked until the queue drains below the watermark.
+
+| Queue depth | Action                                    |
+|-------------|-------------------------------------------|
+| 0–75%       | Accept new events without delay           |
+| 75–95%      | Begin emitting `noctis_pressure` signal   |
+| 95–100%     | Block upstream until 90% watermark        |
+| > 100%      | Drop the event and increment counter      |
+
+The "drop and increment" tier exists to keep the runtime running under
+genuine overload. It is never reached in correctly-sized deployments.
+
+## Memory
+
+Operator state is allocated from a per-mutator arena. Arenas are sized at
+process startup and never grow; if an operator would exceed its arena,
+the runtime refuses to schedule it and emits a `noctis_arena_exceeded`
+error. This is intentional — sudden memory growth in production has
+caused more outages than it has prevented.

--- a/examples/noctis-runtime/content/docs/02-streams.md
+++ b/examples/noctis-runtime/content/docs/02-streams.md
@@ -1,0 +1,72 @@
++++
+title = "Streams"
+description = "Bounded and unbounded sources, backpressure, and ordering guarantees."
+date = "2026-04-26"
+weight = 2
+tags = ["streams", "model"]
++++
+
+## Bounded and unbounded
+
+Every stream in Noctis is one of two kinds:
+
+- **Bounded** — has a known end. Reads a file, replays a Kafka topic from
+  a fixed offset, or drains an in-memory buffer. Operators on bounded
+  streams may emit final aggregates because the source will close.
+- **Unbounded** — has no known end. Reads from a live topic, a socket, or
+  a clock. Operators must emit incremental results because the source
+  never closes.
+
+The runtime distinguishes the two at compile time. An aggregator with no
+window declaration on an unbounded source is a compile error.
+
+## Declaring a stream
+
+```ts
+import { stream } from "noctis"
+
+const orders = stream
+  .from("kafka://orders")
+  .bounded(false)
+  .schema({
+    id: "uuid",
+    amount: "decimal(18,4)",
+    placed_at: "instant"
+  })
+```
+
+The `.schema()` call is mandatory. The runtime refuses to construct a
+stream with a missing or partial schema; downstream operators rely on
+schema for code generation.
+
+## Ordering
+
+Streams preserve order by key, not globally. Two events with the same key
+will always be processed in the order they were produced. Events with
+different keys may be reordered when the dispatcher steals work between
+mutators.
+
+| Property                  | Guarantee   |
+|---------------------------|-------------|
+| Per-key order             | Strong      |
+| Global order              | None        |
+| Exactly-once on bounded   | Yes         |
+| Exactly-once on unbounded | Effectively (idempotent sinks) |
+
+## Watermarks
+
+Unbounded streams carry watermarks. A watermark is an upper bound on the
+event time of any subsequent event with a given key. Operators use
+watermarks to close windows and emit final results.
+
+```ts
+orders
+  .keyBy(e => e.region)
+  .watermark(e => e.placed_at, { allowedLateness: "10s" })
+  .window.tumbling("1m")
+  .reduce((a, b) => ({ ...a, amount: a.amount + b.amount }))
+```
+
+The runtime never advances a watermark backward. If a late event arrives
+after the watermark has passed and the allowed lateness has expired, the
+event is dropped and `noctis_late_dropped` is incremented.

--- a/examples/noctis-runtime/content/docs/03-operators.md
+++ b/examples/noctis-runtime/content/docs/03-operators.md
@@ -1,0 +1,61 @@
++++
+title = "Operators"
+description = "The 38 operators the runtime ships with — purposes and time complexity."
+date = "2026-04-30"
+weight = 3
+tags = ["operators", "api"]
++++
+
+## Categories
+
+The 38 built-in operators fall into five categories. The runtime does not
+allow user-defined operators in core; extensions must be packaged as
+sidecar processes that participate in the event loop over UDS.
+
+| Category    | Count | Examples                          |
+|-------------|-------|-----------------------------------|
+| Transform   | 9     | `map`, `flatMap`, `filter`        |
+| Aggregate   | 8     | `reduce`, `count`, `min`, `max`   |
+| Window      | 6     | `tumbling`, `sliding`, `session`  |
+| Join        | 7     | `innerJoin`, `leftJoin`, `interval` |
+| Sink        | 8     | `kafka`, `http`, `s3`, `stdout`   |
+
+## Complexity table
+
+Every operator declares its time complexity per event. The runtime
+enforces this declaration at compile time using its cost model; an
+operator that would exceed its declared bound is rejected before
+deployment.
+
+| Operator         | Time per event | Space             |
+|------------------|----------------|-------------------|
+| `map`            | O(1)           | O(0)              |
+| `filter`         | O(1)           | O(0)              |
+| `reduce`         | O(1) amortised | O(keyset)         |
+| `tumbling(w)`    | O(1)           | O(w · keyset)     |
+| `sliding(w, s)`  | O(w / s)       | O(w · keyset)     |
+| `session(g)`     | O(log n)       | O(keyset)         |
+| `innerJoin(w)`   | O(w) probe     | O(w · keyset)     |
+| `intervalJoin`   | O(w) probe     | O(w · keyset)     |
+
+## Composition
+
+Operators compose left-to-right. There is no implicit reordering. If two
+operators would benefit from being swapped, the user must swap them; the
+runtime will not.
+
+```ts
+orders
+  .filter(o => o.amount > 0)
+  .keyBy(o => o.region)
+  .window.tumbling("1m")
+  .reduce((a, b) => ({ ...a, amount: a.amount + b.amount }))
+  .sink.http("https://billing.internal/agg")
+```
+
+## Custom logic
+
+For business logic the operators cannot express, drop into a user
+function inside `map` or `flatMap`. The function runs on the same mutator
+as the surrounding operators — no IPC, no thread hop — and is allowed to
+allocate up to 8KB per event from the operator arena.

--- a/examples/noctis-runtime/content/docs/04-deploy.md
+++ b/examples/noctis-runtime/content/docs/04-deploy.md
@@ -1,0 +1,69 @@
++++
+title = "Deploy"
+description = "Topology choices, resource sizing, and the on-call decision tree."
+date = "2026-05-04"
+weight = 4
+tags = ["ops", "deploy"]
++++
+
+## Topology
+
+Noctis ships as a single binary. The same binary runs in three roles
+chosen at startup: `coordinator`, `worker`, `gateway`. A production
+deployment usually has three coordinators, N workers, and two or more
+gateways behind a load balancer.
+
+```text
+   [LB] ──▶ gateway × 2 ──▶ coordinator × 3 ──▶ worker × N
+                                     │
+                                     ▼
+                              [object store]
+```
+
+## Sizing
+
+A worker should be sized so that one instance can absorb the load of any
+other single worker failing. The runtime will redistribute partitions on
+failure, but capacity for the spike must already exist.
+
+| Workload                | Workers | CPU/worker | Mem/worker | Disk        |
+|-------------------------|---------|------------|------------|-------------|
+| 100k events/s, stateless| 3       | 8 vCPU     | 16 GB      | 200 GB NVMe |
+| 1M events/s, stateful   | 12      | 16 vCPU    | 64 GB      | 1 TB NVMe   |
+| 5M events/s, joins      | 32      | 32 vCPU    | 128 GB     | 2 TB NVMe   |
+
+These numbers assume p99 latency targets of 1ms or better. Slower targets
+allow more headroom and fewer workers.
+
+## Observability
+
+Every binary exposes a Prometheus endpoint on port 9111 and an OpenTelemetry
+gRPC endpoint on 4317. Both are always on; there is no flag to disable
+them in production builds.
+
+```text
+noctis_op_latency_p99_us{op="reduce", shard="0"}    420
+noctis_arena_used_bytes{mutator="0"}                 8421376
+noctis_pressure_signal{partition="42"}               1
+noctis_late_dropped_total{stream="orders"}           17
+```
+
+## On-call decision tree
+
+Three symptoms cover roughly all pages.
+
+> **Symptom: `pressure_signal` stuck at 1.**
+> A downstream sink is slow. Check the sink's latency metric first; if
+> the sink is healthy, the partition is hot — split it with
+> `noctis admin split <partition>`.
+
+> **Symptom: `arena_used_bytes` near the cap.**
+> An operator is leaking state. The runtime won't allow growth past the
+> arena, so the operator will eventually be killed. Identify the operator
+> from the metric label and bump its arena allocation in the topology
+> spec, then redeploy.
+
+> **Symptom: `late_dropped_total` rising.**
+> Watermarks are advancing faster than events are arriving. Either the
+> producer is delayed (network, broker pressure) or the allowed lateness
+> is too small. Start with the producer.

--- a/examples/noctis-runtime/content/docs/_index.md
+++ b/examples/noctis-runtime/content/docs/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Reference"
+description = "All Noctis chapters, in reading order."
+sort_by = "weight"
+template = "section"
++++
+
+Four chapters, ordered. Architecture first, then the data model, then the
+operators that act on it, and finally how to run the thing.

--- a/examples/noctis-runtime/content/index.md
+++ b/examples/noctis-runtime/content/index.md
@@ -1,0 +1,9 @@
++++
+title = "Noctis Runtime"
+description = "Reference for the Noctis streaming runtime."
+template = "home"
++++
+
+Noctis is a native streaming runtime tuned for sub-millisecond operator
+latency. This site is the complete reference — what the runtime does, how
+it does it, and the constraints it refuses to relax. Nothing else.

--- a/examples/noctis-runtime/static/css/style.css
+++ b/examples/noctis-runtime/static/css/style.css
@@ -1,0 +1,418 @@
+:root {
+  --bg: #000;
+  --panel: #0a0a0a;
+  --panel-2: #141414;
+  --fg: #fafafa;
+  --fg-2: #c9c9c9;
+  --fg-3: #777;
+  --rule: #2a2a2a;
+  --rule-2: #1c1c1c;
+  --pink: #ff2d75;
+  --pink-ink: #000;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 15px; scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "Space Grotesk", -apple-system, BlinkMacSystemFont, sans-serif;
+  line-height: 1.6;
+  font-feature-settings: "ss01";
+}
+
+a { color: var(--fg); text-decoration: none; }
+a:hover { color: var(--pink); }
+
+code, pre, .mono { font-family: "JetBrains Mono", ui-monospace, monospace; }
+
+.frame {
+  display: grid;
+  grid-template-columns: 14rem 1fr;
+  min-height: 100vh;
+  border: 2px solid var(--fg);
+  margin: 1.25rem;
+  background: var(--bg);
+}
+
+aside.bar {
+  border-right: 2px solid var(--fg);
+  padding: 1.4rem 1.2rem;
+  background: var(--panel);
+  position: sticky;
+  top: 1.25rem;
+  align-self: start;
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+}
+.brand {
+  display: block;
+  font-weight: 700;
+  font-size: 1.4rem;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.2rem;
+  color: var(--fg);
+  line-height: 1;
+}
+.brand .dot { color: var(--pink); }
+.tagline {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  color: var(--fg-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 1.4rem;
+  padding-bottom: 1.2rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+aside.bar h5 {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pink);
+  margin: 1.4rem 0 0.5rem;
+  font-weight: 600;
+}
+aside.bar ul { list-style: none; padding: 0; margin: 0; }
+aside.bar li a {
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.4rem 0;
+  font-size: 0.9rem;
+  color: var(--fg-2);
+  border-bottom: 1px dashed var(--rule);
+}
+aside.bar li:last-child a { border-bottom: none; }
+aside.bar li a:hover { color: var(--pink); }
+aside.bar li a .idx {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--fg-3);
+  min-width: 1.5rem;
+}
+aside.bar li a:hover .idx { color: var(--pink); }
+
+main { min-width: 0; }
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  border-bottom: 2px solid var(--fg);
+  background: var(--panel);
+  position: sticky;
+  top: 1.25rem;
+  z-index: 10;
+}
+.topbar nav { display: flex; gap: 1.4rem; font-family: "JetBrains Mono", monospace; font-size: 0.82rem; color: var(--fg-2); text-transform: uppercase; letter-spacing: 0.08em; }
+.topbar nav a:hover { color: var(--pink); }
+.topbar .meta {
+  display: flex;
+  gap: 0.8rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--fg-3);
+}
+.topbar .meta .status {
+  background: var(--pink);
+  color: var(--pink-ink);
+  padding: 0.18rem 0.6rem;
+  font-weight: 600;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+}
+
+.wrap {
+  padding: 2.5rem 2.5rem 5rem;
+  max-width: 56rem;
+}
+
+.crumbs {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+  margin-bottom: 1.6rem;
+}
+.crumbs a { color: var(--fg-3); }
+.crumbs a:hover { color: var(--pink); }
+.crumbs .sep { color: var(--rule); margin: 0 0.4rem; }
+
+h1.page-title {
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 1;
+  margin: 0 0 0.8rem;
+}
+.lede {
+  font-size: 1.1rem;
+  color: var(--fg-2);
+  max-width: 40rem;
+  margin: 0 0 1.6rem;
+}
+
+.meta-strip {
+  display: flex;
+  gap: 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+  border: 2px solid var(--fg);
+  margin-bottom: 2.4rem;
+  flex-wrap: wrap;
+}
+.meta-strip > * {
+  padding: 0.55rem 1rem;
+  border-right: 1px solid var(--rule);
+}
+.meta-strip > *:last-child { border-right: none; }
+.meta-strip .v { color: var(--fg); font-weight: 600; margin-left: 0.4rem; }
+.tag {
+  background: var(--pink);
+  color: var(--pink-ink);
+  padding: 0.05rem 0.5rem;
+  font-weight: 600;
+  margin-right: 0.3rem;
+}
+
+article h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 3rem 0 0.7rem;
+  padding: 0.4rem 0.8rem;
+  background: var(--fg);
+  color: var(--bg);
+  display: inline-block;
+}
+article h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-top: 2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  border-bottom: 2px solid var(--fg);
+  padding-bottom: 0.3rem;
+}
+article p { color: var(--fg-2); }
+article ul, article ol { color: var(--fg-2); padding-left: 1.4rem; }
+article strong { color: var(--fg); }
+article a { color: var(--pink); border-bottom: 1px solid var(--pink); }
+article a:hover { background: var(--pink); color: var(--pink-ink); border-bottom-color: transparent; }
+
+article pre, pre[class*="language-"] {
+  background: var(--panel-2) !important;
+  border: 2px solid var(--fg);
+  padding: 1rem 1.2rem;
+  overflow-x: auto;
+  font-size: 0.84rem;
+  margin: 1.4rem 0;
+  position: relative;
+}
+article pre::before {
+  content: "▌RUN";
+  position: absolute;
+  top: 0; right: 0;
+  background: var(--pink);
+  color: var(--pink-ink);
+  padding: 0.15rem 0.55rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+article pre code, pre code { background: transparent !important; color: var(--fg) !important; padding: 0; }
+article code {
+  background: var(--panel-2);
+  border: 1px solid var(--rule);
+  padding: 0.05rem 0.4rem;
+  font-size: 0.88em;
+  color: var(--pink);
+}
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.88rem;
+  border: 2px solid var(--fg);
+}
+article th, article td {
+  text-align: left;
+  padding: 0.55rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+}
+article th {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--fg);
+  color: var(--bg);
+  font-weight: 700;
+}
+article tr:last-child td { border-bottom: none; }
+article th:last-child, article td:last-child { border-right: none; }
+
+article blockquote {
+  margin: 1.4rem 0;
+  padding: 0.8rem 1.2rem;
+  border: 2px solid var(--pink);
+  background: var(--panel-2);
+  color: var(--fg);
+}
+article blockquote::before {
+  content: "▌";
+  color: var(--pink);
+  margin-right: 0.4rem;
+  font-weight: 700;
+}
+
+/* HOME */
+.hero {
+  border-bottom: 2px solid var(--fg);
+  padding: 3.5rem 2.5rem 3rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2rem;
+  align-items: end;
+}
+.hero .eyebrow {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pink);
+  margin-bottom: 0.8rem;
+}
+.hero h1 {
+  font-size: 5rem;
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 0.95;
+  margin: 0 0 1rem;
+}
+.hero h1 .pink { color: var(--pink); }
+.hero p {
+  font-size: 1.15rem;
+  color: var(--fg-2);
+  max-width: 36rem;
+  margin: 0 0 1.6rem;
+}
+.btn {
+  display: inline-block;
+  padding: 0.7rem 1.2rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 2px solid var(--fg);
+  background: var(--bg);
+  color: var(--fg);
+  margin-right: 0.5rem;
+}
+.btn:hover { background: var(--fg); color: var(--bg); }
+.btn.primary { background: var(--pink); border-color: var(--pink); color: var(--pink-ink); }
+.btn.primary:hover { background: var(--fg); border-color: var(--fg); color: var(--bg); }
+
+.hero-stats {
+  border: 2px solid var(--fg);
+  background: var(--panel);
+  padding: 0.8rem 1rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  min-width: 14rem;
+}
+.hero-stats .row { display: flex; justify-content: space-between; padding: 0.2rem 0; border-bottom: 1px dashed var(--rule); }
+.hero-stats .row:last-child { border-bottom: none; }
+.hero-stats .row .v { color: var(--pink); font-weight: 600; }
+
+.section-h {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pink);
+  margin: 3rem 0 1rem;
+  font-weight: 700;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+  border: 2px solid var(--fg);
+  margin: 1.5rem 0 2.5rem;
+}
+.cards .c {
+  padding: 1.6rem;
+  border-right: 2px solid var(--fg);
+  border-bottom: 2px solid var(--fg);
+  background: var(--bg);
+  display: block;
+  position: relative;
+}
+.cards .c:nth-child(2n) { border-right: none; }
+.cards .c:nth-last-child(-n+2) { border-bottom: none; }
+.cards .c:hover { background: var(--panel-2); }
+.cards .c .idx {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  color: var(--pink);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+  display: block;
+}
+.cards .c h3 { margin: 0 0 0.4rem; font-size: 1.2rem; font-weight: 700; color: var(--fg); }
+.cards .c p { margin: 0; color: var(--fg-3); font-size: 0.88rem; }
+.cards .c::after {
+  content: "→";
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  font-family: "JetBrains Mono", monospace;
+  color: var(--fg-3);
+  font-size: 1.2rem;
+}
+.cards .c:hover::after { color: var(--pink); }
+
+.foot {
+  border-top: 2px solid var(--fg);
+  padding: 1.4rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+  background: var(--panel);
+}
+.foot a { color: var(--fg-3); }
+.foot a:hover { color: var(--pink); }
+
+.notfound { padding: 5rem 2rem; text-align: center; }
+.notfound h1 { font-size: 8rem; font-weight: 700; margin: 0; color: var(--pink); letter-spacing: -0.05em; line-height: 1; }
+.notfound p { color: var(--fg-2); font-family: "JetBrains Mono", monospace; text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.85rem; }
+
+@media (max-width: 900px) {
+  .frame { margin: 0; grid-template-columns: 1fr; border-left: none; border-right: none; }
+  aside.bar { position: static; max-height: none; border-right: none; border-bottom: 2px solid var(--fg); }
+  .topbar, .wrap, .foot, .hero { padding-left: 1.25rem; padding-right: 1.25rem; }
+  .hero { grid-template-columns: 1fr; }
+  .hero h1 { font-size: 3rem; }
+  .cards { grid-template-columns: 1fr; }
+  .cards .c { border-right: none !important; border-bottom: 2px solid var(--fg) !important; }
+  .cards .c:last-child { border-bottom: none !important; }
+}

--- a/examples/noctis-runtime/static/favicon.svg
+++ b/examples/noctis-runtime/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#000"/><rect x="6" y="6" width="20" height="20" fill="#fafafa"/><rect x="6" y="6" width="20" height="6" fill="#ff2d75"/><rect x="10" y="16" width="12" height="3" fill="#000"/></svg>

--- a/examples/noctis-runtime/templates/404.html
+++ b/examples/noctis-runtime/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p>OPERATOR NOT FOUND IN RUNTIME GRAPH</p>
+  <p style="margin-top:1.4rem;">
+    <a class="btn primary" href="{{ base_url }}/">HOME</a>
+    <a class="btn" href="{{ base_url }}/docs/">DOCS</a>
+  </p>
+</div>
+{% include "footer.html" %}

--- a/examples/noctis-runtime/templates/footer.html
+++ b/examples/noctis-runtime/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="foot">
+      <span>{{ site_title }} · v4.1.0</span>
+      <span>BUILT WITH HWARO · {{ current_year }}</span>
+    </footer>
+  </main>
+</div>
+</body>
+</html>

--- a/examples/noctis-runtime/templates/header.html
+++ b/examples/noctis-runtime/templates/header.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="frame">
+  <aside class="bar">
+    <a class="brand" href="{{ base_url }}/">NOCTIS<span class="dot">.</span></a>
+    <div class="tagline">streaming runtime · v4.1</div>
+    <h5>Reference</h5>
+    <ul>
+      <li><a href="{{ base_url }}/docs/01-architecture/"><span class="idx">01</span><span>Architecture</span></a></li>
+      <li><a href="{{ base_url }}/docs/02-streams/"><span class="idx">02</span><span>Streams</span></a></li>
+      <li><a href="{{ base_url }}/docs/03-operators/"><span class="idx">03</span><span>Operators</span></a></li>
+      <li><a href="{{ base_url }}/docs/04-deploy/"><span class="idx">04</span><span>Deploy</span></a></li>
+    </ul>
+    <h5>Meta</h5>
+    <ul>
+      <li><a href="{{ base_url }}/tags/"><span class="idx">⌗</span><span>All tags</span></a></li>
+      <li><a href="{{ base_url }}/categories/"><span class="idx">⌗</span><span>Categories</span></a></li>
+      <li><a href="{{ base_url }}/docs/"><span class="idx">⌗</span><span>Index</span></a></li>
+    </ul>
+  </aside>
+  <main>
+    <header class="topbar">
+      <nav>
+        <a href="{{ base_url }}/docs/">Docs</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="https://github.com/hahwul/hwaro">Source</a>
+      </nav>
+      <div class="meta">
+        <span class="status">LIVE</span>
+        <span>v4.1.0 / build 28e1</span>
+      </div>
+    </header>

--- a/examples/noctis-runtime/templates/home.html
+++ b/examples/noctis-runtime/templates/home.html
@@ -1,0 +1,58 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="eyebrow">v4.1.0 · stable · 2026-05</div>
+    <h1>Stream<span class="pink">.</span> Sub-millisecond<span class="pink">.</span><br/>Documented<span class="pink">.</span></h1>
+    <p>{{ site.description }}</p>
+    <a class="btn primary" href="{{ base_url }}/docs/01-architecture/">read architecture</a>
+    <a class="btn" href="{{ base_url }}/docs/">browse docs</a>
+  </div>
+  <div class="hero-stats">
+    <div class="row"><span>release</span><span class="v">4.1.0</span></div>
+    <div class="row"><span>tps p99</span><span class="v">1.8M</span></div>
+    <div class="row"><span>latency p99</span><span class="v">0.42 ms</span></div>
+    <div class="row"><span>operators</span><span class="v">38</span></div>
+    <div class="row"><span>runtime</span><span class="v">native</span></div>
+  </div>
+</section>
+
+<div class="wrap" style="max-width:64rem;">
+  {{ content | safe }}
+
+  <h2 class="section-h">// CHAPTERS</h2>
+  <div class="cards">
+    <a class="c" href="{{ base_url }}/docs/01-architecture/">
+      <span class="idx">CH 01</span>
+      <h3>Architecture</h3>
+      <p>How the runtime is wired. Loops, queues, and the single mutator rule.</p>
+    </a>
+    <a class="c" href="{{ base_url }}/docs/02-streams/">
+      <span class="idx">CH 02</span>
+      <h3>Streams</h3>
+      <p>Bounded and unbounded sources, backpressure, and ordering guarantees.</p>
+    </a>
+    <a class="c" href="{{ base_url }}/docs/03-operators/">
+      <span class="idx">CH 03</span>
+      <h3>Operators</h3>
+      <p>The 38 operators the runtime ships with — purposes and time complexity.</p>
+    </a>
+    <a class="c" href="{{ base_url }}/docs/04-deploy/">
+      <span class="idx">CH 04</span>
+      <h3>Deploy</h3>
+      <p>Topology choices, resource sizing, and the on-call decision tree.</p>
+    </a>
+  </div>
+
+  <h2 class="section-h">// PRINCIPLES</h2>
+  <p>
+    Noctis is a streaming runtime, not a general-purpose batch system. Every
+    operator is built around the assumption that events arrive continuously
+    and out of order. The runtime does not retry, does not buffer beyond a
+    bounded window, and does not silently coerce types.
+  </p>
+  <p>
+    If a behaviour is not in this reference, the runtime does not have it.
+    The reference is the source of truth.
+  </p>
+</div>
+{% include "footer.html" %}

--- a/examples/noctis-runtime/templates/page.html
+++ b/examples/noctis-runtime/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<div class="wrap">
+  <nav class="crumbs">
+    <a href="{{ base_url }}/">NOCTIS</a><span class="sep">/</span>
+    <a href="{{ base_url }}/docs/">DOCS</a><span class="sep">/</span>
+    <span>{{ page.title | e | upper }}</span>
+  </nav>
+  <article>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+    <div class="meta-strip">
+      {% if page.date %}<span>DATE<span class="v">{{ page.date | date(format="%Y-%m-%d") }}</span></span>{% endif %}
+      {% if page.reading_time %}<span>READ<span class="v">{{ page.reading_time }}M</span></span>{% endif %}
+      {% if page.word_count %}<span>WORDS<span class="v">{{ page.word_count }}</span></span>{% endif %}
+      {% if page.tags %}<span>TAGS&nbsp;{% for t in page.tags %}<a class="tag" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</span>{% endif %}
+    </div>
+    {{ content | safe }}
+  </article>
+</div>
+{% include "footer.html" %}

--- a/examples/noctis-runtime/templates/section.html
+++ b/examples/noctis-runtime/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<div class="wrap" style="max-width:64rem;">
+  <nav class="crumbs">
+    <a href="{{ base_url }}/">NOCTIS</a><span class="sep">/</span>
+    <span>{{ page.title | e | upper }}</span>
+  </nav>
+  <h1 class="page-title">{{ page.title | e }}</h1>
+  {% if content %}<p class="lede">{{ content | striptags | trim }}</p>{% endif %}
+
+  <h2 class="section-h">// {{ section.pages_count }} CHAPTERS</h2>
+  <div class="cards">
+    {% for p in section.pages %}
+    <a class="c" href="{{ p.url }}">
+      <span class="idx">CH {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <h3>{{ p.title | e }}</h3>
+      {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/noctis-runtime/templates/shortcodes/alert.html
+++ b/examples/noctis-runtime/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div style="border:2px solid var(--pink);background:var(--panel-2);padding:0.9rem 1.1rem;margin:1.2rem 0;color:var(--fg);">
+  <div style="font-family:'JetBrains Mono',monospace;font-size:0.7rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--pink);font-weight:700;margin-bottom:0.3rem;">▌ {{ type | default(value="note") }}</div>
+  {{ body }}
+</div>

--- a/examples/noctis-runtime/templates/taxonomy.html
+++ b/examples/noctis-runtime/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<div class="wrap" style="max-width:64rem;">
+  <nav class="crumbs">
+    <a href="{{ base_url }}/">NOCTIS</a><span class="sep">/</span>
+    <span>{{ taxonomy_name | default(value="tags") | upper }}</span>
+  </nav>
+  <h1 class="page-title">{{ taxonomy_name | default(value="tags") | capitalize }}</h1>
+  <p class="lede">All terms in the <strong>{{ taxonomy_name }}</strong> taxonomy.</p>
+  <div class="cards">
+    {% for term in taxonomy_terms %}
+    <a class="c" href="{{ term.url }}">
+      <span class="idx">#{{ loop.index }}</span>
+      <h3>{{ term.name }}</h3>
+      <p>{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %}</p>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/noctis-runtime/templates/taxonomy_term.html
+++ b/examples/noctis-runtime/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<div class="wrap" style="max-width:64rem;">
+  <nav class="crumbs">
+    <a href="{{ base_url }}/">NOCTIS</a><span class="sep">/</span>
+    <a href="{{ base_url }}/{{ taxonomy_name }}/">{{ taxonomy_name | upper }}</a><span class="sep">/</span>
+    <span>{{ page.title | upper }}</span>
+  </nav>
+  <h1 class="page-title">#{{ page.title }}</h1>
+  <p class="lede">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} tagged <strong>{{ page.title }}</strong>.</p>
+  <div class="cards">
+    {% for p in taxonomy_pages %}
+    <a class="c" href="{{ p.url }}">
+      <span class="idx">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+      <h3>{{ p.title | e }}</h3>
+      {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% include "footer.html" %}

--- a/examples/prose-spec/AGENTS.md
+++ b/examples/prose-spec/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+This site is **Prose Spec**, a documentation example with a light, modern-editorial aesthetic: cream paper, a modern serif (Fraunces) for headings, Inter for body, and IBM Plex Mono for the apparatus.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   └── docs/            # Chapter section
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── 0N-*.md      # Chapters within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── home.html        # Homepage template
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy index template
+│   ├── taxonomy_term.html # Single taxonomy term template
+│   ├── 404.html         # Not-found page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+- **No gradients.** The visual language is solid colors and single-color rules only. Do not introduce CSS gradients, even subtle ones.
+- **No emojis.** Anywhere — content, templates, or commit messages for this site.
+- **Type stack.** Headings: Fraunces (modern serif). Body: Inter. Apparatus / code / labels: IBM Plex Mono. Do not swap these without a redesign.
+- **Color stack.** Paper `#f6f1e7`, ink `#1a1815`, accent `#b03a1c`. The accent is for emphasis and rules only — never a background fill.
+- **Editorial rhythm.** Body line-height stays at 1.7 or higher. Hairline rules (1px `--rule`) separate sections. Drop-caps appear on the first paragraph of each article via CSS, not in markdown.
+- **Margin notes.** Use `<aside class="margin-note">…</aside>` inside an article to add an editorial note in the left margin on wide viewports (it collapses to an inline note on narrow ones).

--- a/examples/prose-spec/archetypes/default.md
+++ b/examples/prose-spec/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/prose-spec/config.toml
+++ b/examples/prose-spec/config.toml
@@ -1,0 +1,186 @@
+title = "Prose Spec"
+description = "Documentation for the Prose Spec publishing engine. Cream paper, modern serif, two-column editorial layout."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/prose-spec/content/docs/01-philosophy.md
+++ b/examples/prose-spec/content/docs/01-philosophy.md
@@ -1,0 +1,94 @@
++++
+title = "Philosophy"
+description = "Why a new publishing engine, and what it refuses to compromise on."
+date = "2026-04-15"
+weight = 1
+tags = ["design", "prose"]
+categories = ["foundations"]
++++
+
+There is a particular kind of document that resists the tools we have. It is
+long enough to need structure but short enough to read in an evening. It is
+technical enough to require code but literary enough to be set with care.
+It will be read on paper, on a phone, and inside an EPUB reader on a train
+with no signal. Prose Spec was written because none of the existing engines
+treat this document as a first-class citizen. Word processors flatten it,
+static site generators ignore the print case, and academic typesetters
+demand a fluency in macros that the modern author has long since traded
+away.
+
+## What we are building
+
+Prose Spec is a build tool for *considered prose*. The source is a tree, not
+a string; the formatter is a renderer, not a templater; and the pipeline is
+a deterministic graph that you can inspect at any step. The engine has
+three goals, in order of stubbornness.
+
+1. **Typography is a primary concern.** Optical sizing, hanging
+   punctuation, balanced paragraphs, and per-document font subsetting are
+   defaults, not opt-ins.
+2. **One source, many artifacts.** A single project produces PDF, paginated
+   HTML, and EPUB without forking the source. Output-specific concerns are
+   isolated in the formatter, never bled into the document.
+3. **The build is auditable.** Every step is named, every artifact is
+   hashed, and the build graph is queryable from the command line.
+
+> The page is not a container for content. The page is content.
+> <cite>&mdash; from the Prose Spec design notes, draft three</cite>
+
+## A small example
+
+A Prose Spec source file looks like Markdown with a few well-defined
+extensions. The front matter is TOML, the body is annotated, and the
+project's typographic stance is declared in one place.
+
+```toml
+# spec.toml
+title       = "An Essay on Light"
+author      = "C. Mendel"
+serif       = "Newsreader"
+sans        = "Inter"
+mono        = "IBM Plex Mono"
+measure     = "28em"
+leading     = 1.65
+output      = ["pdf", "html", "epub"]
+```
+
+The build is invoked the same way for every artifact. The formatter for
+each output is selected by the configuration above, not by a flag.
+
+```bash
+prose build
+# => parse:     12 documents, 4,318 blocks (38 ms)
+# => layout:    1 spread set,  142 pages   (210 ms)
+# => render:    pdf, html, epub            (612 ms)
+# => artifact:  ./build/out/essay-on-light.{pdf,html,epub}
+```
+
+## The three refusals
+
+Prose Spec refuses three things that other engines accept without comment.
+These are not features we lack; they are features we will not add.
+
+| Refusal | Why |
+|---------|-----|
+| Inline styling | A `<span style="...">` in source is a leak. The document model carries semantic marks; the formatter decides their visual treatment. |
+| Output-time CSS | Cosmetic CSS belongs to the formatter, not the document. Source files are the same whether you target paper or screen. |
+| Runtime templates | Templates run at *build* time. Nothing in a Prose Spec artifact requires JavaScript to read. |
+
+These refusals are why Prose Spec produces small, durable artifacts. A
+hundred-page PDF rendered by the engine is typically under two megabytes,
+fully subsetted, and contains no hidden raster fallbacks.
+
+## What this manual will cover
+
+The next three chapters describe the parts of the engine in the order you
+will meet them when you read your first build log. **Chapter two** is the
+document model: the tree, the blocks, and the marks that decorate them.
+**Chapter three** is the formatter family &mdash; how the same tree
+becomes three different artifacts. **Chapter four** is the pipeline: the
+ordered set of passes the engine applies, and how to extend them with
+your own.
+
+If you are in a hurry, read chapter four first and the others later. The
+manual was written in reading order, but the engine does not care.

--- a/examples/prose-spec/content/docs/02-document-model.md
+++ b/examples/prose-spec/content/docs/02-document-model.md
@@ -1,0 +1,118 @@
++++
+title = "Document Model"
+description = "The tree, its blocks, and the marks that decorate them."
+date = "2026-04-19"
+weight = 2
+tags = ["model", "parser"]
+categories = ["foundations"]
++++
+
+Every Prose Spec source file resolves, after parsing, to a single value: a
+*document tree*. The tree is the unit the rest of the engine reasons about.
+It has a stable shape across input formats, which is why a project can mix
+Markdown chapters with S-expression chapters without the formatter knowing
+or caring. Once you understand the tree, the rest of the manual becomes
+a description of operations on it.
+
+## The shape of the tree
+
+A document is a sequence of **blocks**. A block is a self-contained
+typographic unit &mdash; a paragraph, a heading, a list, a code listing, a
+figure. Blocks may contain other blocks (a list contains items; a
+blockquote contains paragraphs), and they may contain inline content
+decorated with **marks** (emphasis, links, citations, mathematical
+notation).
+
+```json
+{
+  "type": "document",
+  "front_matter": { "title": "An Essay on Light" },
+  "children": [
+    { "type": "heading", "level": 1, "children": [
+      { "type": "text", "value": "On Reflection" }
+    ]},
+    { "type": "paragraph", "children": [
+      { "type": "text", "value": "The mirror, " },
+      { "type": "text", "value": "considered closely", "marks": ["em"] },
+      { "type": "text", "value": ", is never quite a copy." }
+    ]}
+  ]
+}
+```
+
+This is the canonical form. You will rarely write it by hand, but every
+plugin, every formatter, and every diagnostic message in the engine refers
+to nodes in exactly this shape.
+
+## Block kinds
+
+The set of block kinds is closed. Plugins may add *attributes* to existing
+blocks, but cannot introduce new top-level kinds without a corresponding
+formatter contribution. This is deliberate: it keeps the tree portable.
+
+| Block | Children | Notes |
+|-------|----------|-------|
+| `paragraph` | inline | The default. Most of your document is paragraphs. |
+| `heading` | inline | Levels 1&ndash;6. Level 1 is reserved for the document title. |
+| `list` | `list_item` | Ordered or unordered. May nest arbitrarily. |
+| `blockquote` | block | Carries an optional `cite` attribute. |
+| `code_block` | text | Has a `language` attribute. Highlighting is a formatter concern. |
+| `figure` | block | Wraps a `figure_body` and an optional `caption`. |
+| `table` | `table_row` | First row is the header unless `headerless = true`. |
+| `divider` | none | A hairline rule. Rendered to a thin line in all formatters. |
+
+> A tree that cannot be enumerated cannot be reasoned about.
+> <cite>&mdash; from the engine's design notes, on the closed block set</cite>
+
+## Marks
+
+Marks decorate inline text. Unlike blocks, marks compose: a single text
+node may carry several marks at once, and the order of marks is preserved
+through the formatter so that, for example, a link inside an emphasized
+phrase is rendered correctly.
+
+```toml
+# Built-in marks
+marks = ["em", "strong", "code", "link", "cite", "smallcaps", "math"]
+```
+
+A mark is always an attribute of a text node; it never wraps other blocks.
+This rule is what lets the engine guarantee that emphasis inside a heading
+behaves the same way as emphasis inside a paragraph &mdash; the same node
+shape, the same rules.
+
+## Walking the tree
+
+The engine exposes a stable iterator over the document. Plugins use it to
+implement linting, indexing, and cross-referencing. The iterator yields
+nodes in document order with a parent pointer.
+
+```python
+# A trivial plugin: collect every figure caption.
+def collect_captions(doc):
+    for node in walk(doc):
+        if node.type == "figure":
+            cap = node.find_child("caption")
+            if cap:
+                yield cap.plain_text()
+```
+
+The walker is read-only. Mutations are expressed as *transforms*, which
+take a tree and return a new one. This is the only way to modify a
+document inside the pipeline, and it is what makes builds reproducible.
+
+## Round-tripping
+
+Because the model is closed, the engine can serialize any tree back to a
+canonical Markdown form. This is how Prose Spec implements `prose fmt`:
+it parses, applies the formatter to the source, and writes the result back
+to disk. Two passes of `prose fmt` on the same document always produce
+the same bytes.
+
+```bash
+prose fmt chapters/01-philosophy.md
+# => normalized: 1 file, 0 substantive changes
+```
+
+The next chapter takes the tree we have built here and turns it into
+artifacts: PDF, HTML, and EPUB.

--- a/examples/prose-spec/content/docs/03-formatters.md
+++ b/examples/prose-spec/content/docs/03-formatters.md
@@ -1,0 +1,131 @@
++++
+title = "Formatters"
+description = "How a single document tree becomes PDF, paginated HTML, and EPUB."
+date = "2026-04-23"
+weight = 3
+tags = ["formatter", "pdf", "html", "epub"]
+categories = ["output"]
++++
+
+A formatter is the part of the engine that turns a document tree into an
+artifact. Prose Spec ships with three: a print formatter that produces
+PDF, a screen formatter that produces paginated HTML, and a reflow
+formatter that produces EPUB. They share a common interface and a common
+type system, but each is free to make decisions appropriate to its
+medium. A long footnote is set at the bottom of a page in print; it
+becomes a popover in HTML; it is moved to a chapter-end note set in EPUB.
+The source does not change.
+
+## The formatter interface
+
+Every formatter implements three calls. The engine drives all three in
+turn, with the tree available at each step but never mutated.
+
+```text
+fn measure(tree, frame) -> Measurement
+fn layout(tree, measurement) -> Frames
+fn render(frames, sink) -> Artifact
+```
+
+`measure` computes intrinsic sizes for each block at a candidate frame
+width. `layout` walks the tree and assigns blocks to frames &mdash; pages
+in print, pages-in-a-scroll in paginated HTML, or a single flowing frame
+in EPUB. `render` writes bytes to a sink. The three calls are pure: given
+the same tree and the same configuration, they produce byte-identical
+output.
+
+## The print formatter
+
+The print formatter is the most opinionated of the three. It enforces a
+typographic baseline grid, applies optical-sized font variants, and
+balances paragraphs across two columns when configured.
+
+```toml
+[output.pdf]
+size        = "a5"
+margin      = { top = "22mm", bottom = "22mm", inner = "20mm", outer = "16mm" }
+baseline    = "13pt"
+columns     = 1
+hyphenation = "en-US"
+widow_lines = 2
+orphan_lines = 2
+```
+
+The baseline grid is the heart of the formatter. Every block in the
+document &mdash; including images, code listings, and tables &mdash;
+is rounded to a multiple of the baseline before placement. The result
+is that facing pages align line-for-line, an effect that is impossible
+to achieve in CSS without manual tuning.
+
+| Feature | Print | HTML | EPUB |
+|---------|-------|------|------|
+| Baseline grid | yes | optional | no (reflow) |
+| Hyphenation | Knuth-Liang | browser hint | reader-defined |
+| Widow / orphan control | yes | yes | reader-defined |
+| Footnotes | bottom of page | popover | chapter-end |
+| Cross-references | page numbers | anchors | anchors |
+
+## The HTML formatter
+
+The HTML formatter produces a paginated reading surface that imitates the
+print artifact without imitating its limitations. Pages have fixed
+heights on desktop, snap to the viewport on mobile, and remember the
+reader's position across sessions. The artifact is plain HTML and CSS;
+there is no runtime JavaScript required to read it.
+
+```html
+<!-- A page emitted by the HTML formatter -->
+<article class="page" data-page="14" data-of="142">
+  <header class="folio">
+    <span class="title">An Essay on Light</span>
+    <span class="num">14</span>
+  </header>
+  <div class="frame">
+    <p class="b-p">The mirror, considered closely, is never quite a copy.</p>
+  </div>
+</article>
+```
+
+The HTML output is also the source-of-truth for the engine's preview
+mode. `prose serve` produces a paginated, navigable rendering at the
+same dimensions as the eventual PDF, so that proof-reading does not
+require a build.
+
+```bash
+prose serve --output html
+# => watching ./content for changes
+# => preview: http://localhost:4400/preview
+# => first build: 318 ms, 142 pages
+```
+
+## The EPUB formatter
+
+EPUB is a reflow format, and the EPUB formatter respects that. The
+baseline grid is dropped; pages do not exist; the reader chooses the
+measure. What remains is structure: chapters are EPUB navigation points,
+footnotes are linked endnotes, and figures carry their captions in
+semantic markup.
+
+> A formatter that fights the reader is a formatter that will be
+> uninstalled.
+> <cite>&mdash; the EPUB formatter's commit message, in full</cite>
+
+The EPUB formatter also handles subsetting. Fonts declared in the
+project configuration are embedded into the EPUB, subsetted to exactly
+the characters that appear in the document. A two-hundred-page novel
+typically ships with under 80 KB of embedded font data.
+
+## Choosing a formatter
+
+You do not choose a formatter; you choose an output. The engine routes
+the tree to the right formatter based on the `output` list in the
+project's configuration. Build all three at once, or one at a time:
+
+```bash
+prose build --output pdf
+prose build --output html epub
+prose build              # all configured outputs
+```
+
+The next chapter describes the pipeline that orchestrates the parser,
+the transforms, and the formatters into a single build.

--- a/examples/prose-spec/content/docs/04-pipeline.md
+++ b/examples/prose-spec/content/docs/04-pipeline.md
@@ -1,0 +1,155 @@
++++
+title = "Pipeline"
+description = "From ingest to artifact: the build pipeline, demystified."
+date = "2026-04-27"
+weight = 4
+tags = ["pipeline", "build", "cli"]
+categories = ["operations"]
++++
+
+The pipeline is the named sequence of passes the engine applies to your
+sources between `prose build` and an artifact on disk. It is the part of
+the engine you will spend the most time with after the first week, and
+it is the part most authors will want to extend. This chapter describes
+every pass in order, what it produces, and how to insert your own.
+
+## The eight passes
+
+The pipeline has eight passes. Each pass is a pure function from the
+output of the previous one. The engine memoizes each pass by content
+hash, so an incremental build skips passes whose inputs have not
+changed.
+
+| # | Pass | Input | Output |
+|---|------|-------|--------|
+| 1 | `ingest` | source files | raw blob set |
+| 2 | `parse` | raw blob set | parsed trees |
+| 3 | `normalize` | parsed trees | canonical trees |
+| 4 | `link` | canonical trees | resolved trees |
+| 5 | `transform` | resolved trees | transformed trees |
+| 6 | `measure` | transformed trees | measured trees |
+| 7 | `layout` | measured trees | frame sets |
+| 8 | `render` | frame sets | artifacts |
+
+Each pass has a name, a hash, and an inspector. You can ask the engine
+to dump the state at the boundary between any two passes, which is the
+fastest way to debug a build that produces unexpected output.
+
+```bash
+prose inspect --after normalize chapters/01-philosophy.md
+# => /tmp/prose-inspect-01-philosophy.normalize.json
+```
+
+## Ingest
+
+Ingest reads the file system. It is the only pass with side effects in
+the read direction, and the only pass that is allowed to block on I/O.
+It produces a *blob set*: an ordered map from a source path to bytes,
+plus the modification time and an integrity hash.
+
+```text
+$ prose inspect --after ingest
+chapters/01-philosophy.md     11,842 B  2026-04-15T09:14:22Z  sha256:8a7e...
+chapters/02-document-model.md 14,209 B  2026-04-19T15:02:08Z  sha256:b14c...
+chapters/03-formatters.md     13,118 B  2026-04-23T08:48:51Z  sha256:9f02...
+chapters/04-pipeline.md       10,773 B  2026-04-27T18:31:44Z  sha256:5e3a...
+```
+
+## Parse and normalize
+
+Parsing turns each blob into a document tree. Normalization rewrites the
+tree into a canonical shape: heading levels are demoted so that no
+document has two level-one headings, trailing whitespace inside text
+nodes is trimmed, and consecutive paragraphs separated by a single line
+break are joined.
+
+> A canonical tree is one whose serialization is byte-equal to the
+> serialization of any other tree with the same meaning.
+> <cite>&mdash; the engine's normalization invariant</cite>
+
+## Link
+
+The link pass resolves cross-references. A `[[chapter-3]]` reference
+becomes a structured `cite` node that knows the chapter's title, its
+page in the print artifact, and its anchor in HTML. References that
+cannot be resolved are recorded as diagnostics and surfaced at the end
+of the build, never as silent failures.
+
+## Transform
+
+Transform is where plugins run. The engine ships with a handful of
+default transforms (small-caps normalization, smart quotes, footnote
+collection), and a project can declare more.
+
+```toml
+[[transform]]
+name = "drop-cap"
+applies_to = "first-paragraph-of-chapter"
+
+[[transform]]
+name = "balance-headings"
+options = { lines = 2 }
+
+[[transform]]
+name = "from-plugin"
+load = "./plugins/redact.py"
+options = { mark = "redacted" }
+```
+
+A transform receives a tree and returns a tree. It may not perform I/O.
+This restriction is what lets the engine memoize the pass and produce
+the deterministic builds the rest of the documentation has been
+promising.
+
+## Measure, layout, render
+
+The last three passes are the formatter's domain. The engine dispatches
+each output to its formatter, and the formatter runs `measure`, then
+`layout`, then `render`. The engine collects the resulting artifacts
+into the output directory and writes a build manifest.
+
+```json
+{
+  "build_id": "2026-04-27T18:31:44Z-5e3a",
+  "duration_ms": 612,
+  "passes": [
+    { "name": "ingest",    "ms":  12, "hits": 0, "items":  4 },
+    { "name": "parse",     "ms":  38, "hits": 0, "items":  4 },
+    { "name": "normalize", "ms":   9, "hits": 0, "items":  4 },
+    { "name": "link",      "ms":  14, "hits": 0, "items":  4 },
+    { "name": "transform", "ms":  41, "hits": 0, "items":  4 },
+    { "name": "measure",   "ms":  82, "hits": 0, "items":  4 },
+    { "name": "layout",    "ms": 210, "hits": 0, "items": 142 },
+    { "name": "render",    "ms": 206, "hits": 0, "items":  3 }
+  ],
+  "artifacts": ["essay-on-light.pdf", "essay-on-light.html", "essay-on-light.epub"]
+}
+```
+
+| Build mode | Cache hits | Wall time |
+|------------|-----------|-----------|
+| Cold | 0 of 8 | 612 ms |
+| Incremental, one chapter changed | 5 of 8 | 178 ms |
+| Incremental, no source changes | 8 of 8 | 22 ms |
+
+## Watch mode
+
+`prose watch` runs the pipeline whenever a source file changes. Because
+every pass is memoized, watch builds are usually under 200 ms even for
+book-length projects, which is fast enough to keep a PDF preview in
+sync with an editor.
+
+```bash
+prose watch --output pdf --reload
+# => watching ./content, ./assets, ./spec.toml
+# => 22:14:08  rebuild  178 ms  (5 of 8 passes cached)
+# => 22:14:34  rebuild  204 ms  (4 of 8 passes cached)
+```
+
+## Where to go from here
+
+This is the end of the included manual. The reference is intentionally
+short; the engine is intentionally small. Once the pipeline is familiar,
+extending the engine is mostly a matter of writing transforms and,
+occasionally, contributing a formatter. The project's plugin guide and
+the formatter author's notes are available in the source repository.

--- a/examples/prose-spec/content/docs/_index.md
+++ b/examples/prose-spec/content/docs/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Chapters"
+description = "The full manual, sorted in reading order."
+sort_by = "weight"
+template = "section"
++++
+
+The manual is organised as a sequence of four chapters. Each chapter is
+self-contained but assumes the reader has digested the chapters that come
+before it. There is no index of orphans here.

--- a/examples/prose-spec/content/index.md
+++ b/examples/prose-spec/content/index.md
@@ -1,0 +1,11 @@
++++
+title = "Prose Spec"
+description = "A publishing engine for considered prose. Source-controlled documents, optical-sized type, and a tree the formatter can reason about."
+template = "home"
++++
+
+Prose Spec is a publishing engine for long-form documents. It accepts a
+structured source &mdash; Markdown with semantic extensions, or a richer
+S-expression tree &mdash; and produces print-grade PDF, paginated HTML, and
+reflowable EPUB from a single build. The reference you are reading was set
+with the same engine it documents.

--- a/examples/prose-spec/static/css/style.css
+++ b/examples/prose-spec/static/css/style.css
@@ -1,0 +1,560 @@
+:root {
+  --paper: #f6f1e7;
+  --paper-2: #efe8d8;
+  --paper-3: #e6dec9;
+  --ink: #1a1815;
+  --ink-2: #3a352e;
+  --ink-3: #6e6657;
+  --rule: #d8cfb8;
+  --rule-faint: #ece4d0;
+  --accent: #b03a1c;
+}
+
+* { box-sizing: border-box; }
+
+html { font-size: 16px; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  transition: color 0.15s, border-color 0.15s;
+}
+a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+.site {
+  max-width: 86rem;
+  margin: 0 auto;
+  padding: 0 2.25rem;
+  display: grid;
+  grid-template-columns: 14rem 1fr;
+  gap: 3.5rem;
+  min-height: 100vh;
+}
+
+/* ====== Topbar ====== */
+.topbar {
+  grid-column: 1 / -1;
+  border-bottom: 1px solid var(--ink);
+  padding: 1.4rem 0 1.2rem;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.topbar .brand {
+  font-family: "Fraunces", "Newsreader", Georgia, serif;
+  font-weight: 600;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+  border-bottom: none;
+  color: var(--ink);
+  font-variation-settings: "SOFT" 30, "opsz" 144;
+}
+.topbar .brand .amp {
+  color: var(--accent);
+  font-style: italic;
+  font-weight: 400;
+  margin: 0 0.15rem;
+}
+
+.topbar nav {
+  display: flex;
+  gap: 1.75rem;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+}
+.topbar nav a { border-bottom: none; color: var(--ink-3); }
+.topbar nav a:hover { color: var(--accent); }
+
+.topbar .imprint {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+}
+
+/* ====== Sidebar ====== */
+aside.sidebar {
+  padding: 2.75rem 0 4rem;
+  border-right: 1px solid var(--rule);
+  font-size: 0.86rem;
+  position: sticky;
+  top: 0;
+  align-self: start;
+  max-height: 100vh;
+  overflow-y: auto;
+  padding-right: 1.25rem;
+}
+
+.sidebar h4 {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.26em;
+  color: var(--ink-3);
+  margin: 1.8rem 0 0.75rem;
+  padding-bottom: 0.45rem;
+  border-bottom: 1px solid var(--rule);
+  font-weight: 500;
+}
+
+.sidebar ol.chapters {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: chap;
+}
+.sidebar ol.chapters li {
+  counter-increment: chap;
+  padding: 0.35rem 0;
+  display: grid;
+  grid-template-columns: 1.8rem 1fr;
+  gap: 0.4rem;
+  align-items: baseline;
+}
+.sidebar ol.chapters li::before {
+  content: "ch. " counter(chap, decimal-leading-zero);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.65rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+}
+.sidebar ol.chapters a {
+  border-bottom: none;
+  color: var(--ink-2);
+  font-family: "Fraunces", serif;
+  font-size: 0.98rem;
+}
+.sidebar ol.chapters a:hover { color: var(--accent); }
+
+.sidebar ul.flat {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.sidebar ul.flat li { padding: 0.25rem 0; }
+.sidebar ul.flat a { border-bottom: none; color: var(--ink-2); }
+.sidebar ul.flat a:hover { color: var(--accent); }
+
+/* ====== Main column ====== */
+main.content {
+  padding: 2.75rem 0 5rem;
+  max-width: 52rem;
+  min-width: 0;
+}
+
+/* ====== Breadcrumbs ====== */
+.crumbs {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+  margin-bottom: 1.75rem;
+}
+.crumbs a { border-bottom: none; color: var(--ink-3); }
+.crumbs a:hover { color: var(--accent); }
+.crumbs .sep { margin: 0 0.5rem; color: var(--rule); }
+
+/* ====== Headings ====== */
+article h1, .hero h1 {
+  font-family: "Fraunces", "Newsreader", Georgia, serif;
+  font-weight: 500;
+  font-size: 3rem;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  margin: 0 0 1rem;
+  color: var(--ink);
+  font-variation-settings: "SOFT" 30, "opsz" 144;
+}
+
+article > p:first-of-type::first-letter {
+  font-family: "Fraunces", serif;
+  font-weight: 500;
+  font-size: 4.4rem;
+  line-height: 0.85;
+  float: left;
+  padding: 0.4rem 0.6rem 0 0;
+  color: var(--accent);
+  font-variation-settings: "SOFT" 30, "opsz" 144;
+}
+
+article h2 {
+  font-family: "Fraunces", serif;
+  font-weight: 500;
+  font-size: 1.7rem;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  margin: 3.25rem 0 1rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--rule);
+  color: var(--ink);
+}
+
+article h3 {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  margin: 2.5rem 0 0.75rem;
+  color: var(--accent);
+}
+
+article p, article li {
+  font-size: 1.02rem;
+  color: var(--ink-2);
+  line-height: 1.75;
+}
+article ul, article ol { padding-left: 1.4rem; }
+article li { padding: 0.18rem 0; }
+article strong { color: var(--ink); font-weight: 600; }
+article em { font-style: italic; color: var(--ink); }
+
+/* ====== Hero ====== */
+.hero {
+  padding: 3.5rem 0 3rem;
+  margin-bottom: 2.5rem;
+  border-bottom: 1px solid var(--ink);
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 2.5rem;
+}
+.hero .marker {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: var(--ink-3);
+  padding-top: 0.65rem;
+  border-top: 2px solid var(--accent);
+  line-height: 1.7;
+}
+.hero h1 {
+  font-size: 3.6rem;
+  font-weight: 400;
+}
+.hero h1 .em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+}
+.hero p {
+  font-family: "Fraunces", serif;
+  font-size: 1.2rem;
+  color: var(--ink-2);
+  max-width: 36rem;
+  margin: 0 0 1.5rem;
+  line-height: 1.5;
+  font-weight: 400;
+  font-style: italic;
+}
+.hero .actions { margin-top: 1.5rem; }
+
+.btn {
+  display: inline-block;
+  padding: 0.55rem 1.1rem;
+  border: 1px solid var(--ink);
+  background: transparent;
+  color: var(--ink);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin-right: 0.5rem;
+}
+.btn:hover { background: var(--ink); color: var(--paper); border-bottom: 1px solid var(--ink); }
+.btn.accent { border-color: var(--accent); color: var(--accent); }
+.btn.accent:hover { background: var(--accent); color: var(--paper); border-color: var(--accent); }
+
+/* ====== Meta strip ====== */
+.meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.75rem;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  padding: 0.8rem 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  margin: 0 0 2.75rem;
+}
+.meta-row span b { color: var(--ink); font-weight: 600; }
+
+/* ====== Margin notes ====== */
+.margin-note {
+  float: left;
+  clear: left;
+  width: 11rem;
+  margin: 0.4rem 1.5rem 0.5rem -13rem;
+  padding-top: 0.4rem;
+  border-top: 1px solid var(--accent);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.72rem;
+  line-height: 1.55;
+  color: var(--ink-3);
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+.margin-note b {
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.62rem;
+  color: var(--ink-2);
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+}
+
+@media (max-width: 1180px) {
+  .margin-note {
+    float: none;
+    width: auto;
+    margin: 1.25rem 0;
+    padding: 0.6rem 0.85rem;
+    border-top: none;
+    border-left: 2px solid var(--accent);
+    background: var(--paper-2);
+  }
+}
+
+/* ====== Code ====== */
+article pre, pre[class*="language-"] {
+  background: var(--paper-2) !important;
+  color: var(--ink) !important;
+  padding: 1rem 1.25rem;
+  border-left: 3px solid var(--accent);
+  border-top: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  overflow-x: auto;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.84rem;
+  line-height: 1.65;
+  margin: 1.5rem 0;
+}
+article pre code, pre code {
+  background: transparent !important;
+  color: inherit !important;
+  padding: 0;
+  font-family: inherit;
+}
+article code {
+  background: var(--paper-2);
+  padding: 0.08rem 0.4rem;
+  border: 1px solid var(--rule);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.86em;
+  color: var(--ink);
+}
+
+/* ====== Tables ====== */
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.75rem 0;
+  font-size: 0.92rem;
+}
+article th, article td {
+  text-align: left;
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+article th {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+  border-bottom: 1px solid var(--ink);
+  font-weight: 500;
+}
+article tr:last-child td { border-bottom: 1px solid var(--ink); }
+
+/* ====== Blockquote (pull quote) ====== */
+article blockquote {
+  margin: 2rem 0;
+  padding: 0.5rem 0 0.5rem 1.5rem;
+  border-left: 2px solid var(--accent);
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  color: var(--ink);
+  font-weight: 400;
+}
+article blockquote p { font-size: inherit; color: inherit; margin: 0.3rem 0; }
+article blockquote cite {
+  display: block;
+  margin-top: 0.6rem;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-style: normal;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ink-3);
+}
+
+article hr {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 2.5rem 0;
+}
+
+/* ====== Section list (used on home/section/taxonomy) ====== */
+.section-list {
+  margin: 2rem 0;
+  border-top: 1px solid var(--ink);
+}
+.section-list .item {
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 5rem 1fr auto;
+  gap: 1.75rem;
+  align-items: baseline;
+}
+.section-list .item:last-child { border-bottom: 1px solid var(--ink); }
+.section-list .item .num {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+}
+.section-list .item h3 {
+  margin: 0;
+  font-family: "Fraunces", serif;
+  font-size: 1.3rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  text-transform: none;
+  color: var(--ink);
+}
+.section-list .item h3 a { border-bottom: none; }
+.section-list .item p {
+  margin: 0.35rem 0 0;
+  color: var(--ink-3);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+.section-list .item .date {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+}
+
+/* ====== Footer ====== */
+.foot {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--ink);
+  margin-top: 4rem;
+  padding: 1.75rem 0 2.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+  gap: 1.5rem;
+}
+.foot .colophon { font-family: "Fraunces", serif; font-style: italic; text-transform: none; letter-spacing: 0; font-size: 0.92rem; color: var(--ink-2); }
+
+/* ====== Tag pills ====== */
+.tag-pill {
+  display: inline-block;
+  border: 1px solid var(--ink);
+  padding: 0.12rem 0.6rem;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-right: 0.4rem;
+  color: var(--ink);
+}
+.tag-pill:hover { background: var(--ink); color: var(--paper); border-bottom: 1px solid var(--ink); }
+
+/* ====== Alert shortcode ====== */
+.alert {
+  margin: 1.75rem 0;
+  padding: 0.85rem 1.1rem;
+  background: var(--paper-2);
+  border-left: 3px solid var(--accent);
+  font-size: 0.95rem;
+  color: var(--ink-2);
+}
+.alert .label {
+  display: block;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: var(--accent);
+  margin-bottom: 0.3rem;
+  font-weight: 500;
+}
+
+/* ====== 404 ====== */
+.notfound {
+  text-align: center;
+  padding: 7rem 0;
+}
+.notfound h1 {
+  font-family: "Fraunces", serif;
+  font-size: 8rem;
+  font-weight: 400;
+  margin: 0;
+  letter-spacing: -0.04em;
+  color: var(--accent);
+}
+.notfound .label {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.26em;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  margin: 0.5rem 0 2rem;
+}
+
+/* ====== Responsive ====== */
+@media (max-width: 980px) {
+  .site { grid-template-columns: 1fr; gap: 1.25rem; padding: 0 1.25rem; }
+  aside.sidebar {
+    position: static;
+    border-right: none;
+    border-bottom: 1px solid var(--rule);
+    padding: 1rem 0 1.5rem;
+    max-height: none;
+  }
+  .hero { grid-template-columns: 1fr; padding: 2.25rem 0; gap: 1.5rem; }
+  .hero h1 { font-size: 2.4rem; }
+  article h1 { font-size: 2.2rem; }
+  article > p:first-of-type::first-letter { font-size: 3.4rem; }
+  .topbar { flex-direction: column; align-items: flex-start; gap: 0.6rem; }
+  .topbar nav { flex-wrap: wrap; gap: 1.1rem; }
+  .foot { flex-direction: column; gap: 0.6rem; }
+  .section-list .item { grid-template-columns: 1fr; gap: 0.5rem; }
+}

--- a/examples/prose-spec/static/favicon.svg
+++ b/examples/prose-spec/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#f6f1e7"/>
+  <rect x="1" y="1" width="30" height="30" rx="2.5" fill="none" stroke="#1a1815" stroke-width="1"/>
+  <text x="16" y="22" text-anchor="middle" font-family="Georgia, 'Fraunces', serif" font-size="20" font-style="italic" font-weight="500" fill="#b03a1c">P</text>
+</svg>

--- a/examples/prose-spec/templates/404.html
+++ b/examples/prose-spec/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p class="label">This page is not in the manuscript.</p>
+  <p>
+    <a class="btn accent" href="{{ base_url }}/">Return to the title page</a>
+    <a class="btn" href="{{ base_url }}/docs/">Open the chapters</a>
+  </p>
+</div>
+{% include "footer.html" %}

--- a/examples/prose-spec/templates/footer.html
+++ b/examples/prose-spec/templates/footer.html
@@ -1,0 +1,9 @@
+  </main>
+  <footer class="foot">
+    <span>{{ site_title }} &middot; Vol. I</span>
+    <span class="colophon">Set in Fraunces, Inter, and IBM Plex Mono.</span>
+    <span>Built with Hwaro &middot; {{ current_year }}</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/prose-spec/templates/header.html
+++ b/examples/prose-spec/templates/header.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..700,30;1,9..144,400..700,30&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="site">
+  <header class="topbar">
+    <a class="brand" href="{{ base_url }}/">Prose<span class="amp">&amp;</span>Spec</a>
+    <nav>
+      <a href="{{ base_url }}/docs/">Chapters</a>
+      <a href="{{ base_url }}/tags/">Tags</a>
+      <a href="{{ base_url }}/categories/">Categories</a>
+      <a href="https://github.com/hahwul/hwaro">Source</a>
+    </nav>
+    <span class="imprint">Vol. I &middot; 2026</span>
+  </header>
+  <aside class="sidebar">
+    <h4>The Manual</h4>
+    <ol class="chapters">
+      <li><a href="{{ base_url }}/docs/01-philosophy/">Philosophy</a></li>
+      <li><a href="{{ base_url }}/docs/02-document-model/">Document Model</a></li>
+      <li><a href="{{ base_url }}/docs/03-formatters/">Formatters</a></li>
+      <li><a href="{{ base_url }}/docs/04-pipeline/">Pipeline</a></li>
+    </ol>
+    <h4>Apparatus</h4>
+    <ul class="flat">
+      <li><a href="{{ base_url }}/docs/">All chapters</a></li>
+      <li><a href="{{ base_url }}/tags/">Tag index</a></li>
+      <li><a href="{{ base_url }}/categories/">Categories</a></li>
+    </ul>
+  </aside>
+  <main class="content">

--- a/examples/prose-spec/templates/home.html
+++ b/examples/prose-spec/templates/home.html
@@ -1,0 +1,76 @@
+{% include "header.html" %}
+<div class="hero">
+  <div class="marker">PROSE&middot;SPEC<br/>VOL. I<br/>2026</div>
+  <div>
+    <h1>A publishing engine for <span class="em">considered</span> prose.</h1>
+    <p>{{ site.description }}</p>
+    <div class="actions">
+      <a href="{{ base_url }}/docs/" class="btn accent">Read the manual</a>
+      <a href="{{ base_url }}/docs/01-philosophy/" class="btn">Begin at chapter one</a>
+    </div>
+  </div>
+</div>
+
+<article>
+  {{ content | safe }}
+
+  <h2>The Chapters</h2>
+  <div class="section-list">
+    <div class="item">
+      <span class="num">Ch. 01</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/01-philosophy/">Philosophy</a></h3>
+        <p>Why a new publishing engine, and what it refuses to compromise on.</p>
+      </div>
+      <span class="date">2026-04-15</span>
+    </div>
+    <div class="item">
+      <span class="num">Ch. 02</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/02-document-model/">Document Model</a></h3>
+        <p>The tree, its blocks, and the marks that decorate them.</p>
+      </div>
+      <span class="date">2026-04-19</span>
+    </div>
+    <div class="item">
+      <span class="num">Ch. 03</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/03-formatters/">Formatters</a></h3>
+        <p>Producing PDF, paginated HTML, and EPUB from the same source.</p>
+      </div>
+      <span class="date">2026-04-23</span>
+    </div>
+    <div class="item">
+      <span class="num">Ch. 04</span>
+      <div>
+        <h3><a href="{{ base_url }}/docs/04-pipeline/">Pipeline</a></h3>
+        <p>From ingest to artifact: the build pipeline, demystified.</p>
+      </div>
+      <span class="date">2026-04-27</span>
+    </div>
+  </div>
+
+  <h2>On the design</h2>
+  <p>
+    Prose Spec begins from a stubborn premise. Most publishing tooling treats
+    typography as an afterthought, a CSS file glued to the end of a build.
+    Prose Spec treats typography as the substrate: the document model knows
+    about widows and orphans, the formatter understands optical sizing, and
+    the pipeline tracks every glyph from source to artifact.
+  </p>
+
+  <h3>The reading rhythm</h3>
+  <p>
+    The reference itself is set the way a Prose Spec output would be set. The
+    body is Inter at a comfortable measure; chapter titles are Fraunces, an
+    optical-sized modern serif; the apparatus &mdash; labels, breadcrumbs,
+    margin notes &mdash; is IBM Plex Mono. There are no decorative flourishes
+    that do not also do work for the reader.
+  </p>
+
+  <blockquote>
+    Composition is the art of removing things until the page reads itself.
+    <cite>&mdash; from the editor's introduction</cite>
+  </blockquote>
+</article>
+{% include "footer.html" %}

--- a/examples/prose-spec/templates/page.html
+++ b/examples/prose-spec/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">Prose Spec</a><span class="sep">/</span><a href="{{ base_url }}/docs/">Chapters</a><span class="sep">/</span>{{ page.title | e }}
+</nav>
+<article>
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p style="font-family:'Fraunces',serif;font-style:italic;font-size:1.2rem;color:var(--ink-2);max-width:42rem;margin:-0.25rem 0 1.5rem;line-height:1.5;">{{ page.description | e }}</p>{% endif %}
+  <div class="meta-row">
+    {% if page.date %}<span>Filed <b>{{ page.date | date(format="%Y-%m-%d") }}</b></span>{% endif %}
+    {% if page.reading_time %}<span>Read <b>{{ page.reading_time }} min</b></span>{% endif %}
+    {% if page.word_count %}<span>Words <b>{{ page.word_count }}</b></span>{% endif %}
+    {% if page.tags %}<span>Tags &middot; {% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/prose-spec/templates/section.html
+++ b/examples/prose-spec/templates/section.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">Prose Spec</a><span class="sep">/</span>{{ page.title | e }}
+</nav>
+<div class="hero">
+  <div class="marker">SECTION<br/>{{ page.title | upper }}</div>
+  <div>
+    <h1>{{ page.title | e }}</h1>
+    {% if content %}<p>{{ content | striptags | trim }}</p>{% endif %}
+    <div class="actions">
+      <a href="{{ base_url }}/" class="btn">Back to title page</a>
+    </div>
+  </div>
+</div>
+
+<div class="section-list">
+  {% for p in section.pages %}
+  <div class="item">
+    <span class="num">Ch. {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <div>
+      <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+      {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+    </div>
+    <span class="date">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+  </div>
+  {% endfor %}
+</div>
+{% include "footer.html" %}

--- a/examples/prose-spec/templates/shortcodes/alert.html
+++ b/examples/prose-spec/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert">
+  <span class="label">{{ type | default(value="Note") | upper }}</span>
+  {{ body }}
+</div>

--- a/examples/prose-spec/templates/taxonomy.html
+++ b/examples/prose-spec/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">Prose Spec</a><span class="sep">/</span>{{ taxonomy_name | default(value="Tags") | capitalize }}
+</nav>
+<article>
+  <h1>{{ taxonomy_name | default(value="Tags") | capitalize }}</h1>
+  <p style="font-family:'Fraunces',serif;font-style:italic;color:var(--ink-3);font-size:1.1rem;">All terms in the <strong>{{ taxonomy_name }}</strong> taxonomy.</p>
+  <div class="section-list" style="margin-top:2rem;">
+    {% for term in taxonomy_terms %}
+    <div class="item">
+      <span class="num">No. {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <h3><a href="{{ term.url }}">{{ term.name }}</a></h3>
+        <p>{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %}</p>
+      </div>
+      <span class="date">/{{ taxonomy_name }}/{{ term.slug }}/</span>
+    </div>
+    {% endfor %}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/prose-spec/templates/taxonomy_term.html
+++ b/examples/prose-spec/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<nav class="crumbs">
+  <a href="{{ base_url }}/">Prose Spec</a><span class="sep">/</span><a href="{{ base_url }}/{{ taxonomy_name }}/">{{ taxonomy_name | capitalize }}</a><span class="sep">/</span>{{ page.title | e }}
+</nav>
+<article>
+  <h1>#{{ page.title | e }}</h1>
+  <p style="font-family:'Fraunces',serif;font-style:italic;color:var(--ink-3);font-size:1.1rem;">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} tagged <strong>{{ page.title }}</strong>.</p>
+  <div class="section-list" style="margin-top:2rem;">
+    {% for p in taxonomy_pages %}
+    <div class="item">
+      <span class="num">No. {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+        {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+      </div>
+      <span class="date">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+    </div>
+    {% endfor %}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,4 +1,34 @@
 {
+  "lattice-handbook": [
+    "dark",
+    "docs",
+    "minimal",
+    "modern"
+  ],
+  "forma-docs": [
+    "light",
+    "docs",
+    "minimal",
+    "modern"
+  ],
+  "noctis-runtime": [
+    "dark",
+    "docs",
+    "cyberpunk",
+    "brutalist"
+  ],
+  "prose-spec": [
+    "light",
+    "docs",
+    "editorial",
+    "modern"
+  ],
+  "circuit-ledger": [
+    "dark",
+    "docs",
+    "terminal",
+    "retro"
+  ],
   "kepler-grid": [
     "dark",
     "dashboard",


### PR DESCRIPTION
## Summary

Adds five new docs-tagged example sites, each with a distinct modern aesthetic. None reuse gradients or emojis — the visual identity comes from typography, layout, and a single accent color.

| Site | Tags | Aesthetic |
|---|---|---|
| `lattice-handbook` | dark, docs, minimal, modern | Dark slate with hairline SVG lattice and mint teal accent — graph engine reference |
| `forma-docs` | light, docs, minimal, modern | Vercel/Geist-style with oversized zinc chapter numerals — typed UI primitives |
| `noctis-runtime` | dark, docs, cyberpunk, brutalist | Black neo-brutalist with electric magenta and blocky H2 chips — streaming runtime |
| `prose-spec` | light, docs, editorial, modern | Cream editorial with Fraunces serif, clay accent, margin-notes — publishing engine |
| `circuit-ledger` | dark, docs, terminal, retro | Mono-dominant dark with ASCII frames and neon-green accent — embedded ledger VM |

Each site ships home/section/page/taxonomy/taxonomy_term/404 templates, a custom stylesheet, an `alert` shortcode, archetype, AGENTS.md, custom favicon SVG, and four substantive chapter pages (40–80 lines each) with realistic code blocks, tables, and pull-quotes. `tags.json` entries added for all five.

## Test plan

- [x] `hwaro build` clean on all 5 sites (6 pages each, no errors)
- [x] No `gradient` (`linear-`, `radial-`, `conic-`) anywhere in site CSS
- [x] No emoji characters in any markdown / templates / CSS
- [x] `tags.json` is valid JSON; all 5 entries resolve
- [ ] CI deploy succeeds and index page lists the new sites