### PR TITLE
Add five modern gallery example sites

### DIFF
--- a/examples/carbon-folio/AGENTS.md
+++ b/examples/carbon-folio/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md — Carbon Folio
+
+Dark bold-display gallery (gallery type). Carbon-black + ember accent.
+Sora display + Inter body + JetBrains Mono UI. Cards alternate 7-/5-column
+widths in a 12-col deck; each card carries a stamped CF-id badge and an
+inline SVG plate.
+
+Per-work `page.extra` fields: `studio`, `discipline`, `year`, `cycle`,
+`material`, `client`, `cf_id`.
+
+## Conventions
+
+- No gradients, no emojis. Single accent: `--accent: #ff5a1f` (ember).
+- All CSS in `static/css/style.css`. Use `{{ base_url }}` for assets.
+
+## Hwaro
+
+| Command | Description |
+|---|---|
+| `hwaro build` | Build to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro tool doctor --fix` | Validate/patch config |
+
+Full reference: <https://hwaro.hahwul.com>

--- a/examples/carbon-folio/archetypes/default.md
+++ b/examples/carbon-folio/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/carbon-folio/config.toml
+++ b/examples/carbon-folio/config.toml
@@ -1,0 +1,45 @@
+title = "Carbon Folio"
+description = "A bold dark folio for industrial design, object photography, and prototype documentation."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/carbon-folio/config.toml
+++ b/examples/carbon-folio/config.toml
@@ -43,3 +43,155 @@ footnotes = true
 
 [doctor]
 ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/carbon-folio/content/index.md
+++ b/examples/carbon-folio/content/index.md
@@ -1,0 +1,14 @@
++++
+title = "Carbon Folio"
+description = "A bold dark folio for industrial design, object photography, and prototype documentation."
+template = "home"
++++
+
+Carbon Folio is a working portfolio for objects, prototypes, and small-run
+industrial work. We publish pieces only after the prototype has been handled by
+someone who is not on the design team — the work has to survive contact with a
+real user before it earns a card on this page.
+
+Pieces are dropped on a twelve-week cycle. The folio is rebuilt at the start of
+each season; entries that have not survived their cycle are removed. We do not
+maintain an archive of failed prototypes here.

--- a/examples/carbon-folio/content/works/01-bench-press.md
+++ b/examples/carbon-folio/content/works/01-bench-press.md
@@ -1,0 +1,39 @@
++++
+title = "Bench Press, model 04"
+description = "A stripped-down arbour press for studio bookbinding, milled from a single block of grey cast iron and finished by hand."
+date = "2026-02-10"
+weight = 1
+tags = ["industrial", "bookbinding", "metal"]
+[extra]
+studio = "Hala 5 / in-house"
+discipline = "Industrial"
+year = "2026"
+cycle = "Q1"
+material = "Grey cast iron, oiled"
+client = "Studio prototype"
+cf_id = "CF-01 / BENCH-PRESS-04"
++++
+
+Model 04 of the bench press is the first to drop the screw stop. The user now
+applies their own travel limit by sliding a brass pin into one of seven holes
+in the side plate. The press is heavy on purpose; it does not need to be
+clamped to the bench in normal use.
+
+## Spec
+
+- Frame: grey cast iron, machined from a single 38 kg blank.
+- Handle: 22 mm bar stock, wax-finished.
+- Travel: 0 to 64 mm.
+- Mass: 31.4 kg.
+
+The throat is 110 mm; this fits all standard bookblock formats up to A4
+landscape. The base footprint is 220 × 180 mm; the press is intended to sit on
+the corner of a working bench, not on a dedicated stand.
+
+> "We removed the stop because the studio kept removing the stop." — *Hala 5*
+
+### What changed in 04
+
+The screw stop is gone, the handle is shorter by 30 mm, and the foot is now
+oiled rather than painted. The painted feet on models 01–03 chipped within the
+first month of any studio's use; the oiled finish is duller and lasts.

--- a/examples/carbon-folio/content/works/02-stool-no-3.md
+++ b/examples/carbon-folio/content/works/02-stool-no-3.md
@@ -1,0 +1,39 @@
++++
+title = "Stool, no. 3"
+description = "A stacking stool for working studios, three legs at uneven splay angles to take an uneven floor without rocking."
+date = "2026-02-24"
+weight = 2
+tags = ["furniture", "wood", "studio"]
+[extra]
+studio = "Bruk · Karlskrona"
+discipline = "Furniture"
+year = "2025"
+cycle = "Q4 / 2025"
+material = "Solid ash, oil-finished"
+client = "Bruk Workshop"
+cf_id = "CF-02 / STOOL-03"
++++
+
+Stool no. 3 has three legs at three different splay angles. The angles were
+chosen by measuring the floor of the actual studio at Bruk over the course of
+four weeks; the stool rests on a section of the floor that pitches 1.4° to the
+north-east and is patched with epoxy in one place. The three legs each carry
+their own splay.
+
+## Spec
+
+- Seat: ash, 18 mm, dished by 6 mm at the centre.
+- Legs: ash, 28 mm round bar, three splay angles (4°, 6°, 11°).
+- Mass: 3.1 kg.
+- Stacking: yes, up to 6 high.
+
+The seat dish is shallow enough to feel like a flat seat at first sit, and
+deep enough that the stool finds the same position under a working back over
+the course of a long shift.
+
+> "The third leg is the bad floor. The good floor gets two legs." — *Bruk*
+
+### Production
+
+Made in batches of twelve at the Bruk workshop in Karlskrona. The next batch
+ships in May 2026; pre-orders close at the end of March.

--- a/examples/carbon-folio/content/works/03-rack-system.md
+++ b/examples/carbon-folio/content/works/03-rack-system.md
@@ -1,0 +1,39 @@
++++
+title = "Rack system, 1U / 6U"
+description = "A modular tool rack for studio walls, sized in 1U increments and bracketed against a vertical batten."
+date = "2026-03-09"
+weight = 3
+tags = ["industrial", "system", "studio"]
+[extra]
+studio = "Hala 5 / Common Goods"
+discipline = "Industrial"
+year = "2026"
+cycle = "Q1"
+material = "Powder-coated steel, oak insert"
+client = "Common Goods Co-op"
+cf_id = "CF-03 / RACK-1U6U"
++++
+
+The rack system addresses one frustration: every wall rack we have used has
+either been too coarse for hand tools or too fine for power tools. The 1U / 6U
+system is gauged so a 1U slot holds a single chisel and a 6U slot holds a
+cordless drill in its case. Anything in between is made up of 1U units.
+
+## Spec
+
+- Unit height: 64 mm (1U).
+- Bracket: 3 mm laser-cut steel, powder-coated graphite.
+- Insert: oak, 12 mm, removable.
+- Wall fixing: against a 22 × 90 mm vertical batten, screwed top and bottom.
+
+The bracket has no adjustment screws. The system is designed to be set once
+and re-batted, not re-tightened. The oak inserts are sized for friction fit
+and are replaced as a unit when the felt liner wears.
+
+> "If you would adjust it twice a year, we sized it wrong." — *Common Goods*
+
+### Drop scope
+
+The current drop is six 1U brackets, two 6U brackets, and one length of batten
+sized for a 2.4 m wall. Larger walls are scaled up by adding battens at 800 mm
+centres.

--- a/examples/carbon-folio/content/works/04-clamp-set.md
+++ b/examples/carbon-folio/content/works/04-clamp-set.md
@@ -1,0 +1,41 @@
++++
+title = "Clamp set, 04 sizes"
+description = "Four bench clamps cast from a single mould, sized by sleeve thickness rather than throat depth — every clamp fits every workpiece up to its weight rating."
+date = "2026-03-28"
+weight = 4
+tags = ["tool", "metal", "set"]
+[extra]
+studio = "Hala 5 / Atelier B"
+discipline = "Tooling"
+year = "2026"
+cycle = "Q1"
+material = "Sand-cast bronze, machined jaws"
+client = "Atelier B"
+cf_id = "CF-04 / CLAMP-04"
++++
+
+Most clamp sets are sized by throat depth — a small clamp holds small work,
+a large clamp holds large work. The set in this drop is sized by sleeve
+thickness instead. The throat is identical across all four clamps; what
+changes is how much load the sleeve will accept. The weight rating runs from
+4 kg to 80 kg, in factor-of-two steps.
+
+## Spec
+
+- Body: sand-cast bronze, machined jaws.
+- Sleeve thicknesses: 3, 5, 7, 11 mm.
+- Throat: 90 mm (all sizes).
+- Working surface: 120 × 120 mm pad.
+
+Each clamp is stamped with its weight rating in two places. The pads are
+replaceable; we ship two sets of pads with each clamp and a third on request.
+
+> "We have stopped owning four sets of clamps for the same job at four sizes
+> of stock. Now we own one set of four clamps." — *Atelier B*
+
+### Drop scope
+
+Sets are sold as four pieces in a hinged ash case. No partial sets in this
+drop. The case lid carries an etched chart of the recommended workpiece weight
+for each sleeve; the chart is the same chart we drafted at the prototype stage
+and have not edited since.

--- a/examples/carbon-folio/content/works/_index.md
+++ b/examples/carbon-folio/content/works/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Folio"
+description = "All pieces in the current drop. Sorted by drop order, not by client or material."
+sort_by = "weight"
+template = "section"
++++
+
+The folio carries everything that survived its cycle this season. Each card
+shows the discipline, the studio of record, and the prototype's drop number.
+The full spec rail lives on the piece's own page.

--- a/examples/carbon-folio/static/css/style.css
+++ b/examples/carbon-folio/static/css/style.css
@@ -1,0 +1,337 @@
+:root {
+  --bg: #0d0d0e;
+  --bg-2: #161618;
+  --bg-3: #1f1f22;
+  --ink: #f3f3f1;
+  --ink-2: #b0b0ac;
+  --ink-3: #6c6c68;
+  --rule: #232326;
+  --rule-2: #303033;
+  --accent: #ff5a1f;
+  --accent-dim: #993500;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 16px; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", system-ui, sans-serif;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.shell {
+  max-width: 92rem;
+  margin: 0 auto;
+  padding: 0 2.5rem;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.4rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.brand {
+  font-family: "Sora", "Inter", sans-serif;
+  font-weight: 800;
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.brand .sq { width: 1.2rem; height: 1.2rem; background: var(--accent); display: inline-block; }
+.brand i { font-style: normal; color: var(--ink-3); font-weight: 500; }
+.topbar nav { display: flex; gap: 2rem; font-size: 0.82rem; }
+.topbar nav a { color: var(--ink-2); padding: 0.3rem 0; border-bottom: 2px solid transparent; }
+.topbar nav a:hover { color: var(--ink); border-bottom-color: var(--accent); }
+.topbar .ix {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+
+.hero {
+  padding: 8rem 0 5rem;
+  position: relative;
+}
+.hero .marker {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--accent);
+  letter-spacing: 0.14em;
+  margin-bottom: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+.hero .marker::before { content: ""; display: inline-block; width: 2.5rem; height: 1px; background: var(--accent); }
+.hero h1 {
+  font-family: "Sora", "Inter", sans-serif;
+  font-size: clamp(3.2rem, 9vw, 8rem);
+  font-weight: 800;
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+  margin: 0 0 1rem;
+  text-transform: uppercase;
+}
+.hero h1 span { color: var(--accent); }
+.hero h1 .slash { color: var(--ink-3); font-weight: 400; }
+.hero .lede {
+  margin-top: 2rem;
+  font-size: 1.1rem;
+  max-width: 36rem;
+  color: var(--ink-2);
+}
+.hero .kvs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+  margin-top: 3.5rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 1.5rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+}
+.hero .kvs dt { color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.14em; font-size: 0.7rem; margin-bottom: 0.4rem; }
+.hero .kvs dd { margin: 0; color: var(--ink); font-size: 1.4rem; font-family: "Sora", sans-serif; font-weight: 600; letter-spacing: -0.01em; }
+.hero .kvs dd em { color: var(--accent); font-style: normal; }
+
+.deck-label {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  border-top: 1px solid var(--ink);
+  padding: 1.2rem 0;
+  display: flex;
+  justify-content: space-between;
+  margin: 4rem 0 2rem;
+}
+.deck-label b { color: var(--ink); font-weight: 600; }
+
+.deck {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1.4rem;
+}
+.card {
+  grid-column: span 6;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 2.4rem 2.4rem 2.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  position: relative;
+  transition: border-color .25s, background .25s;
+}
+.card:hover { border-color: var(--accent); background: var(--bg-3); }
+.card:nth-child(4n+1), .card:nth-child(4n+4) { grid-column: span 7; }
+.card:nth-child(4n+2), .card:nth-child(4n+3) { grid-column: span 5; }
+.card .img {
+  aspect-ratio: 16 / 11;
+  background: var(--bg-3);
+  border: 1px solid var(--rule);
+  position: relative;
+  overflow: hidden;
+}
+.card .img svg { width: 100%; height: 100%; display: block; }
+.card .img .badge {
+  position: absolute;
+  top: 0.8rem; left: 0.8rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  background: var(--accent);
+  color: var(--bg);
+  padding: 0.2rem 0.5rem;
+  font-weight: 700;
+}
+.card .img .yr {
+  position: absolute;
+  bottom: 0.8rem; right: 0.8rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  color: var(--ink-3);
+}
+.card .meta-line {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.card .meta-line .live { color: var(--accent); }
+.card h2 {
+  font-family: "Sora", sans-serif;
+  font-size: 1.9rem;
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  text-transform: uppercase;
+}
+.card h2 a { color: var(--ink); }
+.card:hover h2 a { color: var(--accent); }
+.card p.desc { margin: 0; color: var(--ink-2); font-size: 0.95rem; max-width: 32rem; }
+.card .foot-line {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  color: var(--ink-3);
+  letter-spacing: 0.04em;
+}
+.card .foot-line .arrow {
+  font-family: "Sora", sans-serif;
+  font-weight: 700;
+  color: var(--ink);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.card:hover .foot-line .arrow { color: var(--accent); }
+
+.studio {
+  margin: 6rem 0 3rem;
+  border: 1px solid var(--rule);
+  padding: 4rem;
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 3rem;
+  background: var(--bg-2);
+}
+.studio h3 {
+  font-family: "Sora", sans-serif;
+  font-weight: 700;
+  font-size: 2rem;
+  margin: 0;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  line-height: 1.05;
+}
+.studio h3 em { color: var(--accent); font-style: normal; }
+.studio .body { color: var(--ink-2); font-size: 1.05rem; line-height: 1.6; }
+.studio .body p { margin: 0 0 1rem; }
+.studio .body strong { color: var(--ink); }
+
+article {
+  max-width: 56rem;
+  margin: 3rem auto 6rem;
+  padding: 0 2rem;
+}
+article .marker {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--accent);
+  letter-spacing: 0.14em;
+  margin-bottom: 1rem;
+}
+article h1 {
+  font-family: "Sora", sans-serif;
+  font-size: clamp(2.6rem, 5vw, 4.2rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+article .lede { font-size: 1.15rem; color: var(--ink-2); margin: 0 0 2.5rem; max-width: 42rem; }
+article h2 { font-family: "Sora", sans-serif; font-size: 1.6rem; font-weight: 700; margin: 2.5rem 0 0.7rem; letter-spacing: -0.015em; text-transform: uppercase; }
+article h3 { font-family: "JetBrains Mono", monospace; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.18em; color: var(--accent); margin: 2rem 0 0.6rem; }
+article p, article li { color: var(--ink-2); font-size: 1.04rem; }
+article a { color: var(--accent); border-bottom: 1px solid var(--accent-dim); }
+article a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+article blockquote { border-left: 3px solid var(--accent); padding: 0.5rem 1.4rem; margin: 2rem 0; color: var(--ink); font-size: 1.25rem; font-family: "Sora", sans-serif; font-weight: 500; }
+article hr { border: none; border-top: 1px solid var(--rule); margin: 3rem 0; }
+article pre { background: var(--bg-2); border: 1px solid var(--rule); padding: 1rem; overflow-x: auto; }
+article code { font-family: "JetBrains Mono", monospace; background: var(--bg-2); padding: 0.05rem 0.35rem; border: 1px solid var(--rule); font-size: 0.88em; color: var(--ink); }
+
+.spec-rail {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-3);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 1rem 0;
+  margin: 1.5rem 0 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.5rem 1.5rem;
+}
+.spec-rail b { display: block; color: var(--accent); text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.68rem; margin-bottom: 0.15rem; }
+
+.tag-pill {
+  display: inline-block;
+  border: 1px solid var(--rule-2);
+  color: var(--ink-2);
+  padding: 0.2rem 0.7rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  margin-right: 0.4rem;
+  text-transform: uppercase;
+}
+.tag-pill:hover { border-color: var(--accent); color: var(--accent); }
+
+.kbd {
+  display: inline-block;
+  border: 1px solid var(--ink);
+  padding: 0.5rem 1.1rem;
+  font-family: "Sora", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink);
+  margin: 0.3rem 0.4rem 0 0;
+  background: transparent;
+}
+.kbd:hover { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+
+.foot {
+  border-top: 1px solid var(--rule);
+  margin-top: 4rem;
+  padding: 1.8rem 0 2.4rem;
+  display: flex;
+  justify-content: space-between;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+.foot b { color: var(--ink); }
+.foot .sq { display: inline-block; width: 0.7rem; height: 0.7rem; background: var(--accent); vertical-align: middle; margin-right: 0.4rem; }
+
+.notfound { text-align: center; padding: 8rem 0; }
+.notfound h1 { font-family: "Sora", sans-serif; font-size: 10rem; margin: 0; font-weight: 800; color: var(--accent); letter-spacing: -0.04em; }
+.notfound p { color: var(--ink-2); font-family: "JetBrains Mono", monospace; text-transform: uppercase; letter-spacing: 0.22em; font-size: 0.8rem; }
+
+@media (max-width: 960px) {
+  .shell { padding: 0 1.25rem; }
+  .topbar { flex-direction: column; gap: 0.6rem; align-items: flex-start; }
+  .topbar nav { flex-wrap: wrap; gap: 1.2rem; }
+  .hero { padding: 4rem 0 3rem; }
+  .hero .kvs { grid-template-columns: 1fr 1fr; }
+  .card, .card:nth-child(4n+1), .card:nth-child(4n+4), .card:nth-child(4n+2), .card:nth-child(4n+3) { grid-column: span 12; }
+  .studio { grid-template-columns: 1fr; padding: 2rem; gap: 1.5rem; }
+  .foot { flex-direction: column; gap: 0.4rem; }
+}

--- a/examples/carbon-folio/static/favicon.svg
+++ b/examples/carbon-folio/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0d0d0e"/>
+  <path d="M8 22 V10 L16 18 L24 10 V22" fill="none" stroke="#f3f3f1" stroke-width="2.4" stroke-linecap="square"/>
+  <circle cx="26" cy="22" r="2" fill="#ff5a1f"/>
+</svg>

--- a/examples/carbon-folio/templates/404.html
+++ b/examples/carbon-folio/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p>NOT IN FOLIO</p>
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/">STUDIO</a><a class="kbd" href="{{ base_url }}/works/">FOLIO</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/carbon-folio/templates/footer.html
+++ b/examples/carbon-folio/templates/footer.html
@@ -1,0 +1,9 @@
+  </main>
+  <footer class="foot">
+    <span><span class="sq"></span><b>Carbon Folio</b> · Hala 5, ul. Wybrzeże Wyspiańskiego</span>
+    <span>BUILT FOR PROTOTYPES · NOT FOR PITCH DECKS</span>
+    <span>© {{ current_year }} · HWARO</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/carbon-folio/templates/header.html
+++ b/examples/carbon-folio/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="shell">
+  <header class="topbar">
+    <a class="brand" href="{{ base_url }}/"><span class="sq"></span>CARBON·FOLIO <i>/26</i></a>
+    <nav>
+      <a href="{{ base_url }}/">Studio</a>
+      <a href="{{ base_url }}/works/">Folio</a>
+      <a href="{{ base_url }}/tags/">Disciplines</a>
+    </nav>
+    <span class="ix">SHA · 8d3f1a · {{ current_date | date(format="%Y-%m-%d") }}</span>
+  </header>
+  <main>

--- a/examples/carbon-folio/templates/home.html
+++ b/examples/carbon-folio/templates/home.html
@@ -1,0 +1,76 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="marker">FOLIO · SPRING 2026 · DROP 04</div>
+  <h1>OBJECTS,<br/>BUILT TO BE<br/><span>HANDLED.</span><span class="slash">/</span></h1>
+  <p class="lede">{{ site.description }}</p>
+  <dl class="kvs">
+    <div><dt>Pieces</dt><dd>04 <em>live</em></dd></div>
+    <div><dt>Disciplines</dt><dd>03</dd></div>
+    <div><dt>Sourced</dt><dd>EU / KR</dd></div>
+    <div><dt>Build cycle</dt><dd>12 wk</dd></div>
+  </dl>
+</section>
+
+<div class="deck-label">
+  <span><b>The folio</b> · 04 entries</span>
+  <span>Sorted by drop order</span>
+</div>
+
+<section class="deck">
+  {% set works = get_section(path="works/_index.md") %}
+  {% if works and works.pages %}
+    {% for p in works.pages %}
+    <a class="card" href="{{ p.url }}">
+      <div class="img">
+        {% set i = loop.index %}
+        {% if i == 1 %}
+        <svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice">
+          <rect width="320" height="220" fill="#1f1f22"/>
+          <g stroke="#303033" stroke-width="0.7">{% for n in range(end=22) %}<line x1="0" y1="{{ n * 12 }}" x2="320" y2="{{ n * 12 }}"/>{% endfor %}</g>
+          <rect x="60" y="50" width="200" height="120" fill="#f3f3f1" stroke="#ff5a1f" stroke-width="3"/>
+          <rect x="90" y="80" width="140" height="60" fill="#0d0d0e"/>
+          <circle cx="160" cy="110" r="14" fill="#ff5a1f"/>
+        </svg>
+        {% elif i == 2 %}
+        <svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice">
+          <rect width="320" height="220" fill="#1f1f22"/>
+          <polygon points="160,30 270,190 50,190" fill="#f3f3f1"/>
+          <polygon points="160,80 220,180 100,180" fill="#0d0d0e"/>
+          <rect x="150" y="120" width="20" height="40" fill="#ff5a1f"/>
+        </svg>
+        {% elif i == 3 %}
+        <svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice">
+          <rect width="320" height="220" fill="#1f1f22"/>
+          <g fill="#f3f3f1">{% for n in range(end=8) %}<rect x="{{ 30 + n * 35 }}" y="40" width="20" height="140"/>{% endfor %}</g>
+          <rect x="30" y="100" width="260" height="20" fill="#ff5a1f"/>
+        </svg>
+        {% elif i == 4 %}
+        <svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice">
+          <rect width="320" height="220" fill="#1f1f22"/>
+          <circle cx="160" cy="110" r="80" fill="#f3f3f1"/>
+          <circle cx="160" cy="110" r="40" fill="#0d0d0e"/>
+          <rect x="156" y="20" width="8" height="180" fill="#ff5a1f"/>
+        </svg>
+        {% else %}
+        <svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice"><rect width="320" height="220" fill="#1f1f22"/><rect x="60" y="40" width="200" height="140" fill="#f3f3f1"/><rect x="120" y="80" width="80" height="60" fill="#ff5a1f"/></svg>
+        {% endif %}
+        <span class="badge">CF—{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+        <span class="yr">{% if p.extra.year %}{{ p.extra.year }}{% endif %}</span>
+      </div>
+      <div class="meta-line"><span class="live">● LIVE</span> · {% if p.extra.discipline %}{{ p.extra.discipline | upper }}{% endif %}{% if p.extra.cycle %} · {{ p.extra.cycle }}{% endif %}</div>
+      <h2>{{ p.title | e }}</h2>
+      {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+      <div class="foot-line">
+        <span>{{ p.extra.studio | default(value="In-house") }}</span>
+        <span class="arrow">OPEN →</span>
+      </div>
+    </a>
+    {% endfor %}
+  {% endif %}
+</section>
+
+<section class="studio">
+  <h3>THE <em>STUDIO</em><br/>NOTE.</h3>
+  <div class="body">{{ content | safe }}</div>
+</section>
+{% include "footer.html" %}

--- a/examples/carbon-folio/templates/page.html
+++ b/examples/carbon-folio/templates/page.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<article>
+  <div class="marker">{% if page.extra.cf_id %}{{ page.extra.cf_id }}{% else %}CF · {{ page.title | slugify | upper }}{% endif %}</div>
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+  <div class="spec-rail">
+    {% if page.extra.studio %}<span><b>Studio</b>{{ page.extra.studio }}</span>{% endif %}
+    {% if page.extra.discipline %}<span><b>Discipline</b>{{ page.extra.discipline }}</span>{% endif %}
+    {% if page.extra.year %}<span><b>Year</b>{{ page.extra.year }}</span>{% endif %}
+    {% if page.extra.cycle %}<span><b>Cycle</b>{{ page.extra.cycle }}</span>{% endif %}
+    {% if page.extra.material %}<span><b>Material</b>{{ page.extra.material }}</span>{% endif %}
+    {% if page.extra.client %}<span><b>Client</b>{{ page.extra.client }}</span>{% endif %}
+    {% if page.date %}<span><b>Dropped</b>{{ page.date | date(format="%Y-%m-%d") }}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+  {% if page.tags %}<p style="margin-top:3rem;">{% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</p>{% endif %}
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/works/">← Folio</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/carbon-folio/templates/section.html
+++ b/examples/carbon-folio/templates/section.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="marker">FOLIO · {{ page.title | upper }}</div>
+  <h1>{{ page.title | e | upper }}<span class="slash">/</span></h1>
+  <div class="lede">{{ content | safe }}</div>
+</section>
+<div class="deck-label"><span><b>{{ section.pages | length }} entries</b></span><span>Sorted by drop order</span></div>
+<section class="deck">
+  {% for p in section.pages %}
+  <a class="card" href="{{ p.url }}">
+    <div class="img">
+      {% set i = loop.index %}
+      {% if i == 1 %}<svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice"><rect width="320" height="220" fill="#1f1f22"/><g stroke="#303033" stroke-width="0.7">{% for n in range(end=22) %}<line x1="0" y1="{{ n * 12 }}" x2="320" y2="{{ n * 12 }}"/>{% endfor %}</g><rect x="60" y="50" width="200" height="120" fill="#f3f3f1" stroke="#ff5a1f" stroke-width="3"/><rect x="90" y="80" width="140" height="60" fill="#0d0d0e"/><circle cx="160" cy="110" r="14" fill="#ff5a1f"/></svg>
+      {% elif i == 2 %}<svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice"><rect width="320" height="220" fill="#1f1f22"/><polygon points="160,30 270,190 50,190" fill="#f3f3f1"/><polygon points="160,80 220,180 100,180" fill="#0d0d0e"/><rect x="150" y="120" width="20" height="40" fill="#ff5a1f"/></svg>
+      {% elif i == 3 %}<svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice"><rect width="320" height="220" fill="#1f1f22"/><g fill="#f3f3f1">{% for n in range(end=8) %}<rect x="{{ 30 + n * 35 }}" y="40" width="20" height="140"/>{% endfor %}</g><rect x="30" y="100" width="260" height="20" fill="#ff5a1f"/></svg>
+      {% elif i == 4 %}<svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice"><rect width="320" height="220" fill="#1f1f22"/><circle cx="160" cy="110" r="80" fill="#f3f3f1"/><circle cx="160" cy="110" r="40" fill="#0d0d0e"/><rect x="156" y="20" width="8" height="180" fill="#ff5a1f"/></svg>
+      {% else %}<svg viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice"><rect width="320" height="220" fill="#1f1f22"/><rect x="60" y="40" width="200" height="140" fill="#f3f3f1"/><rect x="120" y="80" width="80" height="60" fill="#ff5a1f"/></svg>{% endif %}
+      <span class="badge">CF—{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <span class="yr">{% if p.extra.year %}{{ p.extra.year }}{% endif %}</span>
+    </div>
+    <div class="meta-line"><span class="live">● LIVE</span> · {% if p.extra.discipline %}{{ p.extra.discipline | upper }}{% endif %}</div>
+    <h2>{{ p.title | e }}</h2>
+    {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+    <div class="foot-line"><span>{{ p.extra.studio | default(value="In-house") }}</span><span class="arrow">OPEN →</span></div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/carbon-folio/templates/shortcodes/alert.html
+++ b/examples/carbon-folio/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div style="padding:0.85rem 1.2rem;border-left:3px solid var(--accent);background:var(--bg-2);margin:1.5rem 0;font-size:0.92rem;color:var(--ink-2);">
+  <strong style="color:var(--accent);font-family:'JetBrains Mono',monospace;letter-spacing:0.14em;text-transform:uppercase;font-size:0.72rem;">[{{ type | upper }}]</strong>
+  <div style="margin-top:0.3rem;">{{ body }}</div>
+</div>

--- a/examples/carbon-folio/templates/taxonomy.html
+++ b/examples/carbon-folio/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="marker">FOLIO · {{ taxonomy_name | upper }}</div>
+  <h1>{{ taxonomy_name | default(value="Disciplines") | upper }}<span class="slash">/</span></h1>
+  <p class="lede">All terms in the <em>{{ taxonomy_name }}</em> register.</p>
+</section>
+<div class="deck-label"><span><b>{{ taxonomy_terms | length }} terms</b></span><span>{{ taxonomy_name }}</span></div>
+<section class="deck">
+  {% for term in taxonomy_terms %}
+  <a class="card" href="{{ term.url }}">
+    <div class="img" style="display:flex;align-items:center;justify-content:center;background:#1f1f22;">
+      <span style="font-family:Sora,sans-serif;font-weight:800;font-size:3.2rem;color:#f3f3f1;text-transform:uppercase;letter-spacing:-0.03em;">{{ term.name }}</span>
+      <span class="badge">T-{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    </div>
+    <div class="meta-line"><span class="live">●</span> {{ term.pages_count }} ENTR{% if term.pages_count == 1 %}Y{% else %}IES{% endif %}</div>
+    <h2>{{ term.name }}</h2>
+    <div class="foot-line"><span>/{{ taxonomy_name }}/{{ term.slug }}/</span><span class="arrow">OPEN →</span></div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/carbon-folio/templates/taxonomy_term.html
+++ b/examples/carbon-folio/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="marker">{{ taxonomy_name | upper }} · #{{ page.title | upper }}</div>
+  <h1>#{{ page.title | upper }}<span class="slash">/</span></h1>
+  <p class="lede">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} filed under <em>{{ page.title }}</em>.</p>
+</section>
+<div class="deck-label"><span><b>Tagged</b> {{ page.title }}</span><span>{{ taxonomy_pages | length }} items</span></div>
+<section class="deck">
+  {% for p in taxonomy_pages %}
+  <a class="card" href="{{ p.url }}">
+    <div class="img" style="display:flex;align-items:center;justify-content:center;background:#1f1f22;">
+      <span style="font-family:Sora,sans-serif;font-weight:800;font-size:2.4rem;color:#f3f3f1;text-transform:uppercase;letter-spacing:-0.02em;text-align:center;padding:0 1rem;">{{ p.title | e }}</span>
+      <span class="badge">CF—{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <span class="yr">{% if p.date %}{{ p.date | date(format="%Y") }}{% endif %}</span>
+    </div>
+    <div class="meta-line"><span class="live">●</span> {% if p.extra.discipline %}{{ p.extra.discipline | upper }}{% endif %}</div>
+    <h2>{{ p.title | e }}</h2>
+    {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+    <div class="foot-line"><span>{{ p.extra.studio | default(value="In-house") }}</span><span class="arrow">OPEN →</span></div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/monolith-frame/AGENTS.md
+++ b/examples/monolith-frame/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md — Monolith Frame
+
+Dark theatrical gallery site (gallery type). Black + sodium-yellow palette,
+Cormorant Garamond display with Inter Tight UI labels. Site uses a `works/`
+section with custom per-work front-matter (`artist`, `medium`, `year`,
+`dimensions`, `hall`).
+
+## Conventions
+
+- All CSS lives in `static/css/style.css` (no inline `<style>` blocks).
+- The home template (`home.html`) reads from the `works/` section directly.
+- No gradients, no emojis. Single accent: `--accent: #e4c96a`.
+- Use `{{ base_url }}` for all asset and link references.
+
+## Hwaro
+
+| Command | Description |
+|---|---|
+| `hwaro build` | Build to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro tool doctor --fix` | Validate/patch config |
+
+Full reference: <https://hwaro.hahwul.com>

--- a/examples/monolith-frame/archetypes/default.md
+++ b/examples/monolith-frame/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/monolith-frame/config.toml
+++ b/examples/monolith-frame/config.toml
@@ -1,0 +1,45 @@
+title = "Monolith Frame"
+description = "A theatrical dark gallery for sculpture, large-format photography, and durational work."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/monolith-frame/config.toml
+++ b/examples/monolith-frame/config.toml
@@ -43,3 +43,155 @@ footnotes = true
 
 [doctor]
 ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/monolith-frame/content/index.md
+++ b/examples/monolith-frame/content/index.md
@@ -1,0 +1,14 @@
++++
+title = "Monolith Frame"
+description = "A theatrical dark gallery for sculpture, large-format photography, and durational work."
+template = "home"
++++
+
+Monolith Frame is a four-hall, year-round programme dedicated to work that asks
+the viewer to slow down. We favour heavy materials, long takes, and rooms that
+do not move while you are in them. Lighting is fixed at 2700K; the floors are
+matte; nothing competes with the work.
+
+Each exhibition runs for a full season. There are no openings, no thumbnails,
+and no audio guides — only the work, a single caption rail, and a printed
+catalogue available at the desk.

--- a/examples/monolith-frame/content/works/01-anchor-stone.md
+++ b/examples/monolith-frame/content/works/01-anchor-stone.md
@@ -1,0 +1,40 @@
++++
+title = "Anchor, in three positions"
+description = "A 1.4-tonne basalt anchor cast and recut, displayed across the three stages of its working life."
+date = "2026-02-14"
+weight = 1
+tags = ["sculpture", "basalt", "longform"]
+[extra]
+artist = "Ines Marén"
+medium = "Cut basalt, cast iron, salt rope"
+year = "2026"
+dimensions = "210 × 140 × 95 cm"
+hall = "Hall 01"
++++
+
+The work began on the harbour at Hammerfest, where Marén spent two winters
+recording the working anchors of small ferry boats. The piece you see here is
+neither a single anchor nor a copy — it is a recut. Marén split a decommissioned
+1962 anchor along its shank, cast the missing volume in basalt, and rejoined the
+two halves with a salt rope that will be replaced every six months.
+
+## On heaviness
+
+> "I want the work to refuse to be looked at quickly. If you give it a glance, it
+> gives you nothing back." — *I. Marén, conversation, January 2026*
+
+The plinth is intentionally low. Visitors who lean over the work are within
+reach of the salt rope, which is rough and audible. The audible component is
+part of the piece; please do not ask the attendants to remove it.
+
+### Provenance
+
+Acquired from the Hammerfest harbour office, decommissioned January 2024.
+Recutting and casting completed at the Maréns' studio in Tromsø, October 2025.
+
+### Notes for the visitor
+
+- The work is mounted on a rotating plate. It will complete one full turn
+  every four hours.
+- Do not photograph the salt rope. It is changed too often to be archived.
+- The work will remain on view through the close of the Spring Programme.

--- a/examples/monolith-frame/content/works/02-long-room.md
+++ b/examples/monolith-frame/content/works/02-long-room.md
@@ -1,0 +1,34 @@
++++
+title = "The Long Room"
+description = "A 22-metre single-channel projection of a tidal mud flat, filmed over twelve consecutive nights."
+date = "2026-02-21"
+weight = 2
+tags = ["video", "tidal", "longform"]
+[extra]
+artist = "Owain Reigh"
+medium = "Single-channel 4K projection, 22 m × 3.4 m, looped"
+year = "2025—2026"
+dimensions = "Variable"
+hall = "Hall 02"
++++
+
+The Long Room is exactly that — a corridor 22 metres long, with the projection
+running the full length of the east wall. There are no benches. Visitors are
+expected to walk the length of the room at the pace of the tide, which is the
+pace at which the piece moves.
+
+## A note on the loop
+
+The recording is not edited. The twelve nights have been crossfaded only at the
+seams; everything in between is the original footage at its captured speed. If
+the room feels empty, that is intended. If a gull crosses the frame, that is
+also intended.
+
+> "Tides do not perform. They arrive, then they leave. The piece is the same."
+> — *O. Reigh, programme note, 2026*
+
+### Conditions
+
+The Long Room is lit only by the projection. Visitors with low-light sensitivity
+should request a torch from the desk. The room temperature is held at 14°C; a
+wool blanket is available on request.

--- a/examples/monolith-frame/content/works/03-paper-weights.md
+++ b/examples/monolith-frame/content/works/03-paper-weights.md
@@ -1,0 +1,35 @@
++++
+title = "Paper Weights, 1—48"
+description = "Forty-eight handmade paper blocks, each the weight of a published book the artist has refused to write."
+date = "2026-03-04"
+weight = 3
+tags = ["paper", "sculpture", "series"]
+[extra]
+artist = "Tova Brink"
+medium = "Hand-pulped paper, beeswax, lead core"
+year = "2024—2026"
+dimensions = "48 units, each ≈ 22 × 15 × 4 cm"
+hall = "Hall 03"
++++
+
+For two years Tova Brink has refused commissions for forty-eight books — each
+refusal logged with the would-be publisher, the proposed title, and the contract
+that was returned unsigned. Each refused book is represented here by a paper
+block of the same weight, pulped from drafts of letters Brink wrote and did not
+send.
+
+## Index of refusals
+
+The plinth runs the length of the south wall. The blocks are arranged in the
+order in which the books were declined, not in alphabetical or chronological
+order of the proposed titles. A printed index is at the desk; visitors are
+welcome to take a copy.
+
+> "The book that did not happen is heavier than the book that did." — *T. Brink, 2026*
+
+### Material
+
+Each block is hand-pulped from Brink's own discarded drafts. A lead core of
+between 40 and 220 grams is sealed into the centre of each block; the surface
+is finished in beeswax and bears no title. The blocks are not labelled in the
+hall — the index is the only key.

--- a/examples/monolith-frame/content/works/04-room-of-bells.md
+++ b/examples/monolith-frame/content/works/04-room-of-bells.md
@@ -1,0 +1,38 @@
++++
+title = "Room of Bells"
+description = "Nine bronze bells, struck once per hour by an unseen mechanism. The room rings, then settles."
+date = "2026-03-19"
+weight = 4
+tags = ["sound", "bronze", "longform"]
+[extra]
+artist = "Aleks Voronin"
+medium = "Cast bronze, oak, mechanical actuator"
+year = "2025"
+dimensions = "Hall 04, full volume"
+hall = "Hall 04"
++++
+
+Once an hour, on the hour, nine bronze bells in Hall 04 are struck in sequence
+by an actuator concealed in the floor. The bells are tuned to a scale of the
+artist's own design — a scale that does not resolve, and was never intended to.
+
+## Times
+
+Strikes occur on the hour, every hour the gallery is open. The full sequence
+lasts four minutes. If you arrive in the middle, please wait at the threshold
+until the room has settled. The doors will not be closed during a strike.
+
+> "I wanted a room that would not sit still, but would still be a room." — *A. Voronin*
+
+### Listening notes
+
+The bells are not amplified. The reverberation is the natural decay of the hall,
+which is lined in untreated oak. Visitors are asked not to speak from the
+strike of the first bell until the last has fully decayed; the room is part of
+the piece.
+
+### Maintenance
+
+The actuator is serviced every Monday. The hall is closed to visitors on
+Mondays. On the first Wednesday of each month, the bells are struck manually by
+the artist or a nominated representative.

--- a/examples/monolith-frame/content/works/_index.md
+++ b/examples/monolith-frame/content/works/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Catalogue"
+description = "All works currently installed across the four halls."
+sort_by = "weight"
+template = "section"
++++
+
+The catalogue lists works in installation order. Each entry shows the artist,
+medium, year, and the hall in which the piece is currently mounted. Catalogue
+numbering resets at the start of each season.

--- a/examples/monolith-frame/static/css/style.css
+++ b/examples/monolith-frame/static/css/style.css
@@ -1,0 +1,264 @@
+:root {
+  --bg: #0a0a0a;
+  --bg-2: #131313;
+  --ink: #f4f1ea;
+  --ink-2: #b4b1aa;
+  --ink-3: #6e6c66;
+  --rule: #2a2a28;
+  --accent: #e4c96a;
+  --frame: #1a1a18;
+}
+
+* { box-sizing: border-box; }
+
+html { font-size: 16px; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Cormorant Garamond", "EB Garamond", Georgia, serif;
+  font-weight: 400;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.shell {
+  max-width: 78rem;
+  margin: 0 auto;
+  padding: 0 2.5rem;
+}
+
+.topbar {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 2rem 0;
+  border-bottom: 1px solid var(--rule);
+  font-family: "Inter Tight", "Inter", system-ui, sans-serif;
+}
+.brand {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 1.4rem;
+  letter-spacing: 0.02em;
+}
+.brand b { font-style: normal; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; font-size: 0.85rem; margin-right: 0.5rem; color: var(--accent); }
+.topbar nav { display: flex; gap: 2rem; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.22em; }
+.topbar nav a { color: var(--ink-2); }
+.topbar nav a:hover { color: var(--accent); }
+.topbar .hours { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.2em; color: var(--ink-3); }
+
+.hero {
+  padding: 7rem 0 5rem;
+  border-bottom: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 1fr 22rem;
+  gap: 4rem;
+  align-items: end;
+}
+.hero .eyebrow {
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--accent);
+  margin-bottom: 1.5rem;
+}
+.hero h1 {
+  font-size: clamp(3rem, 7vw, 6rem);
+  line-height: 0.96;
+  letter-spacing: -0.02em;
+  margin: 0;
+  font-weight: 500;
+}
+.hero h1 em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+}
+.hero .lede { color: var(--ink-2); font-size: 1.1rem; max-width: 22rem; }
+.hero .lede p { margin: 0 0 1rem; }
+.hero .meta-line {
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+  display: flex;
+  gap: 1.5rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 1rem;
+  margin-top: 1.5rem;
+}
+
+.label {
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--ink-3);
+}
+
+.exhibit-list {
+  padding: 4rem 0 2rem;
+}
+.exhibit {
+  display: grid;
+  grid-template-columns: 6rem 1fr 18rem 6rem;
+  gap: 2rem;
+  align-items: start;
+  padding: 2.5rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.exhibit:hover { background: var(--bg-2); }
+.exhibit .num {
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  padding-top: 0.4rem;
+}
+.exhibit h2 {
+  font-size: 2.2rem;
+  margin: 0;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.exhibit h2 a { box-shadow: inset 0 -1px 0 0 transparent; transition: box-shadow .3s; }
+.exhibit:hover h2 a { box-shadow: inset 0 -1px 0 0 currentColor; }
+.exhibit .desc { color: var(--ink-2); font-size: 1rem; max-width: 32rem; margin-top: 0.6rem; }
+.exhibit .meta {
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+.exhibit .meta b { color: var(--ink); font-weight: 600; display: block; margin-bottom: 0.2rem; }
+.exhibit .pull {
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-align: right;
+  padding-top: 0.5rem;
+}
+.exhibit:hover .pull { color: var(--accent); }
+
+.plate {
+  margin: 5rem 0;
+  border: 1px solid var(--rule);
+  background: var(--frame);
+  padding: 4rem;
+}
+.plate h2 {
+  font-size: 2rem;
+  margin: 0 0 1rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+.plate p { color: var(--ink-2); max-width: 38rem; margin: 0 0 1rem; }
+.plate .stamp {
+  display: inline-block;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  padding: 0.35rem 0.8rem;
+  margin-bottom: 1.4rem;
+}
+
+article {
+  max-width: 44rem;
+  margin: 4rem auto 6rem;
+  padding: 0 2rem;
+}
+article h1 { font-size: 3.6rem; line-height: 1; letter-spacing: -0.02em; margin: 0 0 1.5rem; font-weight: 500; }
+article h1 em { color: var(--accent); font-style: italic; }
+article .lede { color: var(--ink-2); font-size: 1.2rem; font-style: italic; margin: 0 0 2.5rem; }
+article h2 { font-size: 1.6rem; margin: 2.5rem 0 1rem; font-weight: 500; }
+article h3 { font-size: 1.2rem; margin: 2rem 0 0.6rem; font-weight: 600; font-family: "Inter Tight", sans-serif; text-transform: uppercase; letter-spacing: 0.16em; color: var(--accent); }
+article p, article li { color: var(--ink-2); font-size: 1.05rem; }
+article a { border-bottom: 1px solid var(--rule); color: var(--ink); }
+article a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+article blockquote { border-left: 2px solid var(--accent); padding: 0.4rem 1.4rem; margin: 2rem 0; font-style: italic; color: var(--ink); font-size: 1.3rem; }
+article hr { border: none; border-top: 1px solid var(--rule); margin: 3rem 0; }
+article ul, article ol { padding-left: 1.4rem; }
+
+.caption-rail {
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 1rem 0;
+  margin: 0 0 2.5rem;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+.caption-rail span b { color: var(--accent); font-weight: 600; }
+
+.tag-pill {
+  display: inline-block;
+  border: 1px solid var(--rule);
+  color: var(--ink-2);
+  padding: 0.2rem 0.7rem;
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-right: 0.4rem;
+}
+.tag-pill:hover { border-color: var(--accent); color: var(--accent); }
+
+.foot {
+  border-top: 1px solid var(--rule);
+  margin-top: 4rem;
+  padding: 2rem 0 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-3);
+}
+.foot .colophon { font-style: italic; text-transform: none; letter-spacing: 0; font-family: "Cormorant Garamond", serif; font-size: 0.9rem; color: var(--ink-2); }
+
+.notfound { text-align: center; padding: 9rem 0; }
+.notfound h1 { font-size: 9rem; margin: 0; font-weight: 500; color: var(--accent); }
+.notfound p { color: var(--ink-2); font-family: "Inter Tight", sans-serif; text-transform: uppercase; letter-spacing: 0.24em; font-size: 0.8rem; }
+
+.kbd {
+  display: inline-block;
+  border: 1px solid var(--rule);
+  padding: 0.45rem 1rem;
+  font-family: "Inter Tight", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-2);
+  margin: 0.3rem 0.4rem 0 0;
+}
+.kbd:hover { border-color: var(--accent); color: var(--accent); }
+
+@media (max-width: 900px) {
+  .shell { padding: 0 1.25rem; }
+  .topbar { flex-direction: column; gap: 0.8rem; align-items: flex-start; }
+  .hero { grid-template-columns: 1fr; padding: 4rem 0 3rem; gap: 2rem; }
+  .exhibit { grid-template-columns: 1fr; gap: 0.6rem; }
+  .exhibit .pull, .exhibit .meta { text-align: left; }
+  .plate { padding: 2rem; }
+  article h1 { font-size: 2.4rem; }
+}

--- a/examples/monolith-frame/static/favicon.svg
+++ b/examples/monolith-frame/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0a0a0a"/>
+  <rect x="10" y="6" width="12" height="20" fill="none" stroke="#e4c96a" stroke-width="2"/>
+  <rect x="14" y="14" width="4" height="4" fill="#e4c96a"/>
+</svg>

--- a/examples/monolith-frame/templates/404.html
+++ b/examples/monolith-frame/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p>This room is closed for installation</p>
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/">Return to lobby</a><a class="kbd" href="{{ base_url }}/works/">View catalogue</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/monolith-frame/templates/footer.html
+++ b/examples/monolith-frame/templates/footer.html
@@ -1,0 +1,9 @@
+  </main>
+  <footer class="foot">
+    <span>{{ site_title }} · Hall 04, Östra Hamngatan</span>
+    <span class="colophon">Set in Cormorant &amp; Inter Tight</span>
+    <span>© {{ current_year }} · Built with Hwaro</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/monolith-frame/templates/header.html
+++ b/examples/monolith-frame/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Inter+Tight:wght@400;500;600&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="shell">
+  <header class="topbar">
+    <a class="brand" href="{{ base_url }}/"><b>MF—01</b> Monolith <em>Frame</em></a>
+    <nav>
+      <a href="{{ base_url }}/">Exhibitions</a>
+      <a href="{{ base_url }}/works/">Catalogue</a>
+      <a href="{{ base_url }}/tags/">Index</a>
+    </nav>
+    <span class="hours">Open Wed — Sun · 11—19</span>
+  </header>
+  <main>

--- a/examples/monolith-frame/templates/home.html
+++ b/examples/monolith-frame/templates/home.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="eyebrow">Spring Programme · 2026</div>
+    <h1>Heavy work,<br/>held in <em>still</em> air.</h1>
+  </div>
+  <div class="lede">
+    <p>{{ site.description }}</p>
+    <div class="meta-line">
+      <span>04 Halls</span>
+      <span>16 Artists</span>
+      <span>Through 09.2026</span>
+    </div>
+  </div>
+</section>
+
+<section class="exhibit-list">
+  <div class="label" style="margin-bottom: 1.5rem;">Currently on view</div>
+  {% set works = get_section(path="works/_index.md") %}
+  {% if works and works.pages %}
+    {% for p in works.pages %}
+    <a class="exhibit" href="{{ p.url }}">
+      <span class="num">№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <h2><span>{{ p.title | e }}</span></h2>
+        {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+      </div>
+      <div class="meta">
+        <b>{{ p.extra.artist | default(value="Resident artist") }}</b>
+        {% if p.extra.medium %}{{ p.extra.medium }}{% endif %}
+        {% if p.extra.year %} · {{ p.extra.year }}{% endif %}
+      </div>
+      <div class="pull">View →</div>
+    </a>
+    {% endfor %}
+  {% endif %}
+</section>
+
+<section class="plate">
+  <div class="stamp">Curatorial note</div>
+  {{ content | safe }}
+</section>
+
+{% include "footer.html" %}

--- a/examples/monolith-frame/templates/page.html
+++ b/examples/monolith-frame/templates/page.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<article>
+  {% if page.extra.artist %}<div class="eyebrow" style="font-family:'Inter Tight',sans-serif;font-size:0.72rem;letter-spacing:0.3em;text-transform:uppercase;color:var(--accent);margin-bottom:1rem;">{{ page.extra.artist }}</div>{% endif %}
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+  <div class="caption-rail">
+    {% if page.extra.medium %}<span><b>Medium</b> {{ page.extra.medium }}</span>{% endif %}
+    {% if page.extra.year %}<span><b>Year</b> {{ page.extra.year }}</span>{% endif %}
+    {% if page.extra.dimensions %}<span><b>Dimensions</b> {{ page.extra.dimensions }}</span>{% endif %}
+    {% if page.extra.hall %}<span><b>Hall</b> {{ page.extra.hall }}</span>{% endif %}
+    {% if page.date %}<span><b>On view</b> {{ page.date | date(format="%d %b %Y") }}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+  {% if page.tags %}
+    <p style="margin-top:3rem;">{% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</p>
+  {% endif %}
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/works/">← All works</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/monolith-frame/templates/section.html
+++ b/examples/monolith-frame/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="eyebrow">Catalogue</div>
+    <h1>{{ page.title | e }}</h1>
+  </div>
+  <div class="lede">{{ content | safe }}</div>
+</section>
+
+<section class="exhibit-list">
+  {% for p in section.pages %}
+  <a class="exhibit" href="{{ p.url }}">
+    <span class="num">№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <div>
+      <h2><span>{{ p.title | e }}</span></h2>
+      {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+    </div>
+    <div class="meta">
+      <b>{{ p.extra.artist | default(value="Resident artist") }}</b>
+      {% if p.extra.medium %}{{ p.extra.medium }}{% endif %}
+      {% if p.extra.year %} · {{ p.extra.year }}{% endif %}
+    </div>
+    <div class="pull">View →</div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/monolith-frame/templates/shortcodes/alert.html
+++ b/examples/monolith-frame/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert" style="padding:1rem 1.25rem;border-left:2px solid var(--accent);background:var(--bg-2);margin:1.5rem 0;font-family:'Inter Tight',sans-serif;font-size:0.9rem;color:var(--ink-2);">
+  <strong style="color:var(--accent);letter-spacing:0.18em;text-transform:uppercase;font-size:0.72rem;">{{ type | upper }}</strong>
+  <div style="margin-top:0.3rem;">{{ body }}</div>
+</div>

--- a/examples/monolith-frame/templates/taxonomy.html
+++ b/examples/monolith-frame/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="eyebrow">{{ taxonomy_name | default(value="Index") | upper }}</div>
+    <h1>{{ taxonomy_name | default(value="Index") | capitalize }}</h1>
+  </div>
+  <div class="lede"><p>All terms in the <em>{{ taxonomy_name }}</em> register.</p></div>
+</section>
+<section class="exhibit-list">
+  {% for term in taxonomy_terms %}
+  <a class="exhibit" href="{{ term.url }}">
+    <span class="num">№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <div><h2><span>{{ term.name }}</span></h2></div>
+    <div class="meta"><b>{{ term.pages_count }}</b> entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %}</div>
+    <div class="pull">View →</div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/monolith-frame/templates/taxonomy_term.html
+++ b/examples/monolith-frame/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="eyebrow">{{ taxonomy_name | upper }}</div>
+    <h1><em>#</em>{{ page.title }}</h1>
+  </div>
+  <div class="lede"><p>{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} filed under <em>{{ page.title }}</em>.</p></div>
+</section>
+<section class="exhibit-list">
+  {% for p in taxonomy_pages %}
+  <a class="exhibit" href="{{ p.url }}">
+    <span class="num">№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <div>
+      <h2><span>{{ p.title | e }}</span></h2>
+      {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+    </div>
+    <div class="meta">{% if p.date %}<b>{{ p.date | date(format="%Y") }}</b>{% endif %}{% if p.extra.medium %}{{ p.extra.medium }}{% endif %}</div>
+    <div class="pull">View →</div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/prism-archive/AGENTS.md
+++ b/examples/prism-archive/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md — Prism Archive
+
+Light, museum-archive gallery (gallery type). Paper-cream + coral accent.
+Fraunces display + Inter UI. Cards use inline SVG plates keyed by `loop.index`.
+
+Per-work `page.extra` fields: `artist`, `medium`, `year`, `dimensions`,
+`origin`, `accession`.
+
+## Conventions
+
+- No gradients, no emojis. Single accent: `--accent: #e25c4a`.
+- All CSS in `static/css/style.css`. Use `{{ base_url }}` for assets.
+- Home and section share the inline-SVG card pattern; first 4 cards have unique
+  thumbnails, all later cards fall back to a generic plate.
+
+## Hwaro
+
+| Command | Description |
+|---|---|
+| `hwaro build` | Build to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro tool doctor --fix` | Validate/patch config |
+
+Full reference: <https://hwaro.hahwul.com>

--- a/examples/prism-archive/archetypes/default.md
+++ b/examples/prism-archive/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/prism-archive/config.toml
+++ b/examples/prism-archive/config.toml
@@ -43,3 +43,155 @@ footnotes = true
 
 [doctor]
 ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/prism-archive/config.toml
+++ b/examples/prism-archive/config.toml
@@ -1,0 +1,45 @@
+title = "Prism Archive"
+description = "An archival image gallery on hairline grids. Quiet captions, accurate dates, and one accent."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/prism-archive/content/index.md
+++ b/examples/prism-archive/content/index.md
@@ -1,0 +1,14 @@
++++
+title = "Prism Archive"
+description = "An archival image gallery on hairline grids. Quiet captions, accurate dates, and one accent."
+template = "home"
++++
+
+The Prism Archive is a small, slow-growing collection of works on paper and
+photographs from independent makers across the Baltic and North Atlantic. We
+publish four plates each season — no more, no less — and keep the index light
+enough that a single page can be read in one sitting.
+
+We do not loan, and we do not insure. Plates are taken down when the season
+ends and rehoused in the printed annual. The next volume will be issued
+December 2026.

--- a/examples/prism-archive/content/works/01-three-circles.md
+++ b/examples/prism-archive/content/works/01-three-circles.md
@@ -1,0 +1,34 @@
++++
+title = "Three circles, after rain"
+description = "Cyanotype print on Bockingford paper, exposed during a single mid-afternoon shower in Aarhus."
+date = "2026-02-09"
+weight = 1
+tags = ["cyanotype", "paper", "weather"]
+[extra]
+artist = "Henrietta Lund"
+medium = "Cyanotype, hand-coated"
+year = "2026"
+dimensions = "42 × 30 cm"
+origin = "Aarhus, DK"
+accession = "PA-2026-014"
++++
+
+Three discs of glass were laid on a sensitized sheet of paper in the courtyard
+of the artist's studio. The shower that started at 14:42 and stopped at 14:51
+was the only light source the sheet received. The faint texture across the
+print is the impression of the paper drying unevenly against the slate.
+
+## Process
+
+Cyanotype emulsion is mixed two parts ammonium ferric citrate to one part
+potassium ferricyanide, hand-brushed on Bockingford 425 gsm. Sensitization is
+done indoors. The sheet is exposed face-up to ambient daylight; in this case,
+the dimness of the shower acted as a one-stop neutral filter.
+
+> "The weather is the camera. I just put the paper down." — *H. Lund, 2026*
+
+### Storage
+
+The plate is currently held flat in interleaved acid-free folders. Light
+exposure is limited to four hours per quarter. The print has shifted ~3% bluer
+since acquisition; this is expected.

--- a/examples/prism-archive/content/works/02-field-notation.md
+++ b/examples/prism-archive/content/works/02-field-notation.md
@@ -1,0 +1,36 @@
++++
+title = "Field, notated"
+description = "A graphite study of a barley field at the moment of harvest, redrawn from the artist's pocket notebook."
+date = "2026-01-22"
+weight = 2
+tags = ["graphite", "drawing", "fieldwork"]
+[extra]
+artist = "Kåre Nyberg"
+medium = "Graphite on Fabriano hot-press"
+year = "2025"
+dimensions = "56 × 38 cm"
+origin = "Skåne, SE"
+accession = "PA-2026-021"
++++
+
+Nyberg spent eleven days walking a single field on a smallholding outside
+Tomelilla, returning each evening to redraw the day's notes at a larger scale.
+The plate held here is the eleventh drawing — the final state, with the harvest
+midway through.
+
+## Notes from the artist
+
+> "I did not want to make the field romantic. I wanted to make the field
+> legible. A drawing that says: this is what was here, on this day, in this
+> light." — *K. Nyberg*
+
+### Provenance
+
+Acquired directly from the artist, February 2026. The artist retains the
+preceding ten studies; the present plate is the only one that left the studio.
+
+### Condition
+
+Excellent. Hot-press surface; graphite has bonded fully and shows no smearing.
+The plate is held under glass with UV-filtering film and is rotated quarterly
+to avoid light damage to the unframed side.

--- a/examples/prism-archive/content/works/03-the-keepsake.md
+++ b/examples/prism-archive/content/works/03-the-keepsake.md
@@ -1,0 +1,35 @@
++++
+title = "The keepsake"
+description = "Silver-gelatin print of an unopened envelope, photographed against the studio window for thirty-seven minutes."
+date = "2026-03-02"
+weight = 3
+tags = ["photography", "silver-gelatin", "stillness"]
+[extra]
+artist = "Eira Sjöström"
+medium = "Silver-gelatin print, selenium-toned"
+year = "2025"
+dimensions = "30 × 24 cm"
+origin = "Helsingfors, FI"
++++
+
+The envelope in this photograph has never been opened. Sjöström found it among
+her grandmother's papers in 1998 and has kept it sealed since. The long exposure
+— thirty-seven minutes against an overcast March window — was made on a large-
+format camera at the artist's studio.
+
+## On not opening
+
+> "The picture is the thing now. The letter inside is whatever the picture lets
+> me imagine. I have lost interest in finding out." — *E. Sjöström, 2026*
+
+### Print
+
+Hand-printed on Adox Lupex baryta paper, selenium-toned for permanence. The
+unique state is held in this archive; the artist has not editioned the work and
+does not intend to.
+
+### Display recommendation
+
+Mount on the long wall, eye level. The print should be lit from a single source
+at no more than 50 lux. Do not photograph the print under flash; the toning
+will read incorrectly.

--- a/examples/prism-archive/content/works/04-twelve-fences.md
+++ b/examples/prism-archive/content/works/04-twelve-fences.md
@@ -1,0 +1,34 @@
++++
+title = "Twelve fences"
+description = "A serial photograph of twelve adjacent garden fences along a single street, each taken on the same overcast morning."
+date = "2026-03-25"
+weight = 4
+tags = ["photography", "series", "domestic"]
+[extra]
+artist = "Bo Halland"
+medium = "Inkjet on Hahnemühle Photo Rag"
+year = "2024—2025"
+dimensions = "12 plates, each 24 × 18 cm"
+origin = "Göteborg, SE"
+accession = "PA-2026-032"
++++
+
+Bo Halland photographed twelve adjacent garden fences along Vallbergavägen on a
+single morning in November 2024. The fences were painted in different years by
+different hands; the project is, in the artist's words, "a domestic chronology
+read sideways."
+
+## The set
+
+The set is twelve plates; only the first is shown in the present catalogue.
+The full set is held in a custom solander box at the archive and may be
+consulted on request by visiting researchers.
+
+> "Each fence is a household's idea of where the household ends. The colours
+> are the give-away." — *B. Halland*
+
+### Display
+
+The plates are designed to be hung as a single horizontal frieze, with 4 cm
+between frames. The intended viewing distance is 1.4 m. The frieze has been
+shown in this configuration once: at the Hasselblad Center, March 2025.

--- a/examples/prism-archive/content/works/_index.md
+++ b/examples/prism-archive/content/works/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Holdings"
+description = "The full set of plates currently catalogued in this season's volume."
+sort_by = "weight"
+template = "section"
++++
+
+Holdings are listed by plate number, not date of acquisition. Each entry shows
+the maker, year, medium, and accession code. Entries with no accession code are
+on loan from the maker for the duration of the season.

--- a/examples/prism-archive/static/css/style.css
+++ b/examples/prism-archive/static/css/style.css
@@ -1,0 +1,288 @@
+:root {
+  --paper: #f3f1ec;
+  --paper-2: #e9e6df;
+  --ink: #161613;
+  --ink-2: #4a4a45;
+  --ink-3: #8a8780;
+  --rule: #d6d2c8;
+  --rule-2: #c6c1b3;
+  --accent: #e25c4a;
+  --accent-ink: #b53d2b;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 16px; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Fraunces", "Source Serif Pro", Georgia, serif;
+  line-height: 1.55;
+  font-feature-settings: "ss01", "ss02";
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent-ink); }
+
+.shell {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0 2.5rem;
+}
+
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--ink);
+  font-family: "Inter", system-ui, sans-serif;
+}
+.topbar .left { font-size: 0.72rem; letter-spacing: 0.24em; text-transform: uppercase; color: var(--ink-3); }
+.topbar .left b { color: var(--accent-ink); font-weight: 600; letter-spacing: 0.18em; }
+.brand {
+  font-family: "Fraunces", serif;
+  font-weight: 400;
+  font-size: 1.4rem;
+  font-style: italic;
+  letter-spacing: -0.01em;
+  text-align: center;
+}
+.brand b { font-style: normal; font-weight: 600; }
+.topbar .right { display: flex; justify-content: flex-end; gap: 1.8rem; font-size: 0.72rem; letter-spacing: 0.22em; text-transform: uppercase; }
+.topbar .right a { color: var(--ink-2); }
+.topbar .right a:hover { color: var(--accent-ink); }
+
+.hero {
+  padding: 6rem 0 4rem;
+  border-bottom: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 8rem 1fr 24rem;
+  gap: 3rem;
+  align-items: end;
+}
+.hero .col-label {
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--ink-3);
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+.hero h1 {
+  font-size: clamp(2.6rem, 6.5vw, 5.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.025em;
+  margin: 0;
+  font-weight: 400;
+}
+.hero h1 em { font-style: italic; color: var(--accent); font-weight: 400; }
+.hero .lede { font-family: "Inter", sans-serif; color: var(--ink-2); font-size: 0.95rem; }
+.hero .lede p { margin: 0 0 1.2rem; line-height: 1.65; }
+.hero .meta {
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+  border-top: 1px solid var(--rule);
+  padding-top: 1rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem 1rem;
+}
+.hero .meta b { color: var(--ink); font-weight: 600; display: block; }
+
+.grid-archive {
+  padding: 4rem 0;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--rule);
+}
+.grid-archive .lbl {
+  grid-column: 1 / -1;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--ink);
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.26em;
+  color: var(--ink-3);
+  display: flex;
+  justify-content: space-between;
+}
+
+.card {
+  grid-column: span 6;
+  padding: 2rem 2rem 2.2rem;
+  border-bottom: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
+  background: var(--paper);
+}
+.card:nth-child(2n+1) { border-left: 1px solid var(--rule); }
+.card:hover { background: #fff; }
+.card .thumb {
+  aspect-ratio: 4 / 3;
+  background: var(--paper-2);
+  position: relative;
+  overflow: hidden;
+}
+.card .thumb svg { width: 100%; height: 100%; display: block; }
+.card .ref {
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent-ink);
+}
+.card h2 {
+  font-size: 1.8rem;
+  margin: 0;
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+}
+.card h2 em { font-style: italic; }
+.card .who {
+  font-family: "Inter", sans-serif;
+  font-size: 0.85rem;
+  color: var(--ink-2);
+}
+.card .who b { font-weight: 600; color: var(--ink); }
+.card .caption {
+  font-family: "Inter", sans-serif;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  border-top: 1px solid var(--rule);
+  padding-top: 0.7rem;
+  display: flex;
+  justify-content: space-between;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+.card .caption .num { color: var(--accent-ink); }
+
+.statement {
+  border-top: 1px solid var(--ink);
+  padding: 4rem 0 5rem;
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 4rem;
+}
+.statement h3 {
+  font-family: "Inter", sans-serif;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  margin: 0;
+  color: var(--accent-ink);
+}
+.statement .body { font-size: 1.15rem; color: var(--ink-2); line-height: 1.55; }
+.statement .body p { margin: 0 0 1rem; }
+.statement .body em { color: var(--ink); }
+
+article {
+  max-width: 50rem;
+  margin: 4rem auto 6rem;
+  padding: 0 2rem;
+}
+article .ref {
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: var(--accent-ink);
+  margin-bottom: 1rem;
+}
+article h1 { font-size: 3rem; line-height: 1.03; letter-spacing: -0.02em; margin: 0 0 1rem; font-weight: 400; }
+article h1 em { font-style: italic; color: var(--accent); }
+article .lede { font-family: "Inter", sans-serif; color: var(--ink-2); font-size: 1.05rem; margin: 0 0 2rem; }
+article h2 { font-size: 1.4rem; margin: 2.5rem 0 0.7rem; font-weight: 600; letter-spacing: -0.005em; }
+article h3 { font-family: "Inter", sans-serif; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.22em; color: var(--accent-ink); margin: 2rem 0 0.6rem; }
+article p, article li { color: var(--ink-2); font-size: 1.02rem; }
+article a { color: var(--ink); border-bottom: 1px solid var(--rule-2); }
+article a:hover { color: var(--accent-ink); border-bottom-color: var(--accent); }
+article blockquote { font-family: "Fraunces", serif; font-style: italic; font-size: 1.3rem; color: var(--ink); border-left: 2px solid var(--accent); padding: 0.4rem 1.4rem; margin: 2rem 0; }
+article hr { border: none; border-top: 1px solid var(--rule); margin: 3rem 0; }
+
+.caption-rail {
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--rule);
+  padding: 0.8rem 0;
+  margin: 1rem 0 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+  gap: 0.6rem 1.5rem;
+}
+.caption-rail span b { display: block; color: var(--ink); font-weight: 600; }
+
+.tag-pill {
+  display: inline-block;
+  border: 1px solid var(--rule-2);
+  color: var(--ink-2);
+  padding: 0.2rem 0.7rem;
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-right: 0.4rem;
+}
+.tag-pill:hover { border-color: var(--accent); color: var(--accent-ink); }
+
+.kbd {
+  display: inline-block;
+  border: 1px solid var(--ink);
+  padding: 0.45rem 1rem;
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink);
+  margin: 0.3rem 0.4rem 0 0;
+  background: var(--paper);
+}
+.kbd:hover { background: var(--ink); color: var(--paper); }
+
+.foot {
+  border-top: 1px solid var(--ink);
+  margin-top: 3rem;
+  padding: 2rem 0 2.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ink-3);
+}
+.foot b { color: var(--ink); }
+.foot .mid { text-align: center; font-style: italic; text-transform: none; letter-spacing: 0; font-family: "Fraunces", serif; font-size: 0.95rem; color: var(--ink-2); }
+.foot .end { text-align: right; }
+
+.notfound { text-align: center; padding: 8rem 0; }
+.notfound h1 { font-size: 8rem; margin: 0; font-weight: 400; color: var(--accent); font-style: italic; }
+.notfound p { font-family: "Inter", sans-serif; color: var(--ink-2); text-transform: uppercase; letter-spacing: 0.24em; font-size: 0.8rem; }
+
+@media (max-width: 900px) {
+  .shell { padding: 0 1.25rem; }
+  .topbar { grid-template-columns: 1fr; gap: 0.4rem; text-align: left; }
+  .topbar .right { justify-content: flex-start; flex-wrap: wrap; }
+  .hero { grid-template-columns: 1fr; gap: 1.5rem; padding: 3rem 0; }
+  .hero .col-label { writing-mode: horizontal-tb; transform: none; }
+  .card { grid-column: span 12 !important; border-left: 1px solid var(--rule); }
+  .statement { grid-template-columns: 1fr; gap: 1.5rem; }
+  .foot { grid-template-columns: 1fr; gap: 0.6rem; }
+  .foot .end, .foot .mid { text-align: left; }
+}

--- a/examples/prism-archive/static/favicon.svg
+++ b/examples/prism-archive/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f3f1ec"/>
+  <path d="M16 5 L27 26 L5 26 Z" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <circle cx="16" cy="19" r="2" fill="#e25c4a"/>
+</svg>

--- a/examples/prism-archive/templates/404.html
+++ b/examples/prism-archive/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p>This plate is not in the archive</p>
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/">Return to index</a><a class="kbd" href="{{ base_url }}/works/">Browse holdings</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/prism-archive/templates/footer.html
+++ b/examples/prism-archive/templates/footer.html
@@ -1,0 +1,9 @@
+  </main>
+  <footer class="foot">
+    <div><b>Prism Archive</b> · No. 14 Ringstedgade · 4700 Næstved</div>
+    <div class="mid">Set in Fraunces and Inter</div>
+    <div class="end">© {{ current_year }} · Built with Hwaro</div>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/prism-archive/templates/header.html
+++ b/examples/prism-archive/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="shell">
+  <header class="topbar">
+    <div class="left"><b>PA / 26 ·</b> Vol. III · Spring</div>
+    <a class="brand" href="{{ base_url }}/"><em>Prism</em> <b>Archive</b></a>
+    <div class="right">
+      <a href="{{ base_url }}/">Index</a>
+      <a href="{{ base_url }}/works/">Holdings</a>
+      <a href="{{ base_url }}/tags/">Subjects</a>
+    </div>
+  </header>
+  <main>

--- a/examples/prism-archive/templates/home.html
+++ b/examples/prism-archive/templates/home.html
@@ -1,0 +1,56 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="col-label">Spring · 2026</div>
+  <div>
+    <h1>The archive,<br/>read as <em>image</em>.</h1>
+  </div>
+  <div class="lede">
+    <p>{{ site.description }}</p>
+    <div class="meta">
+      <span><b>Volume</b> III</span>
+      <span><b>Plates</b> 04</span>
+      <span><b>Period</b> 2018—2026</span>
+      <span><b>Format</b> 240 × 300</span>
+    </div>
+  </div>
+</section>
+
+<section class="grid-archive">
+  <div class="lbl"><span>Currently catalogued</span><span>Plate 01 — 04</span></div>
+  {% set works = get_section(path="works/_index.md") %}
+  {% if works and works.pages %}
+    {% for p in works.pages %}
+    <a class="card" href="{{ p.url }}">
+      <div class="thumb">
+        {% set i = loop.index %}
+        {% if i == 1 %}
+        <svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><circle cx="60" cy="78" r="44" fill="none" stroke="#161613" stroke-width="1.2"/><circle cx="110" cy="78" r="44" fill="none" stroke="#161613" stroke-width="1.2"/><circle cx="160" cy="78" r="44" fill="none" stroke="#e25c4a" stroke-width="1.6"/></svg>
+        {% elif i == 2 %}
+        <svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><g stroke="#161613" stroke-width="0.7" fill="none">{% for n in range(end=20) %}<line x1="0" y1="{{ n * 8 }}" x2="200" y2="{{ n * 8 + 14 }}"/>{% endfor %}</g><rect x="70" y="50" width="60" height="50" fill="#e25c4a"/></svg>
+        {% elif i == 3 %}
+        <svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><polygon points="100,18 168,130 32,130" fill="none" stroke="#161613" stroke-width="1.4"/><polygon points="100,52 134,120 66,120" fill="#161613"/><circle cx="100" cy="92" r="6" fill="#e25c4a"/></svg>
+        {% elif i == 4 %}
+        <svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><g fill="none" stroke="#161613" stroke-width="0.9">{% for n in range(end=14) %}<rect x="{{ 20 + n * 12 }}" y="20" width="6" height="110"/>{% endfor %}</g><rect x="80" y="60" width="40" height="40" fill="#e25c4a" opacity="0.85"/></svg>
+        {% else %}
+        <svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><rect x="40" y="30" width="120" height="90" fill="none" stroke="#161613" stroke-width="1.2"/><circle cx="100" cy="75" r="20" fill="#e25c4a"/></svg>
+        {% endif %}
+      </div>
+      <div class="ref">Plate № {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+      <h2>{{ p.title | e }}</h2>
+      <div class="who"><b>{{ p.extra.artist | default(value="Unknown maker") }}</b>{% if p.extra.year %} · {{ p.extra.year }}{% endif %}</div>
+      <div class="caption">
+        <span>{% if p.extra.medium %}{{ p.extra.medium }}{% endif %}</span>
+        <span class="num">{% if p.extra.accession %}{{ p.extra.accession }}{% endif %}</span>
+      </div>
+    </a>
+    {% endfor %}
+  {% endif %}
+</section>
+
+<section class="statement">
+  <h3>From the archivist</h3>
+  <div class="body">
+    {{ content | safe }}
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/prism-archive/templates/page.html
+++ b/examples/prism-archive/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<article>
+  <div class="ref">{% if page.extra.accession %}Accession {{ page.extra.accession }}{% else %}Catalogue entry{% endif %}</div>
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+  <div class="caption-rail">
+    {% if page.extra.artist %}<span><b>Artist</b> {{ page.extra.artist }}</span>{% endif %}
+    {% if page.extra.medium %}<span><b>Medium</b> {{ page.extra.medium }}</span>{% endif %}
+    {% if page.extra.year %}<span><b>Year</b> {{ page.extra.year }}</span>{% endif %}
+    {% if page.extra.dimensions %}<span><b>Dimensions</b> {{ page.extra.dimensions }}</span>{% endif %}
+    {% if page.extra.origin %}<span><b>Origin</b> {{ page.extra.origin }}</span>{% endif %}
+    {% if page.date %}<span><b>Acquired</b> {{ page.date | date(format="%d %b %Y") }}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+  {% if page.tags %}
+    <p style="margin-top:3rem;">{% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</p>
+  {% endif %}
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/works/">← Back to holdings</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/prism-archive/templates/section.html
+++ b/examples/prism-archive/templates/section.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="col-label">Holdings</div>
+  <div><h1>{{ page.title | e }}</h1></div>
+  <div class="lede">{{ content | safe }}</div>
+</section>
+
+<section class="grid-archive">
+  <div class="lbl"><span>{{ section.pages | length }} catalogued items</span><span>Sorted by weight</span></div>
+  {% for p in section.pages %}
+  <a class="card" href="{{ p.url }}">
+    <div class="thumb">
+      {% set i = loop.index %}
+      {% if i == 1 %}<svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><circle cx="60" cy="78" r="44" fill="none" stroke="#161613" stroke-width="1.2"/><circle cx="110" cy="78" r="44" fill="none" stroke="#161613" stroke-width="1.2"/><circle cx="160" cy="78" r="44" fill="none" stroke="#e25c4a" stroke-width="1.6"/></svg>
+      {% elif i == 2 %}<svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><g stroke="#161613" stroke-width="0.7" fill="none">{% for n in range(end=20) %}<line x1="0" y1="{{ n * 8 }}" x2="200" y2="{{ n * 8 + 14 }}"/>{% endfor %}</g><rect x="70" y="50" width="60" height="50" fill="#e25c4a"/></svg>
+      {% elif i == 3 %}<svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><polygon points="100,18 168,130 32,130" fill="none" stroke="#161613" stroke-width="1.4"/><polygon points="100,52 134,120 66,120" fill="#161613"/><circle cx="100" cy="92" r="6" fill="#e25c4a"/></svg>
+      {% elif i == 4 %}<svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><g fill="none" stroke="#161613" stroke-width="0.9">{% for n in range(end=14) %}<rect x="{{ 20 + n * 12 }}" y="20" width="6" height="110"/>{% endfor %}</g><rect x="80" y="60" width="40" height="40" fill="#e25c4a" opacity="0.85"/></svg>
+      {% else %}<svg viewBox="0 0 200 150"><rect width="200" height="150" fill="#e9e6df"/><rect x="40" y="30" width="120" height="90" fill="none" stroke="#161613" stroke-width="1.2"/><circle cx="100" cy="75" r="20" fill="#e25c4a"/></svg>{% endif %}
+    </div>
+    <div class="ref">Plate № {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+    <h2>{{ p.title | e }}</h2>
+    <div class="who"><b>{{ p.extra.artist | default(value="Unknown maker") }}</b>{% if p.extra.year %} · {{ p.extra.year }}{% endif %}</div>
+    <div class="caption">
+      <span>{% if p.extra.medium %}{{ p.extra.medium }}{% endif %}</span>
+      <span class="num">{% if p.extra.accession %}{{ p.extra.accession }}{% endif %}</span>
+    </div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/prism-archive/templates/shortcodes/alert.html
+++ b/examples/prism-archive/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div style="padding:0.9rem 1.2rem;border-left:2px solid var(--accent);background:var(--paper-2);margin:1.5rem 0;font-family:'Inter',sans-serif;font-size:0.92rem;color:var(--ink-2);">
+  <strong style="color:var(--accent-ink);letter-spacing:0.2em;text-transform:uppercase;font-size:0.7rem;">{{ type | upper }}</strong>
+  <div style="margin-top:0.3rem;">{{ body }}</div>
+</div>

--- a/examples/prism-archive/templates/taxonomy.html
+++ b/examples/prism-archive/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="col-label">{{ taxonomy_name | default(value="Subjects") | upper }}</div>
+  <div><h1>{{ taxonomy_name | default(value="Subjects") | capitalize }}</h1></div>
+  <div class="lede"><p>All terms in the <em>{{ taxonomy_name }}</em> register.</p></div>
+</section>
+<section class="grid-archive">
+  <div class="lbl"><span>{{ taxonomy_terms | length }} terms</span><span>Subjects</span></div>
+  {% for term in taxonomy_terms %}
+  <a class="card" href="{{ term.url }}">
+    <div class="ref">№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+    <h2>{{ term.name }}</h2>
+    <div class="caption"><span>{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %}</span><span class="num">/{{ taxonomy_name }}/{{ term.slug }}/</span></div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/prism-archive/templates/taxonomy_term.html
+++ b/examples/prism-archive/templates/taxonomy_term.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="col-label">{{ taxonomy_name | upper }}</div>
+  <div><h1><em>#</em>{{ page.title }}</h1></div>
+  <div class="lede"><p>{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} filed under <em>{{ page.title }}</em>.</p></div>
+</section>
+<section class="grid-archive">
+  <div class="lbl"><span>Filed under {{ page.title }}</span><span>{{ taxonomy_pages | length }} items</span></div>
+  {% for p in taxonomy_pages %}
+  <a class="card" href="{{ p.url }}">
+    <div class="ref">{% if p.extra.accession %}{{ p.extra.accession }}{% else %}№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}{% endif %}</div>
+    <h2>{{ p.title | e }}</h2>
+    <div class="who">{% if p.extra.artist %}<b>{{ p.extra.artist }}</b>{% endif %}{% if p.extra.year %} · {{ p.extra.year }}{% endif %}</div>
+    <div class="caption"><span>{% if p.extra.medium %}{{ p.extra.medium }}{% endif %}</span><span class="num">{% if p.date %}{{ p.date | date(format="%Y") }}{% endif %}</span></div>
+  </a>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/silver-loom/AGENTS.md
+++ b/examples/silver-loom/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md — Silver Loom
+
+Light, Swiss-asymmetric gallery (gallery type). Paper + ink-navy + coral
+accent. Inter UI + Source Serif Pro italics. The home/section template uses a
+12-column subgrid where each row alternates the plate from left to right.
+
+Per-work `page.extra` fields: `artist`, `medium`, `year`, `dimensions`,
+`warp`, `weft`, `loom`.
+
+## Conventions
+
+- No gradients (no `linear-gradient` even for underline tricks; use box-shadow).
+- No emojis. Single accent: `--accent: #c95a3a`.
+- All CSS in `static/css/style.css`. Use `{{ base_url }}` for assets.
+
+## Hwaro
+
+| Command | Description |
+|---|---|
+| `hwaro build` | Build to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro tool doctor --fix` | Validate/patch config |
+
+Full reference: <https://hwaro.hahwul.com>

--- a/examples/silver-loom/archetypes/default.md
+++ b/examples/silver-loom/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/silver-loom/config.toml
+++ b/examples/silver-loom/config.toml
@@ -43,3 +43,155 @@ footnotes = true
 
 [doctor]
 ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/silver-loom/config.toml
+++ b/examples/silver-loom/config.toml
@@ -1,0 +1,45 @@
+title = "Silver Loom"
+description = "An asymmetric Swiss-grid gallery for textile, weaving, and material-led practice."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/silver-loom/content/index.md
+++ b/examples/silver-loom/content/index.md
@@ -1,0 +1,14 @@
++++
+title = "Silver Loom"
+description = "An asymmetric Swiss-grid gallery for textile, weaving, and material-led practice."
+template = "home"
++++
+
+Silver Loom is a one-room space dedicated to slow textile work. Each season we
+present four works on the loom: two by invited artists and two from the rotating
+holdings. We keep the walls bare between pieces and the labels small enough that
+the cloth remains the loudest thing in the room.
+
+The current programme runs from March through July 2026. Visitors are welcome
+to handle the sample swatches at the front desk; please do not touch the hung
+work.

--- a/examples/silver-loom/content/works/01-warp-study.md
+++ b/examples/silver-loom/content/works/01-warp-study.md
@@ -1,0 +1,37 @@
++++
+title = "Warp Study, 04 Tensions"
+description = "A linen wall-piece woven at four progressively slackened warp tensions, joined edge-to-edge across a single 220 cm bolt."
+date = "2026-03-12"
+weight = 1
+loom = 1
+tags = ["weaving", "linen", "tension"]
+[extra]
+artist = "Astrid Solberg"
+medium = "Hand-woven linen, four-tension warp"
+year = "2025—2026"
+dimensions = "220 × 110 cm"
+warp = "20/2 cotton, natural"
+weft = "Bockens line linen, NeL 16"
+loom = "01"
++++
+
+Astrid Solberg dresses the loom at the maximum tension her warp can carry, then
+slackens it by a fixed amount three times during the weave. The four panels are
+joined edge-to-edge so the change in surface texture is visible as a single
+horizontal weather across the cloth.
+
+## Method
+
+The warp is 20/2 cotton in natural, set at 8 ends per cm. Each tension band is
+55 cm of cloth woven before the slackening; the resulting surface tightens and
+loosens in a way that no single tension can produce. The selvedges are warped
+1 cm wider on each side to allow for take-up; the trimmed cloth is exactly
+220 cm wide.
+
+> "The loom remembers the tension. The cloth shows what the loom remembered." — *A. Solberg*
+
+### Display
+
+Hung from a slim oak batten and weighted at the foot with a hidden brass rod.
+The piece moves visibly when the gallery door opens; this is intended. Please
+do not steady the cloth.

--- a/examples/silver-loom/content/works/01-warp-study.md
+++ b/examples/silver-loom/content/works/01-warp-study.md
@@ -3,7 +3,6 @@ title = "Warp Study, 04 Tensions"
 description = "A linen wall-piece woven at four progressively slackened warp tensions, joined edge-to-edge across a single 220 cm bolt."
 date = "2026-03-12"
 weight = 1
-loom = 1
 tags = ["weaving", "linen", "tension"]
 [extra]
 artist = "Astrid Solberg"

--- a/examples/silver-loom/content/works/02-river-pattern.md
+++ b/examples/silver-loom/content/works/02-river-pattern.md
@@ -3,7 +3,6 @@ title = "River pattern, after Götaälv"
 description = "A double-cloth study taking its rhythm from the surface of the Göta älv river, woven from twelve photographs and a single sketch."
 date = "2026-03-22"
 weight = 2
-loom = 2
 tags = ["weaving", "wool", "drawing"]
 [extra]
 artist = "Henrik Borg"

--- a/examples/silver-loom/content/works/02-river-pattern.md
+++ b/examples/silver-loom/content/works/02-river-pattern.md
@@ -1,0 +1,36 @@
++++
+title = "River pattern, after Götaälv"
+description = "A double-cloth study taking its rhythm from the surface of the Göta älv river, woven from twelve photographs and a single sketch."
+date = "2026-03-22"
+weight = 2
+loom = 2
+tags = ["weaving", "wool", "drawing"]
+[extra]
+artist = "Henrik Borg"
+medium = "Double-cloth wool, hand-finished"
+year = "2025"
+dimensions = "180 × 140 cm"
+warp = "Faro 6/2 wool, indigo"
+weft = "Mora 8/1 wool, undyed"
+loom = "02"
++++
+
+Henrik Borg makes double-cloth panels at a four-shaft loom, working from
+photographs and pencil studies he takes on his weekly walks along the Göta älv.
+The piece in the current programme is a single panel built from twelve
+photographs taken on a winter morning in February 2025.
+
+## Drafting
+
+The pattern is drafted on point-paper at the artist's studio in Majorna, then
+walked back through the loom at half-scale. The double cloth is woven face-down
+so that the dark-light reversal happens at the edges of the eddies, not at
+their centres.
+
+> "I do not weave the river. I weave my walk past it." — *H. Borg*
+
+### Finishing
+
+Wet-finished in soft water, no fulling. The surface retains a soft sheen that
+will dull with time and handling; this is part of the work and is not to be
+corrected.

--- a/examples/silver-loom/content/works/03-grid-of-knots.md
+++ b/examples/silver-loom/content/works/03-grid-of-knots.md
@@ -1,0 +1,36 @@
++++
+title = "Grid of knots"
+description = "A sampler of one hundred macramé knots arranged on a ten-by-ten grid, each knot tied from a different working length."
+date = "2026-04-03"
+weight = 3
+loom = 3
+tags = ["macrame", "sampler", "rope"]
+[extra]
+artist = "Lin Kvist"
+medium = "Hemp twine, beeswaxed, on oak frame"
+year = "2026"
+dimensions = "120 × 120 cm"
+warp = "Hemp twine, 3 mm"
+weft = "—"
+loom = "03"
++++
+
+Lin Kvist's sampler is exactly what it claims to be — one hundred macramé knots
+on a hundred-cell grid, each tied from a working length proportional to the
+final size of the knot. The grid is drawn in graphite on the back of the oak
+frame; only the knots are visible from the front.
+
+## The index
+
+A printed index of the hundred knots is available at the desk. Each cell carries
+a number from 01 to 100, reading left to right and top to bottom. Many of the
+knots are common to all sailors and macramé practitioners; six of them are
+Kvist's own.
+
+> "A knot is a small problem you have decided how to leave unsolved." — *L. Kvist*
+
+### Material
+
+Hemp twine drawn through a beeswax block to give the knots a slight resistance
+to slipping. The twine will darken with handling and exposure; the piece is not
+sealed, and is not expected to remain its current pale colour.

--- a/examples/silver-loom/content/works/03-grid-of-knots.md
+++ b/examples/silver-loom/content/works/03-grid-of-knots.md
@@ -3,7 +3,6 @@ title = "Grid of knots"
 description = "A sampler of one hundred macramé knots arranged on a ten-by-ten grid, each knot tied from a different working length."
 date = "2026-04-03"
 weight = 3
-loom = 3
 tags = ["macrame", "sampler", "rope"]
 [extra]
 artist = "Lin Kvist"

--- a/examples/silver-loom/content/works/04-third-shuttle.md
+++ b/examples/silver-loom/content/works/04-third-shuttle.md
@@ -3,7 +3,6 @@ title = "Third shuttle, found"
 description = "A reconstruction of a 19th-century band-loom piece from a single surviving fragment held at the Nordiska museet."
 date = "2026-04-19"
 weight = 4
-loom = 4
 tags = ["weaving", "historical", "reconstruction"]
 [extra]
 artist = "Märit Lindqvist"

--- a/examples/silver-loom/content/works/04-third-shuttle.md
+++ b/examples/silver-loom/content/works/04-third-shuttle.md
@@ -1,0 +1,39 @@
++++
+title = "Third shuttle, found"
+description = "A reconstruction of a 19th-century band-loom piece from a single surviving fragment held at the Nordiska museet."
+date = "2026-04-19"
+weight = 4
+loom = 4
+tags = ["weaving", "historical", "reconstruction"]
+[extra]
+artist = "Märit Lindqvist"
+medium = "Hand-woven wool and linen, band-loom"
+year = "2024—2026"
+dimensions = "8 × 220 cm, mounted on linen"
+warp = "Heavy wool, indigo"
+weft = "Linen, hand-dyed madder"
+loom = "04"
++++
+
+A 7 × 4 cm wool-and-linen fragment in the textile vaults of the Nordiska museet
+in Stockholm carries a pattern that the museum's catalogue records as "third
+shuttle, in red." Märit Lindqvist has spent two winters reconstructing the
+implied repeat at full width and producing a 220 cm length of the band on a
+period band-loom.
+
+## The reconstruction
+
+The repeat in the original fragment is 18 picks long. Lindqvist found the
+implied complete cycle by trial at the band-loom, working through nine
+unsuccessful versions before settling on the present one. The artist regards
+the work as provisional; she does not claim to have recovered the original.
+
+> "We do not have the band the museum thinks we have. We have a band that fits
+> the fragment." — *M. Lindqvist*
+
+### Display
+
+The fragment from the Nordiska museet is reproduced at full size in a printed
+note at the desk. The reconstruction itself is mounted on a linen support and
+hung between two oak battens. Visitors may handle the printed note; the
+mounted band is not to be touched.

--- a/examples/silver-loom/content/works/_index.md
+++ b/examples/silver-loom/content/works/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Loom Index"
+description = "All works currently mounted, ordered by loom number."
+sort_by = "weight"
+template = "section"
++++
+
+The loom index lists works in the order they are hung in the room. Each entry
+shows the artist, year, materials, and the warp and weft used at the loom.

--- a/examples/silver-loom/static/css/style.css
+++ b/examples/silver-loom/static/css/style.css
@@ -1,0 +1,315 @@
+:root {
+  --paper: #eeece6;
+  --paper-2: #e3e0d6;
+  --ink: #1d2c4a;
+  --ink-2: #4a5675;
+  --ink-3: #8c93a8;
+  --rule: #c9c6bc;
+  --rule-2: #b6b2a3;
+  --accent: #c95a3a;
+  --warp: #8fa3b8;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 16px; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Inter", "Neue Haas Grotesk", system-ui, sans-serif;
+  line-height: 1.55;
+  font-feature-settings: "ss01";
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.frame {
+  max-width: 92rem;
+  margin: 0 auto;
+  padding: 0 3rem;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  column-gap: 1.4rem;
+}
+
+.topbar {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 3fr 9fr;
+  align-items: center;
+  padding: 1.5rem 0 1.2rem;
+  border-bottom: 1px solid var(--ink);
+}
+.brand {
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: -0.005em;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+.brand .mark {
+  display: inline-grid;
+  grid-template-columns: repeat(4, 4px);
+  gap: 2px;
+  width: 22px;
+}
+.brand .mark span { display: block; height: 22px; background: var(--ink); }
+.brand .mark span:nth-child(3) { background: var(--accent); }
+.brand b { letter-spacing: 0.04em; text-transform: uppercase; font-size: 0.78rem; color: var(--ink-3); margin-left: 0.4rem; font-weight: 500; }
+.topbar nav {
+  display: flex;
+  gap: 2.2rem;
+  justify-content: flex-end;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+.topbar nav a { color: var(--ink-2); }
+.topbar nav a:hover { color: var(--accent); }
+
+.hero {
+  grid-column: 1 / -1;
+  padding: 6rem 0 4rem;
+  border-bottom: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: subgrid;
+}
+.hero .num {
+  grid-column: 1 / 2;
+  font-family: "Source Serif Pro", "Times New Roman", serif;
+  font-style: italic;
+  font-size: 4rem;
+  line-height: 1;
+  color: var(--accent);
+  font-weight: 400;
+}
+.hero h1 {
+  grid-column: 2 / 11;
+  font-size: clamp(2.8rem, 7vw, 6rem);
+  line-height: 0.96;
+  letter-spacing: -0.035em;
+  margin: 0;
+  font-weight: 500;
+}
+.hero h1 em {
+  font-family: "Source Serif Pro", serif;
+  font-style: italic;
+  font-weight: 400;
+  color: var(--accent);
+}
+.hero .lede {
+  grid-column: 8 / 13;
+  margin-top: 1.5rem;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  max-width: 32rem;
+  justify-self: end;
+}
+.hero .meta-strip {
+  grid-column: 1 / -1;
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: subgrid;
+  border-top: 1px solid var(--ink);
+  padding-top: 0.8rem;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+}
+.hero .meta-strip span { grid-column: span 3; }
+.hero .meta-strip b { color: var(--ink); font-weight: 500; }
+
+.works-rail {
+  grid-column: 1 / -1;
+  padding: 4rem 0 2rem;
+  display: grid;
+  grid-template-columns: subgrid;
+  row-gap: 4rem;
+}
+.thread {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule);
+  padding-top: 3rem;
+  display: grid;
+  grid-template-columns: subgrid;
+  align-items: start;
+}
+.thread .ix {
+  grid-column: 1 / 2;
+  font-family: "Source Serif Pro", serif;
+  font-style: italic;
+  font-size: 1.6rem;
+  color: var(--accent);
+}
+.thread .ix small { display: block; font-size: 0.72rem; font-family: "Inter", sans-serif; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-3); font-style: normal; margin-top: 0.3rem; }
+.thread .plate {
+  grid-column: 2 / 7;
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+  position: relative;
+  overflow: hidden;
+}
+.thread .plate svg { width: 100%; height: 100%; display: block; }
+.thread .body {
+  grid-column: 8 / 13;
+}
+.thread:nth-child(even) .plate { grid-column: 7 / 13; }
+.thread:nth-child(even) .body { grid-column: 2 / 7; }
+.thread:nth-child(even) .ix { grid-column: 1 / 2; }
+.thread h2 {
+  font-size: 2rem;
+  margin: 0 0 0.6rem;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+}
+.thread h2 em { font-family: "Source Serif Pro", serif; font-style: italic; font-weight: 400; }
+.thread h2 a { box-shadow: inset 0 -1px 0 0 transparent; transition: box-shadow .3s; }
+.thread:hover h2 a { box-shadow: inset 0 -1px 0 0 currentColor; }
+.thread .who { font-size: 0.9rem; color: var(--ink-2); margin-bottom: 1rem; }
+.thread .who b { color: var(--ink); font-weight: 600; }
+.thread .desc { color: var(--ink-2); font-size: 1rem; margin: 0 0 1.4rem; max-width: 30rem; }
+.thread .caption {
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 1rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+}
+.thread .caption b { color: var(--ink); font-weight: 500; display: block; }
+
+.statement {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--ink);
+  margin-top: 3rem;
+  padding: 4rem 0 5rem;
+  display: grid;
+  grid-template-columns: subgrid;
+}
+.statement .label {
+  grid-column: 1 / 4;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+}
+.statement .body {
+  grid-column: 4 / 10;
+  font-family: "Source Serif Pro", "Times New Roman", serif;
+  font-size: 1.35rem;
+  line-height: 1.45;
+  color: var(--ink);
+}
+.statement .body p { margin: 0 0 1rem; }
+.statement .body em { font-style: italic; color: var(--accent); }
+
+article {
+  grid-column: 2 / 11;
+  padding: 4rem 0 6rem;
+}
+article .ix {
+  font-family: "Source Serif Pro", serif;
+  font-style: italic;
+  font-size: 1.4rem;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+article h1 { font-size: 3.4rem; line-height: 1; letter-spacing: -0.025em; margin: 0 0 1rem; font-weight: 500; }
+article h1 em { font-family: "Source Serif Pro", serif; font-style: italic; font-weight: 400; color: var(--accent); }
+article .lede { font-size: 1.15rem; color: var(--ink-2); margin: 0 0 2rem; max-width: 40rem; }
+article h2 { font-size: 1.5rem; margin: 2.5rem 0 0.7rem; font-weight: 500; letter-spacing: -0.005em; }
+article h3 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.22em; color: var(--accent); margin: 2rem 0 0.6rem; }
+article p, article li { color: var(--ink-2); font-size: 1.05rem; max-width: 38rem; }
+article a { color: var(--ink); border-bottom: 1px solid var(--rule-2); }
+article a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+article blockquote { font-family: "Source Serif Pro", serif; font-style: italic; font-size: 1.4rem; color: var(--ink); border-left: 2px solid var(--accent); padding: 0.5rem 1.4rem; margin: 2rem 0; }
+article hr { border: none; border-top: 1px solid var(--rule); margin: 3rem 0; }
+article ul, article ol { padding-left: 1.2rem; }
+
+.caption-rail {
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--rule);
+  padding: 0.8rem 0;
+  margin: 1rem 0 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 0.6rem 1.5rem;
+}
+.caption-rail b { display: block; color: var(--ink); font-weight: 500; }
+
+.tag-pill {
+  display: inline-block;
+  border: 1px solid var(--rule-2);
+  color: var(--ink-2);
+  padding: 0.18rem 0.7rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-right: 0.4rem;
+}
+.tag-pill:hover { border-color: var(--accent); color: var(--accent); }
+
+.kbd {
+  display: inline-block;
+  border: 1px solid var(--ink);
+  padding: 0.45rem 1rem;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink);
+  margin: 0.3rem 0.4rem 0 0;
+  background: var(--paper);
+}
+.kbd:hover { background: var(--ink); color: var(--paper); }
+
+.foot {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--ink);
+  margin-top: 3rem;
+  padding: 1.8rem 0 2.4rem;
+  display: grid;
+  grid-template-columns: subgrid;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+.foot .a { grid-column: 1 / 5; }
+.foot .b { grid-column: 5 / 9; font-style: italic; text-transform: none; letter-spacing: 0; font-family: "Source Serif Pro", serif; font-size: 0.95rem; color: var(--ink-2); }
+.foot .c { grid-column: 9 / 13; text-align: right; }
+.foot b { color: var(--ink); }
+
+.notfound { grid-column: 2 / 12; padding: 7rem 0; text-align: center; }
+.notfound h1 { font-size: 8rem; margin: 0; font-weight: 400; font-family: "Source Serif Pro", serif; font-style: italic; color: var(--accent); }
+.notfound p { color: var(--ink-2); text-transform: uppercase; letter-spacing: 0.22em; font-size: 0.8rem; }
+
+@media (max-width: 980px) {
+  .frame { padding: 0 1.25rem; column-gap: 0.6rem; }
+  .topbar { grid-template-columns: 1fr; gap: 0.6rem; }
+  .topbar nav { justify-content: flex-start; flex-wrap: wrap; gap: 1.2rem; }
+  .hero { padding: 3rem 0 2rem; }
+  .hero .num, .hero h1, .hero .lede, .hero .meta-strip span { grid-column: 1 / -1 !important; }
+  .hero .lede { justify-self: start; margin-top: 1rem; }
+  .hero .meta-strip { display: flex; flex-wrap: wrap; gap: 0.8rem 1.5rem; }
+  .thread, .thread:nth-child(even) { grid-template-columns: 1fr; }
+  .thread .ix, .thread .plate, .thread .body, .thread:nth-child(even) .ix, .thread:nth-child(even) .plate, .thread:nth-child(even) .body { grid-column: 1 / -1; }
+  .thread .plate { aspect-ratio: 4 / 3; }
+  .statement { grid-template-columns: 1fr; }
+  .statement .label, .statement .body { grid-column: 1 / -1; }
+  article { grid-column: 1 / -1; }
+  .foot { display: block; }
+  .foot .a, .foot .b, .foot .c { display: block; text-align: left; margin-bottom: 0.3rem; }
+}

--- a/examples/silver-loom/static/favicon.svg
+++ b/examples/silver-loom/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#eeece6"/>
+  <g stroke="#1d2c4a" stroke-width="1" fill="none">
+    <line x1="6" y1="4" x2="6" y2="28"/>
+    <line x1="12" y1="4" x2="12" y2="28"/>
+    <line x1="18" y1="4" x2="18" y2="28"/>
+    <line x1="24" y1="4" x2="24" y2="28"/>
+  </g>
+  <line x1="2" y1="16" x2="30" y2="16" stroke="#c95a3a" stroke-width="2"/>
+</svg>

--- a/examples/silver-loom/templates/404.html
+++ b/examples/silver-loom/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p>That thread is not on the loom</p>
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/">Programme</a><a class="kbd" href="{{ base_url }}/works/">Loom index</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/silver-loom/templates/footer.html
+++ b/examples/silver-loom/templates/footer.html
@@ -1,0 +1,8 @@
+  <footer class="foot">
+    <span class="a"><b>Silver Loom</b> · Brunnsgatan 14 · 411 33 Göteborg</span>
+    <span class="b">Set in Inter &amp; Source Serif Pro</span>
+    <span class="c">© {{ current_year }} · Built with Hwaro</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/silver-loom/templates/header.html
+++ b/examples/silver-loom/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+Pro:ital,wght@0,400;0,600;1,400;1,600&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="frame">
+  <header class="topbar">
+    <a class="brand" href="{{ base_url }}/">
+      <span class="mark"><span></span><span></span><span></span><span></span></span>
+      Silver Loom <b>EST. 2016</b>
+    </a>
+    <nav>
+      <a href="{{ base_url }}/">Programme</a>
+      <a href="{{ base_url }}/works/">Loom Index</a>
+      <a href="{{ base_url }}/tags/">Materials</a>
+    </nav>
+  </header>

--- a/examples/silver-loom/templates/home.html
+++ b/examples/silver-loom/templates/home.html
@@ -1,0 +1,71 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="num">№ 04</div>
+  <h1>Threads, <em>held</em> and<br/>unfastened, in turn.</h1>
+  <div class="lede">{{ site.description }}</div>
+  <div class="meta-strip">
+    <span><b>Spring</b> 2026</span>
+    <span><b>Programme</b> 4 works</span>
+    <span><b>Hours</b> Wed—Sat · 11—18</span>
+    <span><b>Curator</b> S. Tideström</span>
+  </div>
+</section>
+
+<section class="works-rail">
+  {% set works = get_section(path="works/_index.md") %}
+  {% if works and works.pages %}
+    {% for p in works.pages %}
+    <article class="thread">
+      <div class="ix"><em>№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</em><small>Loom {{ loop.index }}</small></div>
+      <a class="plate" href="{{ p.url }}">
+        {% set i = loop.index %}
+        {% if i == 1 %}
+        <svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice">
+          <rect width="400" height="300" fill="#e3e0d6"/>
+          <g stroke="#1d2c4a" stroke-width="0.7">{% for n in range(end=42) %}<line x1="{{ n * 10 }}" y1="0" x2="{{ n * 10 }}" y2="300"/>{% endfor %}</g>
+          <g stroke="#c95a3a" stroke-width="2">{% for n in range(end=8) %}<line x1="0" y1="{{ 40 + n * 32 }}" x2="400" y2="{{ 40 + n * 32 }}"/>{% endfor %}</g>
+        </svg>
+        {% elif i == 2 %}
+        <svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice">
+          <rect width="400" height="300" fill="#e3e0d6"/>
+          <g stroke="#1d2c4a" stroke-width="1.2" fill="none">{% for n in range(end=12) %}<path d="M 0 {{ 20 + n * 22 }} Q 100 {{ n * 22 }} 200 {{ 20 + n * 22 }} T 400 {{ 20 + n * 22 }}"/>{% endfor %}</g>
+          <circle cx="200" cy="150" r="36" fill="#c95a3a"/>
+        </svg>
+        {% elif i == 3 %}
+        <svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice">
+          <rect width="400" height="300" fill="#e3e0d6"/>
+          <g fill="#1d2c4a">{% for r in range(end=10) %}{% for c in range(end=14) %}<rect x="{{ c * 30 + (r % 2) * 15 }}" y="{{ r * 30 + 5 }}" width="12" height="12"/>{% endfor %}{% endfor %}</g>
+          <rect x="150" y="100" width="100" height="100" fill="#c95a3a"/>
+        </svg>
+        {% elif i == 4 %}
+        <svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice">
+          <rect width="400" height="300" fill="#e3e0d6"/>
+          <g stroke="#8fa3b8" stroke-width="2" fill="none">{% for n in range(end=24) %}<line x1="{{ n * 20 - 200 }}" y1="0" x2="{{ n * 20 }}" y2="300"/>{% endfor %}</g>
+          <g stroke="#1d2c4a" stroke-width="1.5" fill="none">{% for n in range(end=24) %}<line x1="{{ n * 20 }}" y1="0" x2="{{ n * 20 - 200 }}" y2="300"/>{% endfor %}</g>
+          <rect x="170" y="120" width="60" height="60" fill="#c95a3a"/>
+        </svg>
+        {% else %}
+        <svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice"><rect width="400" height="300" fill="#e3e0d6"/><rect x="80" y="60" width="240" height="180" fill="none" stroke="#1d2c4a" stroke-width="1.4"/><circle cx="200" cy="150" r="40" fill="#c95a3a"/></svg>
+        {% endif %}
+      </a>
+      <div class="body">
+        <h2><a href="{{ p.url }}">{{ p.title | e }}</a></h2>
+        <div class="who"><b>{{ p.extra.artist | default(value="Loom artist") }}</b>{% if p.extra.year %} · {{ p.extra.year }}{% endif %}</div>
+        {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+        <div class="caption">
+          {% if p.extra.medium %}<span><b>Medium</b>{{ p.extra.medium }}</span>{% endif %}
+          {% if p.extra.dimensions %}<span><b>Dimensions</b>{{ p.extra.dimensions }}</span>{% endif %}
+          {% if p.extra.warp %}<span><b>Warp</b>{{ p.extra.warp }}</span>{% endif %}
+          {% if p.extra.weft %}<span><b>Weft</b>{{ p.extra.weft }}</span>{% endif %}
+        </div>
+      </div>
+    </article>
+    {% endfor %}
+  {% endif %}
+</section>
+
+<section class="statement">
+  <div class="label">Curator's note</div>
+  <div class="body">{{ content | safe }}</div>
+</section>
+{% include "footer.html" %}

--- a/examples/silver-loom/templates/page.html
+++ b/examples/silver-loom/templates/page.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<article>
+  <div class="ix">№ {% if page.extra.loom %}{{ page.extra.loom }}{% else %}—{% endif %}</div>
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p class="lede">{{ page.description | e }}</p>{% endif %}
+  <div class="caption-rail">
+    {% if page.extra.artist %}<span><b>Artist</b>{{ page.extra.artist }}</span>{% endif %}
+    {% if page.extra.medium %}<span><b>Medium</b>{{ page.extra.medium }}</span>{% endif %}
+    {% if page.extra.year %}<span><b>Year</b>{{ page.extra.year }}</span>{% endif %}
+    {% if page.extra.dimensions %}<span><b>Dimensions</b>{{ page.extra.dimensions }}</span>{% endif %}
+    {% if page.extra.warp %}<span><b>Warp</b>{{ page.extra.warp }}</span>{% endif %}
+    {% if page.extra.weft %}<span><b>Weft</b>{{ page.extra.weft }}</span>{% endif %}
+    {% if page.date %}<span><b>Hung</b>{{ page.date | date(format="%d %b %Y") }}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+  {% if page.tags %}<p style="margin-top:3rem;">{% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</p>{% endif %}
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/works/">← Back to index</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/silver-loom/templates/section.html
+++ b/examples/silver-loom/templates/section.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="num">№</div>
+  <h1>{{ page.title | e }}</h1>
+  <div class="lede">{{ content | safe }}</div>
+</section>
+<section class="works-rail">
+  {% for p in section.pages %}
+  <article class="thread">
+    <div class="ix"><em>№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</em><small>Loom {{ loop.index }}</small></div>
+    <a class="plate" href="{{ p.url }}">
+      {% set i = loop.index %}
+      {% if i == 1 %}<svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice"><rect width="400" height="300" fill="#e3e0d6"/><g stroke="#1d2c4a" stroke-width="0.7">{% for n in range(end=42) %}<line x1="{{ n * 10 }}" y1="0" x2="{{ n * 10 }}" y2="300"/>{% endfor %}</g><g stroke="#c95a3a" stroke-width="2">{% for n in range(end=8) %}<line x1="0" y1="{{ 40 + n * 32 }}" x2="400" y2="{{ 40 + n * 32 }}"/>{% endfor %}</g></svg>
+      {% elif i == 2 %}<svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice"><rect width="400" height="300" fill="#e3e0d6"/><g stroke="#1d2c4a" stroke-width="1.2" fill="none">{% for n in range(end=12) %}<path d="M 0 {{ 20 + n * 22 }} Q 100 {{ n * 22 }} 200 {{ 20 + n * 22 }} T 400 {{ 20 + n * 22 }}"/>{% endfor %}</g><circle cx="200" cy="150" r="36" fill="#c95a3a"/></svg>
+      {% elif i == 3 %}<svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice"><rect width="400" height="300" fill="#e3e0d6"/><g fill="#1d2c4a">{% for r in range(end=10) %}{% for c in range(end=14) %}<rect x="{{ c * 30 + (r % 2) * 15 }}" y="{{ r * 30 + 5 }}" width="12" height="12"/>{% endfor %}{% endfor %}</g><rect x="150" y="100" width="100" height="100" fill="#c95a3a"/></svg>
+      {% elif i == 4 %}<svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice"><rect width="400" height="300" fill="#e3e0d6"/><g stroke="#8fa3b8" stroke-width="2" fill="none">{% for n in range(end=24) %}<line x1="{{ n * 20 - 200 }}" y1="0" x2="{{ n * 20 }}" y2="300"/>{% endfor %}</g><g stroke="#1d2c4a" stroke-width="1.5" fill="none">{% for n in range(end=24) %}<line x1="{{ n * 20 }}" y1="0" x2="{{ n * 20 - 200 }}" y2="300"/>{% endfor %}</g><rect x="170" y="120" width="60" height="60" fill="#c95a3a"/></svg>
+      {% else %}<svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice"><rect width="400" height="300" fill="#e3e0d6"/><rect x="80" y="60" width="240" height="180" fill="none" stroke="#1d2c4a" stroke-width="1.4"/><circle cx="200" cy="150" r="40" fill="#c95a3a"/></svg>{% endif %}
+    </a>
+    <div class="body">
+      <h2><a href="{{ p.url }}">{{ p.title | e }}</a></h2>
+      <div class="who"><b>{{ p.extra.artist | default(value="Loom artist") }}</b>{% if p.extra.year %} · {{ p.extra.year }}{% endif %}</div>
+      {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+      <div class="caption">
+        {% if p.extra.medium %}<span><b>Medium</b>{{ p.extra.medium }}</span>{% endif %}
+        {% if p.extra.dimensions %}<span><b>Dimensions</b>{{ p.extra.dimensions }}</span>{% endif %}
+      </div>
+    </div>
+  </article>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/silver-loom/templates/shortcodes/alert.html
+++ b/examples/silver-loom/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div style="padding:0.9rem 1.2rem;border-left:2px solid var(--accent);background:var(--paper-2);margin:1.5rem 0;font-size:0.95rem;color:var(--ink-2);">
+  <strong style="color:var(--accent);letter-spacing:0.2em;text-transform:uppercase;font-size:0.72rem;">{{ type | upper }}</strong>
+  <div style="margin-top:0.3rem;">{{ body }}</div>
+</div>

--- a/examples/silver-loom/templates/taxonomy.html
+++ b/examples/silver-loom/templates/taxonomy.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="num">№</div>
+  <h1><em>{{ taxonomy_name | default(value="Materials") | capitalize }}</em></h1>
+  <div class="lede">All terms in the <em>{{ taxonomy_name }}</em> register.</div>
+</section>
+<section class="works-rail">
+  {% for term in taxonomy_terms %}
+  <article class="thread">
+    <div class="ix"><em>№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</em><small>Term</small></div>
+    <div class="plate" style="display:flex;align-items:center;justify-content:center;font-family:'Source Serif Pro',serif;font-style:italic;font-size:3rem;color:var(--ink);background:var(--paper-2);">
+      <a href="{{ term.url }}" style="border-bottom:none;color:var(--ink);">{{ term.name }}</a>
+    </div>
+    <div class="body">
+      <h2><a href="{{ term.url }}">{{ term.name }}</a></h2>
+      <p class="desc">{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %} filed under this term.</p>
+      <div class="caption"><span><b>Path</b>/{{ taxonomy_name }}/{{ term.slug }}/</span></div>
+    </div>
+  </article>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/silver-loom/templates/taxonomy_term.html
+++ b/examples/silver-loom/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<section class="hero">
+  <div class="num">№</div>
+  <h1><em>#</em>{{ page.title }}</h1>
+  <div class="lede">{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} filed under <em>{{ page.title }}</em>.</div>
+</section>
+<section class="works-rail">
+  {% for p in taxonomy_pages %}
+  <article class="thread">
+    <div class="ix"><em>№ {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</em><small>Loom {{ loop.index }}</small></div>
+    <a class="plate" href="{{ p.url }}" style="display:flex;align-items:center;justify-content:center;font-family:'Source Serif Pro',serif;font-style:italic;font-size:2rem;color:var(--ink-2);background:var(--paper-2);">{{ p.title | e }}</a>
+    <div class="body">
+      <h2><a href="{{ p.url }}">{{ p.title | e }}</a></h2>
+      <div class="who"><b>{{ p.extra.artist | default(value="—") }}</b>{% if p.extra.year %} · {{ p.extra.year }}{% endif %}</div>
+      {% if p.description %}<p class="desc">{{ p.description | e }}</p>{% endif %}
+    </div>
+  </article>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/vapor-index/AGENTS.md
+++ b/examples/vapor-index/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md — Vapor Index
+
+Dark terminal-modern gallery (gallery type). Ink black + dim-cyan accent.
+Space Grotesk display + JetBrains Mono UI. The home page is rendered as an
+index list with stable per-work IDs.
+
+Per-work `page.extra` fields: `artist`, `year`, `duration`, `format`, `region`,
+`status`, `signal`.
+
+## Conventions
+
+- No gradients (including CSS `linear-gradient` backgrounds), no emojis.
+- Single accent: `--accent: #6ce5e8` (dim cyan).
+- All CSS in `static/css/style.css`. Use `{{ base_url }}` for assets.
+
+## Hwaro
+
+| Command | Description |
+|---|---|
+| `hwaro build` | Build to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro tool doctor --fix` | Validate/patch config |
+
+Full reference: <https://hwaro.hahwul.com>

--- a/examples/vapor-index/archetypes/default.md
+++ b/examples/vapor-index/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/vapor-index/config.toml
+++ b/examples/vapor-index/config.toml
@@ -43,3 +43,155 @@ footnotes = true
 
 [doctor]
 ignore = []
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/vapor-index/config.toml
+++ b/examples/vapor-index/config.toml
@@ -1,0 +1,45 @@
+title = "Vapor Index"
+description = "A terminal-modern index of contemporary moving-image works. Filed, dated, and built to be read at the console."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+footnotes = true
+
+[doctor]
+ignore = []

--- a/examples/vapor-index/content/index.md
+++ b/examples/vapor-index/content/index.md
@@ -1,0 +1,13 @@
++++
+title = "Vapor Index"
+description = "A terminal-modern index of contemporary moving-image works. Filed, dated, and built to be read at the console."
+template = "home"
++++
+
+Vapor Index is a small, indexed gallery for moving-image works that prefer to
+be filed and described, rather than streamed and recommended. Every entry
+carries a stable ID, a short summary, and a single page of notes. Nothing is
+hidden behind a player; the work is downloaded, watched once, and discussed.
+
+The index is rebuilt at the start of each season. We do not archive removed
+entries; if a piece is not in the current build, it is not in the index.

--- a/examples/vapor-index/content/works/01-night-shift.md
+++ b/examples/vapor-index/content/works/01-night-shift.md
@@ -1,0 +1,40 @@
++++
+title = "Night Shift, 04:11"
+description = "A single fixed-frame video captured from a freight-yard catwalk between 04:00 and 04:30. Sound is line-recorded from a contact mic on a steel rail."
+date = "2026-02-04"
+weight = 1
+tags = ["moving-image", "field-recording", "fixed-frame"]
+[extra]
+artist = "Mira Ojanen"
+year = "2025"
+duration = "29:14"
+format = "ProRes 422 HQ, 1080p24"
+region = "Tampere, FI"
+status = "live"
+signal = "NS-0411-A"
++++
+
+The work consists of a single uncut take, made with a tripod-mounted camera on
+the third catwalk of the Tampere freight yard. The artist is not visible. Two
+trains pass; neither stops. The exposure was calibrated for the sodium lamps
+and is not corrected in post.
+
+## Sound
+
+The audio is a single channel from a piezo contact microphone clipped to the
+service rail directly below the camera position. Rumble from passing rolling
+stock is the dominant signal. There is no editing in the sound track other
+than a high-pass at 35 Hz to remove infrasonic noise from the catwalk itself.
+
+> "I want the recording to be a record. The frame does not move because nothing
+> in the frame moves." — *M. Ojanen, 2026*
+
+### Notes for the viewer
+
+The work is presented at full duration. There is no looping logic; if the
+player ends the file, the room goes dark. Vapor Index does not host the file;
+it is distributed by the artist on request, with a checksum.
+
+```
+sha256: 8d3f1a..b7e2c0  night-shift-0411.mov
+```

--- a/examples/vapor-index/content/works/02-route-15.md
+++ b/examples/vapor-index/content/works/02-route-15.md
@@ -1,0 +1,35 @@
++++
+title = "Route 15, dashboard"
+description = "Eleven months of one driver's daily commute, condensed to a single linear video by retaining only the first second of each trip."
+date = "2026-01-18"
+weight = 2
+tags = ["moving-image", "compilation", "commute"]
+[extra]
+artist = "Daniil Schorr"
+year = "2025"
+duration = "03:42"
+format = "H.265, 1440p30"
+region = "Bratislava, SK"
+status = "live"
+signal = "RT-0015-D"
++++
+
+Schorr clipped a phone camera to the dashboard of his car for eleven months.
+At the end of each day, he kept the first second of the morning's footage and
+discarded the rest. The work is the resulting compilation, played in
+chronological order.
+
+## Reading the piece
+
+Watch for: weather, leaves, snow, the gradual replacement of the windscreen
+washers in November, and the small flag of a delivery slip caught against the
+wiper in late August.
+
+> "The dashboard does not lie. It only forgets in the way I tell it to." — *D. Schorr*
+
+### Technical
+
+Footage was captured on the device's default camera profile. There is no
+colour grading. The audio is dropped — the original recordings included road
+noise that the artist did not wish to publish. The video is silent throughout
+and is intended to be shown that way.

--- a/examples/vapor-index/content/works/03-room-tones.md
+++ b/examples/vapor-index/content/works/03-room-tones.md
@@ -1,0 +1,35 @@
++++
+title = "Room Tones, 21 rooms"
+description = "Twenty-one one-minute recordings of empty rooms in a single rented apartment between move-in and move-out."
+date = "2026-02-28"
+weight = 3
+tags = ["sound", "moving-image", "series"]
+[extra]
+artist = "Hye-Jin Park"
+year = "2024—2025"
+duration = "21:00"
+format = "Linear PCM, paired stills"
+region = "Seoul, KR"
+status = "live"
+signal = "RT-0021-P"
++++
+
+The piece pairs twenty-one one-minute room-tone recordings with twenty-one
+still frames. The recordings were made at the same hour, in the same rooms, at
+the start and end of a 14-month tenancy. The first and last recording in each
+room are presented side by side; the difference is what the work is.
+
+## Listening
+
+The recordings are played without crossfade. Between rooms there is a single
+second of digital silence; this is not a defect. The still frames advance with
+the recordings.
+
+### Format
+
+The work is delivered as a single 21-minute linear file. There is no
+interactive version. Vapor Index does not host the audio; the artist
+distributes it via a private link and a checksum.
+
+> "A room is what is left when there is nothing in it. The recording is what
+> is left when there is nobody in it." — *H.-J. Park*

--- a/examples/vapor-index/content/works/04-vending.md
+++ b/examples/vapor-index/content/works/04-vending.md
@@ -1,0 +1,34 @@
++++
+title = "Vending, 11 nights"
+description = "Eleven consecutive nights at a single vending machine, recorded by the machine's own service camera and reissued by the artist."
+date = "2026-03-15"
+weight = 4
+tags = ["moving-image", "appropriation", "vernacular"]
+[extra]
+artist = "Lucia Roth"
+year = "2026"
+duration = "11:00 (looped)"
+format = "MPEG-4, 720p15"
+region = "Trieste, IT"
+status = "live"
+signal = "VN-0011-R"
++++
+
+Lucia Roth obtained the service-camera archive of a single vending machine
+from its operator, who was discarding the 90-day rolling backup. From the 90
+nights, Roth selected the eleven on which the machine recorded the most
+transactions. The work is a one-minute clip from each night, played in order.
+
+## Source material
+
+The original camera writes at 15 fps with timecode in the lower-right corner.
+The artist has retained the timecode and the low frame rate. The piece is
+silent; the service camera does not record audio.
+
+> "I did not film this work. I selected it. The selection is the work." — *L. Roth*
+
+### Distribution
+
+The work is published with the explicit permission of the vending operator,
+whose name is redacted in the credits at the artist's request. Vapor Index
+holds a single archival copy of the 90-night source; access is by appointment.

--- a/examples/vapor-index/content/works/_index.md
+++ b/examples/vapor-index/content/works/_index.md
@@ -1,0 +1,10 @@
++++
+title = "/works"
+description = "All works in the current build of the index."
+sort_by = "weight"
+template = "section"
++++
+
+The works directory is the live filesystem of the index. Entries are sorted by
+weight; the artist's chosen identifier is the canonical name. Duration figures
+include any leader and trailing slate frames.

--- a/examples/vapor-index/static/css/style.css
+++ b/examples/vapor-index/static/css/style.css
@@ -1,0 +1,283 @@
+:root {
+  --bg: #0b0d10;
+  --bg-2: #14171c;
+  --bg-3: #1c2026;
+  --ink: #e6e8eb;
+  --ink-2: #a5abb4;
+  --ink-3: #6a7079;
+  --rule: #232830;
+  --rule-2: #2e343d;
+  --accent: #6ce5e8;
+  --accent-dim: #2c5f60;
+  --amber: #d4a85a;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 15px; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { color: var(--ink); }
+
+.shell {
+  max-width: 88rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+  background: var(--bg);
+  border-left: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+}
+
+.topbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.2rem 0;
+  border-bottom: 1px solid var(--rule);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+}
+.brand {
+  color: var(--ink);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.brand b { color: var(--accent); }
+.topbar nav { display: flex; gap: 1.6rem; }
+.topbar nav a { color: var(--ink-2); border-bottom: 1px dashed transparent; }
+.topbar nav a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+.topbar .status { color: var(--ink-3); }
+.topbar .status .ok { color: var(--accent); }
+.topbar .status .blink { animation: blink 1.4s steps(1) infinite; color: var(--accent); }
+@keyframes blink { 50% { opacity: 0; } }
+
+.hero {
+  padding: 4rem 0 3rem;
+  border-bottom: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 1fr 24rem;
+  gap: 3rem;
+  align-items: end;
+}
+.hero .prompt {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+.hero .prompt .dim { color: var(--ink-3); }
+.hero h1 {
+  font-size: clamp(2.6rem, 6vw, 5rem);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  margin: 0;
+  font-weight: 500;
+  color: var(--ink);
+}
+.hero h1 span { color: var(--accent); }
+.hero h1 .slash { color: var(--ink-3); font-weight: 400; }
+.hero .lede {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-2);
+  line-height: 1.7;
+}
+.hero .lede p { margin: 0 0 1rem; }
+.hero .lede .kvs {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 1.2rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 1rem;
+  margin-top: 1rem;
+  font-size: 0.78rem;
+}
+.hero .lede .kvs dt { color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.12em; }
+.hero .lede .kvs dd { margin: 0; color: var(--ink); }
+
+.index-list {
+  font-family: "JetBrains Mono", monospace;
+}
+.idx-head {
+  display: grid;
+  grid-template-columns: 4rem 1fr 14rem 8rem 6rem;
+  gap: 1.5rem;
+  padding: 1rem 1rem;
+  border-bottom: 1px solid var(--rule);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-3);
+}
+.idx-row {
+  display: grid;
+  grid-template-columns: 4rem 1fr 14rem 8rem 6rem;
+  gap: 1.5rem;
+  padding: 1.25rem 1rem;
+  border-bottom: 1px solid var(--rule);
+  align-items: baseline;
+  position: relative;
+  color: var(--ink);
+}
+.idx-row:hover { background: var(--bg-2); }
+.idx-row::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 2px;
+  background: transparent;
+}
+.idx-row:hover::before { background: var(--accent); }
+.idx-row .id { color: var(--accent); font-size: 0.78rem; letter-spacing: 0.06em; }
+.idx-row .title {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+  font-weight: 500;
+  color: var(--ink);
+}
+.idx-row .title a { color: var(--ink); border-bottom: 1px solid transparent; }
+.idx-row:hover .title a { border-bottom-color: var(--accent); color: var(--accent); }
+.idx-row .desc {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  color: var(--ink-3);
+  margin-top: 0.3rem;
+  letter-spacing: 0.02em;
+}
+.idx-row .by { font-size: 0.78rem; color: var(--ink-2); }
+.idx-row .by b { color: var(--ink); font-weight: 500; }
+.idx-row .at { font-size: 0.75rem; color: var(--ink-3); }
+.idx-row .stat { font-size: 0.72rem; color: var(--amber); letter-spacing: 0.12em; text-transform: uppercase; text-align: right; }
+.idx-row .stat.live { color: var(--accent); }
+
+.terminal-block {
+  margin: 3rem 0;
+  border: 1px solid var(--rule-2);
+  background: var(--bg-2);
+  font-family: "JetBrains Mono", monospace;
+}
+.terminal-block .tt-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border-bottom: 1px solid var(--rule);
+  padding: 0.55rem 1rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-3);
+}
+.terminal-block .tt-head .dot {
+  width: 0.55rem; height: 0.55rem; background: var(--accent); display: inline-block;
+}
+.terminal-block .tt-body { padding: 1.5rem 1.5rem 2rem; }
+.terminal-block .tt-body p { margin: 0 0 0.9rem; color: var(--ink-2); font-size: 0.92rem; }
+.terminal-block .tt-body p:last-child { margin-bottom: 0; }
+.terminal-block .tt-body em { color: var(--accent); font-style: normal; }
+
+article {
+  max-width: 60rem;
+  margin: 3rem auto 5rem;
+  padding: 0 2rem;
+  font-family: "Space Grotesk", sans-serif;
+}
+article .id {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--accent);
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+}
+article h1 { font-size: 2.8rem; line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 1rem; color: var(--ink); font-weight: 500; }
+article .lede { font-family: "JetBrains Mono", monospace; color: var(--ink-2); font-size: 0.92rem; margin: 0 0 2rem; }
+article h2 { font-size: 1.35rem; margin: 2.5rem 0 0.7rem; font-weight: 500; letter-spacing: -0.005em; color: var(--accent); }
+article h3 { font-family: "JetBrains Mono", monospace; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.18em; color: var(--ink-3); margin: 2rem 0 0.6rem; }
+article p, article li { color: var(--ink-2); font-size: 1rem; }
+article a { color: var(--accent); border-bottom: 1px solid var(--accent-dim); }
+article a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+article blockquote { font-family: "JetBrains Mono", monospace; font-size: 0.9rem; color: var(--ink); border-left: 2px solid var(--accent); padding: 0.4rem 1.2rem; margin: 2rem 0; background: var(--bg-2); }
+article pre { background: var(--bg-2); border: 1px solid var(--rule); padding: 1rem; overflow-x: auto; }
+article code { font-family: "JetBrains Mono", monospace; background: var(--bg-2); padding: 0.05rem 0.35rem; border: 1px solid var(--rule); font-size: 0.88em; color: var(--ink); }
+article hr { border: none; border-top: 1px dashed var(--rule-2); margin: 3rem 0; }
+
+.spec-rail {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 0.8rem 0;
+  margin: 1.5rem 0 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.5rem 1.4rem;
+  color: var(--ink-3);
+}
+.spec-rail span { letter-spacing: 0.04em; }
+.spec-rail span b { color: var(--accent); font-weight: 400; text-transform: uppercase; letter-spacing: 0.16em; display: block; font-size: 0.68rem; margin-bottom: 0.15rem; }
+
+.tag-pill {
+  display: inline-block;
+  border: 1px solid var(--rule-2);
+  color: var(--ink-2);
+  padding: 0.2rem 0.7rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  margin-right: 0.4rem;
+}
+.tag-pill:hover { border-color: var(--accent); color: var(--accent); background: var(--bg-2); }
+.tag-pill::before { content: "#"; color: var(--accent); }
+
+.kbd {
+  display: inline-block;
+  border: 1px solid var(--rule-2);
+  padding: 0.45rem 1rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--accent);
+  margin: 0.3rem 0.4rem 0 0;
+  background: var(--bg-2);
+}
+.kbd:hover { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+
+.foot {
+  border-top: 1px solid var(--rule);
+  margin-top: 4rem;
+  padding: 1.4rem 0 2rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-3);
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1rem;
+}
+.foot b { color: var(--accent); }
+.foot .end { text-align: right; }
+.foot .mid { text-align: center; }
+
+.notfound { text-align: center; padding: 7rem 0; font-family: "JetBrains Mono", monospace; }
+.notfound h1 { font-size: 7rem; margin: 0; font-weight: 500; color: var(--accent); }
+.notfound p { color: var(--ink-2); text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.78rem; }
+
+@media (max-width: 900px) {
+  .shell { padding: 0 1rem; }
+  .topbar { grid-template-columns: 1fr; gap: 0.6rem; }
+  .topbar nav { flex-wrap: wrap; }
+  .hero { grid-template-columns: 1fr; padding: 2.5rem 0; gap: 1.5rem; }
+  .idx-head { display: none; }
+  .idx-row { grid-template-columns: 1fr; gap: 0.3rem; }
+  .idx-row .stat { text-align: left; }
+  .foot { grid-template-columns: 1fr; }
+  .foot .end, .foot .mid { text-align: left; }
+}

--- a/examples/vapor-index/static/favicon.svg
+++ b/examples/vapor-index/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0b0d10"/>
+  <rect x="4" y="6" width="24" height="20" fill="none" stroke="#6ce5e8" stroke-width="1.6"/>
+  <path d="M9 14 L13 18 L9 22" fill="none" stroke="#6ce5e8" stroke-width="1.8"/>
+  <line x1="16" y1="22" x2="23" y2="22" stroke="#6ce5e8" stroke-width="1.8"/>
+</svg>

--- a/examples/vapor-index/templates/404.html
+++ b/examples/vapor-index/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<div class="notfound">
+  <h1>404</h1>
+  <p>// segfault: route not in vapor-index</p>
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/">cd ~</a><a class="kbd" href="{{ base_url }}/works/">ls ./works</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/vapor-index/templates/footer.html
+++ b/examples/vapor-index/templates/footer.html
@@ -1,0 +1,9 @@
+  </main>
+  <footer class="foot">
+    <span><b>$</b> vapor index --season=spring --year={{ current_year }}</span>
+    <span class="mid">node-04 · uptime 27d 14h · sha 8d3f1a</span>
+    <span class="end">© {{ current_year }} · built with hwaro</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/examples/vapor-index/templates/header.html
+++ b/examples/vapor-index/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{% if page_title %}{{ page_title }} — {% endif %}{{ site_title }}</title>
+<meta name="description" content="{{ page.description | default(value=site.description) }}" />
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+{{ highlight_tags | safe }}
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="shell">
+  <header class="topbar">
+    <a class="brand" href="{{ base_url }}/"><b>vapor</b>/index <span style="color:var(--ink-3);">~ v0.7</span></a>
+    <nav>
+      <a href="{{ base_url }}/">/root</a>
+      <a href="{{ base_url }}/works/">/works</a>
+      <a href="{{ base_url }}/tags/">/tags</a>
+    </nav>
+    <span class="status">[<span class="ok">live</span>] node-04 <span class="blink">_</span></span>
+  </header>
+  <main>

--- a/examples/vapor-index/templates/home.html
+++ b/examples/vapor-index/templates/home.html
@@ -1,0 +1,45 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="prompt"><span class="dim">~/vapor</span> $ ls -lh ./works/</div>
+    <h1>Moving image<span class="slash">,</span><br/>filed by <span>weight</span><span class="slash">.</span></h1>
+  </div>
+  <div class="lede">
+    <p>{{ site.description }}</p>
+    <dl class="kvs">
+      <dt>build</dt><dd>0.7.3-stable</dd>
+      <dt>entries</dt><dd>04 / 04 live</dd>
+      <dt>updated</dt><dd>{{ current_date | date(format="%Y-%m-%d") }}</dd>
+      <dt>license</dt><dd>CC BY-NC 4.0</dd>
+    </dl>
+  </div>
+</section>
+
+<section class="index-list">
+  <div class="idx-head">
+    <span>ID</span><span>TITLE / DESCRIPTION</span><span>ARTIST</span><span>DURATION</span><span>STATUS</span>
+  </div>
+  {% set works = get_section(path="works/_index.md") %}
+  {% if works and works.pages %}
+    {% for p in works.pages %}
+    <div class="idx-row">
+      <span class="id">VX-{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+      <div>
+        <div class="title"><a href="{{ p.url }}">{{ p.title | e }}</a></div>
+        {% if p.description %}<div class="desc">{{ p.description | e }}</div>{% endif %}
+      </div>
+      <span class="by"><b>{{ p.extra.artist | default(value="(anon)") }}</b>{% if p.extra.year %} · {{ p.extra.year }}{% endif %}</span>
+      <span class="at">{% if p.extra.duration %}{{ p.extra.duration }}{% endif %}</span>
+      <span class="stat live">● {% if p.extra.status %}{{ p.extra.status }}{% else %}LIVE{% endif %}</span>
+    </div>
+    {% endfor %}
+  {% endif %}
+</section>
+
+<section class="terminal-block">
+  <div class="tt-head"><span class="dot"></span> ~/vapor/about.md</div>
+  <div class="tt-body">
+    {{ content | safe }}
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/vapor-index/templates/page.html
+++ b/examples/vapor-index/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<article>
+  <div class="id">VX · {% if page.extra.signal %}{{ page.extra.signal }}{% else %}{{ page.title | slugify | upper }}{% endif %}</div>
+  <h1>{{ page.title | e }}</h1>
+  {% if page.description %}<p class="lede">// {{ page.description | e }}</p>{% endif %}
+  <div class="spec-rail">
+    {% if page.extra.artist %}<span><b>artist</b> {{ page.extra.artist }}</span>{% endif %}
+    {% if page.extra.year %}<span><b>year</b> {{ page.extra.year }}</span>{% endif %}
+    {% if page.extra.duration %}<span><b>duration</b> {{ page.extra.duration }}</span>{% endif %}
+    {% if page.extra.format %}<span><b>format</b> {{ page.extra.format }}</span>{% endif %}
+    {% if page.extra.region %}<span><b>region</b> {{ page.extra.region }}</span>{% endif %}
+    {% if page.date %}<span><b>filed</b> {{ page.date | date(format="%Y-%m-%d") }}</span>{% endif %}
+  </div>
+  {{ content | safe }}
+  {% if page.tags %}
+    <p style="margin-top:3rem;">{% for t in page.tags %}<a class="tag-pill" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}</p>
+  {% endif %}
+  <p style="margin-top:2rem;"><a class="kbd" href="{{ base_url }}/works/">cd ../</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/vapor-index/templates/section.html
+++ b/examples/vapor-index/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="prompt"><span class="dim">~</span> $ cd {{ page.title | lower }} && ls</div>
+    <h1>{{ page.title | e }}</h1>
+  </div>
+  <div class="lede">{{ content | safe }}</div>
+</section>
+
+<section class="index-list">
+  <div class="idx-head">
+    <span>ID</span><span>TITLE / DESCRIPTION</span><span>ARTIST</span><span>DURATION</span><span>STATUS</span>
+  </div>
+  {% for p in section.pages %}
+  <div class="idx-row">
+    <span class="id">VX-{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <div>
+      <div class="title"><a href="{{ p.url }}">{{ p.title | e }}</a></div>
+      {% if p.description %}<div class="desc">{{ p.description | e }}</div>{% endif %}
+    </div>
+    <span class="by"><b>{{ p.extra.artist | default(value="(anon)") }}</b>{% if p.extra.year %} · {{ p.extra.year }}{% endif %}</span>
+    <span class="at">{% if p.extra.duration %}{{ p.extra.duration }}{% endif %}</span>
+    <span class="stat live">● {% if p.extra.status %}{{ p.extra.status }}{% else %}LIVE{% endif %}</span>
+  </div>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/vapor-index/templates/shortcodes/alert.html
+++ b/examples/vapor-index/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div style="padding:0.8rem 1.2rem;border-left:2px solid var(--accent);background:var(--bg-2);margin:1.5rem 0;font-family:'JetBrains Mono',monospace;font-size:0.85rem;color:var(--ink-2);">
+  <strong style="color:var(--accent);letter-spacing:0.14em;text-transform:uppercase;font-size:0.7rem;">[{{ type | upper }}]</strong>
+  <div style="margin-top:0.3rem;">{{ body }}</div>
+</div>

--- a/examples/vapor-index/templates/taxonomy.html
+++ b/examples/vapor-index/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="prompt"><span class="dim">~</span> $ ls ./{{ taxonomy_name }}/</div>
+    <h1>{{ taxonomy_name | default(value="tags") | capitalize }}</h1>
+  </div>
+  <div class="lede"><p>{{ taxonomy_terms | length }} terms in <em>{{ taxonomy_name }}</em>.</p></div>
+</section>
+<section class="index-list">
+  <div class="idx-head"><span>ID</span><span>TERM</span><span></span><span>COUNT</span><span></span></div>
+  {% for term in taxonomy_terms %}
+  <div class="idx-row">
+    <span class="id">T-{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <div><div class="title"><a href="{{ term.url }}">#{{ term.name }}</a></div></div>
+    <span></span>
+    <span class="at">{{ term.pages_count }} entr{% if term.pages_count == 1 %}y{% else %}ies{% endif %}</span>
+    <span class="stat">/{{ taxonomy_name }}/</span>
+  </div>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/examples/vapor-index/templates/taxonomy_term.html
+++ b/examples/vapor-index/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<section class="hero">
+  <div>
+    <div class="prompt"><span class="dim">~</span> $ grep -l "{{ page.title }}" ./works/</div>
+    <h1>#{{ page.title }}</h1>
+  </div>
+  <div class="lede"><p>{{ taxonomy_pages | length }} entr{% if taxonomy_pages | length == 1 %}y{% else %}ies{% endif %} tagged <em>{{ page.title }}</em>.</p></div>
+</section>
+<section class="index-list">
+  <div class="idx-head"><span>ID</span><span>TITLE / DESCRIPTION</span><span>ARTIST</span><span>DURATION</span><span>FILED</span></div>
+  {% for p in taxonomy_pages %}
+  <div class="idx-row">
+    <span class="id">VX-{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+    <div><div class="title"><a href="{{ p.url }}">{{ p.title | e }}</a></div>{% if p.description %}<div class="desc">{{ p.description | e }}</div>{% endif %}</div>
+    <span class="by"><b>{{ p.extra.artist | default(value="(anon)") }}</b></span>
+    <span class="at">{% if p.extra.duration %}{{ p.extra.duration }}{% endif %}</span>
+    <span class="stat">{% if p.date %}{{ p.date | date(format="%Y-%m-%d") }}{% endif %}</span>
+  </div>
+  {% endfor %}
+</section>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,4 +1,31 @@
 {
+  "monolith-frame": [
+    "dark",
+    "gallery",
+    "editorial"
+  ],
+  "prism-archive": [
+    "light",
+    "gallery",
+    "minimal",
+    "editorial"
+  ],
+  "vapor-index": [
+    "dark",
+    "gallery",
+    "cyberpunk",
+    "minimal"
+  ],
+  "silver-loom": [
+    "light",
+    "gallery",
+    "minimal"
+  ],
+  "carbon-folio": [
+    "dark",
+    "gallery",
+    "minimal"
+  ],
   "lattice-handbook": [
     "dark",
     "docs",


### PR DESCRIPTION
## Summary
- Five gallery-tagged example sites, each with a distinct modern aesthetic
- All ship `config.toml`, home, section index, four work pages, full template set, bespoke stylesheet, favicon, and `AGENTS.md`
- No gradients, no emojis

| Site | Theme | Tags |
|---|---|---|
| **monolith-frame** | Dark theatrical serif gallery (Cormorant Garamond + sodium yellow); exhibition catalogue with caption rails | `dark`, `gallery`, `editorial` |
| **prism-archive** | Light museum hairline archive (Fraunces + coral); 12-col grid with inline-SVG plates and accession codes | `light`, `gallery`, `minimal`, `editorial` |
| **vapor-index** | Dark terminal-modern index (Space Grotesk + JetBrains Mono + dim cyan); shell-prompt hero, stable VX-IDs | `dark`, `gallery`, `cyberpunk`, `minimal` |
| **silver-loom** | Light Swiss-asymmetric textile gallery (Inter + Source Serif Pro italics + coral); subgrid alternating plate L/R | `light`, `gallery`, `minimal` |
| **carbon-folio** | Dark bold industrial folio (Sora 800 + ember); asymmetric 12-col deck cards (7/5) with stamped CF-IDs | `dark`, `gallery`, `minimal` |

## Test plan
- [x] `hwaro build` succeeds on each of the five sites (6 pages each)
- [x] No `linear-gradient` in any CSS or template
- [x] No emoji characters in content or templates
- [x] `tags.json` updated for all five entries (valid JSON)