### PR TITLE
Add five more modern dashboard example sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,7 +331,7 @@ Adding a new subdirectory under `examples/` with a valid `config.toml` + `tags.j
 3. **`base_url` stays `http://localhost:3000`.** CI overrides it at build time. Do not hardcode production URLs.
 4. **Use `{{ base_url }}` in templates** for all asset/link references (e.g., `{{ base_url }}/css/style.css`). Never use absolute paths without the prefix.
 5. **Preserve TOML front matter.** Always keep `+++` delimiters and valid TOML syntax when editing content files.
-6. **Templates use Jinja2 (Crinja).** Use `{% include %}`, `{% extends %}`, `{% block %}`, `{{ var | filter }}` syntax.
+6. **Templates use Jinja2 (Crinja).** Use `{% include %}`, `{% extends %}`, `{% block %}`, `{{ var | filter }}` syntax. **Crinja's `in` operator does not accept array literals** — `{% if x in [1, 2, 3] %}` will fail to parse. Use `{% if x == 1 or x == 2 or x == 3 %}` instead.
 7. **`public/` is build output.** It is gitignored. Never commit or edit files in `public/`.
 8. **Keep sites minimal and focused.** Each example should demonstrate a specific use case or design pattern clearly.
 9. **Use `hwaro serve` for local preview.** Default port is 3000. Use `-p` to change.

