### PR TITLE
Fix 404 links in velvet-sky templates

### DIFF
--- a/examples/velvet-sky/templates/404.html
+++ b/examples/velvet-sky/templates/404.html
@@ -4,6 +4,6 @@
 <div class="not-found-container">
     <h1 class="not-found-title">404</h1>
     <p class="not-found-message">The page you are looking for has vanished into the night sky.</p>
-    <a href="{{ base_url }}" class="return-home">Return Home</a>
+    <a href="{{ base_url }}/" class="return-home">Return Home</a>
 </div>
 {% endblock %}

--- a/examples/velvet-sky/templates/base.html
+++ b/examples/velvet-sky/templates/base.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ base_url }}css/style.css">
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
 
     {% if auto_includes_css %}
       {{ auto_includes_css | safe }}
@@ -28,11 +28,11 @@
 <body>
     <header class="site-header">
         <div class="container header-inner">
-            <a href="{{ base_url }}" class="site-title">{{ site.title }}</a>
+            <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
             <nav class="site-nav" aria-label="Main Navigation">
-                <a href="{{ base_url }}">Home</a>
-                <a href="{{ base_url }}about/">About</a>
-                <a href="{{ base_url }}posts/">Journal</a>
+                <a href="{{ base_url }}/">Home</a>
+                <a href="{{ base_url }}/about/">About</a>
+                <a href="{{ base_url }}/posts/">Journal</a>
             </nav>
         </div>
     </header>

--- a/examples/velvet-sky/templates/index.html
+++ b/examples/velvet-sky/templates/index.html
@@ -18,7 +18,7 @@
                     {% set has_posts = true %}
                     {% for post in section.pages %}
                         <article class="post-card">
-                            <h3 class="post-title"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h3>
+                            <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
                             <div class="post-meta">
                                 {% if post.date %}
                                     <time datetime="{{ post.date | date('%Y-%m-%d') }}">{{ post.date | date('%B %d, %Y') }}</time>
@@ -29,7 +29,7 @@
                             {% elif post.description %}
                                 <div class="post-summary">{{ post.description }}</div>
                             {% endif %}
-                            <a href="{{ post.url | absolute_url }}" class="read-more">Read Entry</a>
+                            <a href="{{ base_url }}{{ post.url }}" class="read-more">Read Entry</a>
                         </article>
                     {% endfor %}
                 {% endif %}

--- a/examples/velvet-sky/templates/page.html
+++ b/examples/velvet-sky/templates/page.html
@@ -19,7 +19,7 @@
         <div class="page-tags">
             <span class="tags-label">Tags:</span>
             {% for tag in page.tags %}
-                <a href="{{ base_url }}tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+                <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
             {% endfor %}
         </div>
     {% endif %}

--- a/examples/velvet-sky/templates/section.html
+++ b/examples/velvet-sky/templates/section.html
@@ -13,7 +13,7 @@
         {% if section.pages %}
             {% for post in section.pages %}
                 <article class="list-item">
-                    <h2 class="item-title"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h2>
+                    <h2 class="item-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
                     <div class="item-meta">
                         {% if post.date %}
                             <time datetime="{{ post.date | date('%Y-%m-%d') }}">{{ post.date | date('%B %d, %Y') }}</time>

--- a/examples/velvet-sky/templates/taxonomy.html
+++ b/examples/velvet-sky/templates/taxonomy.html
@@ -11,7 +11,7 @@
             <ul class="term-list">
                 {% for term in taxonomy_terms %}
                     <li>
-                        <a href="{{ base_url }}{{ taxonomy_name | slugify }}/{{ term | slugify }}/" class="term-link">
+                        <a href="{{ base_url }}/{{ taxonomy_name | slugify }}/{{ term | slugify }}/" class="term-link">
                             {{ term }}
                         </a>
                     </li>

--- a/examples/velvet-sky/templates/taxonomy_term.html
+++ b/examples/velvet-sky/templates/taxonomy_term.html
@@ -10,7 +10,7 @@
         {% if taxonomy_pages %}
             {% for post in taxonomy_pages %}
                 <article class="list-item">
-                    <h2 class="item-title"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h2>
+                    <h2 class="item-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
                     <div class="item-meta">
                         {% if post.date %}
                             <time datetime="{{ post.date | date('%Y-%m-%d') }}">{{ post.date | date('%B %d, %Y') }}</time>


### PR DESCRIPTION
Added missing slashes to base_url and replaced absolute_url filter with base_url prefix to resolve 404 errors.

---
*PR created automatically by Jules for task [4955858786653045396](https://jules.google.com/task/4955858786653045396) started by @chei-l*