--- a/examples/atlas-pulse/AGENTS.md
+++ b/examples/atlas-pulse/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+## Project Overview
+
+Static website built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Site-Specific Notes
+
+- Theme: editorial light portfolio review for a small partnership. Bone (`#f6f2ea`) bg, deep olive (`#4a5d23`) accent, oxblood (`#a83a2c`) for losses. Source Serif 4 headings + Inter body + JetBrains Mono numerals.
+- Content sections: `content/notes/` for research notes; plus `index.md` (review) and `about.md` (colophon).
+- CSS lives in `static/css/style.css`.
+- No gradients, no emojis.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/atlas-pulse/archetypes/default.md
+++ b/examples/atlas-pulse/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/atlas-pulse/config.toml
+++ b/examples/atlas-pulse/config.toml
@@ -1,0 +1,217 @@
+title = "Atlas Pulse"
+description = "A monthly portfolio review for a small private partnership."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "themes"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["notes"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/atlas-pulse/content/about.md
+++ b/examples/atlas-pulse/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About this review"
+description = "Atlas Pulse is the monthly review for a small private partnership. Here is what it is for, and what it is not."
++++
+
+Atlas Pulse is a monthly review for a small private partnership. The audience is the partners themselves and a handful of friends-and-family limited partners who have asked, repeatedly, that we put our thinking on paper. The audience is not the general public, and the document is not a marketing piece. We mention this at the top because the form of the page is very deliberately a summary at the front and an essay at the back.
+
+## What is on the cover page
+
+Five numbers. Net asset value as of the last close. The month's return, with our composite benchmark beside it. The trailing twelve-month return. Volatility, computed over the trailing twelve months on monthly returns. Maximum drawdown over the same window. We do not show year-to-date, ever — anchoring on the calendar year is a form of self-deception we have promised to avoid.
+
+> The review is honest. We promise not to hide a number we report on the cover, and we promise not to put a number on the cover that we cannot defend.
+
+## What is not on the cover page
+
+Anything that requires a footnote to be true. We try very hard to keep the cover page non-footnoted. The exposure and contribution tables are footnoted because they have to be; the cover summary is not.
+
+## How we choose what to write about
+
+The **Notes** section is whatever was on the partners' minds in the month. It is not a beat-the-market column and it is not a hot-take column. The closer to a question of judgement the entry is, the longer we sit on it.

--- a/examples/atlas-pulse/content/index.md
+++ b/examples/atlas-pulse/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Review"
+description = "Atlas Pulse — the monthly review for a small private partnership."
+template = "home"
++++

--- a/examples/atlas-pulse/content/notes/_index.md
+++ b/examples/atlas-pulse/content/notes/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Notes"
+description = "Monthly research notes from the partnership. Slow, by intent."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/atlas-pulse/content/notes/april-drawdown-postmortem.md
+++ b/examples/atlas-pulse/content/notes/april-drawdown-postmortem.md
@@ -1,0 +1,19 @@
++++
+title = "April drawdown postmortem"
+date = "2026-04-30"
+description = "We lost three percent in April. Two-thirds of it was on one name. The other third is the part worth discussing."
+tags = ["drawdown", "postmortem"]
+themes = ["risk"]
++++
+
+We lost three percent in April. Two-thirds of the loss came from one position, and we have written about that name elsewhere. The remaining one percent is the part we want to discuss here, because the remaining one percent is the part that says something about the portfolio.
+
+Aside from the named position, the portfolio was uniformly down. Every theme contributed something between thirty and seventy basis points of drag. That uniformity is the kind of thing that gets called *correlation breakdown* in good times and *risk-on, risk-off* in bad times; in either case it is a reminder that diversification is partial.
+
+- Defensive sleeve: −44 bp
+- Cyclicals: −38 bp
+- Quality compounders: −31 bp
+- Real assets: −22 bp
+- Cash and equivalents: +12 bp
+
+The lesson is not that diversification failed. The lesson is that we wrote about the diversification benefit during the calm months as if it were a permanent feature; April was a reminder that it is a partial benefit, and a fee we pay during the bad months when everything moves together. We have updated the language we use about the sleeve construction in the cover-page footnotes.

--- a/examples/atlas-pulse/content/notes/benchmark-honest.md
+++ b/examples/atlas-pulse/content/notes/benchmark-honest.md
@@ -1,0 +1,15 @@
++++
+title = "On choosing a benchmark that can lose"
+date = "2026-04-18"
+description = "A benchmark you cannot lose against is not a benchmark, it is a slogan."
+tags = ["benchmark", "process"]
+themes = ["portfolio-construction"]
++++
+
+We carry a composite benchmark on the cover page and a long footnote in the appendix explaining how it is built. The composite is mostly equities, a small slug of high-quality fixed income, and a dollar of cash for every hundred dollars of risk. It is constructed to be losable.
+
+A benchmark you cannot lose against is not a benchmark, it is a slogan. The composite has beaten us in three of the last twelve months. We expect a similar ratio over any rolling twelve-month window. The point of the comparison is not that we win; the point is that we *can* lose, in which case the partners can call.
+
+> If you want to compare us to the right thing, this is the right thing. If the right thing is going to embarrass us this quarter, the right thing is still the right thing.
+
+We rebuild the composite once a year and we will publish the new weights for next year's review in the November note. The rebuild is mechanical — there is no discretionary choice to nudge the comparison in a friendlier direction.

--- a/examples/atlas-pulse/content/notes/concentration-discipline.md
+++ b/examples/atlas-pulse/content/notes/concentration-discipline.md
@@ -1,0 +1,15 @@
++++
+title = "On concentration, and the discipline of not adding"
+date = "2026-05-06"
+description = "Our top five positions are 41% of the portfolio. We are not adding more, and here is the rule we use to know."
+tags = ["concentration", "rules", "process"]
+themes = ["portfolio-construction"]
++++
+
+The top five positions are forty-one percent of the portfolio at month-end. By our own rule we are at the cap, and by the same rule we will not be adding to them. We write this down here because the rule is much easier to keep when it is in print.
+
+The rule is simple: no single position passes ten percent, and the top five do not exceed forty-five. The rule is unfashionable. We have lived through three quarters where the rule has cost us absolute return. We have also lived through one quarter where the rule prevented a position-level mistake from becoming a portfolio-level mistake.
+
+> Concentration without a rule is conviction. Concentration with a rule is process. We pay ourselves to be the second kind.
+
+The names at the cap will continue to be the names at the cap until one of them either crosses the position limit on its own — at which point we will trim — or the partnership's conviction in one of them changes. The latter is not a forecast; it is a fact we will report when it occurs.

--- a/examples/atlas-pulse/content/notes/may-rates-pause.md
+++ b/examples/atlas-pulse/content/notes/may-rates-pause.md
@@ -1,0 +1,15 @@
++++
+title = "On the rate pause and what we are not doing"
+date = "2026-05-14"
+description = "A note on why we have not changed the duration profile in response to the pause."
+tags = ["macro", "fixed-income", "duration"]
+themes = ["rates"]
++++
+
+The central bank paused this month for the first time in seven meetings. The pause was widely expected, narrowly priced, and probably the right call for the data on the page. We do not have a strong view on whether the next move is up or down — and that is the entire point of this note.
+
+We have not changed the duration profile in the portfolio. The temptation to do so is real: a pause is the moment when a manager looks decisive, and decisiveness is the kind of thing the partners would compliment. But the portfolio is positioned for a band of outcomes that includes both "hold for two more meetings" and "cut once before year-end". A duration shift would express a view we do not have.
+
+> The most useful response to a pause is the smallest one. We have done the work of building a portfolio that does not require a decision today, and the decision today is to honour that work.
+
+What we will do is the quiet work behind the cover: revisit the credit-spread regime on the names we own, dust off the dollar-bond exposure, and prepare a one-paragraph view on each. None of that appears on the cover page; all of it will be visible in the exposure tables next month.

--- a/examples/atlas-pulse/static/css/style.css
+++ b/examples/atlas-pulse/static/css/style.css
@@ -1,0 +1,446 @@
+:root {
+  --bg: #f6f2ea;
+  --bg-2: #ede7d8;
+  --panel: #fbf8f1;
+  --ink: #1a1814;
+  --ink-2: #3a3530;
+  --ink-mute: #6a6258;
+  --ink-dim: #9a9285;
+  --line: #d4cdba;
+  --line-2: #b8af96;
+  --accent: #4a5d23;
+  --accent-2: #a83a2c;
+  --gold: #9a7a2f;
+  --pos: #2d5a3a;
+  --neg: #a83a2c;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.serif, h1, h2, .essay-h, .cover h1, .page-title {
+  font-family: "Source Serif 4", "Source Serif Pro", Georgia, serif;
+}
+.mono, code, pre, .num, .v, .bp, .val { font-family: "JetBrains Mono", ui-monospace, monospace; font-feature-settings: "tnum"; }
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.folio { max-width: 1300px; margin: 0 auto; padding: 28px 40px 80px; }
+
+/* MASTHEAD */
+.masthead {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--line);
+}
+.masthead .brand {
+  display: flex; align-items: center; gap: 18px;
+  color: var(--ink);
+}
+.masthead .seal {
+  width: 56px; height: 56px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.masthead .seal svg { width: 100%; height: 100%; display: block; }
+.masthead .title {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 1.9rem;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+}
+.masthead .title em { font-style: italic; font-weight: 500; color: var(--accent); }
+.masthead .title b { font-weight: 700; }
+.masthead .title small {
+  display: block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  font-style: normal;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-top: 4px;
+}
+.masthead nav {
+  display: flex;
+  gap: 28px;
+  padding-bottom: 8px;
+}
+.masthead nav a {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 0.98rem;
+  font-style: italic;
+  font-weight: 500;
+  color: var(--ink-mute);
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.masthead nav a:hover { color: var(--accent); border-color: var(--accent); }
+
+.ledger {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0 26px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  border-bottom: 3px double var(--line-2);
+  margin-bottom: 36px;
+}
+
+/* COVER */
+.cover {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 56px;
+  align-items: start;
+  margin-bottom: 36px;
+}
+.cover .issue {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  display: block;
+  margin-bottom: 18px;
+}
+.cover h1 {
+  font-size: clamp(2.6rem, 5vw, 4.2rem);
+  line-height: 0.98;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  margin: 0 0 22px;
+  color: var(--ink);
+}
+.cover h1 em { font-style: italic; color: var(--accent); font-weight: 600; }
+.cover .dek {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 1.16rem;
+  font-style: italic;
+  color: var(--ink-2);
+  line-height: 1.5;
+  max-width: 48ch;
+  margin: 0;
+}
+
+.cover-stat { display: grid; gap: 14px; }
+.stat {
+  padding: 20px 22px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+}
+.stat.lead {
+  background: var(--ink);
+  color: var(--bg);
+  border-color: var(--ink);
+}
+.stat.lead .lbl { color: rgba(246,242,234,0.7); }
+.stat.lead .note { color: rgba(246,242,234,0.55); }
+.stat .lbl {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-bottom: 4px;
+}
+.stat .val {
+  font-size: 1.85rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: inherit;
+}
+.stat.lead .val { font-size: 2.6rem; }
+.stat .val small { font-size: 0.85rem; color: inherit; opacity: 0.7; margin-left: 4px; }
+.stat .val.pos { color: var(--pos); }
+.stat .val.neg { color: var(--neg); }
+.stat .note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--ink-dim);
+  margin-top: 4px;
+}
+.stat-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+
+/* RULE */
+.rule { border: 0; border-top: 1px solid var(--line); margin: 36px 0; }
+.rule-double { border-top: 3px double var(--line-2); }
+
+/* BLOCKS */
+.folio-row { display: grid; gap: 36px; }
+.folio-row.split { grid-template-columns: 1.05fr 1fr; }
+.folio-row.tri { grid-template-columns: repeat(3, 1fr); }
+.block {}
+.block-head { margin-bottom: 18px; }
+.block-head .folio-num {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  margin-right: 12px;
+}
+.block-head h2 {
+  display: inline;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+  font-weight: 700;
+  margin: 0;
+}
+.block-head .caption {
+  display: block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-top: 6px;
+}
+
+/* RETURNS */
+.returns { display: grid; gap: 6px; }
+.ret {
+  display: grid;
+  grid-template-columns: 60px 1fr 70px;
+  align-items: center;
+  gap: 14px;
+  padding: 4px 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+}
+.ret .m { color: var(--ink-mute); letter-spacing: 0.06em; }
+.ret .v { text-align: right; color: var(--ink); }
+.ret.bold .m, .ret.bold .v { color: var(--ink); font-weight: 600; }
+.ret .bar {
+  position: relative;
+  height: 18px;
+  display: block;
+  border-left: 1px solid var(--line);
+  border-right: 1px solid var(--line);
+}
+.ret .bar::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -4px; bottom: -4px;
+  width: 1px;
+  background: var(--ink-2);
+}
+.ret .bar i {
+  position: absolute; top: 2px; bottom: 2px;
+  width: var(--w, 30%);
+}
+.ret .bar i.pos { left: 50%; background: var(--accent); }
+.ret .bar i.neg { right: 50%; background: var(--accent-2); }
+
+/* LEDGER TABLE */
+.ledger-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+.ledger-table thead th {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  text-align: left;
+  padding: 8px 10px 8px 0;
+  border-bottom: 2px solid var(--ink-2);
+  font-weight: 500;
+}
+.ledger-table tbody td {
+  padding: 14px 10px 14px 0;
+  border-bottom: 1px dotted var(--line);
+  vertical-align: top;
+}
+.ledger-table tbody td:first-child b { font-weight: 600; color: var(--ink); }
+.ledger-table tbody td small { display: block; font-size: 11px; color: var(--ink-dim); margin-top: 3px; }
+.ledger-table .num { font-family: "JetBrains Mono", monospace; text-align: right; color: var(--ink); font-feature-settings: "tnum"; }
+.ledger-table .pos { color: var(--pos); }
+.ledger-table .neg { color: var(--neg); }
+.ledger-table .dim { color: var(--ink-dim); font-style: italic; font-family: "Source Serif 4", Georgia, serif; }
+.ledger-table tfoot td { padding: 14px 10px 0 0; border-top: 2px solid var(--ink-2); border-bottom: 0; font-weight: 700; }
+
+/* DOT LIST */
+.dot-list { list-style: none; padding: 0; margin: 0; }
+.dot-list li {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 12px 0;
+  border-top: 1px dotted var(--line);
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 1.02rem;
+}
+.dot-list li:first-child { border-top: 0; padding-top: 4px; }
+.dot-list b { font-weight: 600; color: var(--ink); }
+.dot-list .bp {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  font-feature-settings: "tnum";
+}
+.dot-list .bp.pos { color: var(--pos); }
+.dot-list .bp.neg { color: var(--neg); }
+
+/* DEFS */
+.defs { margin: 0; display: grid; grid-template-columns: 1fr auto; gap: 6px 18px; }
+.defs dt { font-family: "Source Serif 4", Georgia, serif; color: var(--ink-2); font-style: italic; }
+.defs dd { margin: 0; font-family: "JetBrains Mono", monospace; font-size: 13px; color: var(--ink); font-feature-settings: "tnum"; }
+
+/* ESSAY LIST */
+.essay-list { margin-top: 0; }
+.essay-h { font-size: 1.8rem; letter-spacing: -0.015em; margin: 0 0 6px; font-weight: 700; }
+.essay-d { color: var(--ink-mute); font-style: italic; margin: 0 0 22px; font-family: "Source Serif 4", Georgia, serif; }
+.notes { list-style: none; padding: 0; margin: 0; }
+.notes li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 22px;
+  align-items: baseline;
+  padding: 22px 0;
+  border-top: 1px solid var(--line);
+}
+.notes li:last-child { border-bottom: 1px solid var(--line); }
+.notes .copy a {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  display: inline-block;
+  margin-bottom: 6px;
+}
+.notes .copy a:hover { color: var(--accent); }
+.notes .copy p { margin: 0; color: var(--ink-mute); font-family: "Source Serif 4", Georgia, serif; font-style: italic; max-width: 64ch; }
+.notes .meta time {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  white-space: nowrap;
+}
+.notes.plain li { padding: 26px 0; }
+.notes.plain .copy a { font-size: 1.55rem; }
+
+/* PAGE */
+.page-title {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  margin: 16px 0 8px;
+  font-family: "Source Serif 4", Georgia, serif;
+}
+.page-desc {
+  color: var(--ink-mute);
+  font-family: "Source Serif 4", Georgia, serif;
+  font-style: italic;
+  font-size: 1.08rem;
+  max-width: 60ch;
+  margin: 0 0 22px;
+}
+.page-date {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin-bottom: 36px;
+}
+
+.cta {
+  display: inline-block;
+  padding: 10px 22px;
+  background: var(--ink);
+  color: var(--bg);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.cta:hover { background: var(--accent); color: var(--bg); }
+
+article.prose {
+  max-width: 62ch;
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 1.12rem;
+  line-height: 1.65;
+  color: var(--ink);
+}
+article.prose h2 { font-size: 1.55rem; letter-spacing: -0.01em; margin: 1.8em 0 0.5em; font-weight: 700; }
+article.prose h3 { font-size: 1.2rem; margin: 1.4em 0 0.4em; font-weight: 600; }
+article.prose blockquote {
+  border-left: 3px solid var(--accent);
+  padding: 6px 22px;
+  margin: 1.6em 0;
+  color: var(--ink-2);
+  font-style: italic;
+}
+article.prose ul li::marker { color: var(--accent); }
+article.prose ul li, article.prose ol li { margin: 0.4em 0; }
+article.prose a { color: var(--accent); border-bottom: 1px solid var(--accent); }
+article.prose a:hover { background: var(--accent); color: var(--bg); }
+
+.aside {
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  background: var(--panel);
+  padding: 14px 18px;
+  margin: 1.4em 0;
+  display: flex; gap: 12px; align-items: baseline;
+}
+.aside strong {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+
+footer.colophon {
+  margin-top: 60px;
+  padding-top: 28px;
+  border-top: 3px double var(--line-2);
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1.2fr;
+  gap: 36px;
+  font-size: 13px;
+  color: var(--ink-mute);
+  font-family: "Source Serif 4", Georgia, serif;
+}
+footer.colophon strong {
+  display: block;
+  margin-bottom: 10px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+footer.colophon p { margin: 0; font-style: italic; }
+footer.colophon a { color: var(--accent); border-bottom: 1px solid var(--line); }
+
+@media (max-width: 1000px) {
+  .cover, .folio-row.split, .folio-row.tri { grid-template-columns: 1fr; }
+  .masthead { flex-direction: column; align-items: flex-start; gap: 18px; }
+  .masthead nav { flex-wrap: wrap; }
+  .ledger { flex-direction: column; gap: 6px; }
+  .notes li { grid-template-columns: 1fr; }
+}

--- a/examples/atlas-pulse/static/favicon.svg
+++ b/examples/atlas-pulse/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f6f2ea"/>
+  <circle cx="16" cy="16" r="13" fill="none" stroke="#4a5d23" stroke-width="1.2"/>
+  <circle cx="16" cy="16" r="8" fill="none" stroke="#4a5d23" stroke-width="0.8"/>
+  <path d="M 16 4 L 16 28 M 4 16 L 28 16" stroke="#4a5d23" stroke-width="0.8"/>
+</svg>

--- a/examples/atlas-pulse/templates/404.html
+++ b/examples/atlas-pulse/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">404 — folio not in the index</h1>
+    <p class="page-desc">That page has not been issued. The review is on the front.</p>
+    <p><a href="{{ base_url }}/" class="cta">Return to review</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/atlas-pulse/templates/footer.html
+++ b/examples/atlas-pulse/templates/footer.html
@@ -1,0 +1,20 @@
+    <footer class="colophon">
+      <div>
+        <strong>{{ site.title }}</strong>
+        <p>A monthly review for a small private partnership. Distributed to the partners and a small set of named limited partners. Set in Source Serif and Inter. Built with Hwaro on Crystal.</p>
+      </div>
+      <div>
+        <strong>Sections</strong>
+        <a href="{{ base_url }}/">Review</a> ·
+        <a href="{{ base_url }}/notes/">Notes</a> ·
+        <a href="{{ base_url }}/about/">Colophon</a>
+      </div>
+      <div>
+        <strong>Office of the partnership · {{ current_year }}</strong>
+        <p>Issued {{ current_date }} · revision r-04 · no part of this document constitutes investment advice.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/atlas-pulse/templates/header.html
+++ b/examples/atlas-pulse/templates/header.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700;8..60,800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="folio">
+    <header class="masthead">
+      <div class="left">
+        <a href="{{ base_url }}/" class="brand">
+          <span class="seal" aria-hidden="true">
+            <svg viewBox="0 0 40 40">
+              <circle cx="20" cy="20" r="18" fill="none" stroke="currentColor" stroke-width="1.5"/>
+              <circle cx="20" cy="20" r="12" fill="none" stroke="currentColor" stroke-width="1"/>
+              <path d="M 20 8 L 20 32 M 8 20 L 32 20" stroke="currentColor" stroke-width="1"/>
+            </svg>
+          </span>
+          <span class="title">
+            <em>Atlas</em> <b>Pulse</b>
+            <small>Monthly Review · No. 38 · {{ current_date }}</small>
+          </span>
+        </a>
+      </div>
+      <nav>
+        <a href="{{ base_url }}/">Review</a>
+        <a href="{{ base_url }}/notes/">Notes</a>
+        <a href="{{ base_url }}/about/">Colophon</a>
+      </nav>
+    </header>
+    <div class="ledger">
+      <span>Issued at the close · 5 PM ET</span>
+      <span>Form ADV on file · pages 1 — 14 superseded</span>
+      <span>For partners and named LPs</span>
+    </div>

--- a/examples/atlas-pulse/templates/home.html
+++ b/examples/atlas-pulse/templates/home.html
@@ -1,0 +1,179 @@
+{% include "header.html" %}
+  <main>
+    <section class="cover">
+      <div class="cover-text">
+        <span class="issue">Issue 38 · May 2026</span>
+        <h1>A quiet month,<br>by the partnership's own<br><em>preferred kind of standard.</em></h1>
+        <p class="dek">Net asset value, the month's return, the trailing twelve, the volatility, the drawdown — and not a single number we cannot defend. Anything else in this review is colour, footnote, or argument.</p>
+      </div>
+      <div class="cover-stat">
+        <div class="stat lead">
+          <span class="lbl">Net asset value</span>
+          <span class="val">$ 248.4<small>m</small></span>
+          <span class="note">at close · 30 Apr</span>
+        </div>
+        <div class="stat-row">
+          <div class="stat"><span class="lbl">Month</span><span class="val pos">+ 0.84%</span><span class="note">benchmark + 1.02%</span></div>
+          <div class="stat"><span class="lbl">Trailing 12m</span><span class="val pos">+ 11.6%</span><span class="note">benchmark + 9.4%</span></div>
+        </div>
+        <div class="stat-row">
+          <div class="stat"><span class="lbl">Volatility (12m)</span><span class="val">8.4%</span><span class="note">annualised, monthly</span></div>
+          <div class="stat"><span class="lbl">Max drawdown</span><span class="val neg">− 6.2%</span><span class="note">peak to trough</span></div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule rule-double">
+
+    <section class="folio-row split">
+      <article class="block">
+        <header class="block-head">
+          <span class="folio-num">I</span>
+          <h2>Performance, twelve months</h2>
+          <span class="caption">Monthly returns vs. composite benchmark</span>
+        </header>
+        <div class="returns">
+          <div class="ret"><span class="m">May 25</span><span class="bar"><i style="--w:42%; --side:right" class="pos"></i></span><span class="v">+ 0.74</span></div>
+          <div class="ret"><span class="m">Jun</span><span class="bar"><i style="--w:38%; --side:right" class="pos"></i></span><span class="v">+ 0.66</span></div>
+          <div class="ret"><span class="m">Jul</span><span class="bar"><i style="--w:22%; --side:right" class="pos"></i></span><span class="v">+ 0.38</span></div>
+          <div class="ret"><span class="m">Aug</span><span class="bar"><i style="--w:30%; --side:left" class="neg"></i></span><span class="v">− 0.52</span></div>
+          <div class="ret"><span class="m">Sep</span><span class="bar"><i style="--w:62%; --side:right" class="pos"></i></span><span class="v">+ 1.18</span></div>
+          <div class="ret"><span class="m">Oct</span><span class="bar"><i style="--w:48%; --side:right" class="pos"></i></span><span class="v">+ 0.92</span></div>
+          <div class="ret"><span class="m">Nov</span><span class="bar"><i style="--w:18%; --side:right" class="pos"></i></span><span class="v">+ 0.32</span></div>
+          <div class="ret"><span class="m">Dec</span><span class="bar"><i style="--w:72%; --side:right" class="pos"></i></span><span class="v">+ 1.41</span></div>
+          <div class="ret"><span class="m">Jan 26</span><span class="bar"><i style="--w:14%; --side:left" class="neg"></i></span><span class="v">− 0.24</span></div>
+          <div class="ret"><span class="m">Feb</span><span class="bar"><i style="--w:54%; --side:right" class="pos"></i></span><span class="v">+ 1.04</span></div>
+          <div class="ret"><span class="m">Mar</span><span class="bar"><i style="--w:88%; --side:right" class="pos"></i></span><span class="v">+ 1.72</span></div>
+          <div class="ret"><span class="m">Apr</span><span class="bar"><i style="--w:62%; --side:left" class="neg"></i></span><span class="v">− 1.18</span></div>
+          <div class="ret bold"><span class="m">May</span><span class="bar"><i style="--w:44%; --side:right" class="pos"></i></span><span class="v">+ 0.84</span></div>
+        </div>
+      </article>
+
+      <article class="block">
+        <header class="block-head">
+          <span class="folio-num">II</span>
+          <h2>Exposure by theme</h2>
+          <span class="caption">As a percent of net asset value</span>
+        </header>
+        <table class="ledger-table">
+          <thead>
+            <tr><th>Theme</th><th>Wt.</th><th>YTD</th><th>Note</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><b>Quality compounders</b><small>14 names · 9 sectors</small></td>
+              <td class="num">28.4%</td>
+              <td class="num pos">+ 8.2</td>
+              <td class="dim">core holding</td>
+            </tr>
+            <tr>
+              <td><b>Defensive sleeve</b><small>11 names · 4 sectors</small></td>
+              <td class="num">22.1%</td>
+              <td class="num pos">+ 3.4</td>
+              <td class="dim">added Mar</td>
+            </tr>
+            <tr>
+              <td><b>Cyclicals · industrials</b><small>9 names</small></td>
+              <td class="num">14.8%</td>
+              <td class="num pos">+ 12.6</td>
+              <td class="dim">trimmed Feb</td>
+            </tr>
+            <tr>
+              <td><b>Real assets</b><small>energy, materials, REIT</small></td>
+              <td class="num">11.2%</td>
+              <td class="num neg">− 1.8</td>
+              <td class="dim">unchanged</td>
+            </tr>
+            <tr>
+              <td><b>Fixed income · IG</b><small>blended, duration 4.2y</small></td>
+              <td class="num">14.4%</td>
+              <td class="num pos">+ 2.1</td>
+              <td class="dim">held duration</td>
+            </tr>
+            <tr>
+              <td><b>Cash &amp; equivalents</b><small>USD, EUR money funds</small></td>
+              <td class="num">9.1%</td>
+              <td class="num pos">+ 1.2</td>
+              <td class="dim">target 8 — 12</td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr><td><b>Total</b></td><td class="num">100.0%</td><td class="num pos">+ 4.8</td><td class="dim">YTD net</td></tr>
+          </tfoot>
+        </table>
+      </article>
+    </section>
+
+    <hr class="rule">
+
+    <section class="folio-row tri">
+      <article class="block">
+        <header class="block-head">
+          <span class="folio-num">III</span>
+          <h2>Top contributors</h2>
+          <span class="caption">May, in basis points</span>
+        </header>
+        <ul class="dot-list">
+          <li><b>Industrial holding · A</b><span class="bp pos">+ 42 bp</span></li>
+          <li><b>Defensive · B</b><span class="bp pos">+ 31 bp</span></li>
+          <li><b>Compounder · C</b><span class="bp pos">+ 24 bp</span></li>
+          <li><b>Real assets · D</b><span class="bp pos">+ 18 bp</span></li>
+          <li><b>Compounder · E</b><span class="bp pos">+ 14 bp</span></li>
+        </ul>
+      </article>
+
+      <article class="block">
+        <header class="block-head">
+          <span class="folio-num">IV</span>
+          <h2>Top detractors</h2>
+          <span class="caption">May, in basis points</span>
+        </header>
+        <ul class="dot-list">
+          <li><b>Cyclical · F</b><span class="bp neg">− 28 bp</span></li>
+          <li><b>Compounder · G</b><span class="bp neg">− 16 bp</span></li>
+          <li><b>Real assets · H</b><span class="bp neg">− 12 bp</span></li>
+          <li><b>Defensive · I</b><span class="bp neg">− 8 bp</span></li>
+          <li><b>FX · GBP/USD overlay</b><span class="bp neg">− 6 bp</span></li>
+        </ul>
+      </article>
+
+      <article class="block">
+        <header class="block-head">
+          <span class="folio-num">V</span>
+          <h2>Risk profile</h2>
+          <span class="caption">As of 30 Apr · trailing 12m</span>
+        </header>
+        <dl class="defs">
+          <dt>Concentration · top 5</dt><dd>41.4%</dd>
+          <dt>Largest position</dt><dd>9.2%</dd>
+          <dt>Beta to composite</dt><dd>0.74</dd>
+          <dt>Sharpe (12m)</dt><dd>1.21</dd>
+          <dt>Net equity exposure</dt><dd>62.4%</dd>
+          <dt>Liquidity (T+5)</dt><dd>94.8%</dd>
+        </dl>
+      </article>
+    </section>
+
+    <hr class="rule rule-double">
+
+    <section class="essay-list">
+      <h2 class="essay-h">From the notes</h2>
+      <p class="essay-d">The slower thinking. New entries appear on the second Sunday of the month.</p>
+      <ul class="notes">
+        {% for post in site.pages | where("section", "notes") | sort_by("date", reverse=true) %}
+          {% if loop.index <= 4 %}
+          <li>
+            <div class="copy">
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+            </div>
+            <div class="meta">
+              <time>{{ post.date | date("%d %b · %Y") }}</time>
+            </div>
+          </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/atlas-pulse/templates/page.html
+++ b/examples/atlas-pulse/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.date %}<div class="page-date">{{ page.date | date("%d %B %Y") }}</div>{% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/atlas-pulse/templates/section.html
+++ b/examples/atlas-pulse/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    {{ content }}
+    <ul class="notes plain">
+      {% for post in section.pages %}
+        <li>
+          <div class="copy">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+          </div>
+          <div class="meta">
+            <time>{{ post.date | date("%d %b · %Y") }}</time>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/atlas-pulse/templates/shortcodes/alert.html
+++ b/examples/atlas-pulse/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<aside class="aside" data-type="{{ type | default('note') }}">
+  <strong>{{ type | default('note') | upper }}</strong>
+  <span>{{ body }}</span>
+</aside>

--- a/examples/atlas-pulse/templates/taxonomy.html
+++ b/examples/atlas-pulse/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Browse all terms in this taxonomy.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/atlas-pulse/templates/taxonomy_term.html
+++ b/examples/atlas-pulse/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Posts tagged with this term.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/harbor-metrics/AGENTS.md
+++ b/examples/harbor-metrics/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+Static website built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Site-Specific Notes
+
+- Theme: light Swiss-modernist terminal operations board. Cream (`#f4f1ea`) bg, black + cherry red (`#d72d1f`) accents.
+- Content sections: `content/berth-log/` for shift entries; plus `index.md` (board) and `about.md` (operator manual).
+- CSS lives in `static/css/style.css`.
+- No gradients, no emojis.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/harbor-metrics/archetypes/default.md
+++ b/examples/harbor-metrics/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/harbor-metrics/config.toml
+++ b/examples/harbor-metrics/config.toml
@@ -1,0 +1,217 @@
+title = "Harbor Metrics"
+description = "Operations control for a working deep-water container terminal."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "berths"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["berth-log"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/harbor-metrics/content/about.md
+++ b/examples/harbor-metrics/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "Reading the board"
+description = "How to use the Harbor Metrics operations board without slowing the gate down."
++++
+
+Harbor Metrics is the operations board for a working deep-water container terminal. The page you came from is what the duty supervisor watches across an eight-hour shift, and what the night gate consults when a driver presents an unexpected booking. The contents of this manual were written by the people who built the board, not by the people who specified it.
+
+## The numbers
+
+Every number on the board is the smallest one we can be sure of. The current count of containers on the yard is the count at the last reconciliation tick — not the count that would be right if the camera system caught up. If the count has not been reconciled in the last fifteen minutes, the number turns black-on-cream and a clock starts in the corner. We would rather show a stale number with a clock than a fresh number with no provenance.
+
+> Black on cream is a warning. The clock tells you how long the warning has been on. If the clock passes thirty minutes, call the yard.
+
+## Berths and bays
+
+Each berth has a name, a draft, and a fender envelope. The board shows the **occupancy** plot for each berth — the rolling twelve-hour history of arrivals, dwell, and departures. The fender alerts are wired into the same system that drives the alongside lighting; if the board says a fender is hot, the fender is also flashing in real life.
+
+## The team
+
+The terminal is run by a duty supervisor, two yard masters, four gate clerks, and the operating engineers for the four ship-to-shore cranes. Everyone on the rotation has read this manual. New hires read it twice and sign the back page before they touch the board.

--- a/examples/harbor-metrics/content/berth-log/_index.md
+++ b/examples/harbor-metrics/content/berth-log/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Berth log"
+description = "Vessel-level events, written by the duty supervisor who closed the shift."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/harbor-metrics/content/berth-log/fender-replacement-b1.md
+++ b/examples/harbor-metrics/content/berth-log/fender-replacement-b1.md
@@ -1,0 +1,18 @@
++++
+title = "Fender F-04 replaced at berth one"
+date = "2026-05-09"
+description = "We pulled the F-04 cell fender at berth one after a routine ultrasonic flagged a delamination. No vessel impact."
+tags = ["fender", "maintenance", "ultrasonic"]
+berths = ["b1"]
++++
+
+The cell fender at the F-04 position on berth one was pulled at 02:00 and replaced by 04:42. The original was flagged by the routine quarterly ultrasonic for a 38 mm delamination at the rubber-steel interface. We had a spare on the apron and the crane was scheduled to be down for its own maintenance.
+
+This is the third fender from the same vendor lot to fail in eighteen months. We are going to test the remaining two from the lot in advance of their next quarterly and we have written the vendor about the lot history.
+
+- **Lot:** 22-NL-04
+- **Fenders in service from lot:** 5
+- **Fenders failed early from lot:** 3
+- **Decision:** test remaining two early; replace proactively if any indication
+
+No vessels were on the berth during the swap; the Tirana shifted to berth two for the window, lost forty minutes off its first wire and recovered them on a stretched lunch.

--- a/examples/harbor-metrics/content/berth-log/gate-9-throughput.md
+++ b/examples/harbor-metrics/content/berth-log/gate-9-throughput.md
@@ -1,0 +1,15 @@
++++
+title = "Gate 9 throughput crossed twelve hundred lanes"
+date = "2026-05-14"
+description = "First time we held twelve hundred truck moves through gate nine in a single shift. The pinch is now the bay walk."
+tags = ["gate", "throughput", "trucks"]
+berths = []
++++
+
+We crossed twelve hundred truck moves through gate nine in a single shift for the first time. The previous wall was 1,108 in March; today's number landed at 1,221, with the last hour holding 84 per hour.
+
+The bottleneck has moved. For two years the bottleneck was the gate camera read — we burned three minutes per truck on a misread license plate. New OCR firmware landed in February and that wall is gone. The bottleneck now is the bay walk: drivers parking in the wrong lane and having to be redirected.
+
+> When the gate stops being the bottleneck, the yard starts being the bottleneck. That is exactly the order we want.
+
+We are going to repaint the bay lines next week. The yard tower will also start enforcing lane assignments in software — the gate clerks already hate it, which is how we know it will work.

--- a/examples/harbor-metrics/content/berth-log/maersk-talinn-discharge.md
+++ b/examples/harbor-metrics/content/berth-log/maersk-talinn-discharge.md
@@ -1,0 +1,18 @@
++++
+title = "Maersk Tallinn discharge cleared in four hours flat"
+date = "2026-05-17"
+description = "A clean discharge cycle for the Tallinn — fourteen hundred boxes on the rail, four cranes, four hours."
+tags = ["discharge", "crane-cycle", "rail"]
+berths = ["b3"]
++++
+
+The Maersk Tallinn cleared berth three at 13:14 with a full discharge against four ship-to-shore cranes. Fourteen hundred and twelve boxes on the wire in four hours flat. The yard absorbed all of it on the rail spur; no chassis pickup needed for the discharge half.
+
+- **Bonnet up:** 09:02
+- **First wire:** 09:11
+- **Last wire:** 13:08
+- **Bonnet down:** 13:14
+
+Crane four ran at 41 moves per hour, a season best for the crew. Crane two paused for nineteen minutes during the lashing reset; we expected longer based on the cell map but the gangs caught up.
+
+The Tallinn is on the same call next week. We will pre-stage the empties two hours earlier and try to push the discharge under three forty.

--- a/examples/harbor-metrics/content/berth-log/yard-reconciliation-drift.md
+++ b/examples/harbor-metrics/content/berth-log/yard-reconciliation-drift.md
@@ -1,0 +1,15 @@
++++
+title = "Yard reconciliation drifted by sixty-four boxes"
+date = "2026-04-30"
+description = "The reconciliation tick fell behind by sixty-four boxes during a peak hour. We held the count in black on cream and called it."
+tags = ["reconciliation", "yard", "drift"]
+berths = []
++++
+
+The yard reconciliation tick drifted by sixty-four boxes during the 14:00 peak hour. The board correctly went black on cream — and the clock in the corner reached twenty-three minutes before the yard team caught up.
+
+Root cause was a saturated message queue between the gate camera farm and the reconciliation worker. The queue is sized for our annual peak; the 14:00 hour today was an annual-peak hour. We have raised the alarm threshold on the queue depth so that the next time we approach the cap, the duty supervisor sees it before the count goes stale.
+
+> The board did the right thing. We saw stale data labeled as stale data, and we did not act on it. The fix is upstream, not on the board.
+
+The reconciliation queue cap will be doubled in next week's maintenance window. The reconciliation worker will also run with two replicas instead of one. Both are reversible if the doubled cap turns out to mask the underlying problem.

--- a/examples/harbor-metrics/content/index.md
+++ b/examples/harbor-metrics/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Operations"
+description = "Harbor Metrics is the working board for a deep-water container terminal."
+template = "home"
++++

--- a/examples/harbor-metrics/static/css/style.css
+++ b/examples/harbor-metrics/static/css/style.css
@@ -1,0 +1,481 @@
+:root {
+  --bg: #f4f1ea;
+  --bg-2: #ece7dc;
+  --panel: #ffffff;
+  --ink: #0a0a0a;
+  --ink-2: #2a2a2a;
+  --ink-mute: #5a5a5a;
+  --ink-dim: #8b8680;
+  --line: #1a1a1a;
+  --line-soft: #d6d1c4;
+  --accent: #d72d1f;
+  --accent-deep: #1c1a16;
+  --ok: #2e6b3a;
+  --warn: #c98512;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Space Grotesk", "Helvetica Neue", Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+.mono, code, pre { font-family: "JetBrains Mono", ui-monospace, monospace; }
+
+.shell {
+  max-width: 1380px;
+  margin: 0 auto;
+  padding: 24px 36px 80px;
+}
+
+/* TOP BAR */
+.topbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 36px;
+  padding: 18px 0 20px;
+  border-bottom: 2px solid var(--line);
+  margin-bottom: 36px;
+}
+.topbar .brand { display: flex; align-items: center; gap: 14px; }
+.topbar .mark {
+  width: 36px; height: 36px;
+  background: var(--ink);
+  position: relative;
+  display: inline-block;
+}
+.topbar .mark i {
+  display: block; width: 36px; height: 6px;
+  background: var(--accent);
+  position: absolute; top: 14px; left: 0;
+}
+.topbar .wordmark {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  display: flex; flex-direction: column;
+}
+.topbar .wordmark b { font-weight: 700; }
+.topbar .wordmark span { color: var(--accent); margin: 0 4px; }
+.topbar .wordmark em {
+  font-style: normal;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-dim);
+  margin-top: 2px;
+}
+.topbar .meta {
+  display: flex;
+  gap: 24px;
+  justify-self: center;
+}
+.topbar .meta .kv {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  display: flex; flex-direction: column;
+  border-left: 1px solid var(--line-soft);
+  padding-left: 14px;
+}
+.topbar .meta .kv span { color: var(--ink-dim); text-transform: uppercase; letter-spacing: 0.14em; }
+.topbar .meta .kv b { color: var(--ink); font-weight: 600; font-size: 14px; margin-top: 2px; }
+.topbar nav { display: flex; gap: 4px; }
+.topbar nav a {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 8px 12px;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+}
+.topbar nav a:hover { background: var(--ink); color: var(--bg); }
+
+/* LEDE */
+.lede {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 36px;
+  padding-bottom: 36px;
+  border-bottom: 1px solid var(--line-soft);
+  margin-bottom: 28px;
+}
+.lede .kicker {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 22px;
+}
+.lede h1 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(2.4rem, 4.6vw, 4rem);
+  line-height: 0.98;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  margin: 0 0 22px;
+  color: var(--ink);
+}
+.lede h1 .under {
+  border-bottom: 6px solid var(--accent);
+  padding-bottom: 2px;
+}
+.lede p {
+  color: var(--ink-mute);
+  max-width: 56ch;
+  font-size: 1.02rem;
+  margin: 0;
+}
+.lede-side { display: flex; align-items: center; justify-content: center; }
+.hex-stack { display: grid; gap: 14px; width: 100%; max-width: 300px; }
+.hex {
+  background: var(--ink);
+  color: var(--bg);
+  padding: 18px 22px;
+  font-family: "Space Grotesk", sans-serif;
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 14px;
+}
+.hex b {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 1.7rem;
+  font-weight: 500;
+  font-feature-settings: "tnum";
+  letter-spacing: -0.01em;
+}
+.hex span {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-align: right;
+  color: rgba(244,241,234,0.7);
+  max-width: 9ch;
+}
+.hex:nth-child(2) { background: var(--accent); color: #fff; }
+.hex:nth-child(2) span { color: rgba(255,255,255,0.75); }
+
+/* ROWS */
+.row {
+  display: grid;
+  grid-template-columns: 1.7fr 1fr;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+.row.tri { grid-template-columns: repeat(3, 1fr); }
+.row.half { grid-template-columns: 1fr 1fr; }
+
+/* CARD */
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 22px 26px 24px;
+  display: flex;
+  flex-direction: column;
+}
+.card .head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 18px;
+}
+.card .head .tag {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--ink);
+  color: var(--bg);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 7px;
+  letter-spacing: 0.08em;
+}
+.card .head h2 {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  font-size: 1.05rem;
+  margin: 0;
+  letter-spacing: -0.005em;
+}
+.card .head .hint {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-dim);
+}
+
+/* BERTHS */
+.berths .berth-row {
+  display: grid;
+  grid-template-columns: 36px 1fr 220px 64px;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--line-soft);
+}
+.berths .berth-row:last-child { border-bottom: 0; }
+.berths .berth-row.warn .berth-id { background: var(--accent); color: #fff; }
+.berths .berth-id {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--ink);
+  color: var(--bg);
+  text-align: center;
+  font-weight: 600;
+  font-size: 13px;
+  padding: 7px 0;
+  letter-spacing: 0.05em;
+}
+.berths .berth-name { font-family: "Space Grotesk", sans-serif; font-weight: 500; color: var(--ink); font-size: 0.98rem; }
+.berths .berth-name small { display: block; font-family: "JetBrains Mono", monospace; font-size: 10.5px; color: var(--ink-dim); letter-spacing: 0.06em; margin-top: 2px; font-weight: 400; }
+.berths .berth-bar {
+  background: var(--bg-2);
+  height: 22px;
+  position: relative;
+  border: 1px solid var(--line-soft);
+}
+.berths .berth-bar span {
+  position: absolute; top: 0; bottom: 0;
+  background: var(--ink);
+}
+.berths .berth-bar span.ghost {
+  background: var(--bg-2);
+  border: 1px dashed var(--accent);
+}
+.berths .berth-meta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  color: var(--ink-mute);
+  text-align: right;
+}
+
+/* NUM BLOCK */
+.num-block { margin-bottom: 18px; }
+.num-block .big {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 3.4rem;
+  font-weight: 500;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  font-feature-settings: "tnum";
+  color: var(--ink);
+}
+.num-block .big small { font-size: 1.1rem; color: var(--ink-mute); margin-left: 4px; }
+.num-block .caption {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-dim);
+  margin-top: 6px;
+}
+
+/* BAR LIST */
+.bar-list { list-style: none; padding: 0; margin: 0; }
+.bar-list li {
+  display: grid;
+  grid-template-columns: 32px 44px 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+}
+.bar-list li span { color: var(--ink-dim); }
+.bar-list li b { color: var(--ink); font-weight: 600; }
+.bar-list li i { background: var(--bg-2); height: 6px; position: relative; }
+.bar-list li i::after { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: var(--w, 60%); background: var(--accent); }
+
+/* DENSITY */
+.density {
+  display: grid;
+  grid-template-columns: repeat(16, 1fr);
+  gap: 3px;
+  margin-bottom: 14px;
+}
+.density i {
+  display: block; aspect-ratio: 1;
+  background: var(--bg-2);
+  border: 1px solid var(--line-soft);
+}
+.density i.on { background: var(--ink); border-color: var(--ink); }
+.density i.hot { background: var(--accent); border-color: var(--accent); }
+.row-meta {
+  display: flex; align-items: center; gap: 8px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-dim);
+  letter-spacing: 0.08em;
+}
+.row-meta span { color: var(--ink-dim); text-transform: uppercase; letter-spacing: 0.14em; }
+.row-meta b { color: var(--ink); margin-right: 14px; font-weight: 600; }
+
+/* CHART BARS */
+.chart-bars { display: flex; align-items: flex-end; gap: 4px; height: 110px; }
+.chart-bars span { flex: 1; background: var(--bg-2); position: relative; }
+.chart-bars span::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; background: var(--ink); height: var(--h, 30%); }
+.chart-bars span.hi::after { background: var(--accent); }
+.axis-row {
+  display: flex; justify-content: space-between;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-dim);
+  letter-spacing: 0.12em;
+  margin-top: 8px;
+}
+
+/* QUEUE */
+.queue { list-style: none; padding: 0; margin: 0; }
+.queue li {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px dashed var(--line-soft);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12.5px;
+}
+.queue li:last-child { border-bottom: 0; }
+.queue .seq { background: var(--ink); color: var(--bg); font-weight: 600; text-align: center; padding: 4px 0; letter-spacing: 0.04em; }
+.queue .vessel { color: var(--ink); font-weight: 500; letter-spacing: 0.04em; }
+.queue .eta { color: var(--accent); font-weight: 500; }
+.queue .more .seq { background: var(--bg-2); color: var(--ink); }
+.queue .more .vessel { color: var(--ink-dim); }
+.queue .more .eta { color: var(--ink-dim); }
+
+/* MARGIN */
+.margin-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+.m-cell {
+  border: 1px solid var(--line);
+  padding: 18px 14px;
+  text-align: center;
+}
+.m-cell b { display: block; font-family: "Space Grotesk", sans-serif; font-weight: 700; font-size: 1.3rem; color: var(--ink); }
+.m-cell span {
+  display: inline-block;
+  margin-top: 6px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  padding: 3px 8px;
+  background: var(--bg-2);
+}
+.m-cell span.ok { color: var(--ok); }
+.m-cell span.warn { background: var(--accent); color: #fff; }
+.note { color: var(--ink-mute); font-size: 0.92rem; margin: 14px 0 0; }
+
+/* POSTS */
+.post-list { list-style: none; padding: 0; margin: 0; }
+.post-list li {
+  padding: 14px 0;
+  border-top: 1px solid var(--line-soft);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 14px;
+}
+.post-list li:last-child { border-bottom: 1px solid var(--line-soft); }
+.post-list li a { font-family: "Space Grotesk", sans-serif; font-weight: 500; font-size: 1rem; color: var(--ink); }
+.post-list li a:hover { color: var(--accent); }
+.post-list li time { font-family: "JetBrains Mono", monospace; font-size: 11px; color: var(--ink-dim); letter-spacing: 0.12em; }
+.post-list.big li { padding: 22px 0; }
+.post-list.big li a { font-size: 1.3rem; font-weight: 600; }
+
+/* PAGE */
+.page-title {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  margin: 16px 0 8px;
+}
+.page-desc { color: var(--ink-mute); max-width: 64ch; margin: 0 0 28px; }
+.page-date {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 22px;
+}
+
+.cta {
+  display: inline-block;
+  background: var(--ink);
+  color: var(--bg);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 10px 18px;
+  font-weight: 600;
+}
+.cta:hover { background: var(--accent); color: #fff; }
+
+article.prose { max-width: 70ch; font-size: 1.02rem; }
+article.prose h2 { font-family: "Space Grotesk", sans-serif; font-size: 1.5rem; letter-spacing: -0.015em; margin: 1.8em 0 0.5em; font-weight: 700; }
+article.prose h3 { font-size: 1.15rem; margin: 1.4em 0 0.4em; font-weight: 600; }
+article.prose blockquote { border-left: 3px solid var(--accent); padding: 4px 18px; margin: 1.4em 0; color: var(--ink-mute); font-style: italic; }
+article.prose ul li::marker { color: var(--accent); }
+article.prose a { border-bottom: 1px solid var(--ink); }
+article.prose a:hover { color: var(--accent); border-color: var(--accent); }
+
+.alert {
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  background: #fff;
+  padding: 14px 18px;
+  margin: 1.4em 0;
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+.alert strong {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+
+footer.foot {
+  margin-top: 60px;
+  border-top: 2px solid var(--line);
+  padding-top: 28px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 30px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--ink-mute);
+}
+footer.foot strong { color: var(--ink); display: block; margin-bottom: 8px; letter-spacing: 0.16em; text-transform: uppercase; }
+
+@media (max-width: 1000px) {
+  .lede, .row, .row.tri, .row.half { grid-template-columns: 1fr; }
+  .topbar { grid-template-columns: auto auto; row-gap: 14px; }
+  .topbar .meta { grid-column: 1 / -1; flex-wrap: wrap; gap: 16px; }
+  .berths .berth-row { grid-template-columns: 36px 1fr; gap: 10px; }
+  .berths .berth-bar, .berths .berth-meta { grid-column: 1 / -1; }
+}

--- a/examples/harbor-metrics/static/favicon.svg
+++ b/examples/harbor-metrics/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f4f1ea"/>
+  <rect x="5" y="5" width="22" height="22" fill="#0a0a0a"/>
+  <rect x="5" y="13" width="22" height="3" fill="#d72d1f"/>
+</svg>

--- a/examples/harbor-metrics/templates/404.html
+++ b/examples/harbor-metrics/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">404 — bay not assigned</h1>
+    <p class="page-desc">That URL is not on the manifest. Try the board.</p>
+    <p><a href="{{ base_url }}/" class="cta">Return to board</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/harbor-metrics/templates/footer.html
+++ b/examples/harbor-metrics/templates/footer.html
@@ -1,0 +1,20 @@
+    <footer class="foot">
+      <div>
+        <strong>{{ site.title }}</strong>
+        The operations board for a deep-water container terminal. Built with Hwaro on Crystal.
+      </div>
+      <div>
+        <strong>Sections</strong>
+        <a href="{{ base_url }}/">Board</a> ·
+        <a href="{{ base_url }}/berth-log/">Log</a> ·
+        <a href="{{ base_url }}/about/">Manual</a>
+      </div>
+      <div>
+        <strong>Duty desk · {{ current_year }}</strong>
+        Shift {{ current_date }} · board build r-148
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/harbor-metrics/templates/header.html
+++ b/examples/harbor-metrics/templates/header.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="topbar">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="mark"><i></i></span>
+        <span class="wordmark">
+          <b>HARBOR</b><span>/</span>METRICS
+          <em>terminal&nbsp;board · b1—b4</em>
+        </span>
+      </a>
+      <div class="meta">
+        <div class="kv"><span>VESSELS IN PORT</span><b>06</b></div>
+        <div class="kv"><span>WIND</span><b>11 kt NNE</b></div>
+        <div class="kv"><span>TIDE</span><b>+1.84 m</b></div>
+        <div class="kv"><span>SHIFT</span><b>{{ current_date }}</b></div>
+      </div>
+      <nav>
+        <a href="{{ base_url }}/">Board</a>
+        <a href="{{ base_url }}/berth-log/">Log</a>
+        <a href="{{ base_url }}/about/">Manual</a>
+      </nav>
+    </header>

--- a/examples/harbor-metrics/templates/home.html
+++ b/examples/harbor-metrics/templates/home.html
@@ -1,0 +1,170 @@
+{% include "header.html" %}
+  <main>
+    <section class="lede">
+      <div class="lede-text">
+        <span class="kicker">Board · 14:02 local · shift two</span>
+        <h1>Six vessels alongside,<br>fourteen at anchor,<br><span class="under">one cup of coffee.</span></h1>
+        <p>Harbor Metrics is the operations board for a deep-water container terminal. Berths one through four are alongside; the inner roads carry the anchor queue. Every counter on this page comes from the gate cameras, the crane PLCs, or the yard reconciliation tick — never an estimate, never a projection.</p>
+      </div>
+      <div class="lede-side">
+        <div class="hex-stack">
+          <div class="hex"><b>1,221</b><span>gate moves this shift</span></div>
+          <div class="hex"><b>04:00</b><span>average alongside dwell</span></div>
+          <div class="hex"><b>96.4%</b><span>plan adherence</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="row">
+      <article class="card berths">
+        <header class="head">
+          <span class="tag">01</span>
+          <h2>Berth occupancy</h2>
+          <span class="hint">last 12 h</span>
+        </header>
+        <div class="berth-row">
+          <div class="berth-id">B1</div>
+          <div class="berth-name">Maersk Tirana <small>arrived 06:11 · sailing 22:30</small></div>
+          <div class="berth-bar"><span style="left:6%; width:78%;"></span></div>
+          <div class="berth-meta">14 → 22</div>
+        </div>
+        <div class="berth-row">
+          <div class="berth-id">B2</div>
+          <div class="berth-name">ONE Hibiscus <small>arrived 04:48 · sailing 18:00</small></div>
+          <div class="berth-bar"><span style="left:0%; width:74%;"></span></div>
+          <div class="berth-meta">14 → 18</div>
+        </div>
+        <div class="berth-row">
+          <div class="berth-id">B3</div>
+          <div class="berth-name">CMA CGM Aristotle <small>arrived 09:02 · sailing 16:00</small></div>
+          <div class="berth-bar"><span style="left:24%; width:48%;"></span></div>
+          <div class="berth-meta">14 → 16</div>
+        </div>
+        <div class="berth-row warn">
+          <div class="berth-id">B4</div>
+          <div class="berth-name">Hapag Lloyd Yokohama <small>delayed · ETA 16:40</small></div>
+          <div class="berth-bar"><span style="left:74%; width:14%;" class="ghost"></span></div>
+          <div class="berth-meta">→ 16:40</div>
+        </div>
+        <div class="berth-row">
+          <div class="berth-id">B5</div>
+          <div class="berth-name">— vacant</div>
+          <div class="berth-bar"></div>
+          <div class="berth-meta">—</div>
+        </div>
+        <div class="berth-row">
+          <div class="berth-id">B6</div>
+          <div class="berth-name">— vacant</div>
+          <div class="berth-bar"></div>
+          <div class="berth-meta">—</div>
+        </div>
+      </article>
+
+      <article class="card stat-3">
+        <header class="head">
+          <span class="tag">02</span>
+          <h2>Crane cycle</h2>
+          <span class="hint">moves / hr</span>
+        </header>
+        <div class="num-block">
+          <div class="big">38.4</div>
+          <div class="caption">live · four cranes alongside</div>
+        </div>
+        <ul class="bar-list">
+          <li><span>C1</span><b>41</b><i style="--w:88%"></i></li>
+          <li><span>C2</span><b>36</b><i style="--w:72%"></i></li>
+          <li><span>C3</span><b>40</b><i style="--w:84%"></i></li>
+          <li><span>C4</span><b>37</b><i style="--w:76%"></i></li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="row tri">
+      <article class="card">
+        <header class="head">
+          <span class="tag">03</span>
+          <h2>Yard density</h2>
+          <span class="hint">reconciled 14:01</span>
+        </header>
+        <div class="num-block">
+          <div class="big">82<small>%</small></div>
+          <div class="caption">14,208 of 17,300 slots</div>
+        </div>
+        <div class="density">
+          {% for i in range(64) %}<i class="{% if loop.index == 13 or loop.index == 27 or loop.index == 41 %}hot{% elif loop.index <= 52 %}on{% endif %}"></i>{% endfor %}
+        </div>
+        <div class="row-meta"><span>Imports</span><b>62%</b><span>Empties</span><b>20%</b></div>
+      </article>
+
+      <article class="card">
+        <header class="head">
+          <span class="tag">04</span>
+          <h2>Gate flow</h2>
+          <span class="hint">last 60 min</span>
+        </header>
+        <div class="num-block">
+          <div class="big">142</div>
+          <div class="caption">trucks · 84 per hour pace</div>
+        </div>
+        <div class="chart-bars">
+          <span style="--h:42%"></span><span style="--h:58%"></span><span style="--h:60%"></span>
+          <span style="--h:72%"></span><span style="--h:88%"></span><span class="hi" style="--h:100%"></span>
+          <span style="--h:84%"></span><span style="--h:72%"></span><span style="--h:64%"></span>
+          <span style="--h:54%"></span><span style="--h:46%"></span><span style="--h:38%"></span>
+        </div>
+        <div class="axis-row"><span>−60</span><span>−45</span><span>−30</span><span>−15</span><span>now</span></div>
+      </article>
+
+      <article class="card">
+        <header class="head">
+          <span class="tag">05</span>
+          <h2>Anchor queue</h2>
+          <span class="hint">14 vessels</span>
+        </header>
+        <ul class="queue">
+          <li><span class="seq">01</span><span class="vessel">EVER GREENS</span><span class="eta">+02:14</span></li>
+          <li><span class="seq">02</span><span class="vessel">MSC ANDORRA</span><span class="eta">+03:38</span></li>
+          <li><span class="seq">03</span><span class="vessel">YM ARROW</span><span class="eta">+06:12</span></li>
+          <li><span class="seq">04</span><span class="vessel">ONE COSMOS</span><span class="eta">+08:44</span></li>
+          <li><span class="seq">05</span><span class="vessel">MAERSK BREMEN</span><span class="eta">+12:18</span></li>
+          <li class="more"><span class="seq">+9</span><span class="vessel">further out</span><span class="eta">—</span></li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="row half">
+      <article class="card">
+        <header class="head">
+          <span class="tag">06</span>
+          <h2>Wind / draft margin</h2>
+          <span class="hint">B1 — B4</span>
+        </header>
+        <div class="margin-grid">
+          <div class="m-cell"><b>B1</b><span class="ok">+2.1 m</span></div>
+          <div class="m-cell"><b>B2</b><span class="ok">+2.4 m</span></div>
+          <div class="m-cell"><b>B3</b><span class="ok">+1.8 m</span></div>
+          <div class="m-cell"><b>B4</b><span class="warn">+0.6 m</span></div>
+        </div>
+        <p class="note">Berth four flagged — draft margin within operating limit, watch on falling tide. Tide turns 16:48.</p>
+      </article>
+
+      <article class="card">
+        <header class="head">
+          <span class="tag">07</span>
+          <h2>Latest from the berth log</h2>
+          <span class="hint">last 4</span>
+        </header>
+        <ul class="post-list">
+          {% for post in site.pages | where("section", "berth-log") | sort_by("date", reverse=true) %}
+            {% if loop.index <= 4 %}
+            <li>
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              <time>{{ post.date | date("%Y · %m · %d") }}</time>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </article>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/harbor-metrics/templates/page.html
+++ b/examples/harbor-metrics/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.date %}<div class="page-date">{{ page.date | date("%Y · %m · %d") }}</div>{% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/harbor-metrics/templates/section.html
+++ b/examples/harbor-metrics/templates/section.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    {{ content }}
+    <ul class="post-list big">
+      {% for post in section.pages %}
+        <li>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          <time>{{ post.date | date("%Y · %m · %d") }}</time>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/harbor-metrics/templates/shortcodes/alert.html
+++ b/examples/harbor-metrics/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert" data-type="{{ type | default('info') }}">
+  <strong>{{ type | default('note') | upper }}</strong>
+  <span>{{ body }}</span>
+</div>

--- a/examples/harbor-metrics/templates/taxonomy.html
+++ b/examples/harbor-metrics/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Browse all terms in this taxonomy.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/harbor-metrics/templates/taxonomy_term.html
+++ b/examples/harbor-metrics/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Posts tagged with this term.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lumen-grid/AGENTS.md
+++ b/examples/lumen-grid/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Site-Specific Notes
+
+- Theme: dark, NOC/SRE edge observability console. Lime green (`#b4ff39`) accent.
+- Content sections: `content/incidents/` for postmortems, plus `index.md` (console) and `about.md` (operator manual).
+- CSS lives in `static/css/style.css` (over 200 lines, extracted per repo convention).
+- Use `{{ base_url }}` for all asset/link references.
+- No gradients, no emojis — design brief.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt)

--- a/examples/lumen-grid/archetypes/default.md
+++ b/examples/lumen-grid/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/lumen-grid/config.toml
+++ b/examples/lumen-grid/config.toml
@@ -1,0 +1,217 @@
+title = "Lumen Grid"
+description = "Edge observability for a distributed delivery network."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "regions"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["incidents"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/lumen-grid/content/about.md
+++ b/examples/lumen-grid/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "Operator manual"
+description = "How to read the Lumen Grid console without making the night shift call you."
++++
+
+Lumen Grid is the working console for a distributed delivery network — eighty-two edge sites, four hundred and twelve peering links, and a control plane that is intentionally boring. The page you came from is what the night shift watches; everything below is the rulebook for what those numbers mean.
+
+## Reading the panels
+
+Every panel is live. Numbers move when telemetry moves, and they stop moving when telemetry stops — there is no resampling layer between the edge and the screen. If a panel goes dim, the source has gone away. The panel itself is honest; the world behind it is not.
+
+> The lime square is operator-defined attention. Anything green is fine without you. Anything red is already paged.
+
+The three colored squares mean three different things. **Green** is nominal; the system is doing what it was asked to do and you can ignore it. **Lime** is operator attention — a value worth looking at but not worth a page. **Red** is the alarm color and by the time it surfaces here, somebody has already been woken up.
+
+## Why we keep stale values
+
+Caching a stale value would let a panel look healthy while the underlying source had stopped reporting hours ago. We display the staleness instead. A reading more than thirty seconds old gets a dotted underline. A reading more than ten minutes old gets a strikethrough and a banner. We would rather a panel look broken than lie.
+
+## The team
+
+The grid is run by two on-call rotations — site reliability and edge networking — plus a small platform group that owns the control plane. New on-call read the **Incidents** stream front-to-back before a handover and never accept a shift change with red on the board.

--- a/examples/lumen-grid/content/incidents/_index.md
+++ b/examples/lumen-grid/content/incidents/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Incidents"
+description = "Edge network postmortems, written by the operator who closed the page."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/lumen-grid/content/incidents/ams-cert-rotation.md
+++ b/examples/lumen-grid/content/incidents/ams-cert-rotation.md
@@ -1,0 +1,15 @@
++++
+title = "AMS certificate rotation, no customer impact"
+date = "2026-05-12"
+description = "Quarterly cert rotation across the Amsterdam ring. We rotated 412 leaf certificates without dropping a single connection."
+tags = ["tls", "ams", "automation"]
+regions = ["emea"]
++++
+
+The Amsterdam ring rotated all four hundred and twelve leaf certificates between 02:00 and 02:18 UTC. Customer connections were drained per-node and rebound to a sibling before the rotation began on each node, so no in-flight connection saw the swap.
+
+This is the third quarter where the rotation has been fully automated. The first quarter took ninety minutes, the second forty, this one eighteen. The bottleneck is now the OCSP responder.
+
+> The boring rotations are the ones we want. Every minute we save here is a minute we get back for the next incident.
+
+We have two more rings due this quarter — Frankfurt and Singapore. Both will use the same automation. The Frankfurt rotation is scheduled for the 23rd.

--- a/examples/lumen-grid/content/incidents/lhr-control-plane-drift.md
+++ b/examples/lumen-grid/content/incidents/lhr-control-plane-drift.md
@@ -1,0 +1,17 @@
++++
+title = "LHR control plane drift, caught at the diff layer"
+date = "2026-04-28"
+description = "London edge nodes drifted off the canonical config for sixteen hours. The reconciler caught it, the operator did not."
+tags = ["control-plane", "lhr", "drift"]
+regions = ["emea"]
++++
+
+Sixteen hours of configuration drift on the London edge nodes. The reconciler caught it on the next pass and re-applied the canonical config; the operator who shipped the drift did not realise it was a drift at all and went home.
+
+This is the failure mode we have been trying to design out for a year: a human change that looks like a regular deploy but is actually a manual edit on a single node. The reconciler eventually wins, but the window between the drift and the reconcile is a window where the canonical config does not describe reality.
+
+- **Drift width:** sixteen hours.
+- **Customer impact:** none. The drifted config was a tunable, not a routing rule.
+- **Fix:** we now block direct SSH to edge nodes for non-emergency work. The control plane is the only writer.
+
+The escape hatch — emergency SSH — has been kept. Two operators (the on-call SRE and the on-call edge engineer) carry the key on a hardware token. The token is on a thirty-day rotation.

--- a/examples/lumen-grid/content/incidents/sjc-cache-poison.md
+++ b/examples/lumen-grid/content/incidents/sjc-cache-poison.md
@@ -1,0 +1,15 @@
++++
+title = "SJC cache invalidation race condition"
+date = "2026-05-04"
+description = "A race condition in the purge pipeline let a stale object survive an invalidation for 41 minutes in San Jose."
+tags = ["cache", "sjc", "race-condition"]
+regions = ["americas"]
++++
+
+A purge pipeline race condition let a stale object survive an invalidation in San Jose. The object — a customer's homepage asset — kept being served for forty-one minutes after the purge had been acknowledged.
+
+The race was between the purge fan-out and the asset re-warming worker. The re-warming worker ran from the canonical origin, but it ran *before* the fan-out had propagated, so it caught the same stale object and re-cached it. From there it was sticky until TTL expired.
+
+We fixed it by adding a generation counter to every purge event. The re-warming worker now refuses to operate on an object whose generation it cannot read from the central log. The race is closed and the fix shipped to the four other regions that share the pipeline.
+
+Five customer requests were served the stale object during the window. We have reached out to all five.

--- a/examples/lumen-grid/content/incidents/tokyo-peer-flap.md
+++ b/examples/lumen-grid/content/incidents/tokyo-peer-flap.md
@@ -1,0 +1,17 @@
++++
+title = "TYO peering flap took out four upstreams for nine minutes"
+date = "2026-05-17"
+description = "A misconfigured BFD timer caused four upstreams to drop simultaneously in Tokyo. We held traffic by leaning on Osaka and Singapore."
+tags = ["peering", "tyo", "bfd"]
+regions = ["apac"]
++++
+
+The Tokyo edge cluster lost four of its seven upstreams at 03:11 UTC. Our latency board lit up before the first page fired, which is exactly how we want it to work — the user-visible latency rose only seven milliseconds because the load steering had already rerouted traffic to Osaka and Singapore.
+
+Root cause was a stale BFD timer that we had inherited from a vendor template. When a peer flapped briefly, the timer interpreted it as a hard down and pulled the whole session. The other three peers happened to share the same router and went with it.
+
+- **Detection:** 41 seconds from peer drop to dashboard lime.
+- **Mitigation:** 23 seconds — automated, no human in the loop.
+- **Resolution:** 9 minutes 02 seconds to restore all four peers.
+
+We have shipped a fix to the template and audited every site that uses it. Twelve sites had the same configuration. None of them are likely to flap the same way again, but we are also adding a damp on the steering controller so that a multi-peer event has to clear human review before it propagates beyond a region.

--- a/examples/lumen-grid/content/index.md
+++ b/examples/lumen-grid/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Console"
+description = "Lumen Grid edge observability — the working surface for the global NOC."
+template = "home"
++++

--- a/examples/lumen-grid/static/css/style.css
+++ b/examples/lumen-grid/static/css/style.css
@@ -1,0 +1,472 @@
+:root {
+  --bg: #08090b;
+  --bg-2: #0d0f14;
+  --panel: #111319;
+  --panel-2: #171a22;
+  --line: #20242e;
+  --line-2: #2d323e;
+  --ink: #e7ebf2;
+  --ink-mute: #8b91a0;
+  --ink-dim: #5b6172;
+  --accent: #b4ff39;
+  --accent-2: #7ad6ff;
+  --warn: #ffb454;
+  --err: #ff5c5c;
+  --ok: #5ee0a0;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-size: 14.5px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+.mono, code, pre { font-family: "JetBrains Mono", ui-monospace, monospace; }
+
+.shell { max-width: 1380px; margin: 0 auto; padding: 22px 32px 80px; }
+
+.topbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 32px;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--panel);
+  margin-bottom: 24px;
+}
+.topbar .brand { display: flex; align-items: center; gap: 12px; }
+.topbar .cube {
+  width: 22px; height: 22px;
+  border: 2px solid var(--accent);
+  position: relative;
+}
+.topbar .cube::after { content:""; position: absolute; inset: 4px; background: var(--accent); }
+.topbar .wordmark {
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--ink-mute);
+}
+.topbar .wordmark b { color: var(--ink); }
+.topbar .wordmark i { width: 4px; height: 4px; background: var(--accent); display: inline-block; }
+.topbar .status {
+  display: flex; align-items: center; gap: 10px;
+  font-family: "JetBrains Mono", monospace; font-size: 11px;
+  color: var(--ink-dim); letter-spacing: 0.08em;
+}
+.topbar .status .lbl { color: var(--ink-dim); }
+.topbar .status .val { color: var(--ink); margin-left: 4px; font-weight: 500; }
+.topbar .status .sep { width: 1px; height: 12px; background: var(--line-2); }
+.topbar .status .dot { width: 8px; height: 8px; background: var(--ok); display: inline-block; border-radius: 50%; box-shadow: 0 0 0 3px rgba(94,224,160,0.12); }
+.topbar nav { display: flex; gap: 4px; }
+.topbar nav a {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  color: var(--ink-mute);
+}
+.topbar nav a:hover { color: var(--ink); border-color: var(--line-2); }
+
+.hero {
+  display: grid;
+  grid-template-columns: 7fr 5fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.hero .lead {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  padding: 36px 38px;
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+}
+.hero .lead::before {
+  content: ""; position: absolute; top: 0; left: 0; width: 6px; height: 100%;
+  background: var(--accent);
+}
+.hero .lead .crumb {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ink-dim);
+  margin-bottom: 26px;
+}
+.hero .lead h1 {
+  font-family: "Inter", sans-serif;
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  font-weight: 800;
+  margin: 0 0 18px;
+}
+.hero .lead h1 .hl { color: var(--accent); }
+.hero .lead p { color: var(--ink-mute); max-width: 50ch; margin: 0 0 22px; }
+.hero .lead .quick { display: flex; gap: 8px; flex-wrap: wrap; }
+.hero .lead .pill {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 4px 10px;
+  border: 1px solid var(--line-2);
+  color: var(--ink-mute);
+  border-radius: 99px;
+}
+.hero .lead .pill.ok { color: var(--bg); background: var(--accent); border-color: var(--accent); }
+
+.hero .kpis {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 4px;
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+}
+.hero .kpis .kpi-row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr auto;
+  align-items: baseline;
+  gap: 16px;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--line);
+}
+.hero .kpis .kpi-row:last-child { border-bottom: 0; }
+.hero .kpis .k {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-dim);
+}
+.hero .kpis .v {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 1.6rem;
+  font-weight: 500;
+  color: var(--ink);
+  text-align: right;
+  font-feature-settings: "tnum";
+}
+.hero .kpis .d {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 99px;
+  border: 1px solid var(--line-2);
+}
+.hero .kpis .d.up { color: var(--accent); border-color: rgba(180,255,57,0.28); }
+.hero .kpis .d.dn { color: var(--accent-2); border-color: rgba(122,214,255,0.28); }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 20px 22px;
+  display: flex;
+  flex-direction: column;
+}
+.span-4 { grid-column: span 4; }
+.span-5 { grid-column: span 5; }
+.span-6 { grid-column: span 6; }
+.span-7 { grid-column: span 7; }
+.span-8 { grid-column: span 8; }
+
+.card-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 0 0 14px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--line);
+}
+.card-head .idx {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  color: var(--bg);
+  background: var(--accent);
+  padding: 3px 7px;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+.card-head h3 {
+  margin: 0;
+  font-family: "Inter", sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+.card-head .meta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+.chart-bars { display: flex; align-items: flex-end; gap: 4px; height: 130px; }
+.chart-bars.tall { height: 180px; }
+.chart-bars span { flex: 1; background: var(--line-2); position: relative; min-width: 6px; }
+.chart-bars span::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; background: var(--ink-mute); height: var(--h, 30%); }
+.chart-bars span.hi::after { background: var(--accent); }
+.axis-row {
+  display: flex; justify-content: space-between;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-dim);
+  letter-spacing: 0.12em;
+  margin-top: 10px;
+}
+
+.region-list { list-style: none; padding: 0; margin: 0; }
+.region-list li {
+  display: grid;
+  grid-template-columns: 14px 1.2fr auto 1.4fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px dashed var(--line);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+}
+.region-list li:last-child { border-bottom: 0; }
+.region-list .dot { width: 8px; height: 8px; background: var(--ok); border-radius: 50%; }
+.region-list .dot.warn { background: var(--warn); }
+.region-list .dot.err { background: var(--err); }
+.region-list .rg { color: var(--ink); }
+.region-list .rps { color: var(--ink-mute); }
+.region-list .lat { color: var(--accent); text-align: right; }
+.region-list .bar { background: var(--line); height: 4px; position: relative; }
+.region-list .bar i { display: block; height: 100%; width: var(--w, 50%); background: var(--accent); }
+.region-list .bar.warn i { background: var(--warn); }
+
+.big-num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 3.2rem;
+  font-weight: 500;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--ink);
+  font-feature-settings: "tnum";
+}
+.big-num small {
+  font-size: 1.1rem;
+  color: var(--ink-mute);
+  margin-left: 6px;
+}
+.card .sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-mute);
+  margin-top: 8px;
+  letter-spacing: 0.06em;
+}
+
+.spark { margin-top: 18px; color: var(--accent); }
+.spark svg { width: 100%; height: 60px; display: block; }
+
+.hbar {
+  display: flex;
+  height: 10px;
+  background: var(--line);
+  margin-top: 18px;
+  overflow: hidden;
+}
+.hbar .seg { display: block; height: 100%; }
+.hbar .seg.a { width: var(--w, 50%); background: var(--accent); }
+.hbar .seg.b { width: var(--w, 50%); background: var(--accent-2); }
+
+.page-list { list-style: none; margin: 16px 0 0; padding: 0; }
+.page-list li {
+  padding: 8px 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: var(--ink);
+  border-top: 1px dashed var(--line);
+}
+.page-list li:first-child { border-top: 0; }
+.tag {
+  display: inline-block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  margin-right: 8px;
+  letter-spacing: 0.06em;
+}
+.tag.sev1 { background: var(--err); color: #fff; }
+.tag.sev2 { background: var(--warn); color: var(--bg); }
+.tag.sev3 { background: var(--line-2); color: var(--ink); }
+
+.logstream {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  line-height: 1.85;
+  color: var(--ink-mute);
+  margin: 0;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  padding: 14px 16px;
+}
+.logstream .t { color: var(--ink-dim); margin-right: 10px; }
+.logstream .ok { color: var(--ok); }
+.logstream .wn { color: var(--warn); }
+.logstream .er { color: var(--err); }
+.logstream .g { color: var(--accent); float: right; }
+
+.score { display: grid; grid-template-columns: 1fr 1fr; align-items: center; gap: 18px; }
+.ring {
+  width: 130px; height: 130px;
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+.ring svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+.ring .num {
+  position: relative;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: var(--ink);
+  font-feature-settings: "tnum";
+}
+.legend {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-mute);
+  display: grid;
+  gap: 8px;
+}
+.legend b { color: var(--ink); font-weight: 500; }
+.legend .sw { width: 10px; height: 10px; background: var(--accent); display: inline-block; margin-right: 6px; vertical-align: middle; }
+.legend .sw.warn { background: var(--warn); }
+.legend .sw.err { background: var(--err); }
+
+.fleet { display: grid; grid-template-columns: repeat(auto-fill, minmax(72px, 1fr)); gap: 6px; }
+.fleet .node {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  text-align: center;
+  padding: 7px 4px;
+  border: 1px solid var(--line);
+  background: var(--bg-2);
+  color: var(--ink-mute);
+  letter-spacing: 0.05em;
+}
+.fleet .node.warn { background: rgba(255,180,84,0.08); border-color: var(--warn); color: var(--warn); }
+.fleet .node.err { background: rgba(255,92,92,0.08); border-color: var(--err); color: var(--err); }
+
+.post-list { list-style: none; padding: 0; margin: 0; }
+.post-list li {
+  padding: 14px 0;
+  border-top: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+.post-list li:last-child { border-bottom: 1px solid var(--line); }
+.post-list li a { font-size: 1rem; color: var(--ink); border: 0; }
+.post-list li a:hover { color: var(--accent); }
+.post-list li time { font-family: "JetBrains Mono", monospace; font-size: 11px; color: var(--ink-dim); letter-spacing: 0.12em; }
+
+.divider { border: 0; border-top: 1px dashed var(--line); margin: 24px 0; }
+
+.page-title {
+  font-family: "Inter", sans-serif;
+  font-size: 2.2rem;
+  letter-spacing: -0.025em;
+  font-weight: 800;
+  margin: 12px 0 8px;
+}
+.page-desc { color: var(--ink-mute); max-width: 64ch; margin: 0 0 28px; }
+.page-date {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-bottom: 24px;
+}
+
+.cta {
+  display: inline-block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 700;
+}
+.cta:hover { background: var(--ink); color: var(--bg); }
+
+article.prose { max-width: 72ch; }
+article.prose h2 { font-family: "Inter", sans-serif; font-size: 1.4rem; letter-spacing: -0.015em; margin: 1.8em 0 0.5em; font-weight: 700; }
+article.prose h3 { font-size: 1.1rem; margin: 1.4em 0 0.4em; font-weight: 600; }
+article.prose p { color: var(--ink); }
+article.prose blockquote { border-left: 3px solid var(--accent); padding: 4px 18px; margin: 1.4em 0; color: var(--ink-mute); font-style: italic; }
+article.prose ul li::marker { color: var(--accent); }
+article.prose a { border-bottom: 1px solid var(--line-2); }
+article.prose a:hover { border-color: var(--accent); }
+
+.alert {
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  border-left: 4px solid var(--accent);
+  padding: 14px 18px;
+  margin: 1.4em 0;
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+.alert strong {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+
+footer.foot {
+  margin-top: 60px;
+  border-top: 1px solid var(--line);
+  padding-top: 28px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 30px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--ink-dim);
+}
+footer.foot strong { color: var(--ink); display: block; margin-bottom: 8px; letter-spacing: 0.16em; text-transform: uppercase; }
+
+@media (max-width: 1000px) {
+  .hero { grid-template-columns: 1fr; }
+  .span-4, .span-5, .span-6, .span-7, .span-8 { grid-column: span 12; }
+  .topbar { grid-template-columns: auto auto; row-gap: 12px; }
+  .topbar .status { grid-column: 1 / -1; flex-wrap: wrap; }
+}

--- a/examples/lumen-grid/static/favicon.svg
+++ b/examples/lumen-grid/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#08090b"/>
+  <rect x="6" y="6" width="20" height="20" fill="none" stroke="#b4ff39" stroke-width="2"/>
+  <rect x="13" y="13" width="6" height="6" fill="#b4ff39"/>
+</svg>

--- a/examples/lumen-grid/templates/404.html
+++ b/examples/lumen-grid/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">404 · Not Found</h1>
+    <p class="page-desc">That route did not resolve at any edge.</p>
+    <p><a href="{{ base_url }}/" class="cta">Return to console</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumen-grid/templates/footer.html
+++ b/examples/lumen-grid/templates/footer.html
@@ -1,0 +1,20 @@
+    <footer class="foot">
+      <div>
+        <strong>{{ site.title }}</strong>
+        Edge observability for a small, distributed delivery network. Built with Hwaro on Crystal.
+      </div>
+      <div>
+        <strong>Sections</strong>
+        <a href="{{ base_url }}/">Console</a> ·
+        <a href="{{ base_url }}/incidents/">Incidents</a> ·
+        <a href="{{ base_url }}/about/">Manual</a>
+      </div>
+      <div>
+        <strong>NOC · {{ current_year }}</strong>
+        Last sync {{ current_date }} · console build 12.r4
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/lumen-grid/templates/header.html
+++ b/examples/lumen-grid/templates/header.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="topbar">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="cube"></span>
+        <span class="wordmark"><b>LUMEN</b><i></i>GRID</span>
+      </a>
+      <div class="status">
+        <span class="dot ok"></span><span class="lbl">SYS</span><span class="val">NOMINAL</span>
+        <span class="sep"></span>
+        <span class="lbl">SITES</span><span class="val">82/82</span>
+        <span class="sep"></span>
+        <span class="lbl">P95</span><span class="val">38ms</span>
+        <span class="sep"></span>
+        <span class="lbl">{{ current_date }}</span>
+      </div>
+      <nav>
+        <a href="{{ base_url }}/">Console</a>
+        <a href="{{ base_url }}/incidents/">Incidents</a>
+        <a href="{{ base_url }}/about/">Manual</a>
+      </nav>
+    </header>

--- a/examples/lumen-grid/templates/home.html
+++ b/examples/lumen-grid/templates/home.html
@@ -1,0 +1,224 @@
+{% include "header.html" %}
+  <main>
+    <section class="hero">
+      <div class="lead">
+        <div class="crumb">Console · global edge · realtime</div>
+        <h1>Eighty-two sites, <span class="hl">one quiet board.</span></h1>
+        <p>Lumen Grid is the working console for our edge network. Every number on this page comes straight off the wire — there is no resampling, no smoothing, no overnight rollup. If the panel is bright, the source is reporting; if the panel is dim, the source has stopped.</p>
+        <div class="quick">
+          <span class="pill">edge.global</span>
+          <span class="pill">v12.r4</span>
+          <span class="pill ok">all sites reporting</span>
+        </div>
+      </div>
+      <div class="kpis">
+        <div class="kpi-row"><span class="k">Requests / s</span><span class="v">418,206</span><span class="d up">+2.1%</span></div>
+        <div class="kpi-row"><span class="k">Bytes out / s</span><span class="v">12.4 Gb</span><span class="d up">+0.4%</span></div>
+        <div class="kpi-row"><span class="k">Error rate</span><span class="v">0.018%</span><span class="d dn">−12 bp</span></div>
+        <div class="kpi-row"><span class="k">P95 latency</span><span class="v">38 ms</span><span class="d up">+1 ms</span></div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card span-7">
+        <header class="card-head">
+          <span class="idx">01</span>
+          <h3>Request volume</h3>
+          <span class="meta">last 24h · 5m buckets</span>
+        </header>
+        <div class="chart-bars tall">
+          <span style="--h:32%"></span><span style="--h:38%"></span><span style="--h:30%"></span>
+          <span style="--h:28%"></span><span style="--h:34%"></span><span style="--h:40%"></span>
+          <span style="--h:46%"></span><span style="--h:52%"></span><span style="--h:58%"></span>
+          <span style="--h:62%"></span><span style="--h:64%"></span><span style="--h:70%"></span>
+          <span class="hi" style="--h:78%"></span><span class="hi" style="--h:82%"></span><span class="hi" style="--h:88%"></span>
+          <span class="hi" style="--h:84%"></span><span style="--h:74%"></span><span style="--h:68%"></span>
+          <span style="--h:60%"></span><span style="--h:56%"></span><span style="--h:52%"></span>
+          <span style="--h:48%"></span><span style="--h:44%"></span><span style="--h:42%"></span>
+        </div>
+        <div class="axis-row">
+          <span>00:00</span><span>04:00</span><span>08:00</span><span>12:00</span><span>16:00</span><span>20:00</span>
+        </div>
+      </div>
+
+      <div class="card span-5">
+        <header class="card-head">
+          <span class="idx">02</span>
+          <h3>Region health</h3>
+          <span class="meta">5 regions</span>
+        </header>
+        <ul class="region-list">
+          <li>
+            <span class="dot ok"></span>
+            <span class="rg">Americas</span>
+            <span class="rps">142.8k rps</span>
+            <span class="bar"><i style="--w:84%"></i></span>
+            <span class="lat">31 ms</span>
+          </li>
+          <li>
+            <span class="dot ok"></span>
+            <span class="rg">EMEA</span>
+            <span class="rps">128.4k rps</span>
+            <span class="bar"><i style="--w:74%"></i></span>
+            <span class="lat">29 ms</span>
+          </li>
+          <li>
+            <span class="dot ok"></span>
+            <span class="rg">APAC</span>
+            <span class="rps">96.2k rps</span>
+            <span class="bar"><i style="--w:62%"></i></span>
+            <span class="lat">44 ms</span>
+          </li>
+          <li>
+            <span class="dot warn"></span>
+            <span class="rg">South America</span>
+            <span class="rps">28.4k rps</span>
+            <span class="bar warn"><i style="--w:48%"></i></span>
+            <span class="lat">88 ms</span>
+          </li>
+          <li>
+            <span class="dot ok"></span>
+            <span class="rg">Oceania</span>
+            <span class="rps">22.4k rps</span>
+            <span class="bar"><i style="--w:40%"></i></span>
+            <span class="lat">52 ms</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="card span-4">
+        <header class="card-head">
+          <span class="idx">03</span>
+          <h3>P95 latency</h3>
+          <span class="meta">global · 60 min</span>
+        </header>
+        <div class="big-num">38<small>ms</small></div>
+        <div class="sub">target 50ms · floor 22ms</div>
+        <div class="spark">
+          <svg viewBox="0 0 240 60" preserveAspectRatio="none" aria-hidden="true">
+            <polyline fill="none" stroke="currentColor" stroke-width="1.5"
+              points="0,36 16,34 32,38 48,32 64,36 80,30 96,34 112,28 128,32 144,26 160,30 176,24 192,28 208,22 224,26 240,20" />
+          </svg>
+        </div>
+      </div>
+
+      <div class="card span-4">
+        <header class="card-head">
+          <span class="idx">04</span>
+          <h3>Cache hit ratio</h3>
+          <span class="meta">global · 60 min</span>
+        </header>
+        <div class="big-num">94.2<small>%</small></div>
+        <div class="sub">edge 88.4% · regional 5.8%</div>
+        <div class="hbar">
+          <i class="seg a" style="--w:88.4%"></i>
+          <i class="seg b" style="--w:5.8%"></i>
+        </div>
+      </div>
+
+      <div class="card span-4">
+        <header class="card-head">
+          <span class="idx">05</span>
+          <h3>Open pages</h3>
+          <span class="meta">SRE on-call</span>
+        </header>
+        <div class="big-num">02</div>
+        <div class="sub">acknowledged · primary on shift</div>
+        <ul class="page-list">
+          <li><span class="tag sev3">SEV-3</span> TYO upstream flap</li>
+          <li><span class="tag sev3">SEV-3</span> SP3 cert near expiry</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card span-8">
+        <header class="card-head">
+          <span class="idx">06</span>
+          <h3>Live request stream</h3>
+          <span class="meta">tail · 12 lines</span>
+        </header>
+        <pre class="logstream">
+<span class="t">04:18:02.114</span> <span class="ok">200</span> GET  edge-fra-04  /static/app.css      <span class="g">12ms</span>
+<span class="t">04:18:02.108</span> <span class="ok">200</span> GET  edge-tyo-02  /api/v3/feed         <span class="g">28ms</span>
+<span class="t">04:18:02.103</span> <span class="ok">200</span> POST edge-iad-01  /api/v3/events       <span class="g">14ms</span>
+<span class="t">04:18:02.097</span> <span class="ok">304</span> GET  edge-sin-03  /assets/hero.webp    <span class="g">9ms</span>
+<span class="t">04:18:02.091</span> <span class="ok">200</span> GET  edge-syd-01  /api/v3/profile      <span class="g">31ms</span>
+<span class="t">04:18:02.088</span> <span class="wn">429</span> GET  edge-gru-02  /api/v3/search       <span class="g">42ms</span>
+<span class="t">04:18:02.085</span> <span class="ok">200</span> GET  edge-lhr-04  /                    <span class="g">11ms</span>
+<span class="t">04:18:02.079</span> <span class="ok">200</span> GET  edge-fra-01  /static/app.js       <span class="g">8ms</span>
+<span class="t">04:18:02.074</span> <span class="ok">200</span> GET  edge-iad-03  /api/v3/feed         <span class="g">22ms</span>
+<span class="t">04:18:02.067</span> <span class="ok">200</span> GET  edge-tyo-04  /static/logo.svg     <span class="g">7ms</span>
+<span class="t">04:18:02.062</span> <span class="er">503</span> GET  edge-gru-02  /api/v3/search       <span class="g">timeout</span>
+<span class="t">04:18:02.058</span> <span class="ok">200</span> GET  edge-fra-02  /api/v3/feed         <span class="g">26ms</span></pre>
+      </div>
+
+      <div class="card span-4">
+        <header class="card-head">
+          <span class="idx">07</span>
+          <h3>Anomaly score</h3>
+          <span class="meta">14 day rolling</span>
+        </header>
+        <div class="score">
+          <div class="ring">
+            <svg viewBox="0 0 120 120" aria-hidden="true">
+              <circle cx="60" cy="60" r="48" fill="none" stroke="#2d323e" stroke-width="14"/>
+              <circle cx="60" cy="60" r="48" fill="none" stroke="#b4ff39" stroke-width="14"
+                stroke-dasharray="54.3 301.6" stroke-dashoffset="0"
+                transform="rotate(-90 60 60)"/>
+            </svg>
+            <div class="num">0.18</div>
+          </div>
+          <div class="legend">
+            <div><span class="sw"></span><b>quiet</b> 0.00 – 0.30</div>
+            <div><span class="sw warn"></span>watch 0.30 – 0.60</div>
+            <div><span class="sw err"></span>page 0.60 – 1.00</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="divider">
+
+    <section class="grid">
+      <div class="card span-6">
+        <header class="card-head">
+          <span class="idx">08</span>
+          <h3>Site fleet</h3>
+          <span class="meta">82 sites · sample</span>
+        </header>
+        <div class="fleet">
+          {% set fleet = [
+            "FRA-01","FRA-02","FRA-03","FRA-04","AMS-01","AMS-02","AMS-03",
+            "LHR-01","LHR-02","LHR-03","LHR-04","CDG-01","CDG-02",
+            "IAD-01","IAD-02","IAD-03","IAD-04","SJC-01","SJC-02","SJC-03",
+            "DFW-01","DFW-02","ORD-01","ORD-02","SEA-01","SEA-02",
+            "TYO-01","TYO-02","TYO-03","TYO-04","NRT-01","KIX-01","KIX-02",
+            "SIN-01","SIN-02","SIN-03","HKG-01","HKG-02",
+            "SYD-01","SYD-02","SYD-03","AKL-01",
+            "GRU-01","GRU-02","SCL-01"
+          ] %}
+          {% for s in fleet %}<span class="node{% if s == 'GRU-02' %} warn{% endif %}">{{ s }}</span>{% endfor %}
+        </div>
+      </div>
+
+      <div class="card span-6">
+        <header class="card-head">
+          <span class="idx">09</span>
+          <h3>Recent incidents</h3>
+          <span class="meta">last 4</span>
+        </header>
+        <ul class="post-list">
+          {% for post in site.pages | where("section", "incidents") | sort_by("date", reverse=true) %}
+            {% if loop.index <= 4 %}
+            <li>
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumen-grid/templates/page.html
+++ b/examples/lumen-grid/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.date %}<div class="page-date">{{ page.date | date("%Y · %m · %d") }}</div>{% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumen-grid/templates/section.html
+++ b/examples/lumen-grid/templates/section.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    {{ content }}
+    <ul class="post-list">
+      {% for post in section.pages %}
+        <li>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          <time>{{ post.date | date("%Y.%m.%d") }}</time>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lumen-grid/templates/shortcodes/alert.html
+++ b/examples/lumen-grid/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert" data-type="{{ type | default('info') }}">
+  <strong>{{ type | default('note') | upper }}</strong>
+  <span>{{ body }}</span>
+</div>

--- a/examples/lumen-grid/templates/taxonomy.html
+++ b/examples/lumen-grid/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Browse all terms in this taxonomy.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/lumen-grid/templates/taxonomy_term.html
+++ b/examples/lumen-grid/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Posts tagged with this term.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/nimbus-cortex/AGENTS.md
+++ b/examples/nimbus-cortex/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+## Project Overview
+
+Static website built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Site-Specific Notes
+
+- Theme: dark ML/AI training cluster console. Deep gray-blue (`#0a0c10`) bg, cyan (`#00d4d4`) primary, magenta (`#ff5e9c`) secondary, yellow (`#d9d959`) for power. Terminal aesthetic in IBM Plex Mono with Inter for prose.
+- Content sections: `content/runs/` for training journal; plus `index.md` (cluster overview) and `about.md` (handbook).
+- CSS lives in `static/css/style.css`.
+- No gradients, no emojis.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/nimbus-cortex/archetypes/default.md
+++ b/examples/nimbus-cortex/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/nimbus-cortex/config.toml
+++ b/examples/nimbus-cortex/config.toml
@@ -1,0 +1,217 @@
+title = "Nimbus Cortex"
+description = "Training console for the research cluster."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "models"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["runs"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/nimbus-cortex/content/about.md
+++ b/examples/nimbus-cortex/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "Cluster handbook"
+description = "How the research cluster is operated, and what the console will and will not do for you."
++++
+
+Nimbus Cortex is the training console for a research cluster of two hundred and eighty-eight accelerators. It is the working surface for a small ML research team — three permanent researchers, two rotating residents, and the platform engineer who keeps the slab from melting. The page you stepped away from is what the team watches from the moment a run is submitted to the moment it lands a checkpoint.
+
+## What the console does
+
+The console shows you the run, the GPU envelope, and the loss curve. It does not show you the model, the data, or the prompt. We deliberately keep the working surface to *the training itself* — the model lives in the repo, the data lives in the catalog, and the prompts live in evaluation. Mixing them on the same page makes for a cluttered console and a confused team.
+
+> The console is for training health. If you want to know what the model is doing, run the eval. If you want to know what the model means, write the note.
+
+## What the console will not do
+
+The console will not interpret your loss curve for you. Two researchers can look at the same curve and write different runbooks; we would rather both researchers see the same curve than have the console pick a winner.
+
+The console will not kill your run. The kill switch lives behind a confirmation in the CLI and a second confirmation in the cluster's web UI. We have stopped enough good runs on a bad gut feel that we no longer trust ourselves with a single-click kill.
+
+## The team
+
+Three researchers, two residents, one platform engineer. The platform engineer is the only person on rotation; researchers are paired by topic, not by shift. The handbook here is canonical — if it disagrees with a wiki page, the handbook wins.

--- a/examples/nimbus-cortex/content/index.md
+++ b/examples/nimbus-cortex/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Cluster"
+description = "Nimbus Cortex — training console for the research cluster."
+template = "home"
++++

--- a/examples/nimbus-cortex/content/runs/_index.md
+++ b/examples/nimbus-cortex/content/runs/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Runs"
+description = "Training run journal — what we ran, what we learned, what we did not."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/nimbus-cortex/content/runs/r-170-spiky-loss.md
+++ b/examples/nimbus-cortex/content/runs/r-170-spiky-loss.md
@@ -1,0 +1,15 @@
++++
+title = "R-170 · loss spike at step 12k traced to one bad batch"
+date = "2026-04-22"
+description = "A 4.8σ loss spike at step 12k was traced to a single batch containing a long run of low-entropy tokens. We left it in."
+tags = ["loss-spike", "data", "investigation"]
+models = ["nm-1b4"]
++++
+
+R-170 had a loss spike at step 12,041 — four-point-eight standard deviations above the trailing mean. The spike was a single step; loss recovered to trend within thirty steps. The on-call researcher paused submission of follow-up runs while we investigated.
+
+The spike was traced to a single batch that contained an unusually long run of low-entropy tokens — a repeated whitespace sequence from a particular document in the mix. The batch was technically in-distribution; the run of low-entropy tokens within a single batch was the unusual feature.
+
+We decided to leave the data in. The justification: removing the batch would have made the loss curve cleaner and the model worse on the underlying distribution. A model that cannot handle an in-distribution batch is not a model we want; an investigation triggered by a 4.8σ spike on an in-distribution batch is an investigation we should be willing to do.
+
+The runbook for loss spikes has been updated. The new rule of thumb: a 3σ spike calls a researcher; a 5σ spike pauses the queue. R-170 sat at 4.8σ — closer to the second than the first — and we will not refine the threshold until we have seen more events.

--- a/examples/nimbus-cortex/content/runs/r-178-mfu.md
+++ b/examples/nimbus-cortex/content/runs/r-178-mfu.md
@@ -1,0 +1,17 @@
++++
+title = "R-178 · MFU climbed to 54% after the pipeline rework"
+date = "2026-05-02"
+description = "Pipeline parallelism rework added eight points of MFU. Wall-clock per epoch fell by 14%."
+tags = ["mfu", "pipeline-parallel", "shipped"]
+models = ["nm-6b"]
++++
+
+The pipeline parallelism rework that we shipped last week paid for itself on R-178. Model FLOPs utilisation climbed from forty-six percent to fifty-four. Wall-clock per epoch fell by fourteen percent.
+
+The win came from two places. First, the rework reduced bubble time during the warmup phase by interleaving the second micro-batch into the first stage's idle slot. Second, the activation recomputation policy is now layer-aware — we recompute attention but cache the FFN, which trades a small amount of memory for a meaningful throughput gain at this scale.
+
+- **MFU before:** 46.2%
+- **MFU after:** 54.1%
+- **Memory headroom:** 9.4% (was 14.2%)
+
+The memory headroom is now within our normal operating band. We are not going to chase further MFU at the cost of additional memory until we have run R-186 and R-187 — both planned to use the freed cycles for longer sequence lengths rather than larger batch sizes.

--- a/examples/nimbus-cortex/content/runs/r-182-killed.md
+++ b/examples/nimbus-cortex/content/runs/r-182-killed.md
@@ -1,0 +1,15 @@
++++
+title = "R-182 · killed at step 4,128 (data corruption)"
+date = "2026-05-10"
+description = "A duplicated shard introduced a 0.3% poisoning that surfaced as a slow loss creep. We caught it on the eval, not the loss."
+tags = ["data", "killed", "poisoning"]
+models = ["nm-1b4"]
++++
+
+R-182 was killed at step 4,128 after a small but persistent eval regression on the math subset. Training loss looked nominal; eval loss had crept by 0.04 over the previous thousand steps. Investigation found a duplicated data shard that had been written into the run's mix at 0.3% — a small enough fraction to be invisible in the loss curve, large enough to bias the math eval consistently.
+
+The duplicated shard came from a botched dedupe pass earlier in the month. The dedupe pipeline has been pinned to a known-good revision and the affected mix removed from the catalog. We have also added a per-step hash assertion at the loader; a duplicated shard will now refuse to load rather than land silently.
+
+> Two lessons. The loss curve will not save you — the eval will. And the dedupe pass is exactly the kind of thing that should be reproducible from a hash, not a date.
+
+The replacement run, R-183, was submitted the same evening and is on the board now.

--- a/examples/nimbus-cortex/content/runs/r-184-mu-transfer.md
+++ b/examples/nimbus-cortex/content/runs/r-184-mu-transfer.md
@@ -1,0 +1,19 @@
++++
+title = "R-184 · µTransfer hyperparams held across a 4× scale"
+date = "2026-05-15"
+description = "Hyperparameter transfer from the 1.4B model held cleanly to the 6B. Loss curve and gradient norms tracked within 2% of the prediction."
+tags = ["mu-transfer", "scaling", "shipped"]
+models = ["nm-6b"]
++++
+
+R-184 finished overnight at 88% of the planned compute budget. The µTransfer hyperparameter prediction from the 1.4B grid landed within two percent of the observed loss at the same token count, and the gradient norms tracked the prediction even more closely. We expected to need to retune for the 6B run; we did not.
+
+What this means for the project: the 1.4B sweep is now load-bearing. Every hyperparameter decision we make for runs at this scale and the next will come from the 1.4B grid until we see evidence that it does not hold. We will publish the grid weights internally on Friday.
+
+- **Cluster:** 144 H100, ZeRO-3, BF16
+- **Tokens:** 412B
+- **Steps:** 38,400
+- **Wall clock:** 31h 12m
+- **Final loss:** 1.842 (predicted 1.851)
+
+The next run is R-185, a continued pretrain on a 70B-token math corpus. It is queued for tonight; the platform engineer has the duty page.

--- a/examples/nimbus-cortex/static/css/style.css
+++ b/examples/nimbus-cortex/static/css/style.css
@@ -1,0 +1,529 @@
+:root {
+  --bg: #0a0c10;
+  --bg-2: #0f1218;
+  --panel: #14171f;
+  --panel-2: #1b1f29;
+  --line: #232732;
+  --line-2: #2f3441;
+  --ink: #e8ebf2;
+  --ink-mute: #8c92a3;
+  --ink-dim: #5b6076;
+  --accent: #00d4d4;
+  --accent-2: #ff5e9c;
+  --accent-3: #d9d959;
+  --ok: #4ade80;
+  --warn: #ffb454;
+  --err: #ff4d4d;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 13.5px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20'><rect x='9.5' y='9.5' width='1' height='1' fill='%2300d4d4' fill-opacity='0.18'/></svg>");
+  background-size: 20px 20px;
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+.sans { font-family: "Inter", system-ui, sans-serif; }
+
+.frame { max-width: 1380px; margin: 0 auto; padding: 22px 28px 80px; }
+
+/* RAIL */
+.rail {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 28px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 14px 20px;
+  margin-bottom: 12px;
+}
+.rail .brand { display: flex; align-items: center; gap: 12px; }
+.rail .glyph {
+  display: inline-block;
+  width: 28px; height: 28px;
+  color: var(--accent);
+}
+.rail .glyph svg { width: 100%; height: 100%; display: block; }
+.rail .wm {
+  font-family: "Inter", sans-serif;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+.rail .wm b { font-weight: 700; }
+.rail .wm .op { color: var(--accent); margin: 0 4px; font-family: "IBM Plex Mono", monospace; font-weight: 400; }
+.rail .wm i { font-style: normal; color: var(--accent-2); font-weight: 500; }
+.rail .prompt {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12.5px;
+  color: var(--ink-mute);
+  justify-self: center;
+}
+.rail .prompt .user { color: var(--accent); }
+.rail .prompt .sep { color: var(--ink-dim); }
+.rail .prompt .path { color: var(--accent-2); }
+.rail .prompt .cur {
+  display: inline-block;
+  color: var(--accent);
+  animation: blink 1s steps(2) infinite;
+  margin-left: 2px;
+}
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+.rail nav { display: flex; gap: 4px; }
+.rail .navlink {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 7px 12px;
+  color: var(--ink-mute);
+  border: 1px solid transparent;
+}
+.rail .navlink:hover { color: var(--ink); border-color: var(--line-2); }
+
+/* STRIP */
+.strip {
+  display: flex;
+  justify-content: space-between;
+  gap: 28px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  padding: 8px 18px;
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+.strip b { color: var(--ink-dim); margin-right: 6px; }
+.strip .ok b { color: var(--ok); }
+
+/* LEDE */
+.lede {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.lede-copy {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 32px 36px;
+  position: relative;
+  overflow: hidden;
+}
+.lede-copy::before {
+  content: ""; position: absolute; top: 0; left: 0; width: 4px; height: 100%; background: var(--accent);
+}
+.lede-copy .kicker {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 22px;
+}
+.lede-copy h1 {
+  font-family: "Inter", sans-serif;
+  font-size: clamp(2.2rem, 4.4vw, 3.5rem);
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  font-weight: 800;
+  margin: 0 0 18px;
+  color: var(--ink);
+}
+.lede-copy h1 .hl { color: var(--accent); }
+.lede-copy p {
+  font-family: "Inter", sans-serif;
+  color: var(--ink-mute);
+  max-width: 50ch;
+  margin: 0 0 22px;
+  font-size: 0.96rem;
+}
+.lede-copy p code { background: var(--bg-2); color: var(--accent-2); padding: 1px 6px; border: 1px solid var(--line); font-family: "IBM Plex Mono", monospace; font-size: 0.9em; }
+
+.cmd {
+  background: var(--bg);
+  border: 1px solid var(--line-2);
+  padding: 10px 14px;
+  font-size: 12.5px;
+  color: var(--ink-mute);
+  display: flex; gap: 10px; align-items: baseline;
+}
+.cmd .prompt-mark { color: var(--accent); }
+.cmd .cmd-text .hl-tok { color: var(--accent-2); }
+.cmd .cmd-text .hl-num { color: var(--accent-3); }
+
+.lede-stats {
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  gap: 0;
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+.lede-stats .ls {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: baseline;
+  gap: 14px;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--line);
+}
+.lede-stats .ls:last-child { border-bottom: 0; }
+.lede-stats .k {
+  font-size: 10.5px;
+  color: var(--ink-dim);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.lede-stats .v {
+  font-size: 1.8rem;
+  font-weight: 500;
+  color: var(--ink);
+  font-feature-settings: "tnum";
+  letter-spacing: -0.02em;
+}
+.lede-stats .v small { font-size: 1rem; color: var(--ink-mute); margin-left: 2px; }
+.lede-stats .u { font-size: 10.5px; color: var(--ink-dim); letter-spacing: 0.06em; text-align: right; }
+
+/* BOARD */
+.bd {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 18px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+.card::before {
+  content: "";
+  position: absolute;
+  top: -1px; left: -1px;
+  width: 8px; height: 8px;
+  border-top: 1px solid var(--accent);
+  border-left: 1px solid var(--accent);
+}
+.card::after {
+  content: "";
+  position: absolute;
+  bottom: -1px; right: -1px;
+  width: 8px; height: 8px;
+  border-bottom: 1px solid var(--accent);
+  border-right: 1px solid var(--accent);
+}
+.span-4 { grid-column: span 4; }
+.span-6 { grid-column: span 6; }
+.span-8 { grid-column: span 8; }
+.span-12 { grid-column: span 12; }
+
+.card-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding-bottom: 12px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+.card-head .tag {
+  background: var(--accent);
+  color: var(--bg);
+  font-size: 10.5px;
+  font-weight: 700;
+  padding: 3px 7px;
+  letter-spacing: 0.1em;
+}
+.card-head h3 {
+  margin: 0;
+  font-family: "Inter", sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+.card-head .status {
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  color: var(--ink-dim);
+  text-transform: uppercase;
+}
+.card-head .status.running { color: var(--ok); }
+.card-head .status.running::before { content: "● "; }
+
+/* LOSS CHART */
+.loss-area { flex: 1; min-height: 200px; }
+.loss-area svg { width: 100%; height: 220px; }
+.legend {
+  display: flex; gap: 18px; margin-top: 10px;
+  font-size: 11px; color: var(--ink-mute);
+  letter-spacing: 0.06em;
+}
+.legend .dot { display: inline-block; width: 10px; height: 10px; margin-right: 6px; vertical-align: middle; }
+.legend .dot.c1 { background: var(--accent); }
+.legend .dot.c2 { background: var(--accent-2); }
+.legend.small { font-size: 10.5px; color: var(--ink-dim); margin-top: 14px; }
+
+.metrics-row {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  margin-top: 16px;
+}
+.metrics-row .m { background: var(--panel); padding: 10px 12px; }
+.metrics-row .k {
+  display: block;
+  font-size: 10px;
+  color: var(--ink-dim);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.metrics-row .m b {
+  font-size: 1.15rem;
+  font-weight: 500;
+  color: var(--ink);
+  font-feature-settings: "tnum";
+}
+
+/* GPU GRID */
+.gpu-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 3px;
+  margin-bottom: 14px;
+}
+.gpu-grid i {
+  display: block; aspect-ratio: 1;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+}
+.gpu-grid i.g-on { background: var(--accent); border-color: var(--accent); }
+.gpu-grid i.g-mid { background: rgba(0,212,212,0.4); border-color: rgba(0,212,212,0.5); }
+.gpu-grid i.g-hot { background: var(--accent-3); border-color: var(--accent-3); }
+.gpu-grid i.g-err { background: var(--err); border-color: var(--err); }
+.legend-list {
+  list-style: none; padding: 0; margin: 0;
+  display: grid; gap: 6px;
+  font-size: 11px; color: var(--ink-mute);
+}
+.legend-list .sw {
+  display: inline-block; width: 10px; height: 10px;
+  background: var(--bg-2); border: 1px solid var(--line);
+  margin-right: 8px; vertical-align: middle;
+}
+.legend-list .sw.g-on { background: var(--accent); border-color: var(--accent); }
+.legend-list .sw.g-mid { background: rgba(0,212,212,0.4); border-color: rgba(0,212,212,0.5); }
+.legend-list .sw.g-hot { background: var(--accent-3); border-color: var(--accent-3); }
+.legend-list .sw.g-err { background: var(--err); border-color: var(--err); }
+
+/* BIG NUM */
+.big {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 3rem;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--ink);
+  font-feature-settings: "tnum";
+}
+.big small { font-size: 1.1rem; color: var(--ink-mute); margin-left: 4px; }
+.card .sub {
+  font-size: 11px;
+  color: var(--ink-mute);
+  margin-top: 8px;
+  letter-spacing: 0.06em;
+}
+
+.hbar {
+  position: relative;
+  height: 10px;
+  background: var(--bg-2);
+  margin-top: 16px;
+  overflow: visible;
+}
+.hbar i { display: block; height: 100%; width: var(--w, 50%); background: var(--accent); }
+.hbar .mark {
+  position: absolute; top: -3px; bottom: -3px;
+  width: 1px; background: var(--accent-2);
+}
+.hbar .mark.dim { background: var(--ink-dim); }
+
+.pwr-chart { margin-top: 16px; }
+.pwr-chart svg { width: 100%; height: 56px; }
+
+/* QUEUE */
+.queue { list-style: none; padding: 0; margin: 0; }
+.queue li {
+  display: grid;
+  grid-template-columns: 28px 50px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--line);
+  font-size: 12px;
+}
+.queue li:last-child { border-bottom: 0; }
+.queue .prio {
+  font-size: 9.5px; font-weight: 700;
+  padding: 2px 4px; text-align: center;
+  letter-spacing: 0.05em;
+}
+.queue .prio.p1 { background: var(--accent-2); color: var(--bg); }
+.queue .prio.p3 { background: var(--line-2); color: var(--ink); }
+.queue .rid { color: var(--accent); letter-spacing: 0.04em; }
+.queue .rname { color: var(--ink); }
+.queue .when { color: var(--ink-dim); }
+
+/* LOG */
+.log-card { padding: 0; }
+.log-card .card-head { padding: 14px 20px 12px; margin: 0; }
+.log {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11.5px;
+  line-height: 1.9;
+  color: var(--ink-mute);
+  background: var(--bg);
+  margin: 0;
+  padding: 16px 20px 18px;
+  border-top: 1px solid var(--line);
+  overflow-x: auto;
+}
+.log .t { color: var(--ink-dim); margin-right: 10px; }
+.log .ok { color: var(--ok); margin-right: 8px; }
+.log .warn { color: var(--warn); margin-right: 8px; }
+.log .err { color: var(--err); margin-right: 8px; }
+.log .src { color: var(--accent-2); margin-right: 14px; }
+
+/* RUN LIST */
+.run-list { list-style: none; padding: 0; margin: 0; }
+.run-list li {
+  display: grid;
+  grid-template-columns: 14px 1fr auto;
+  gap: 14px;
+  align-items: baseline;
+  padding: 14px 0;
+  border-top: 1px solid var(--line);
+}
+.run-list li:first-child { border-top: 0; padding-top: 6px; }
+.run-list .rdot {
+  width: 8px; height: 8px;
+  background: var(--accent);
+  align-self: center;
+}
+.run-list li a {
+  font-family: "Inter", sans-serif;
+  color: var(--ink);
+  font-weight: 500;
+  font-size: 0.98rem;
+}
+.run-list li a:hover { color: var(--accent); }
+.run-list li time {
+  font-size: 11px;
+  color: var(--ink-dim);
+  letter-spacing: 0.12em;
+}
+.run-list.big li { padding: 20px 0; }
+.run-list.big li a { font-size: 1.18rem; font-weight: 600; }
+
+/* PAGE */
+.page-title {
+  font-family: "Inter", sans-serif;
+  font-size: 2.2rem;
+  letter-spacing: -0.025em;
+  font-weight: 800;
+  margin: 14px 0 8px;
+}
+.page-desc {
+  font-family: "Inter", sans-serif;
+  color: var(--ink-mute);
+  max-width: 64ch;
+  margin: 0 0 22px;
+}
+.page-date {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin-bottom: 28px;
+}
+
+.cta {
+  display: inline-block;
+  background: var(--accent);
+  color: var(--bg);
+  padding: 9px 16px;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.cta:hover { background: var(--accent-2); color: var(--bg); }
+
+article.prose {
+  font-family: "Inter", sans-serif;
+  max-width: 72ch;
+  font-size: 1rem;
+  line-height: 1.62;
+  color: var(--ink);
+}
+article.prose h2 { font-size: 1.4rem; letter-spacing: -0.015em; margin: 1.8em 0 0.5em; font-weight: 700; }
+article.prose h3 { font-size: 1.1rem; margin: 1.4em 0 0.4em; font-weight: 600; }
+article.prose p { color: var(--ink); }
+article.prose blockquote { border-left: 3px solid var(--accent); padding: 6px 18px; margin: 1.4em 0; color: var(--ink-mute); font-style: italic; }
+article.prose ul li::marker { color: var(--accent); }
+article.prose a { color: var(--accent); border-bottom: 1px solid var(--line-2); }
+article.prose a:hover { border-color: var(--accent); }
+article.prose code { background: var(--bg-2); padding: 2px 6px; border: 1px solid var(--line); color: var(--accent-2); font-family: "IBM Plex Mono", monospace; font-size: 0.9em; }
+
+.alert {
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  border-left: 4px solid var(--accent);
+  padding: 14px 18px;
+  margin: 1.4em 0;
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+.alert strong {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+
+footer.foot {
+  margin-top: 60px;
+  border-top: 1px solid var(--line);
+  padding-top: 24px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 30px;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-dim);
+}
+footer.foot strong { color: var(--ink); display: block; margin-bottom: 8px; letter-spacing: 0.14em; text-transform: uppercase; }
+
+@media (max-width: 1000px) {
+  .lede { grid-template-columns: 1fr; }
+  .span-4, .span-6, .span-8, .span-12 { grid-column: span 12; }
+  .strip { font-size: 10.5px; gap: 14px; }
+  .metrics-row { grid-template-columns: repeat(3, 1fr); }
+  .gpu-grid { grid-template-columns: repeat(16, 1fr); }
+}

--- a/examples/nimbus-cortex/static/favicon.svg
+++ b/examples/nimbus-cortex/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0e0f12"/>
+  <rect x="4" y="4" width="11" height="11" fill="#00d4d4"/>
+  <rect x="17" y="4" width="11" height="11" fill="none" stroke="#00d4d4" stroke-width="2"/>
+  <rect x="4" y="17" width="11" height="11" fill="none" stroke="#ff5e9c" stroke-width="2"/>
+  <rect x="17" y="17" width="11" height="11" fill="#ff5e9c"/>
+</svg>

--- a/examples/nimbus-cortex/templates/404.html
+++ b/examples/nimbus-cortex/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">404 · run not found</h1>
+    <p class="page-desc">That endpoint is not on the scheduler. Try the cluster overview.</p>
+    <p><a href="{{ base_url }}/" class="cta">cd /cluster</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/nimbus-cortex/templates/footer.html
+++ b/examples/nimbus-cortex/templates/footer.html
@@ -1,0 +1,20 @@
+    <footer class="foot">
+      <div>
+        <strong>{{ site.title }}</strong>
+        Training console for the research cluster. Built with Hwaro on Crystal.
+      </div>
+      <div>
+        <strong>Sections</strong>
+        <a href="{{ base_url }}/">Cluster</a> ·
+        <a href="{{ base_url }}/runs/">Runs</a> ·
+        <a href="{{ base_url }}/about/">Handbook</a>
+      </div>
+      <div>
+        <strong>Cortex · {{ current_year }}</strong>
+        sync {{ current_date }} · console v8.r2
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/nimbus-cortex/templates/header.html
+++ b/examples/nimbus-cortex/templates/header.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="frame">
+    <header class="rail">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="glyph" aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <rect x="2" y="2" width="9" height="9" fill="currentColor"/>
+            <rect x="13" y="2" width="9" height="9" fill="none" stroke="currentColor" stroke-width="2"/>
+            <rect x="2" y="13" width="9" height="9" fill="none" stroke="currentColor" stroke-width="2"/>
+            <rect x="13" y="13" width="9" height="9" fill="currentColor"/>
+          </svg>
+        </span>
+        <span class="wm">
+          <b>nimbus</b><span class="op">::</span><i>cortex</i>
+        </span>
+      </a>
+      <div class="prompt">
+        <span class="user">research@cortex-01</span>
+        <span class="sep">:</span>
+        <span class="path">~/queue</span>
+        <span class="cur">▍</span>
+      </div>
+      <nav>
+        <a href="{{ base_url }}/" class="navlink">Cluster</a>
+        <a href="{{ base_url }}/runs/" class="navlink">Runs</a>
+        <a href="{{ base_url }}/about/" class="navlink">Handbook</a>
+      </nav>
+    </header>
+    <div class="strip">
+      <span><b>UTC</b> {{ current_date }}</span>
+      <span><b>RUNS</b> 12 active · 4 queued · 1 paused</span>
+      <span><b>GPU</b> 288 / 288 reachable</span>
+      <span><b>POWER</b> 412 kW · within envelope</span>
+      <span class="ok"><b>STATUS</b> nominal</span>
+    </div>

--- a/examples/nimbus-cortex/templates/home.html
+++ b/examples/nimbus-cortex/templates/home.html
@@ -1,0 +1,165 @@
+{% include "header.html" %}
+  <main>
+    <section class="lede">
+      <div class="lede-copy">
+        <span class="kicker">// cluster overview · realtime</span>
+        <h1>288 accelerators,<br>twelve open runs,<br><span class="hl">one quiet queue.</span></h1>
+        <p>Nimbus Cortex is the working console for the research cluster. Every counter on this page comes from the schedulers and the per-node telemetry, sampled once a second. Training health lives here; model evaluation lives in <code>eval/</code>; everything else lives somewhere else on purpose.</p>
+        <div class="cmd">
+          <span class="prompt-mark">$</span>
+          <span class="cmd-text">cortex submit <span class="hl-tok">run-spec.toml</span> --gpus <span class="hl-num">144</span> --priority <span class="hl-num">3</span></span>
+        </div>
+      </div>
+      <div class="lede-stats">
+        <div class="ls"><span class="k">Active GPUs</span><span class="v">242</span><span class="u">/ 288 · 84%</span></div>
+        <div class="ls"><span class="k">Power draw</span><span class="v">412<small>kW</small></span><span class="u">envelope 460 kW</span></div>
+        <div class="ls"><span class="k">Tokens / s</span><span class="v">1.84<small>M</small></span><span class="u">aggregate · all runs</span></div>
+        <div class="ls"><span class="k">Queue depth</span><span class="v">04</span><span class="u">2 priority · 2 std</span></div>
+      </div>
+    </section>
+
+    <section class="bd">
+      <article class="card span-8 run-card">
+        <header class="card-head">
+          <span class="tag">RUN</span>
+          <h3>R-185 · continued-pretrain · math-70b</h3>
+          <span class="status running">running · step 18,412 / 38,400</span>
+        </header>
+        <div class="loss-area">
+          <svg viewBox="0 0 600 200" preserveAspectRatio="none" aria-hidden="true">
+            <defs>
+              <pattern id="grid" width="50" height="40" patternUnits="userSpaceOnUse">
+                <path d="M 50 0 L 0 0 0 40" fill="none" stroke="#262931" stroke-width="0.5"/>
+              </pattern>
+            </defs>
+            <rect width="600" height="200" fill="url(#grid)"/>
+            <polyline fill="none" stroke="#00d4d4" stroke-width="2"
+              points="0,40 30,52 60,58 90,68 120,72 150,78 180,82 210,86 240,92 270,96 300,102 330,106 360,110 390,114 420,118 450,122 480,124 510,127 540,129 570,131 600,133"/>
+            <polyline fill="none" stroke="#ff5e9c" stroke-width="1.5" stroke-dasharray="4 4" opacity="0.6"
+              points="0,46 30,58 60,64 90,72 120,76 150,80 180,84 210,88 240,92 270,96 300,100 330,104 360,108 390,112 420,116 450,120 480,123 510,126 540,128 570,130 600,132"/>
+          </svg>
+          <div class="legend">
+            <span class="dot c1"></span>train loss
+            <span class="dot c2"></span>eval loss
+          </div>
+        </div>
+        <div class="metrics-row">
+          <div class="m"><span class="k">loss</span><b>1.842</b></div>
+          <div class="m"><span class="k">eval</span><b>1.918</b></div>
+          <div class="m"><span class="k">lr</span><b>3.0e-4</b></div>
+          <div class="m"><span class="k">grad norm</span><b>0.41</b></div>
+          <div class="m"><span class="k">tokens</span><b>184B</b></div>
+          <div class="m"><span class="k">tflops</span><b>312</b></div>
+        </div>
+      </article>
+
+      <article class="card span-4">
+        <header class="card-head">
+          <span class="tag">GPU</span>
+          <h3>Utilisation map</h3>
+          <span class="status">288 cards</span>
+        </header>
+        <div class="gpu-grid">
+          {% for i in range(72) %}<i class="g{% if loop.index == 3 or loop.index == 17 or loop.index == 41 %} g-hot{% elif loop.index <= 12 %} g-mid{% elif loop.index <= 56 %} g-on{% endif %}{% if loop.index == 38 %} g-err{% endif %}"></i>{% endfor %}
+        </div>
+        <ul class="legend-list">
+          <li><span class="sw g-on"></span>active · 218</li>
+          <li><span class="sw g-mid"></span>warmup · 24</li>
+          <li><span class="sw g-hot"></span>thermal watch · 3</li>
+          <li><span class="sw g-err"></span>fault · 1</li>
+          <li><span class="sw"></span>idle · 42</li>
+        </ul>
+      </article>
+
+      <article class="card span-4">
+        <header class="card-head">
+          <span class="tag">MFU</span>
+          <h3>Model FLOPs</h3>
+          <span class="status">live</span>
+        </header>
+        <div class="big">54.1<small>%</small></div>
+        <div class="sub">target 55% · floor 48%</div>
+        <div class="hbar">
+          <i style="--w:54%"></i>
+          <span class="mark" style="left:55%"></span>
+          <span class="mark dim" style="left:48%"></span>
+        </div>
+        <div class="legend small">peak 56.4% · trail 7d</div>
+      </article>
+
+      <article class="card span-4">
+        <header class="card-head">
+          <span class="tag">QUEUE</span>
+          <h3>Pending runs</h3>
+          <span class="status">04</span>
+        </header>
+        <ul class="queue">
+          <li><span class="prio p1">P1</span><span class="rid">R-186</span><span class="rname">long-context · 32k</span><span class="when">+02h</span></li>
+          <li><span class="prio p1">P1</span><span class="rid">R-187</span><span class="rname">long-context · 64k</span><span class="when">+18h</span></li>
+          <li><span class="prio p3">P3</span><span class="rid">R-188</span><span class="rname">ablation · norm</span><span class="when">+24h</span></li>
+          <li><span class="prio p3">P3</span><span class="rid">R-189</span><span class="rname">ablation · attn</span><span class="when">+30h</span></li>
+        </ul>
+      </article>
+
+      <article class="card span-4">
+        <header class="card-head">
+          <span class="tag">PWR</span>
+          <h3>Power envelope</h3>
+          <span class="status">412 kW</span>
+        </header>
+        <div class="big">90<small>%</small></div>
+        <div class="sub">412 of 460 kW · 14 day peak 446 kW</div>
+        <div class="pwr-chart">
+          <svg viewBox="0 0 240 60" preserveAspectRatio="none" aria-hidden="true">
+            <polyline fill="none" stroke="#d9d959" stroke-width="2"
+              points="0,38 12,34 24,38 36,28 48,32 60,22 72,26 84,18 96,24 108,16 120,22 132,12 144,18 156,14 168,20 180,16 192,22 204,18 216,24 228,20 240,22"/>
+          </svg>
+        </div>
+      </article>
+
+      <article class="card span-12 log-card">
+        <header class="card-head">
+          <span class="tag">STREAM</span>
+          <h3>cluster-tail · 16 lines</h3>
+          <span class="status">live</span>
+        </header>
+        <pre class="log">
+<span class="t">04:18:02.114</span> <span class="ok">INFO </span> <span class="src">cortex-01</span> R-185 step 18,412 loss=1.842 grad=0.41 tflops=312 mfu=54.1%
+<span class="t">04:18:01.882</span> <span class="ok">INFO </span> <span class="src">cortex-01</span> R-185 step 18,411 loss=1.844 grad=0.40 tflops=311 mfu=54.0%
+<span class="t">04:18:01.640</span> <span class="ok">INFO </span> <span class="src">cortex-01</span> R-185 step 18,410 loss=1.843 grad=0.41 tflops=313 mfu=54.2%
+<span class="t">04:18:01.402</span> <span class="ok">INFO </span> <span class="src">cortex-04</span> R-183 step 28,109 loss=2.014 grad=0.38 tflops=287
+<span class="t">04:18:00.918</span> <span class="warn">WARN </span> <span class="src">cortex-02</span> gpu-038 thermal 84°C → reduced clock
+<span class="t">04:17:59.244</span> <span class="ok">INFO </span> <span class="src">cortex-01</span> R-185 checkpoint saved · step 18,400 · 612MB
+<span class="t">04:17:58.140</span> <span class="ok">INFO </span> <span class="src">cortex-03</span> R-184 eval cycle · perplexity=14.2 · math=44.8
+<span class="t">04:17:54.318</span> <span class="err">ERR  </span> <span class="src">cortex-02</span> gpu-211 NVLink timeout · marked degraded
+<span class="t">04:17:52.044</span> <span class="ok">INFO </span> <span class="src">cortex-03</span> R-184 step 38,200 loss=1.842 (predicted 1.851) · within tol
+<span class="t">04:17:51.018</span> <span class="ok">INFO </span> <span class="src">scheduler</span> R-186 queued · priority P1 · 144 cards · ETA +02:00
+<span class="t">04:17:48.642</span> <span class="ok">INFO </span> <span class="src">cortex-01</span> R-185 step 18,409 loss=1.845 grad=0.42 tflops=312
+<span class="t">04:17:46.220</span> <span class="ok">INFO </span> <span class="src">cortex-01</span> R-185 step 18,408 loss=1.844 grad=0.41 tflops=313
+<span class="t">04:17:42.114</span> <span class="ok">INFO </span> <span class="src">data-cat</span> shard 0044 verified · sha256 ok
+<span class="t">04:17:40.802</span> <span class="ok">INFO </span> <span class="src">cortex-01</span> R-185 step 18,407 loss=1.846 grad=0.40 tflops=311
+<span class="t">04:17:38.612</span> <span class="ok">INFO </span> <span class="src">cortex-04</span> R-183 step 28,108 loss=2.016 grad=0.38 tflops=286
+<span class="t">04:17:36.118</span> <span class="ok">INFO </span> <span class="src">cortex-01</span> R-185 step 18,406 loss=1.843 grad=0.41 tflops=313</pre>
+      </article>
+
+      <article class="card span-12">
+        <header class="card-head">
+          <span class="tag">JRNL</span>
+          <h3>Recent run journal</h3>
+          <span class="status">last 4</span>
+        </header>
+        <ul class="run-list">
+          {% for post in site.pages | where("section", "runs") | sort_by("date", reverse=true) %}
+            {% if loop.index <= 4 %}
+            <li>
+              <span class="rdot"></span>
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </article>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/nimbus-cortex/templates/page.html
+++ b/examples/nimbus-cortex/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.date %}<div class="page-date">{{ page.date | date("%Y · %m · %d") }}</div>{% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/nimbus-cortex/templates/section.html
+++ b/examples/nimbus-cortex/templates/section.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    {{ content }}
+    <ul class="run-list big">
+      {% for post in section.pages %}
+        <li>
+          <span class="rdot"></span>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          <time>{{ post.date | date("%Y · %m · %d") }}</time>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/nimbus-cortex/templates/shortcodes/alert.html
+++ b/examples/nimbus-cortex/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert" data-type="{{ type | default('info') }}">
+  <strong>{{ type | default('note') | upper }}</strong>
+  <span>{{ body }}</span>
+</div>

--- a/examples/nimbus-cortex/templates/taxonomy.html
+++ b/examples/nimbus-cortex/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Browse all terms in this taxonomy.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/nimbus-cortex/templates/taxonomy_term.html
+++ b/examples/nimbus-cortex/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Posts tagged with this term.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/velocity-board/AGENTS.md
+++ b/examples/velocity-board/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+## Project Overview
+
+Static website built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Site-Specific Notes
+
+- Theme: dark product-analytics bento grid. Deep navy (`#07090f`) background, electric blue (`#4d8eff`) primary accent, lime/teal supports.
+- Content sections: `content/changelog/` for ship notes; plus `index.md` (overview) and `about.md` (manual).
+- CSS lives in `static/css/style.css`.
+- No gradients, no emojis.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/velocity-board/archetypes/default.md
+++ b/examples/velocity-board/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/velocity-board/config.toml
+++ b/examples/velocity-board/config.toml
@@ -1,0 +1,217 @@
+title = "Velocity Board"
+description = "Product analytics for a small team that ships every week."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "surfaces"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["changelog"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/velocity-board/content/about.md
+++ b/examples/velocity-board/content/about.md
@@ -1,0 +1,23 @@
++++
+title = "How we read the board"
+description = "Velocity Board is opinionated. Here is the opinion."
++++
+
+Velocity Board is the product-analytics surface for a small team that ships every week. It is not a chart farm. The board is opinionated about which numbers a small team should look at, and unapologetic about hiding the ones that do not help that team make decisions.
+
+## The four numbers
+
+There are four numbers on the board that we believe matter every week. Anything else is interesting context or a debugging detail.
+
+1. **Weekly active accounts.** Not users, not sessions — accounts. Multi-seat teams count once.
+2. **Week-over-week retention.** Of the accounts that were active last week, what fraction were active this week. The rolling six-week curve is the second most-watched number on the board.
+3. **Time to first value.** The median time from sign-up to the first event that the customer would have paid us for. We sample this nightly across the previous seven days.
+4. **Hard errors per thousand events.** Anything the client reports as a hard error. We treat the rate, not the absolute count.
+
+> If a number is not on this list, it is here to help us understand one of the four numbers above. Promotion onto the four list is a quarterly discussion, not a Slack thread.
+
+## The discipline
+
+The board is regenerated nightly from the events warehouse. There is no real-time path; we do not want to optimise for a number that has not had a chance to settle. When you see today's number, it is the close-of-yesterday number, and we are happy with that.
+
+We also do not display a number we do not trust. If the events pipeline missed a window, the affected panel turns into a striped placeholder and surfaces an incident link. We would rather show nothing than show a number that we will spend the morning explaining.

--- a/examples/velocity-board/content/changelog/_index.md
+++ b/examples/velocity-board/content/changelog/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Changelog"
+description = "What shipped, what moved the needle, what did not."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/velocity-board/content/changelog/error-rate-flat-week.md
+++ b/examples/velocity-board/content/changelog/error-rate-flat-week.md
@@ -1,0 +1,13 @@
++++
+title = "Three weeks under our error-rate floor"
+date = "2026-05-04"
+description = "Hard errors per thousand events have stayed below 0.4 for three consecutive weeks. We have a new floor to chase."
+tags = ["errors", "reliability"]
+surfaces = ["api", "mobile"]
++++
+
+Hard errors per thousand events stayed below 0.4 for the third week running. The previous floor was 0.6 and held for most of the winter. We are crediting two changes — the new circuit breaker on the events ingest, and the retry budget that the mobile clients picked up in the February release.
+
+We have moved the floor down on the board. The new threshold for promotion of a release to all-accounts is 0.4 hard errors per thousand. Anything above that becomes a staged rollout with a 24-hour bake.
+
+We considered moving the floor to the new observed value but a one-week noise margin is more honest than the headline number. Aim for the number you can hit on a Sunday night release, not the one you hit on a Wednesday afternoon.

--- a/examples/velocity-board/content/changelog/onboarding-rework-week-22.md
+++ b/examples/velocity-board/content/changelog/onboarding-rework-week-22.md
@@ -1,0 +1,18 @@
++++
+title = "Onboarding rework cut time-to-first-value by 41%"
+date = "2026-05-16"
+description = "We rewrote the onboarding flow around a single working example. Median time-to-first-value dropped from 38 minutes to 22."
+tags = ["onboarding", "tt-fv", "shipped"]
+surfaces = ["web"]
++++
+
+The onboarding rework that we have been talking about since March shipped to all new accounts on Tuesday. The thesis was that the existing flow taught customers about *features* before letting them try *the product*, and that flipping that order would move time-to-first-value.
+
+It did. Median TTFV across the first three days of new accounts fell from thirty-eight minutes to twenty-two — a forty-one percent improvement, and well outside our pre-registered noise band.
+
+- **New accounts (3-day cohort):** 412
+- **Median TTFV before:** 38m
+- **Median TTFV after:** 22m
+- **First-week retention:** +4.2 points
+
+We are sitting on the change for two weeks before we declare victory. The retention number is the one we are watching — if a few days of skipped feature education shows up as a churn signal in week three, we will rework the trailing tour.

--- a/examples/velocity-board/content/changelog/quiet-week-q1.md
+++ b/examples/velocity-board/content/changelog/quiet-week-q1.md
@@ -1,0 +1,15 @@
++++
+title = "Quiet week: paying down a year of debt"
+date = "2026-04-26"
+description = "Nothing shipped to customers this week. Two engineers cleared eleven flagged items off the technical-debt backlog."
+tags = ["debt", "internal"]
+surfaces = []
++++
+
+Nothing shipped to customers this week, on purpose. Two engineers spent the week clearing eleven items off the technical-debt backlog. The full list is on the wiki; the three items worth surfacing here are:
+
+- **Events pipeline:** the dead-letter queue is now reconciled into the warehouse rather than discarded. We have already used the reconciled feed twice to fix a missing-data bug.
+- **Auth refresh:** the refresh-token rotation now happens on a deterministic schedule rather than the previous "first request after expiry" pattern. The change shaved a P99 latency spike that we had been chasing for six months.
+- **Build cache:** CI restored a build cache that had silently been disabled in November. CI median wall-clock fell from 18 minutes to 11.
+
+The board for next week looks normal. We do this kind of debt week once a quarter and it is usually the most-loved week of the calendar.

--- a/examples/velocity-board/content/changelog/search-relevance-shipped.md
+++ b/examples/velocity-board/content/changelog/search-relevance-shipped.md
@@ -1,0 +1,15 @@
++++
+title = "Search relevance: shipped, no measurable lift"
+date = "2026-05-12"
+description = "We rebuilt the search ranker. Customer-visible relevance stayed flat. We are keeping the new ranker because it is half the cost."
+tags = ["search", "ranker", "shipped"]
+surfaces = ["web", "api"]
++++
+
+The new search ranker shipped last week and the verdict is: customer-visible relevance is statistically indistinguishable from the previous one. We are keeping it anyway because it is half the inference cost and a third the latency.
+
+The mistake we made was scoping the project as a relevance win when it was actually a cost win. We sold it internally as the former for a year and the team spent a month worrying when the relevance numbers came back flat.
+
+> A relevance-flat, cost-half ship is a good ship. We just shipped it for the wrong stated reason.
+
+We have updated the project doc and the retrospective is on the calendar for Monday. The retro will mostly be about how we describe projects, not about the ranker.

--- a/examples/velocity-board/content/index.md
+++ b/examples/velocity-board/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Overview"
+description = "Velocity Board is the working product-analytics surface for a small team that ships every week."
+template = "home"
++++

--- a/examples/velocity-board/static/css/style.css
+++ b/examples/velocity-board/static/css/style.css
@@ -1,0 +1,401 @@
+:root {
+  --bg: #07090f;
+  --bg-2: #0c111c;
+  --panel: #121826;
+  --panel-2: #18203a;
+  --line: #1f2638;
+  --line-2: #2a3350;
+  --ink: #ebeefc;
+  --ink-mute: #8e95b0;
+  --ink-dim: #5b6280;
+  --accent: #4d8eff;
+  --accent-2: #c4f154;
+  --accent-3: #2dd4a4;
+  --accent-4: #f0a042;
+  --r: 16px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-size: 14.5px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+.mono, code, pre { font-family: "JetBrains Mono", ui-monospace, monospace; }
+
+.page { max-width: 1320px; margin: 0 auto; padding: 22px 28px 80px; }
+
+.nav {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 24px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 10px 22px 10px 14px;
+  margin-bottom: 36px;
+}
+.nav .brand { display: flex; align-items: center; gap: 12px; padding: 4px 0; }
+.nav .logo {
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  width: 28px; height: 28px;
+}
+.nav .logo i { display: block; border-radius: 4px; }
+.nav .logo .d1 { background: var(--accent); }
+.nav .logo .d2 { background: var(--accent-2); }
+.nav .logo .d3 { background: var(--accent-3); }
+.nav .logo .d4 { background: var(--ink); }
+.nav .wm { font-weight: 600; font-size: 14px; letter-spacing: -0.005em; color: var(--ink); }
+.nav .wm b { font-weight: 700; }
+.nav .env {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  color: var(--ink-mute);
+  letter-spacing: 0.04em;
+  display: flex; align-items: center; gap: 8px;
+  justify-self: center;
+  background: var(--bg-2);
+  padding: 6px 14px;
+  border-radius: 99px;
+  border: 1px solid var(--line);
+}
+.nav .env-dot {
+  width: 7px; height: 7px;
+  background: var(--accent-3);
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px rgba(45,212,164,0.15);
+}
+.nav .nav-links { display: flex; gap: 4px; }
+.nav .nav-links a {
+  font-size: 13px;
+  padding: 7px 14px;
+  border-radius: 99px;
+  color: var(--ink-mute);
+}
+.nav .nav-links a:hover { background: var(--panel-2); color: var(--ink); }
+
+/* HERO */
+.hero {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.hero-text {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  padding: 44px 48px;
+}
+.hero-text .eyebrow {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 22px;
+}
+.hero-text h1 {
+  font-size: clamp(2.4rem, 4.4vw, 3.8rem);
+  line-height: 1.0;
+  letter-spacing: -0.03em;
+  font-weight: 800;
+  margin: 0 0 22px;
+}
+.hero-text p { color: var(--ink-mute); max-width: 50ch; margin: 0 0 22px; font-size: 1rem; }
+.hero-pills { display: flex; gap: 8px; flex-wrap: wrap; }
+.pill {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  padding: 5px 12px;
+  border-radius: 99px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  color: var(--ink-mute);
+}
+.pill.on { color: var(--accent-3); border-color: rgba(45,212,164,0.4); background: rgba(45,212,164,0.08); }
+
+.hero-art {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  padding: 24px;
+  overflow: hidden;
+}
+.hero-art svg { width: 100%; height: 100%; min-height: 240px; }
+
+/* BENTO */
+.bento {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-auto-rows: minmax(190px, auto);
+  gap: 16px;
+}
+.b {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 22px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+.b-big { grid-column: span 6; grid-row: span 2; }
+.b-wide { grid-column: span 8; }
+.b-tall { grid-column: span 4; grid-row: span 2; }
+.b:not(.b-big):not(.b-wide):not(.b-tall) { grid-column: span 3; }
+
+.b-head { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.b-tag {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: rgba(77,142,255,0.12);
+  color: var(--accent);
+}
+.b-tag.tag-2 { background: rgba(196,241,84,0.12); color: var(--accent-2); }
+.b-tag.tag-3 { background: rgba(45,212,164,0.12); color: var(--accent-3); }
+.b-tag.tag-4 { background: rgba(240,160,66,0.12); color: var(--accent-4); }
+.b-head h3 { margin: 0; font-size: 0.95rem; font-weight: 500; color: var(--ink-mute); letter-spacing: -0.005em; }
+
+.b-val {
+  font-family: "Inter", sans-serif;
+  font-size: 3.1rem;
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  color: var(--ink);
+  line-height: 1;
+  font-feature-settings: "tnum";
+  margin: 4px 0 6px;
+}
+.b-big .b-val { font-size: 4.6rem; }
+.b-val small { font-size: 1.2rem; color: var(--ink-mute); margin-left: 4px; font-weight: 600; }
+.b-delta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  color: var(--ink-mute);
+  letter-spacing: 0.02em;
+  margin-bottom: 14px;
+}
+.b-delta.up { color: var(--accent-3); }
+.b-delta.up::before { content: "▲ "; }
+.b-delta.dn { color: var(--accent-2); }
+.b-delta.dn::before { content: "▼ "; }
+
+.bento-spark { flex: 1; min-height: 100px; margin-top: auto; }
+.bento-spark svg { width: 100%; height: 100%; }
+.bento-axis {
+  display: flex; justify-content: space-between;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-dim);
+  letter-spacing: 0.1em;
+  margin-top: 6px;
+}
+
+.bento-bars {
+  display: flex; align-items: flex-end; gap: 6px;
+  height: 64px;
+  margin-top: auto;
+}
+.bento-bars span {
+  flex: 1; background: var(--line-2); position: relative; border-radius: 4px 4px 0 0;
+}
+.bento-bars span::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: 0;
+  background: var(--accent-2); border-radius: 4px 4px 0 0;
+  height: var(--h, 50%);
+}
+.bento-bars span.hi::after { background: var(--accent-2); }
+
+.ttfv { display: grid; grid-template-columns: repeat(6, 1fr); gap: 4px; height: 56px; align-items: flex-end; margin-top: auto; }
+.ttfv .bin { background: var(--bg-2); border-radius: 4px 4px 0 0; position: relative; height: 100%; overflow: hidden; }
+.ttfv .bin i { position: absolute; left: 0; right: 0; bottom: 0; background: var(--accent-3); height: var(--h, 30%); border-radius: 4px 4px 0 0; }
+.ttfv .bin i.hi { background: var(--accent-3); box-shadow: 0 0 0 2px var(--panel), 0 0 0 3px var(--accent-3); }
+.ttfv-axis { display: grid; grid-template-columns: repeat(6, 1fr); gap: 4px; font-family: "JetBrains Mono", monospace; font-size: 10px; color: var(--ink-dim); margin-top: 4px; text-align: center; }
+
+.err-line { flex: 1; min-height: 60px; margin-top: auto; }
+.err-line svg { width: 100%; height: 60px; }
+
+.funnel { display: grid; gap: 10px; }
+.funnel .step {
+  display: grid;
+  grid-template-columns: 200px 80px 1fr;
+  align-items: center;
+  gap: 16px;
+  font-family: "Inter", sans-serif;
+}
+.funnel .step b { color: var(--ink); font-weight: 600; font-size: 0.95rem; }
+.funnel .step span {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  color: var(--ink-mute);
+  font-feature-settings: "tnum";
+}
+.funnel .step .bar { display: block; height: 26px; background: var(--accent); border-radius: 6px; width: var(--w, 100%); }
+.funnel .step .bar.hi { background: var(--accent-2); }
+
+.surfaces { list-style: none; padding: 0; margin: 0; display: grid; gap: 10px; }
+.surfaces li {
+  display: grid;
+  grid-template-columns: 100px 76px 1fr;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+.surfaces .name { color: var(--ink); font-weight: 500; }
+.surfaces .num { font-family: "JetBrains Mono", monospace; color: var(--ink-mute); text-align: right; font-feature-settings: "tnum"; }
+.surfaces i { display: block; height: 6px; background: var(--accent); border-radius: 99px; width: var(--w, 50%); }
+
+.cohort { display: grid; gap: 6px; }
+.cohort .row {
+  display: grid;
+  grid-template-columns: 36px repeat(6, 1fr);
+  gap: 4px;
+  align-items: center;
+}
+.cohort .row .lbl {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-dim);
+  letter-spacing: 0.06em;
+}
+.cohort .row .c {
+  height: 24px; border-radius: 6px;
+  display: block;
+  background: var(--bg-2);
+}
+.cohort .row .c.c5 { background: var(--accent); }
+.cohort .row .c.c4 { background: rgba(77,142,255,0.72); }
+.cohort .row .c.c3 { background: rgba(77,142,255,0.46); }
+.cohort .row .c.c2 { background: rgba(77,142,255,0.28); }
+.cohort .row.legend {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-dim);
+  letter-spacing: 0.04em;
+  text-align: center;
+  margin-top: 4px;
+}
+
+.ship-list { list-style: none; padding: 0; margin: 0; }
+.ship-list li {
+  display: grid;
+  grid-template-columns: 14px 1fr auto;
+  gap: 14px;
+  align-items: baseline;
+  padding: 14px 0;
+  border-top: 1px solid var(--line);
+}
+.ship-list li:first-child { border-top: 0; padding-top: 6px; }
+.ship-list .dot { width: 8px; height: 8px; background: var(--accent); border-radius: 50%; align-self: center; }
+.ship-list li a { color: var(--ink); font-weight: 500; font-size: 0.97rem; }
+.ship-list li a:hover { color: var(--accent); }
+.ship-list li time {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-dim);
+  letter-spacing: 0.06em;
+}
+.ship-list.big li { padding: 20px 0; }
+.ship-list.big li a { font-size: 1.18rem; font-weight: 600; }
+
+.page-title {
+  font-size: 2.2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 16px 0 8px;
+}
+.page-desc { color: var(--ink-mute); max-width: 64ch; margin: 0 0 28px; }
+.page-date {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  color: var(--accent);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 22px;
+}
+
+.cta {
+  display: inline-block;
+  padding: 10px 18px;
+  background: var(--accent);
+  color: var(--bg);
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+}
+.cta:hover { background: var(--accent-2); color: var(--bg); }
+
+article.prose { max-width: 70ch; }
+article.prose h2 { font-size: 1.5rem; letter-spacing: -0.02em; margin: 1.8em 0 0.5em; font-weight: 700; }
+article.prose h3 { font-size: 1.15rem; margin: 1.4em 0 0.4em; font-weight: 600; }
+article.prose blockquote { border-left: 3px solid var(--accent); padding: 4px 18px; margin: 1.4em 0; color: var(--ink-mute); font-style: italic; }
+article.prose a { color: var(--accent); border-bottom: 1px solid var(--line-2); }
+article.prose a:hover { border-color: var(--accent); }
+article.prose ul li::marker { color: var(--accent); }
+article.prose code { background: var(--panel); padding: 2px 6px; border-radius: 4px; font-size: 0.92em; color: var(--accent-2); }
+
+.alert {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-left: 4px solid var(--accent);
+  padding: 14px 18px;
+  margin: 1.4em 0;
+  border-radius: 10px;
+}
+.alert strong {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-right: 12px;
+}
+
+footer.foot {
+  margin-top: 60px;
+  border-top: 1px solid var(--line);
+  padding-top: 28px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 30px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-dim);
+}
+footer.foot strong { color: var(--ink); display: block; margin-bottom: 8px; letter-spacing: 0.14em; text-transform: uppercase; }
+
+@media (max-width: 1100px) {
+  .hero { grid-template-columns: 1fr; }
+  .bento { grid-template-columns: repeat(6, 1fr); }
+  .b-big { grid-column: span 6; }
+  .b-wide { grid-column: span 6; }
+  .b-tall { grid-column: span 6; grid-row: span 1; }
+  .b:not(.b-big):not(.b-wide):not(.b-tall) { grid-column: span 3; }
+}
+@media (max-width: 700px) {
+  .bento, .bento { grid-template-columns: 1fr; }
+  .b, .b-big, .b-wide, .b-tall { grid-column: span 1; }
+  .b:not(.b-big):not(.b-wide):not(.b-tall) { grid-column: span 1; }
+  .funnel .step { grid-template-columns: 1fr auto; }
+  .funnel .step .bar { grid-column: 1 / -1; }
+  .nav { grid-template-columns: auto auto; flex-wrap: wrap; }
+  .nav .env { grid-column: 1 / -1; }
+}

--- a/examples/velocity-board/static/favicon.svg
+++ b/examples/velocity-board/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#0a0e1a"/>
+  <rect x="6" y="6" width="8" height="8" rx="2" fill="#4d8eff"/>
+  <rect x="18" y="6" width="8" height="8" rx="2" fill="#c4f154"/>
+  <rect x="6" y="18" width="8" height="8" rx="2" fill="#2dd4a4"/>
+  <rect x="18" y="18" width="8" height="8" rx="2" fill="#ebeefc"/>
+</svg>

--- a/examples/velocity-board/templates/404.html
+++ b/examples/velocity-board/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">404 — no event matched</h1>
+    <p class="page-desc">That URL did not resolve. Try the overview.</p>
+    <p><a href="{{ base_url }}/" class="cta">Back to overview</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/velocity-board/templates/footer.html
+++ b/examples/velocity-board/templates/footer.html
@@ -1,0 +1,20 @@
+    <footer class="foot">
+      <div>
+        <strong>{{ site.title }}</strong>
+        Product analytics for a team that ships every week. Built with Hwaro on Crystal.
+      </div>
+      <div>
+        <strong>Sections</strong>
+        <a href="{{ base_url }}/">Overview</a> ·
+        <a href="{{ base_url }}/changelog/">Changelog</a> ·
+        <a href="{{ base_url }}/about/">About</a>
+      </div>
+      <div>
+        <strong>Build · {{ current_year }}</strong>
+        Last sync {{ current_date }} · board v3.0
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/velocity-board/templates/header.html
+++ b/examples/velocity-board/templates/header.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="page">
+    <header class="nav">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="logo">
+          <i class="d1"></i><i class="d2"></i><i class="d3"></i><i class="d4"></i>
+        </span>
+        <span class="wm"><b>Velocity</b> Board</span>
+      </a>
+      <div class="env">
+        <span class="env-dot"></span>
+        <span class="env-text">production · prod-1a · {{ current_date }}</span>
+      </div>
+      <nav class="nav-links">
+        <a href="{{ base_url }}/">Overview</a>
+        <a href="{{ base_url }}/changelog/">Changelog</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/examples/velocity-board/templates/home.html
+++ b/examples/velocity-board/templates/home.html
@@ -1,0 +1,182 @@
+{% include "header.html" %}
+  <main>
+    <section class="hero">
+      <div class="hero-text">
+        <span class="eyebrow">Week 21 · close of {{ current_date }}</span>
+        <h1>Four numbers,<br>one screen,<br>no negotiation.</h1>
+        <p>Velocity Board collects every event we record, lands it in the warehouse overnight, and renders it back as four numbers and a small set of supporting panels. The four numbers are the only ones we promise to look at every Monday.</p>
+        <div class="hero-pills">
+          <span class="pill on">events pipeline: live</span>
+          <span class="pill">last warehouse run · 04:11 UTC</span>
+        </div>
+      </div>
+      <div class="hero-art">
+        <svg viewBox="0 0 280 200" preserveAspectRatio="none" aria-hidden="true">
+          <defs>
+            <pattern id="g" width="14" height="14" patternUnits="userSpaceOnUse">
+              <rect width="14" height="14" fill="none"/>
+              <circle cx="7" cy="7" r="1" fill="#1f2638"/>
+            </pattern>
+          </defs>
+          <rect width="280" height="200" fill="url(#g)"/>
+          <polyline fill="none" stroke="#4d8eff" stroke-width="3"
+            points="0,160 24,158 48,150 72,148 96,138 120,132 144,118 168,102 192,86 216,72 240,52 264,40 280,28"/>
+          <polyline fill="none" stroke="#c4f154" stroke-width="2" stroke-dasharray="3 4"
+            points="0,170 24,168 48,164 72,158 96,150 120,142 144,134 168,126 192,116 216,108 240,98 264,90 280,84"/>
+        </svg>
+      </div>
+    </section>
+
+    <section class="bento">
+      <article class="b b-big">
+        <header class="b-head">
+          <span class="b-tag">North star</span>
+          <h3>Weekly active accounts</h3>
+        </header>
+        <div class="b-val">24,118</div>
+        <div class="b-delta up">+ 3.4% week-over-week · + 21% quarter-over-quarter</div>
+        <div class="bento-spark">
+          <svg viewBox="0 0 320 80" preserveAspectRatio="none" aria-hidden="true">
+            <polyline fill="none" stroke="#4d8eff" stroke-width="2.5"
+              points="0,64 32,60 64,58 96,52 128,48 160,42 192,38 224,36 256,30 288,26 320,18"/>
+            <g fill="#4d8eff">
+              <circle cx="0" cy="64" r="2.5"/>
+              <circle cx="64" cy="58" r="2.5"/>
+              <circle cx="128" cy="48" r="2.5"/>
+              <circle cx="192" cy="38" r="2.5"/>
+              <circle cx="256" cy="30" r="2.5"/>
+              <circle cx="320" cy="18" r="3"/>
+            </g>
+          </svg>
+        </div>
+        <div class="bento-axis"><span>W14</span><span>W16</span><span>W18</span><span>W20</span><span>W21</span></div>
+      </article>
+
+      <article class="b">
+        <header class="b-head">
+          <span class="b-tag tag-2">Retention</span>
+          <h3>Week-over-week</h3>
+        </header>
+        <div class="b-val">68.4<small>%</small></div>
+        <div class="b-delta up">+ 0.8 pt</div>
+        <div class="bento-bars">
+          <span style="--h:54%"></span>
+          <span style="--h:60%"></span>
+          <span style="--h:62%"></span>
+          <span style="--h:64%"></span>
+          <span style="--h:66%"></span>
+          <span class="hi" style="--h:72%"></span>
+        </div>
+      </article>
+
+      <article class="b">
+        <header class="b-head">
+          <span class="b-tag tag-3">Activation</span>
+          <h3>Time to first value</h3>
+        </header>
+        <div class="b-val">22<small>min</small></div>
+        <div class="b-delta dn">− 16 min vs. last quarter</div>
+        <div class="ttfv">
+          <div class="bin"><i style="--h:14%"></i></div>
+          <div class="bin"><i style="--h:46%"></i></div>
+          <div class="bin"><i style="--h:84%" class="hi"></i></div>
+          <div class="bin"><i style="--h:62%"></i></div>
+          <div class="bin"><i style="--h:38%"></i></div>
+          <div class="bin"><i style="--h:22%"></i></div>
+        </div>
+        <div class="ttfv-axis"><span>0</span><span>15</span><span>30</span><span>45</span><span>60</span><span>90+</span></div>
+      </article>
+
+      <article class="b">
+        <header class="b-head">
+          <span class="b-tag tag-4">Reliability</span>
+          <h3>Hard errors / 1k events</h3>
+        </header>
+        <div class="b-val">0.34</div>
+        <div class="b-delta dn">below the 0.40 floor for 21 days</div>
+        <div class="err-line">
+          <svg viewBox="0 0 200 60" preserveAspectRatio="none" aria-hidden="true">
+            <line x1="0" y1="38" x2="200" y2="38" stroke="#1f2638" stroke-dasharray="3 3"/>
+            <polyline fill="none" stroke="#2dd4a4" stroke-width="2"
+              points="0,28 16,32 32,30 48,34 64,28 80,32 96,28 112,30 128,26 144,32 160,28 176,30 192,26 200,28"/>
+          </svg>
+        </div>
+      </article>
+
+      <article class="b b-wide">
+        <header class="b-head">
+          <span class="b-tag">Funnel</span>
+          <h3>Sign-up to first paid event · last 14 days</h3>
+        </header>
+        <div class="funnel">
+          <div class="step"><b>Sign up</b><span>3,841</span><i class="bar" style="--w:100%"></i></div>
+          <div class="step"><b>Verify email</b><span>3,228</span><i class="bar" style="--w:84%"></i></div>
+          <div class="step"><b>Onboarding done</b><span>2,612</span><i class="bar" style="--w:68%"></i></div>
+          <div class="step"><b>First project</b><span>2,084</span><i class="bar" style="--w:54%"></i></div>
+          <div class="step"><b>First paid event</b><span>1,442</span><i class="bar hi" style="--w:38%"></i></div>
+        </div>
+      </article>
+
+      <article class="b">
+        <header class="b-head">
+          <span class="b-tag tag-2">Surfaces</span>
+          <h3>Active accounts by surface</h3>
+        </header>
+        <ul class="surfaces">
+          <li><span class="name">Web app</span><span class="num">17,802</span><i style="--w:74%"></i></li>
+          <li><span class="name">CLI</span><span class="num">4,118</span><i style="--w:21%"></i></li>
+          <li><span class="name">Mobile</span><span class="num">1,884</span><i style="--w:9%"></i></li>
+          <li><span class="name">Public API</span><span class="num">3,420</span><i style="--w:18%"></i></li>
+        </ul>
+      </article>
+
+      <article class="b b-tall">
+        <header class="b-head">
+          <span class="b-tag tag-3">Cohort</span>
+          <h3>Six-week retention cohort</h3>
+        </header>
+        <div class="cohort">
+          <div class="row"><span class="lbl">W16</span>
+            <i class="c c5"></i><i class="c c4"></i><i class="c c4"></i><i class="c c3"></i><i class="c c3"></i><i class="c c2"></i>
+          </div>
+          <div class="row"><span class="lbl">W17</span>
+            <i class="c c5"></i><i class="c c5"></i><i class="c c4"></i><i class="c c3"></i><i class="c c3"></i><i></i>
+          </div>
+          <div class="row"><span class="lbl">W18</span>
+            <i class="c c5"></i><i class="c c5"></i><i class="c c4"></i><i class="c c4"></i><i></i><i></i>
+          </div>
+          <div class="row"><span class="lbl">W19</span>
+            <i class="c c5"></i><i class="c c5"></i><i class="c c5"></i><i></i><i></i><i></i>
+          </div>
+          <div class="row"><span class="lbl">W20</span>
+            <i class="c c5"></i><i class="c c5"></i><i></i><i></i><i></i><i></i>
+          </div>
+          <div class="row"><span class="lbl">W21</span>
+            <i class="c c5"></i><i></i><i></i><i></i><i></i><i></i>
+          </div>
+          <div class="row legend">
+            <span></span><span>W+0</span><span>W+1</span><span>W+2</span><span>W+3</span><span>W+4</span><span>W+5</span>
+          </div>
+        </div>
+      </article>
+
+      <article class="b b-wide">
+        <header class="b-head">
+          <span class="b-tag tag-4">Changelog</span>
+          <h3>What shipped this month</h3>
+        </header>
+        <ul class="ship-list">
+          {% for post in site.pages | where("section", "changelog") | sort_by("date", reverse=true) %}
+            {% if loop.index <= 4 %}
+            <li>
+              <span class="dot"></span>
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              <time>{{ post.date | date("%b %d") }}</time>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </article>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/velocity-board/templates/page.html
+++ b/examples/velocity-board/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.date %}<div class="page-date">{{ page.date | date("%b %d · %Y") }}</div>{% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/velocity-board/templates/section.html
+++ b/examples/velocity-board/templates/section.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main>
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    {{ content }}
+    <ul class="ship-list big">
+      {% for post in section.pages %}
+        <li>
+          <span class="dot"></span>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          <time>{{ post.date | date("%b %d · %Y") }}</time>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/velocity-board/templates/shortcodes/alert.html
+++ b/examples/velocity-board/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert" data-type="{{ type | default('info') }}">
+  <strong>{{ type | default('note') | upper }}</strong>
+  <span>{{ body }}</span>
+</div>

--- a/examples/velocity-board/templates/taxonomy.html
+++ b/examples/velocity-board/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Browse all terms in this taxonomy.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/velocity-board/templates/taxonomy_term.html
+++ b/examples/velocity-board/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Posts tagged with this term.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,124 +1,4 @@
 {
-  "kepler-grid": [
-    "dark",
-    "dashboard",
-    "minimal"
-  ],
-  "vexel-ops": [
-    "light",
-    "dashboard",
-    "editorial"
-  ],
-  "prism-stack": [
-    "light",
-    "dashboard",
-    "minimal"
-  ],
-  "monolith-analytics": [
-    "dark",
-    "dashboard",
-    "editorial"
-  ],
-  "stratum-bi": [
-    "light",
-    "dashboard",
-    "minimal"
-  ],
-  "obsidian-press": [
-    "dark",
-    "blog",
-    "editorial"
-  ],
-  "luminal": [
-    "light",
-    "landing",
-    "minimal"
-  ],
-  "terra-folio": [
-    "light",
-    "portfolio",
-    "minimal"
-  ],
-  "vector-os": [
-    "dark",
-    "docs",
-    "sidebar"
-  ],
-  "slate-journal": [
-    "light",
-    "blog",
-    "editorial",
-    "minimal"
-  ],
-  "cement-type": [
-    "light",
-    "blog",
-    "brutalist",
-    "minimal"
-  ],
-  "dusk-portal": [
-    "dark",
-    "portfolio",
-    "sci-fi"
-  ],
-  "acid-zine": [
-    "dark",
-    "blog",
-    "zine",
-    "punk"
-  ],
-  "signal-white": [
-    "light",
-    "blog",
-    "minimal",
-    "swiss"
-  ],
-  "noir-dispatch": [
-    "dark",
-    "blog",
-    "editorial",
-    "retro"
-  ],
-  "marble-haus": [
-    "light",
-    "portfolio",
-    "minimal",
-    "elegant"
-  ],
-  "volt-terminal": [
-    "dark",
-    "blog",
-    "terminal",
-    "retro"
-  ],
-  "ink-press": [
-    "light",
-    "blog",
-    "editorial"
-  ],
-  "chrome-folio": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
-  "obsidian-grid": [
-    "dark",
-    "blog",
-    "minimal",
-    "grid"
-  ],
-  "cosmic-glass-chronicles": [
-    "dark",
-    "portfolio",
-    "cyberpunk",
-    "minimal"
-  ],
-  "aura": [
-    "dark",
-    "glassmorphism",
-    "neon",
-    "ambient"
-  ],
   "abacus-ref": [
     "calculation",
     "logical",
@@ -146,6 +26,11 @@
     "deep-sea",
     "immersive"
   ],
+  "abyssal-cipher": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
   "accordion-fold": [
     "book",
     "light",
@@ -157,6 +42,12 @@
     "dark",
     "blog",
     "cyberpunk"
+  ],
+  "acid-zine": [
+    "dark",
+    "blog",
+    "zine",
+    "punk"
   ],
   "acme-docs": [
     "light",
@@ -180,6 +71,12 @@
     "dashboard",
     "admin",
     "sidebar"
+  ],
+  "aegis-shield": [
+    "dark",
+    "landing",
+    "minimal",
+    "docs"
   ],
   "aether": [
     "dark",
@@ -383,6 +280,13 @@
     "landing",
     "minimal"
   ],
+  "apolo-luxe": [
+    "elegant",
+    "luxury",
+    "dark",
+    "serif",
+    "blog"
+  ],
   "apothecary": [
     "light",
     "blog",
@@ -517,6 +421,11 @@
     "glow",
     "portfolio"
   ],
+  "astral-resonance": [
+    "dark",
+    "elegant",
+    "blog"
+  ],
   "astral-symphony-glass": [
     "dark",
     "portfolio",
@@ -568,6 +477,17 @@
     "light",
     "navigation"
   ],
+  "atlas-pulse": [
+    "light",
+    "dashboard",
+    "editorial"
+  ],
+  "aura": [
+    "dark",
+    "glassmorphism",
+    "neon",
+    "ambient"
+  ],
   "aurelia": [
     "elegant",
     "minimalist",
@@ -606,6 +526,11 @@
     "dark",
     "animation"
   ],
+  "aurora-nebula-vanguard": [
+    "dark",
+    "sci-fi",
+    "glassmorphism"
+  ],
   "aurum": [
     "elegant",
     "dark",
@@ -638,6 +563,11 @@
     "design-system",
     "geometric",
     "mathematical"
+  ],
+  "axiom-grid": [
+    "light",
+    "docs",
+    "bauhaus"
   ],
   "axiom-ref": [
     "formal",
@@ -1299,6 +1229,21 @@
     "cosmic",
     "portfolio"
   ],
+  "celestial-weaver": [
+    "celestial",
+    "weaver",
+    "loom",
+    "ethereal",
+    "dark",
+    "elegant",
+    "ui"
+  ],
+  "cement-type": [
+    "light",
+    "blog",
+    "brutalist",
+    "minimal"
+  ],
   "center-stage": [
     "event",
     "solo",
@@ -1461,6 +1406,14 @@
     "chromatic",
     "portfolio"
   ],
+  "chromatic-veil": [
+    "glassmorphism",
+    "gradient",
+    "vibrant",
+    "portfolio",
+    "creative",
+    "dark-mode"
+  ],
   "chromatic-wave": [
     "dark",
     "portfolio",
@@ -1477,6 +1430,11 @@
     "bold",
     "minimal",
     "creative"
+  ],
+  "chrome-folio": [
+    "dark",
+    "portfolio",
+    "minimal"
   ],
   "chrome-pulse": [
     "minimal",
@@ -1507,6 +1465,12 @@
     "dark",
     "steampunk",
     "retro-futuristic"
+  ],
+  "chronos-flux": [
+    "dark",
+    "blog",
+    "elegant",
+    "cyberpunk"
   ],
   "chronos-forge": [
     "dark",
@@ -1672,6 +1636,12 @@
     "medieval",
     "illuminated",
     "luxurious"
+  ],
+  "codex-mono": [
+    "light",
+    "docs",
+    "minimal",
+    "sidebar"
   ],
   "codex-noir": [
     "archival",
@@ -1895,6 +1865,12 @@
     "errata",
     "formal"
   ],
+  "cosmic-glass-chronicles": [
+    "dark",
+    "portfolio",
+    "cyberpunk",
+    "minimal"
+  ],
   "cosmic-wave": [
     "cyberpunk",
     "dark",
@@ -1947,6 +1923,13 @@
     "glassmorphism",
     "crimson",
     "blog"
+  ],
+  "crimson-void-nexus": [
+    "dark",
+    "glassmorphism",
+    "crimson",
+    "void",
+    "elegant"
   ],
   "cross-sectional": [
     "paper",
@@ -2076,10 +2059,22 @@
     "nature",
     "digital"
   ],
+  "cyber-glade": [
+    "dark",
+    "neon",
+    "cyber",
+    "retro"
+  ],
   "cyber-glass": [
     "blog",
     "cyberpunk",
     "glassmorphism"
+  ],
+  "cyber-neo": [
+    "dark",
+    "cyberpunk",
+    "portfolio",
+    "neon"
   ],
   "cyber-prism": [
     "cyberpunk",
@@ -2402,6 +2397,11 @@
     "blog",
     "sunset"
   ],
+  "dusk-portal": [
+    "dark",
+    "portfolio",
+    "sci-fi"
+  ],
   "dust-jacket": [
     "book",
     "light",
@@ -2458,6 +2458,12 @@
     "blog",
     "metallic",
     "plating"
+  ],
+  "elegance-aura": [
+    "dark",
+    "blog",
+    "portfolio",
+    "elegant"
   ],
   "elevate": [
     "landing",
@@ -2607,12 +2613,37 @@
     "etching",
     "printmaking"
   ],
+  "ether-weave": [
+    "elegant",
+    "glassmorphism",
+    "portfolio"
+  ],
   "ethereal-canvas": [
     "blog",
     "dark",
     "elegant",
     "minimal",
     "portfolio"
+  ],
+  "ethereal-geometric-vault": [
+    "dark",
+    "minimal",
+    "portfolio",
+    "editorial"
+  ],
+  "ethereal-loom": [
+    "ethereal",
+    "elegant",
+    "dark-mode",
+    "glassmorphism",
+    "weaving"
+  ],
+  "ethereal-plasma-glass": [
+    "dark",
+    "glassmorphism",
+    "plasma",
+    "portfolio",
+    "elegant"
   ],
   "ethereal-shimmer": [
     "dark",
@@ -2916,6 +2947,12 @@
     "generative",
     "mathematical"
   ],
+  "fractal-pulse": [
+    "dark",
+    "creative",
+    "glow",
+    "geometric"
+  ],
   "frequency": [
     "dark",
     "blog",
@@ -3092,6 +3129,11 @@
     "light",
     "landing",
     "geometric"
+  ],
+  "geometric-aether-lattice": [
+    "dark",
+    "minimal",
+    "blog"
   ],
   "gilded": [
     "dark",
@@ -3463,6 +3505,11 @@
     "warm",
     "serif"
   ],
+  "harbor-metrics": [
+    "light",
+    "dashboard",
+    "editorial"
+  ],
   "hardcore-pit": [
     "event",
     "punk",
@@ -3570,6 +3617,13 @@
     "stark",
     "modern",
     "jakarta"
+  ],
+  "holo-vista": [
+    "dark",
+    "glassmorphism",
+    "neon",
+    "cyberpunk",
+    "holographic"
   ],
   "hologram": [
     "dark",
@@ -3758,6 +3812,11 @@
     "elegant",
     "serif"
   ],
+  "ink-press": [
+    "light",
+    "blog",
+    "editorial"
+  ],
   "ink-seoul": [
     "light",
     "blog",
@@ -3899,6 +3958,11 @@
     "bridge",
     "horizontal-scroll"
   ],
+  "ivory": [
+    "light",
+    "portfolio",
+    "minimal"
+  ],
   "jackhammer": [
     "heavy",
     "industrial",
@@ -3949,6 +4013,11 @@
     "event",
     "psychedelic",
     "pattern"
+  ],
+  "kepler-grid": [
+    "dark",
+    "dashboard",
+    "minimal"
   ],
   "ketubah": [
     "book",
@@ -4263,11 +4332,21 @@
     "minimal",
     "portfolio"
   ],
+  "lumen-grid": [
+    "dark",
+    "dashboard",
+    "minimal"
+  ],
   "lumiere": [
     "dark",
     "elegant",
     "minimal",
     "luminescent"
+  ],
+  "lumin-sphere": [
+    "dark",
+    "portfolio",
+    "cyberpunk"
   ],
   "lumina": [
     "dark",
@@ -4285,6 +4364,11 @@
     "elegant",
     "soft",
     "glassmorphism"
+  ],
+  "lumina-canvas": [
+    "elegant",
+    "gallery",
+    "dark-mode"
   ],
   "lumina-chroma": [
     "blog",
@@ -4322,6 +4406,11 @@
     "neon",
     "glow",
     "animation"
+  ],
+  "luminal": [
+    "light",
+    "landing",
+    "minimal"
   ],
   "luminal-glass": [
     "dark",
@@ -4416,6 +4505,12 @@
     "dark",
     "blog",
     "elegant",
+    "minimal"
+  ],
+  "lunar-monolith": [
+    "dark",
+    "elegant",
+    "monolith",
     "minimal"
   ],
   "lunar-tide": [
@@ -4543,6 +4638,12 @@
     "gallery",
     "luxury",
     "marble-texture"
+  ],
+  "marble-haus": [
+    "light",
+    "portfolio",
+    "minimal",
+    "elegant"
   ],
   "marble-slab": [
     "sophisticated",
@@ -4848,6 +4949,11 @@
     "gold",
     "trendy"
   ],
+  "mono-stack": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
   "monochrome": [
     "light",
     "photo-essay",
@@ -4865,6 +4971,11 @@
     "dark",
     "landing",
     "onepage"
+  ],
+  "monolith-analytics": [
+    "dark",
+    "dashboard",
+    "editorial"
   ],
   "monolith-blog": [
     "dark",
@@ -4911,6 +5022,13 @@
     "texture",
     "unity",
     "monospace"
+  ],
+  "moonlit-sakura": [
+    "moonlight",
+    "sakura",
+    "parallax",
+    "dark-mode",
+    "elegant"
   ],
   "moonrise": [
     "dark",
@@ -5049,6 +5167,12 @@
     "space",
     "ethereal"
   ],
+  "nebulous-enigma": [
+    "dark",
+    "cosmic",
+    "glassmorphism",
+    "portfolio"
+  ],
   "nebulous-void-glass": [
     "dark",
     "portfolio",
@@ -5140,11 +5264,31 @@
     "dark",
     "grid"
   ],
+  "neon-blossom": [
+    "cyberpunk",
+    "neon",
+    "dark-mode",
+    "elegant",
+    "creative"
+  ],
   "neon-cipher": [
     "blog",
     "cyberpunk",
     "dark",
     "minimal"
+  ],
+  "neon-crystal-forge": [
+    "neon",
+    "crystal",
+    "dark-mode",
+    "glassmorphism",
+    "portfolio",
+    "creative"
+  ],
+  "neon-drift": [
+    "cyberpunk",
+    "neon",
+    "dark"
   ],
   "neon-dusk": [
     "dark",
@@ -5314,6 +5458,11 @@
     "blog",
     "minimal"
   ],
+  "nimbus-cortex": [
+    "dark",
+    "dashboard",
+    "cyberpunk"
+  ],
   "no-style-please": [
     "light",
     "blog",
@@ -5325,6 +5474,11 @@
     "glassmorphism",
     "neon"
   ],
+  "noctura": [
+    "dark",
+    "portfolio",
+    "landing"
+  ],
   "nocturne": [
     "dark",
     "blog",
@@ -5335,6 +5489,12 @@
     "dark",
     "blog",
     "noir"
+  ],
+  "noir-dispatch": [
+    "dark",
+    "blog",
+    "editorial",
+    "retro"
   ],
   "noire-gazette": [
     "dark",
@@ -5421,6 +5581,13 @@
     "glass",
     "oled"
   ],
+  "obsidian-abyss": [
+    "dark",
+    "abyss",
+    "elegant",
+    "blog",
+    "obsidian"
+  ],
   "obsidian-docs": [
     "docs",
     "dark",
@@ -5451,6 +5618,17 @@
     "glow",
     "portfolio",
     "glassmorphism"
+  ],
+  "obsidian-grid": [
+    "dark",
+    "blog",
+    "minimal",
+    "grid"
+  ],
+  "obsidian-press": [
+    "dark",
+    "blog",
+    "editorial"
   ],
   "obsidian-whisper": [
     "dark",
@@ -6115,11 +6293,40 @@
     "translucency",
     "outfit"
   ],
+  "prism-grid": [
+    "light",
+    "blog",
+    "editorial",
+    "brutalist"
+  ],
   "prism-pulse": [
     "dark",
     "neon",
     "pulsing",
     "creative"
+  ],
+  "prism-shift": [
+    "dark",
+    "docs",
+    "cyberpunk",
+    "sidebar"
+  ],
+  "prism-stack": [
+    "light",
+    "dashboard",
+    "minimal"
+  ],
+  "prism-tesserae": [
+    "portfolio",
+    "glassmorphism",
+    "dark"
+  ],
+  "prism-wave": [
+    "design",
+    "glassmorphism",
+    "vibrant",
+    "prism",
+    "wave"
   ],
   "prismatic-void": [
     "dark",
@@ -6669,6 +6876,12 @@
     "viking",
     "mystic"
   ],
+  "rune-archive": [
+    "dark",
+    "docs",
+    "editorial",
+    "sidebar"
+  ],
   "rupture": [
     "broken-grid",
     "dark",
@@ -6907,6 +7120,24 @@
     "immersive",
     "jakarta"
   ],
+  "signal-white": [
+    "light",
+    "blog",
+    "minimal",
+    "swiss"
+  ],
+  "silent-obelisk": [
+    "dark",
+    "minimal",
+    "brutalist",
+    "architecture"
+  ],
+  "silent-tide": [
+    "dark",
+    "minimal",
+    "portfolio",
+    "blog"
+  ],
   "silhouette": [
     "dark",
     "landing",
@@ -6964,6 +7195,12 @@
     "blog",
     "skeuomorphic",
     "realistic"
+  ],
+  "slate-journal": [
+    "light",
+    "blog",
+    "editorial",
+    "minimal"
   ],
   "slate-tile": [
     "dark",
@@ -7143,6 +7380,13 @@
     "seasonal",
     "time-based"
   ],
+  "solstice-aurora-glass": [
+    "dark",
+    "glassmorphism",
+    "portfolio",
+    "creative",
+    "elegant"
+  ],
   "sonar": [
     "dark",
     "hub",
@@ -7273,6 +7517,17 @@
     "portfolio",
     "elegant",
     "minimal"
+  ],
+  "starlight-nebula": [
+    "dark",
+    "blog",
+    "sci-fi"
+  ],
+  "starlight-sonata": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "cosmic"
   ],
   "starlight-synth-glass": [
     "dark",
@@ -7406,6 +7661,18 @@
     "timeline",
     "geological",
     "layered"
+  ],
+  "stratum-bi": [
+    "light",
+    "dashboard",
+    "minimal"
+  ],
+  "stratum-docs": [
+    "light",
+    "docs",
+    "minimal",
+    "swiss",
+    "sidebar"
   ],
   "strobe": [
     "dark",
@@ -7674,6 +7941,11 @@
     "stark",
     "docs",
     "jakarta"
+  ],
+  "terra-folio": [
+    "light",
+    "portfolio",
+    "minimal"
   ],
   "terrace": [
     "light",
@@ -8056,20 +8328,51 @@
     "industrial",
     "jakarta"
   ],
+  "vector-os": [
+    "dark",
+    "docs",
+    "sidebar"
+  ],
   "vellum": [
     "light",
     "blog",
     "editorial"
+  ],
+  "vellum-press": [
+    "light",
+    "docs",
+    "editorial",
+    "traditional"
   ],
   "velocity": [
     "landing",
     "dark",
     "saas"
   ],
+  "velocity-board": [
+    "dark",
+    "dashboard",
+    "minimal"
+  ],
+  "velour": [
+    "light",
+    "blog",
+    "minimal",
+    "editorial"
+  ],
   "velvet": [
     "dark",
     "landing",
     "luxury"
+  ],
+  "velvet-cyber-lotus": [
+    "velvet",
+    "cyber",
+    "lotus",
+    "pink",
+    "dark",
+    "neon",
+    "futuristic"
   ],
   "velvet-rope": [
     "event",
@@ -8119,6 +8422,11 @@
     "one-page",
     "experimental",
     "perspective"
+  ],
+  "vexel-ops": [
+    "light",
+    "dashboard",
+    "editorial"
   ],
   "vibrant-brutalism": [
     "dark",
@@ -8191,6 +8499,12 @@
     "dark",
     "portfolio",
     "cyberpunk"
+  ],
+  "volt-terminal": [
+    "dark",
+    "blog",
+    "terminal",
+    "retro"
   ],
   "voltage": [
     "dark",
@@ -8390,6 +8704,20 @@
     "x-ray",
     "transparent"
   ],
+  "xeno-crystal-echo": [
+    "dark",
+    "neon",
+    "glassmorphism",
+    "cyberpunk",
+    "elegant"
+  ],
+  "xeno-vortex": [
+    "dark",
+    "glassmorphism",
+    "futuristic",
+    "neon",
+    "elegant"
+  ],
   "xerograph": [
     "dark",
     "blog",
@@ -8401,6 +8729,17 @@
     "cyber",
     "metallic",
     "retro"
+  ],
+  "z-mystic-nova": [
+    "mystic",
+    "nova",
+    "dark"
+  ],
+  "z-mystic-nova-plus": [
+    "mystic",
+    "dark",
+    "neon",
+    "elegant"
   ],
   "zen": [
     "light",
@@ -8445,325 +8784,11 @@
     "raw",
     "unconventional"
   ],
-  "chromatic-veil": [
-    "glassmorphism",
-    "gradient",
-    "vibrant",
-    "portfolio",
-    "creative",
-    "dark-mode"
-  ],
-  "neon-crystal-forge": [
-    "neon",
-    "crystal",
-    "dark-mode",
-    "glassmorphism",
-    "portfolio",
-    "creative"
-  ],
-  "neon-blossom": [
-    "cyberpunk",
-    "neon",
-    "dark-mode",
-    "elegant",
-    "creative"
-  ],
-  "ethereal-loom": [
-    "ethereal",
-    "elegant",
-    "dark-mode",
-    "glassmorphism",
-    "weaving"
-  ],
-  "moonlit-sakura": [
-    "moonlight",
-    "sakura",
-    "parallax",
-    "dark-mode",
-    "elegant"
-  ],
-  "cyber-neo": [
-    "dark",
-    "cyberpunk",
-    "portfolio",
-    "neon"
-  ],
-  "lumin-sphere": [
-    "dark",
-    "portfolio",
-    "cyberpunk"
-  ],
-  "celestial-weaver": [
-    "celestial",
-    "weaver",
-    "loom",
-    "ethereal",
-    "dark",
-    "elegant",
-    "ui"
-  ],
-  "prism-wave": [
-    "design",
-    "glassmorphism",
-    "vibrant",
-    "prism",
-    "wave"
-  ],
-  "z-mystic-nova": [
-    "mystic",
-    "nova",
-    "dark"
-  ],
-  "astral-resonance": [
-    "dark",
-    "elegant",
-    "blog"
-  ],
-  "chronos-flux": [
-    "dark",
-    "blog",
-    "elegant",
-    "cyberpunk"
-  ],
-  "holo-vista": [
-    "dark",
-    "glassmorphism",
-    "neon",
-    "cyberpunk",
-    "holographic"
-  ],
-  "lumina-canvas": [
-    "elegant",
-    "gallery",
-    "dark-mode"
-  ],
-  "obsidian-abyss": [
-    "dark",
-    "abyss",
-    "elegant",
-    "blog",
-    "obsidian"
-  ],
-  "ether-weave": [
-    "elegant",
-    "glassmorphism",
-    "portfolio"
-  ],
-  "xeno-crystal-echo": [
-    "dark",
-    "neon",
-    "glassmorphism",
-    "cyberpunk",
-    "elegant"
-  ],
-  "velvet-cyber-lotus": [
-    "velvet",
-    "cyber",
-    "lotus",
-    "pink",
-    "dark",
-    "neon",
-    "futuristic"
-  ],
-  "xeno-vortex": [
-    "dark",
-    "glassmorphism",
-    "futuristic",
-    "neon",
-    "elegant"
-  ],
   "zircon-matrix-ui": [
     "dark",
     "portfolio",
     "glassmorphism",
     "elegant",
     "cyberpunk"
-  ],
-  "cyber-glade": [
-    "dark",
-    "neon",
-    "cyber",
-    "retro"
-  ],
-  "crimson-void-nexus": [
-    "dark",
-    "glassmorphism",
-    "crimson",
-    "void",
-    "elegant"
-  ],
-  "ethereal-plasma-glass": [
-    "dark",
-    "glassmorphism",
-    "plasma",
-    "portfolio",
-    "elegant"
-  ],
-  "z-mystic-nova-plus": [
-    "mystic",
-    "dark",
-    "neon",
-    "elegant"
-  ],
-  "solstice-aurora-glass": [
-    "dark",
-    "glassmorphism",
-    "portfolio",
-    "creative",
-    "elegant"
-  ],
-  "apolo-luxe": [
-    "elegant",
-    "luxury",
-    "dark",
-    "serif",
-    "blog"
-  ],
-  "prism-tesserae": [
-    "portfolio",
-    "glassmorphism",
-    "dark"
-  ],
-  "starlight-nebula": [
-    "dark",
-    "blog",
-    "sci-fi"
-  ],
-  "fractal-pulse": [
-    "dark",
-    "creative",
-    "glow",
-    "geometric"
-  ],
-  "nebulous-enigma": [
-    "dark",
-    "cosmic",
-    "glassmorphism",
-    "portfolio"
-  ],
-  "starlight-sonata": [
-    "dark",
-    "portfolio",
-    "elegant",
-    "cosmic"
-  ],
-  "neon-drift": [
-    "cyberpunk",
-    "neon",
-    "dark"
-  ],
-  "ivory": [
-    "light",
-    "portfolio",
-    "minimal"
-  ],
-  "aurora-nebula-vanguard": [
-    "dark",
-    "sci-fi",
-    "glassmorphism"
-  ],
-  "elegance-aura": [
-    "dark",
-    "blog",
-    "portfolio",
-    "elegant"
-  ],
-  "geometric-aether-lattice": [
-    "dark",
-    "minimal",
-    "blog"
-  ],
-  "silent-tide": [
-    "dark",
-    "minimal",
-    "portfolio",
-    "blog"
-  ],
-  "ethereal-geometric-vault": [
-    "dark",
-    "minimal",
-    "portfolio",
-    "editorial"
-  ],
-  "aegis-shield": [
-    "dark",
-    "landing",
-    "minimal",
-    "docs"
-  ],
-  "lunar-monolith": [
-    "dark",
-    "elegant",
-    "monolith",
-    "minimal"
-  ],
-  "silent-obelisk": [
-    "dark",
-    "minimal",
-    "brutalist",
-    "architecture"
-  ],
-  "abyssal-cipher": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
-  "prism-grid": [
-    "light",
-    "blog",
-    "editorial",
-    "brutalist"
-  ],
-  "mono-stack": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
-  "velour": [
-    "light",
-    "blog",
-    "minimal",
-    "editorial"
-  ],
-  "axiom-grid": [
-    "light",
-    "docs",
-    "bauhaus"
-  ],
-  "noctura": [
-    "dark",
-    "portfolio",
-    "landing"
-  ],
-  "codex-mono": [
-    "light",
-    "docs",
-    "minimal",
-    "sidebar"
-  ],
-  "rune-archive": [
-    "dark",
-    "docs",
-    "editorial",
-    "sidebar"
-  ],
-  "stratum-docs": [
-    "light",
-    "docs",
-    "minimal",
-    "swiss",
-    "sidebar"
-  ],
-  "prism-shift": [
-    "dark",
-    "docs",
-    "cyberpunk",
-    "sidebar"
-  ],
-  "vellum-press": [
-    "light",
-    "docs",
-    "editorial",
-    "traditional"
   ]
 }


### PR DESCRIPTION
## Summary

Adds five new dashboard-tagged examples, each exploring a distinct modern aesthetic. No gradients, no emojis.

- **lumen-grid** — dark NOC/SRE edge-observability console. Lime green on charcoal, dense panels with KPIs, region health, anomaly ring, live request log, and an 82-site fleet map.
- **harbor-metrics** — light Swiss-modernist terminal operations board. Cream + black + cherry red, berth occupancy bars, crane-cycle list, 16×4 yard density grid, anchor queue, draft-margin cells.
- **velocity-board** — dark Bento-grid product analytics. Deep navy + electric blue with lime/teal supports, North Star, retention, TTFV histogram, error-rate sparkline, funnel, and a six-week cohort heatmap.
- **atlas-pulse** — light editorial monthly portfolio review. Bone + deep olive, Source Serif headlines with JetBrains Mono numerals, cover-page stat stack, 12-month returns bar, exposure ledger, contributors/detractors, essay list.
- **nimbus-cortex** — dark ML training cluster console. IBM Plex Mono terminal aesthetic with cyan/magenta accents, lede + cluster strip, loss curve, 72-cell GPU map, MFU ring, queue, power chart, and a 16-line cluster log tail.

Each site is fully content-populated (homepage console + about/manual + four section posts) and registered in `tags.json` with `dashboard` plus theme tags. All sites build cleanly (7 pages each) via `hwaro build`.

## Test plan

- [x] \`hwaro doctor --fix\` and \`hwaro build\` clean on all five sites
- [x] \`grep gradient\` returns nothing across new CSS/templates
- [x] \`grep\` for emoji-style characters returns nothing in new content
- [x] tags.json keys preserved alphabetical, five new entries added
- [ ] CI deploy renders index page with five new screenshots