### PR TITLE
Add five bold, fresh dashboard example sites

### DIFF
--- a/examples/eclipse-tape/AGENTS.md
+++ b/examples/eclipse-tape/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+## Project Overview
+
+Static website built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Site-Specific Notes
+
+- Theme: dark trading-desk readout. Graphite `#0a0a0c` background, bone `#e9e6df` foreground, signal-green `#34d28e` for bids/up, blood-red `#ff4d5a` for asks/down, electric-yellow `#ffd24d` for highlights only. No blue, no purple. No gradients, no emojis.
+- Typography: JetBrains Mono for all numerics and tabular data; Inter Tight for non-numeric labels. Tabular numerals everywhere.
+- Signature: giant 200px P&L number anchors the home dashboard. Pure CSS marquee tape under it. Level-2 book uses solid color blocks sized by `width: %` (not opacity).
+- Content sections: `content/wraps/` for end-of-day desk wraps; plus `index.md` (tape) and `about.md` (desk).
+- CSS lives in `static/css/style.css`.
+- Crinja: `{% if x in [a,b] %}` does not work — use `or` chains. Rendered content is `{{ content }}`, custom metadata is `page.extra.field`.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/eclipse-tape/archetypes/default.md
+++ b/examples/eclipse-tape/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
+[extra]
+session = "regular"
++++

--- a/examples/eclipse-tape/config.toml
+++ b/examples/eclipse-tape/config.toml
@@ -1,0 +1,217 @@
+title = "Eclipse Tape"
+description = "Tape and order book for a small US equities desk. End-of-day positions, fills, and Greeks."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "desks"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "daily"
+priority = 0.6
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["wraps"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/eclipse-tape/content/about.md
+++ b/examples/eclipse-tape/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About the desk"
+date = "2026-05-22"
+description = "Who runs Eclipse Tape, what the desk trades, and how to read the screen."
++++
+
+Eclipse Tape is the end-of-day readout for a four-seat US equities desk that runs a market-neutral pairs book against a thin overlay of single-name options. The book is small by Wall Street standards — gross around 90 million, net under 10 — but the cadence is institutional. The tape closes at 16:00 ET, the print clears by 16:08, and this page is the artifact.
+
+The strategy is not exotic. We hold roughly 40 names on the long side and 40 on the short, paired against each other inside the same sub-industry. The pair is held until either leg dislocates more than 1.4 standard deviations from its 60-day spread, at which point the lagging leg is taken off and replaced. Options sit on top of the most concentrated pairs as a tail hedge — usually long puts on the more crowded leg, financed by selling premium on the cleaner one.
+
+The page is read top-down. The number across the top is the day's realized P&L — the only figure on the screen that has settled. Underneath it scrolls the tape: the last thirty fills, in order, with side, symbol, size, price, and venue. To the left of the tape sits the Level-2 book for the active pair; rows are color-blocked at a width proportional to displayed size, so the shape of the imbalance is visible at a glance without reading the numbers. The ledger below is the positions book — symbol, side, quantity, average, mark, and the open P&L on each line. The option chain ladder shows the strikes we are working in and around. The risk panel at the foot prints gross, net, beta-adjusted net, and the four Greeks across the option book.
+
+Numbers are tabular. Color is signal: green is up or a bid, red is down or an ask, yellow is a manual override or an exception we flagged for review. No other color carries meaning. The screen is meant to be read in under twenty seconds, which is roughly how long a partner looks at it before asking the only question that matters — did we lose money on anything we did not understand.
+
+A wrap is filed every session worth filing. Most days are not; we publish four to six a month.

--- a/examples/eclipse-tape/content/index.md
+++ b/examples/eclipse-tape/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Tape"
+description = "Eclipse Tape — the end-of-day readout for a small US equities desk."
+template = "home"
++++

--- a/examples/eclipse-tape/content/wraps/_index.md
+++ b/examples/eclipse-tape/content/wraps/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Wraps"
+description = "End-of-day desk wraps. Filed only on sessions worth writing about."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/eclipse-tape/content/wraps/cpi-print-and-the-quiet-fade.md
+++ b/examples/eclipse-tape/content/wraps/cpi-print-and-the-quiet-fade.md
@@ -1,0 +1,21 @@
++++
+title = "CPI print and the quiet fade"
+date = "2026-02-12"
+description = "Headline came in two-tenths hot; the curve barely moved. We faded the first ten minutes and let the book do the work."
+tags = ["macro", "cpi", "pairs"]
+desks = ["equities"]
+[extra]
+session = "regular"
+pnl = "+ 184,902.10"
+trades = 142
++++
+
+Headline CPI printed at 3.1, two-tenths above consensus. The two-year sold off twelve basis points in the first ninety seconds, then gave back nine of them before the cash open. The curve, in other words, did not really believe the print, and neither did we.
+
+Our standing instruction on a hot CPI is to let the open clear before adding. The first ten minutes are populated by participants who are not us — macro books shifting rates exposure, vol funds re-marking gamma, retail buying the dip on the consumer names. We sat. The pairs book ran on its own; the two cleanest legs (a regional bank against a money-center, a software compounder against a hardware peer) traded inside a one-percent band the whole session. We did not touch either pair.
+
+What we did do was lift two short legs that had gotten too cheap to carry — a mid-cap industrial that was down 4.2% before 10:30 on no name-specific news, and a homebuilder short whose pair had recoupled three days earlier. Both were closed for small gains. The option overlay was unchanged; the front-month puts on the two crowded longs are still in the book and will roll on Friday.
+
+The day's print, +184,902, is roughly in line with the rolling thirty-day average. Nothing about it was clever. The book did what it was built to do, which is mostly nothing on a day like this.
+
+Open positions: 78. Pairs intact: 39 of 40. Greeks unchanged within tolerance.

--- a/examples/eclipse-tape/content/wraps/earnings-anomaly-on-the-software-leg.md
+++ b/examples/eclipse-tape/content/wraps/earnings-anomaly-on-the-software-leg.md
@@ -1,0 +1,21 @@
++++
+title = "Earnings anomaly on the software leg"
+date = "2026-03-04"
+description = "A clean beat on the long leg, an inline print on the short — and the spread went the wrong way for ninety minutes."
+tags = ["earnings", "pairs", "dislocation"]
+desks = ["equities"]
+[extra]
+session = "post-close"
+pnl = "− 47,118.32"
+trades = 88
++++
+
+The cleanest pair in the book went sideways tonight, in the wrong direction. Our long beat top and bottom and raised the full year by 2.4%. The short printed inline. On paper, the pair should have widened by sixty to ninety basis points. It tightened by forty.
+
+The mechanical answer is that the long was already up 8% into the print on a Bloomberg note that morning, and the short was already down 3% on a sell-side downgrade we had read but not weighted heavily enough. The market had front-run both legs, and the realized print produced a "sell the news" on the long and a relief bid on the short. The pair recoupled in the after-hours session, ninety minutes after the close.
+
+We did not trade the print. House rule is that no pair gets adjusted between 15:55 and 16:30 unless one leg gaps more than 3%. Both legs were inside the band. The pair is still on, the spread is still inside our one-and-a-half sigma tolerance, and we expect a normalisation by Friday. If it does not recouple by Friday's close we will take off the leg with the worse carry.
+
+The day closed down 47,118 on the pair, offset by 12,400 on the rest of the book. Net day, − 47,118 against a thirty-day average of + 158k.
+
+We are flagging this one in the postmortem stack. It is not a loss that requires explanation, but it is a loss that asks one — specifically whether our sigma band is too wide for names that have an analyst day inside the holding window. Notes to follow.

--- a/examples/eclipse-tape/content/wraps/postmortem-on-a-slipped-fill.md
+++ b/examples/eclipse-tape/content/wraps/postmortem-on-a-slipped-fill.md
@@ -1,0 +1,23 @@
++++
+title = "Postmortem on a slipped fill"
+date = "2026-05-19"
+description = "A parent IOC slipped 18 cents through the NBBO because the child sizing was wrong. Walking through what happened and what we fixed."
+tags = ["postmortem", "execution", "ioc"]
+desks = ["equities"]
+[extra]
+session = "post-close"
+pnl = "+ 91,402.74"
+trades = 167
++++
+
+We slipped a fill today. The dollar number is small — 18 cents through the NBBO on 12,400 shares, so about 2,232 in implementation shortfall on a 1.1m notional order — but the mechanism is interesting enough to write up.
+
+The order was a sell on the long leg of a pair that had recoupled overnight. The leg had to come off before 11:00 because a Fed speaker was on the calendar at 11:30 and we do not work pair-adjustments through macro events. We issued a parent order with an IOC overlay and child sizing set to 8% of the trailing-thirty-minute volume.
+
+The first child cleared at the mid. The second went out at 09:47:14 with a child size that had not refreshed since 09:42 — and in those five minutes the prior trade had spiked the trailing volume by 3.6x. So the child went out at 8% of a stale denominator, which meant it was four times the size it should have been. It blew through three NBBO levels and walked the book.
+
+The root cause is a stale denominator in our parent algo's child sizing — the trailing-volume window refreshes every sixty seconds, not every fill. We have changed the refresh to "on fill" and rerun the prior week of orders against the new logic; the average slip improves by 0.4 cents per share, which is small but consistent.
+
+Day closed +91,402, with the slipped fill accounting for −2,232 of that. The pair is closed and off the book. The fix is deployed for tomorrow's open. The post-incident review will sit in the operations folder.
+
+Lessons: a parameter that looks slow-moving (trailing-volume) is fast-moving on the worst possible day. Refresh on fill.

--- a/examples/eclipse-tape/content/wraps/quarterly-hedge-rebalance.md
+++ b/examples/eclipse-tape/content/wraps/quarterly-hedge-rebalance.md
@@ -1,0 +1,21 @@
++++
+title = "Quarterly hedge rebalance"
+date = "2026-04-01"
+description = "The option overlay rolled forward by a quarter. Gross unchanged, vega down 14%, theta cleaner."
+tags = ["hedging", "options", "rebalance"]
+desks = ["equities", "options"]
+[extra]
+session = "regular"
+pnl = "+ 62,401.55"
+trades = 214
++++
+
+The option overlay rolled today. The quarterly rebalance is the largest scheduled activity on the desk and the only day of the calendar when we run more than two hundred fills.
+
+The old book was a mix of front-month and second-month puts on twelve of the more concentrated long legs, financed by short premium on the cleanest two shorts. The new book is the same structure, pushed forward one calendar quarter, with two material changes. First, we tightened the strike on three of the put legs from 95% to 92.5% of spot — the implied vol on these names had been crushed enough since February that the further-out-of-the-money strike is now the better risk-adjusted hedge. Second, we removed two of the short-premium legs entirely: the names had moved into our crowded list and we did not want to be net short gamma into a potential squeeze.
+
+Net effect on the Greeks: vega is down 14%, theta is down 9% (a cleaner number to carry into a holiday-shortened week), and gamma is essentially flat. The delta of the overlay is +0.02 on a portfolio basis, well inside our +/-0.05 band.
+
+The day's P&L is the difference between the close-out marks on the old book and the open marks on the new — +62,401 net of commissions and fees, which is the smallest absolute rebalance number we have run in six quarters. That is mostly a feature of the prior overlay having been priced cleanly, and partly a feature of the market having sat still for the morning while we worked the orders. We finished at 13:50, with the last twenty minutes deliberately quiet.
+
+Next rebalance: July 1. Greeks panel reflects the new book at the close.

--- a/examples/eclipse-tape/static/css/style.css
+++ b/examples/eclipse-tape/static/css/style.css
@@ -1,0 +1,969 @@
+/* ============================================================
+   ECLIPSE TAPE — dark trading desk readout
+   Solid colors only. No gradients. No emojis.
+   ============================================================ */
+
+:root {
+  --bg:        #0a0a0c;
+  --bg-1:     #0e0e11;
+  --bg-2:     #131318;
+  --bg-3:     #18181d;
+  --fg:        #e9e6df;
+  --fg-dim:    #a8a59e;
+  --fg-vdim:   #6e6c66;
+  --border:    #1e1e22;
+  --border-2:  #28282e;
+  --up:        #34d28e;
+  --dn:        #ff4d5a;
+  --hi:        #ffd24d;
+  --up-block:  #18412f;
+  --dn-block:  #4a161c;
+  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --sans: "Inter Tight", system-ui, -apple-system, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.5;
+  font-variant-numeric: tabular-nums;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: geometricPrecision;
+}
+
+a { color: var(--fg); text-decoration: none; }
+a:hover { color: var(--hi); }
+
+.terminal {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 0 20px 64px;
+}
+
+/* ============================ MASTHEAD ============================ */
+
+.masthead {
+  border-bottom: 1px solid var(--border);
+  padding: 14px 0 0;
+}
+
+.brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding-bottom: 10px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand .seal {
+  display: inline-flex;
+  color: var(--fg);
+}
+
+.brand .title b {
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 16px;
+}
+
+.brand .title em {
+  font-style: normal;
+  font-family: var(--sans);
+  font-weight: 400;
+  letter-spacing: 0.32em;
+  margin-left: 6px;
+  color: var(--fg-dim);
+}
+
+.brand .title small {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-vdim);
+  letter-spacing: 0.12em;
+  margin-top: 2px;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--fg-dim);
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  display: inline-block;
+  background: var(--up);
+  border-radius: 0;
+}
+
+.status-label { color: var(--fg); }
+.status-clock b { color: var(--up); font-weight: 600; }
+.status-date { color: var(--fg-vdim); }
+
+.topnav {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 10px 0;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+}
+
+.topnav a {
+  font-family: var(--sans);
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.topnav a:hover { color: var(--hi); }
+
+.topnav-spacer { flex: 1; }
+
+.topnav-stat {
+  color: var(--fg-dim);
+  font-family: var(--mono);
+  letter-spacing: 0.06em;
+  font-size: 11px;
+}
+
+.topnav-stat i { font-style: normal; margin-left: 4px; }
+.up { color: var(--up); }
+.dn { color: var(--dn); }
+
+/* ============================ P&L ANCHOR ============================ */
+
+.pnl-anchor {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 24px;
+  align-items: center;
+  padding: 32px 0 28px;
+  border-bottom: 1px solid var(--border);
+}
+
+.pnl-meta-left, .pnl-meta-right {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pnl-meta-right {
+  align-items: stretch;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 18px 28px;
+}
+
+.pnl-meta-left .lbl {
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  font-size: 12px;
+  color: var(--fg);
+}
+
+.pnl-meta-left .sub {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--fg-vdim);
+}
+
+.pnl-figure {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 200px;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.pnl-pos { color: var(--up); }
+.pnl-neg { color: var(--dn); }
+
+.pnl-figure .sign {
+  font-size: 0.6em;
+  vertical-align: 0.18em;
+  margin-right: 0.05em;
+  font-weight: 500;
+}
+
+.pnl-figure .frac {
+  font-size: 0.42em;
+  vertical-align: 0.85em;
+  font-weight: 500;
+  color: var(--fg-dim);
+}
+
+.mini {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  min-width: 88px;
+}
+
+.mini .k {
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  color: var(--fg-vdim);
+  font-family: var(--sans);
+  font-weight: 500;
+}
+
+.mini .v {
+  font-family: var(--mono);
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+/* ============================ TAPE STRIP ============================ */
+
+.tape-strip {
+  position: relative;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-1);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+}
+
+.tape-tag {
+  flex: 0 0 auto;
+  padding: 10px 14px;
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 10.5px;
+  color: var(--hi);
+  border-right: 1px solid var(--border);
+  background: var(--bg-2);
+}
+
+.tape-track {
+  flex: 1 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  position: relative;
+  height: 38px;
+}
+
+.tape-row {
+  display: inline-flex;
+  align-items: center;
+  height: 38px;
+  animation: tape-scroll 80s linear infinite;
+}
+
+.tape-row .t-cell {
+  padding: 0 18px;
+  border-right: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg);
+}
+
+.tape-row .t-cell b {
+  font-weight: 700;
+  margin-right: 6px;
+}
+
+@keyframes tape-scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+/* ============================ GRID ============================ */
+
+.grid { display: grid; gap: 14px; margin-top: 18px; }
+.grid-2 { grid-template-columns: 1fr 1fr; }
+.grid-3 { grid-template-columns: 1.1fr 1fr 1fr; }
+
+.panel {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+}
+
+.panel-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: baseline;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+
+.panel-head .num {
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--hi);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+}
+
+.panel-head h2 {
+  margin: 0;
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  font-size: 11.5px;
+  color: var(--fg);
+}
+
+.panel-head .hint {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-vdim);
+  letter-spacing: 0.08em;
+}
+
+.panel-foot {
+  display: flex;
+  gap: 18px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-dim);
+  letter-spacing: 0.06em;
+  flex-wrap: wrap;
+}
+
+.panel-foot b { color: var(--fg); font-weight: 600; }
+
+/* ============================ L2 BOOK ============================ */
+
+.l2-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+
+.l2-col + .l2-col { border-left: 1px solid var(--border); }
+
+.l2-head {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 6px;
+  padding: 6px 12px;
+  font-family: var(--sans);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  font-size: 10px;
+  color: var(--fg-vdim);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+
+.l2-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 6px;
+  padding: 5px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.l2-row .bar {
+  position: absolute;
+  top: 0; bottom: 0;
+  height: 100%;
+  z-index: 0;
+}
+
+.l2-col:first-child .l2-row .bar { right: 0; }
+.l2-col:last-child .l2-row .bar { left: 0; }
+
+.l2-row .bar.bid { background: var(--up-block); }
+.l2-row .bar.ask { background: var(--dn-block); }
+
+.l2-row .sz, .l2-row .px, .l2-row .vn {
+  position: relative;
+  z-index: 1;
+}
+
+.l2-col:first-child .l2-row {
+  text-align: right;
+  direction: rtl;
+}
+.l2-col:first-child .l2-row .sz,
+.l2-col:first-child .l2-row .px,
+.l2-col:first-child .l2-row .vn { direction: ltr; }
+
+.l2-row .sz { color: var(--fg); font-weight: 500; }
+.l2-row .px { color: var(--fg); font-weight: 600; }
+.l2-row .vn { color: var(--fg-vdim); font-size: 11px; }
+
+.l2-row.b .px { color: var(--up); }
+.l2-row.a .px { color: var(--dn); }
+
+/* ============================ OPTION CHAIN ============================ */
+
+.chain-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.chain-table thead th {
+  font-family: var(--sans);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  font-size: 10px;
+  color: var(--fg-vdim);
+  padding: 7px 8px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+  text-align: center;
+}
+
+.chain-table tbody td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  text-align: center;
+}
+
+.chain-table tbody td:nth-child(1),
+.chain-table tbody td:nth-child(7) { color: var(--fg-vdim); font-size: 11px; }
+
+.chain-table tbody td:nth-child(2),
+.chain-table tbody td:nth-child(3) { color: var(--up); }
+
+.chain-table tbody td:nth-child(5),
+.chain-table tbody td:nth-child(6) { color: var(--dn); }
+
+.chain-table td.k {
+  font-weight: 700;
+  color: var(--fg);
+  background: var(--bg-2);
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+
+.chain-table tr.atm td { background: var(--bg-3); }
+.chain-table tr.atm td.k { color: var(--hi); }
+
+/* ============================ FILLS ============================ */
+
+.fill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.fill-list li {
+  display: grid;
+  grid-template-columns: 64px 36px 56px 1fr 70px 50px;
+  gap: 8px;
+  padding: 5px 12px;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  align-items: baseline;
+}
+
+.fill-list li:hover { background: var(--bg-2); }
+
+.fill-list .ts { color: var(--fg-vdim); }
+.fill-list .sd { font-weight: 700; letter-spacing: 0.04em; }
+.fill-list .sd.up { color: var(--up); }
+.fill-list .sd.dn { color: var(--dn); }
+.fill-list .sy { color: var(--fg); font-weight: 600; }
+.fill-list .sz { color: var(--fg-dim); text-align: right; }
+.fill-list .px { color: var(--fg); text-align: right; font-weight: 500; }
+.fill-list .vn { color: var(--fg-vdim); text-align: right; font-size: 10.5px; letter-spacing: 0.06em; }
+
+/* ============================ POSITIONS LEDGER ============================ */
+
+.positions { margin-top: 18px; }
+
+.ledger-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.ledger-table thead th {
+  font-family: var(--sans);
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  font-size: 10px;
+  color: var(--fg-vdim);
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-2);
+  background: var(--bg-2);
+  text-align: left;
+}
+
+.ledger-table thead th.num { text-align: right; }
+
+.ledger-table tbody td {
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ledger-table tbody tr:hover td { background: var(--bg-2); }
+
+.ledger-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.ledger-table td.sy b { color: var(--fg); font-weight: 700; }
+.ledger-table td.dim { color: var(--fg-vdim); font-size: 11px; }
+
+.ledger-table tfoot td {
+  padding: 9px 12px;
+  border-top: 1px solid var(--border-2);
+  background: var(--bg-2);
+  font-weight: 600;
+  color: var(--fg);
+}
+
+/* ============================ RISK ============================ */
+
+.risk-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+
+.rsk {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+
+.rsk:nth-child(even) { border-right: none; }
+
+.rsk .k {
+  font-family: var(--sans);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--fg-vdim);
+}
+
+.rsk .v {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--fg);
+}
+
+.greeks {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--border-2);
+}
+
+.gk {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.gk:nth-child(3n) { border-right: none; }
+
+.gk .k {
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--hi);
+  font-weight: 700;
+}
+
+.gk .v {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+/* ============================ EXCEPTIONS ============================ */
+
+.flag-list { list-style: none; margin: 0; padding: 0; }
+
+.flag-list li {
+  display: grid;
+  grid-template-columns: 90px 1fr 60px;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  align-items: baseline;
+}
+
+.flag-list .tag {
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  font-size: 10px;
+  color: var(--fg-vdim);
+}
+
+.flag-list li.warn .tag { color: var(--hi); }
+
+.flag-list .msg {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+
+.flag-list .msg b { color: var(--fg); font-weight: 600; }
+
+.flag-list .t {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-vdim);
+  text-align: right;
+}
+
+/* ============================ WRAPS LIST ============================ */
+
+.section-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: baseline;
+  margin: 32px 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.section-head .num {
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--hi);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+}
+
+.section-head h2 {
+  margin: 0;
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 13px;
+  color: var(--fg);
+}
+
+.section-head .hint {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-vdim);
+  letter-spacing: 0.08em;
+}
+
+.wraps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.wraps li {
+  display: grid;
+  grid-template-columns: 1fr 200px;
+  gap: 24px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.wraps .copy a {
+  font-family: var(--sans);
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: -0.005em;
+}
+
+.wraps .copy p {
+  margin: 6px 0 8px;
+  color: var(--fg-dim);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.wraps .tags { display: flex; flex-wrap: wrap; gap: 6px; }
+.wraps .tags .t {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--fg-vdim);
+  border: 1px solid var(--border-2);
+  padding: 1px 6px;
+}
+
+.wraps .meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  font-family: var(--mono);
+}
+
+.wraps .meta time {
+  color: var(--fg-dim);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+}
+
+.wraps .meta .pnl {
+  font-weight: 700;
+  color: var(--up);
+  font-size: 14px;
+}
+
+.wraps .meta .cnt {
+  color: var(--fg-vdim);
+  font-size: 11px;
+}
+
+/* ============================ PAGE / SECTION ============================ */
+
+.dash-page, .dash-section { padding-top: 24px; }
+
+.page-card {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  padding: 28px 32px;
+}
+
+.page-title {
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  font-size: 28px;
+  margin: 0 0 12px;
+  color: var(--fg);
+}
+
+.page-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-vdim);
+  letter-spacing: 0.08em;
+}
+
+.page-meta time { color: var(--fg-dim); }
+
+.chip {
+  border: 1px solid var(--border-2);
+  padding: 2px 8px;
+  color: var(--fg-dim);
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.chip.pnl { color: var(--up); border-color: var(--up); }
+
+.page-desc {
+  font-family: var(--mono);
+  color: var(--fg-dim);
+  font-size: 13px;
+  margin: 0 0 18px;
+  line-height: 1.6;
+}
+
+.prose {
+  font-family: var(--sans);
+  color: var(--fg);
+  font-size: 14.5px;
+  line-height: 1.72;
+}
+
+.prose p { margin: 0 0 16px; }
+.prose b, .prose strong { font-weight: 600; }
+.prose blockquote {
+  margin: 18px 0;
+  padding: 12px 16px;
+  border-left: 2px solid var(--hi);
+  background: var(--bg-2);
+  color: var(--fg);
+  font-style: italic;
+}
+
+.prose a { color: var(--hi); text-decoration: underline; text-underline-offset: 3px; }
+.prose code {
+  font-family: var(--mono);
+  font-size: 0.92em;
+  background: var(--bg-3);
+  padding: 1px 5px;
+  border: 1px solid var(--border-2);
+}
+
+.page-tags {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.page-tags .t {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  border: 1px solid var(--border-2);
+  padding: 2px 8px;
+  color: var(--fg-dim);
+}
+
+.page-tags .t:hover { color: var(--hi); border-color: var(--hi); }
+
+.section-cover {
+  padding: 24px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.section-stat {
+  display: flex;
+  gap: 18px;
+  font-family: var(--mono);
+  font-size: 12px;
+  margin-top: 12px;
+}
+
+.section-stat .k { color: var(--fg-vdim); margin-right: 6px; letter-spacing: 0.12em; }
+.section-stat .v { color: var(--fg); margin-right: 12px; }
+.section-stat a { color: var(--hi); }
+
+.wraps-full li { padding: 22px 0; }
+
+/* ============================ 404 ============================ */
+
+.dash-404 { padding-top: 60px; text-align: center; }
+
+.four-oh-four {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.big-404 {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 180px;
+  line-height: 1;
+  color: var(--dn);
+  letter-spacing: -0.05em;
+}
+
+.four-oh-four .cta {
+  display: inline-block;
+  padding: 10px 18px;
+  border: 1px solid var(--up);
+  color: var(--up);
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 12px;
+  margin-top: 12px;
+}
+
+.four-oh-four .cta:hover { background: var(--up); color: var(--bg); }
+
+/* ============================ FOOTER ============================ */
+
+.colophon {
+  margin-top: 48px;
+  padding: 24px 0 8px;
+  border-top: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 1.4fr 0.8fr 1.2fr 1fr;
+  gap: 32px;
+}
+
+.colophon .col strong {
+  display: block;
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 11px;
+  color: var(--fg);
+  margin-bottom: 8px;
+}
+
+.colophon .col p {
+  font-family: var(--mono);
+  color: var(--fg-vdim);
+  font-size: 11.5px;
+  line-height: 1.6;
+  margin: 0 0 6px;
+}
+
+.colophon .col a {
+  display: inline-block;
+  margin-right: 12px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--fg-dim);
+}
+
+.colophon .col a:hover { color: var(--hi); }
+
+/* ============================ RESPONSIVE ============================ */
+
+@media (max-width: 1100px) {
+  .grid-3 { grid-template-columns: 1fr 1fr; }
+  .fills { grid-column: span 2; }
+  .pnl-figure { font-size: 140px; }
+  .colophon { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 760px) {
+  .terminal { padding: 0 12px 32px; }
+  .brand-row { flex-direction: column; align-items: flex-start; }
+  .topnav { flex-wrap: wrap; gap: 12px; }
+  .pnl-anchor { grid-template-columns: 1fr; text-align: left; }
+  .pnl-figure { font-size: 92px; text-align: left; }
+  .pnl-meta-right { justify-content: flex-start; }
+  .grid-3, .grid-2 { grid-template-columns: 1fr; }
+  .fills { grid-column: auto; }
+  .ledger-table { font-size: 11px; }
+  .ledger-table thead th, .ledger-table tbody td { padding: 6px 8px; }
+  .wraps li { grid-template-columns: 1fr; }
+  .wraps .meta { align-items: flex-start; }
+  .colophon { grid-template-columns: 1fr; }
+  .big-404 { font-size: 110px; }
+}

--- a/examples/eclipse-tape/static/favicon.svg
+++ b/examples/eclipse-tape/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" fill="#0a0a0c"/>
+  <circle cx="30" cy="32" r="22" fill="none" stroke="#e9e6df" stroke-width="2.5"/>
+  <circle cx="38" cy="32" r="20" fill="#0a0a0c" stroke="#e9e6df" stroke-width="2.5"/>
+  <rect x="6" y="56" width="52" height="2" fill="#34d28e"/>
+</svg>

--- a/examples/eclipse-tape/templates/404.html
+++ b/examples/eclipse-tape/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="dash dash-404">
+    <div class="four-oh-four">
+      <div class="big-404">404</div>
+      <div class="meta">
+        <p class="page-desc">ORDER REJECTED · SYMBOL NOT IN BOOK</p>
+        <p>The path you requested is not in the index. The tape is on the front.</p>
+        <p><a href="{{ base_url }}/" class="cta">RETURN TO TAPE</a></p>
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/eclipse-tape/templates/footer.html
+++ b/examples/eclipse-tape/templates/footer.html
@@ -1,0 +1,25 @@
+    <footer class="colophon">
+      <div class="col">
+        <strong>{{ site.title }}</strong>
+        <p>End-of-day readout for a four-seat US equities desk. Post-mark data, not a live tape. Numbers are settled at 16:08 ET.</p>
+      </div>
+      <div class="col">
+        <strong>SECTIONS</strong>
+        <a href="{{ base_url }}/">Tape</a>
+        <a href="{{ base_url }}/wraps/">Wraps</a>
+        <a href="{{ base_url }}/about/">Desk</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </div>
+      <div class="col">
+        <strong>DISCLAIMER · {{ current_year }}</strong>
+        <p>For desk and partnership use only. Not a recommendation. All figures stylised. Past performance is not indicative. NBBO marks from consolidated tape; book depth from primary venue only.</p>
+      </div>
+      <div class="col">
+        <strong>BUILD</strong>
+        <p>r-218 · {{ current_date }} · set in JetBrains Mono &amp; Inter Tight · static site, Hwaro on Crystal.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/eclipse-tape/templates/header.html
+++ b/examples/eclipse-tape/templates/header.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="terminal">
+    <header class="masthead">
+      <div class="brand-row">
+        <a href="{{ base_url }}/" class="brand">
+          <span class="seal" aria-hidden="true">
+            <svg viewBox="0 0 40 40" width="28" height="28">
+              <circle cx="20" cy="20" r="16" fill="none" stroke="currentColor" stroke-width="1.2"/>
+              <circle cx="24" cy="20" r="14" fill="#0a0a0c" stroke="currentColor" stroke-width="1.2"/>
+            </svg>
+          </span>
+          <span class="title">
+            <b>ECLIPSE</b><em>TAPE</em>
+            <small>US EQUITIES · DESK 04 · v3.18</small>
+          </span>
+        </a>
+        <div class="status">
+          <span class="status-dot dot-on" aria-hidden="true"></span>
+          <span class="status-label">SESSION CLOSED · POST-MARK</span>
+          <span class="status-clock"><b>16:08:42</b> ET</span>
+          <span class="status-date">{{ current_date }}</span>
+        </div>
+      </div>
+      <nav class="topnav">
+        <a href="{{ base_url }}/">TAPE</a>
+        <a href="{{ base_url }}/wraps/">WRAPS</a>
+        <a href="{{ base_url }}/about/">DESK</a>
+        <a href="{{ base_url }}/tags/">TAGS</a>
+        <span class="topnav-spacer"></span>
+        <span class="topnav-stat">SPX 5,184.42 <i class="up">+ 0.31%</i></span>
+        <span class="topnav-stat">VIX 14.18 <i class="dn">− 2.04%</i></span>
+        <span class="topnav-stat">10Y 4.218 <i class="up">+ 1.2bp</i></span>
+        <span class="topnav-stat">DXY 103.42 <i class="dn">− 0.12%</i></span>
+      </nav>
+    </header>

--- a/examples/eclipse-tape/templates/home.html
+++ b/examples/eclipse-tape/templates/home.html
@@ -1,0 +1,295 @@
+{% include "header.html" %}
+  <main class="dash">
+
+    <section class="pnl-anchor">
+      <div class="pnl-meta-left">
+        <span class="lbl">SESSION P&amp;L · REALIZED</span>
+        <span class="sub">DESK 04 · 22 MAY 2026 · POST-MARK</span>
+      </div>
+      <div class="pnl-figure pnl-pos">
+        <span class="sign">+</span><span class="amount">1,284,407</span><span class="frac">.20</span>
+      </div>
+      <div class="pnl-meta-right">
+        <div class="mini"><span class="k">DAY</span><span class="v up">+ 1.42%</span></div>
+        <div class="mini"><span class="k">MTD</span><span class="v up">+ 4.18%</span></div>
+        <div class="mini"><span class="k">YTD</span><span class="v up">+ 9.74%</span></div>
+        <div class="mini"><span class="k">SHARPE 60d</span><span class="v">1.84</span></div>
+        <div class="mini"><span class="k">HIT-RATE</span><span class="v">61.4%</span></div>
+        <div class="mini"><span class="k">AVG WIN/LOSS</span><span class="v">1.42x</span></div>
+      </div>
+    </section>
+
+    <section class="tape-strip" aria-label="Last trades tape">
+      <span class="tape-tag">LAST 30 · CONSOLIDATED TAPE</span>
+      <div class="tape-track">
+        <div class="tape-row">
+          <span class="t-cell"><b class="up">B</b> AAPL 1,200 @ 184.42 NSDQ</span>
+          <span class="t-cell"><b class="dn">S</b> MSFT 800 @ 412.18 NSDQ</span>
+          <span class="t-cell"><b class="up">B</b> NVDA 400 @ 884.20 ARCA</span>
+          <span class="t-cell"><b class="dn">S</b> META 600 @ 484.02 NSDQ</span>
+          <span class="t-cell"><b class="up">B</b> AMZN 900 @ 178.84 NSDQ</span>
+          <span class="t-cell"><b class="dn">S</b> GOOGL 1,400 @ 152.40 NSDQ</span>
+          <span class="t-cell"><b class="up">B</b> TSLA 300 @ 174.18 NSDQ</span>
+          <span class="t-cell"><b class="up">B</b> JPM 1,100 @ 198.42 NYSE</span>
+          <span class="t-cell"><b class="dn">S</b> XOM 1,800 @ 114.20 NYSE</span>
+          <span class="t-cell"><b class="up">B</b> WMT 700 @ 64.18 NYSE</span>
+          <span class="t-cell"><b class="dn">S</b> CVX 500 @ 158.40 NYSE</span>
+          <span class="t-cell"><b class="up">B</b> AMD 1,000 @ 162.84 NSDQ</span>
+          <span class="t-cell"><b class="dn">S</b> ORCL 600 @ 124.42 NSDQ</span>
+          <span class="t-cell"><b class="up">B</b> CRM 400 @ 268.20 NSDQ</span>
+          <span class="t-cell"><b class="up">B</b> NFLX 200 @ 642.18 NSDQ</span>
+          <span class="t-cell"><b class="dn">S</b> ADBE 300 @ 484.40 NSDQ</span>
+          <span class="t-cell"><b class="up">B</b> INTC 2,400 @ 31.84 NSDQ</span>
+          <span class="t-cell"><b class="up">B</b> GS 250 @ 484.42 NYSE</span>
+          <span class="t-cell"><b class="dn">S</b> MS 600 @ 102.18 NYSE</span>
+          <span class="t-cell"><b class="up">B</b> BAC 2,000 @ 38.42 NYSE</span>
+          <span class="t-cell"><b class="dn">S</b> WFC 1,200 @ 64.18 NYSE</span>
+          <span class="t-cell"><b class="up">B</b> COST 100 @ 814.40 NSDQ</span>
+          <span class="t-cell"><b class="dn">S</b> TGT 800 @ 148.20 NYSE</span>
+          <span class="t-cell"><b class="up">B</b> HD 300 @ 348.42 NYSE</span>
+          <span class="t-cell"><b class="dn">S</b> LOW 400 @ 232.18 NYSE</span>
+          <span class="t-cell"><b class="up">B</b> UNH 200 @ 524.18 NYSE</span>
+          <span class="t-cell"><b class="up">B</b> LLY 150 @ 814.40 NYSE</span>
+          <span class="t-cell"><b class="dn">S</b> PFE 3,000 @ 28.42 NYSE</span>
+          <span class="t-cell"><b class="up">B</b> KO 1,200 @ 64.18 NYSE</span>
+          <span class="t-cell"><b class="dn">S</b> PEP 600 @ 174.20 NSDQ</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid grid-3 book-row">
+      <article class="panel l2">
+        <header class="panel-head">
+          <span class="num">01</span>
+          <h2>LEVEL 2 · TOP-OF-BOOK · AAPL</h2>
+          <span class="hint">BID / ASK · DEPTH 10 · MID 184.420</span>
+        </header>
+        <div class="l2-grid">
+          <div class="l2-col">
+            <div class="l2-head"><span>SIZE</span><span>PRICE</span><span>VENUE</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:96%"></span><span class="sz">14,200</span><span class="px">184.41</span><span class="vn">NSDQ</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:82%"></span><span class="sz">12,100</span><span class="px">184.40</span><span class="vn">ARCA</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:68%"></span><span class="sz">10,000</span><span class="px">184.39</span><span class="vn">EDGX</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:54%"></span><span class="sz">8,000</span><span class="px">184.38</span><span class="vn">BATY</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:46%"></span><span class="sz">6,800</span><span class="px">184.37</span><span class="vn">NSDQ</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:38%"></span><span class="sz">5,600</span><span class="px">184.36</span><span class="vn">IEX</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:28%"></span><span class="sz">4,100</span><span class="px">184.35</span><span class="vn">ARCA</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:22%"></span><span class="sz">3,200</span><span class="px">184.34</span><span class="vn">EDGA</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:16%"></span><span class="sz">2,400</span><span class="px">184.33</span><span class="vn">NSDQ</span></div>
+            <div class="l2-row b"><span class="bar bid" style="width:10%"></span><span class="sz">1,400</span><span class="px">184.32</span><span class="vn">BATS</span></div>
+          </div>
+          <div class="l2-col">
+            <div class="l2-head"><span>SIZE</span><span>PRICE</span><span>VENUE</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:88%"></span><span class="sz">13,400</span><span class="px">184.43</span><span class="vn">NSDQ</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:74%"></span><span class="sz">11,200</span><span class="px">184.44</span><span class="vn">ARCA</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:62%"></span><span class="sz">9,400</span><span class="px">184.45</span><span class="vn">EDGX</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:50%"></span><span class="sz">7,400</span><span class="px">184.46</span><span class="vn">BATY</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:42%"></span><span class="sz">6,200</span><span class="px">184.47</span><span class="vn">NSDQ</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:34%"></span><span class="sz">5,100</span><span class="px">184.48</span><span class="vn">IEX</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:26%"></span><span class="sz">3,800</span><span class="px">184.49</span><span class="vn">ARCA</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:20%"></span><span class="sz">2,900</span><span class="px">184.50</span><span class="vn">EDGA</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:14%"></span><span class="sz">2,000</span><span class="px">184.51</span><span class="vn">NSDQ</span></div>
+            <div class="l2-row a"><span class="bar ask" style="width:08%"></span><span class="sz">1,200</span><span class="px">184.52</span><span class="vn">BATS</span></div>
+          </div>
+        </div>
+        <footer class="panel-foot">
+          <span>NBBO 184.41 × 184.43</span>
+          <span>SPREAD 2&cent;</span>
+          <span>VWAP 183.74</span>
+          <span>VOL 38.4M</span>
+          <span>IMBALANCE <b class="up">+ 8.4k</b></span>
+        </footer>
+      </article>
+
+      <article class="panel chain">
+        <header class="panel-head">
+          <span class="num">02</span>
+          <h2>OPTION CHAIN · AAPL · 21 JUN</h2>
+          <span class="hint">CALLS  ·  STRIKE  ·  PUTS · IV30 24.8</span>
+        </header>
+        <table class="chain-table">
+          <thead>
+            <tr><th>OI</th><th>BID</th><th>ASK</th><th class="k">K</th><th>BID</th><th>ASK</th><th>OI</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>4.2k</td><td>14.20</td><td>14.35</td><td class="k">170</td><td>0.14</td><td>0.18</td><td>8.4k</td></tr>
+            <tr><td>6.1k</td><td>10.20</td><td>10.40</td><td class="k">175</td><td>0.32</td><td>0.36</td><td>9.6k</td></tr>
+            <tr><td>9.4k</td><td>6.80</td><td>6.95</td><td class="k">180</td><td>1.14</td><td>1.20</td><td>12.4k</td></tr>
+            <tr class="atm"><td>14.2k</td><td>3.40</td><td>3.55</td><td class="k">184</td><td>3.20</td><td>3.35</td><td>18.2k</td></tr>
+            <tr><td>11.8k</td><td>1.84</td><td>1.92</td><td class="k">185</td><td>4.40</td><td>4.55</td><td>14.4k</td></tr>
+            <tr><td>8.2k</td><td>0.62</td><td>0.68</td><td class="k">190</td><td>8.20</td><td>8.40</td><td>10.2k</td></tr>
+            <tr><td>5.6k</td><td>0.18</td><td>0.22</td><td class="k">195</td><td>12.40</td><td>12.60</td><td>6.8k</td></tr>
+            <tr><td>3.4k</td><td>0.06</td><td>0.09</td><td class="k">200</td><td>17.20</td><td>17.45</td><td>4.2k</td></tr>
+          </tbody>
+        </table>
+        <footer class="panel-foot">
+          <span>SKEW 25Δ <b>− 2.18</b></span>
+          <span>PCR 0.84</span>
+          <span>TERM 30/60 <b class="up">+ 1.4v</b></span>
+          <span>GAMMA-MAX 184</span>
+        </footer>
+      </article>
+
+      <article class="panel fills">
+        <header class="panel-head">
+          <span class="num">03</span>
+          <h2>RECENT FILLS · DESK 04</h2>
+          <span class="hint">LAST 14 · CHRONOLOGICAL</span>
+        </header>
+        <ol class="fill-list">
+          <li><span class="ts">15:59:42</span><span class="sd up">BUY</span><span class="sy">AAPL</span><span class="sz">12,400</span><span class="px">184.42</span><span class="vn">IOC</span></li>
+          <li><span class="ts">15:58:18</span><span class="sd dn">SELL</span><span class="sy">MSFT</span><span class="sz">8,000</span><span class="px">412.18</span><span class="vn">VWAP</span></li>
+          <li><span class="ts">15:54:02</span><span class="sd dn">SELL</span><span class="sy">NVDA</span><span class="sz">2,200</span><span class="px">884.20</span><span class="vn">PEG</span></li>
+          <li><span class="ts">15:48:40</span><span class="sd up">BUY</span><span class="sy">JPM</span><span class="sz">11,000</span><span class="px">198.42</span><span class="vn">DARK</span></li>
+          <li><span class="ts">15:42:18</span><span class="sd dn">SELL</span><span class="sy">XOM</span><span class="sz">18,400</span><span class="px">114.20</span><span class="vn">VWAP</span></li>
+          <li><span class="ts">15:38:04</span><span class="sd up">BUY</span><span class="sy">WMT</span><span class="sz">7,200</span><span class="px">64.18</span><span class="vn">IOC</span></li>
+          <li><span class="ts">15:31:42</span><span class="sd dn">SELL</span><span class="sy">CVX</span><span class="sz">5,400</span><span class="px">158.40</span><span class="vn">PEG</span></li>
+          <li><span class="ts">15:24:18</span><span class="sd up">BUY</span><span class="sy">AMD</span><span class="sz">10,800</span><span class="px">162.84</span><span class="vn">VWAP</span></li>
+          <li><span class="ts">15:18:42</span><span class="sd dn">SELL</span><span class="sy">ORCL</span><span class="sz">6,400</span><span class="px">124.42</span><span class="vn">IOC</span></li>
+          <li><span class="ts">15:12:04</span><span class="sd up">BUY</span><span class="sy">CRM</span><span class="sz">4,200</span><span class="px">268.20</span><span class="vn">DARK</span></li>
+          <li><span class="ts">15:04:18</span><span class="sd up">BUY</span><span class="sy">NFLX</span><span class="sz">2,400</span><span class="px">642.18</span><span class="vn">IOC</span></li>
+          <li><span class="ts">14:58:42</span><span class="sd dn">SELL</span><span class="sy">ADBE</span><span class="sz">3,200</span><span class="px">484.40</span><span class="vn">PEG</span></li>
+          <li><span class="ts">14:52:18</span><span class="sd up">BUY</span><span class="sy">INTC</span><span class="sz">24,400</span><span class="px">31.84</span><span class="vn">VWAP</span></li>
+          <li><span class="ts">14:46:04</span><span class="sd up">BUY</span><span class="sy">GS</span><span class="sz">2,500</span><span class="px">484.42</span><span class="vn">DARK</span></li>
+        </ol>
+      </article>
+    </section>
+
+    <section class="panel positions">
+      <header class="panel-head">
+        <span class="num">04</span>
+        <h2>POSITIONS LEDGER · END OF DAY</h2>
+        <span class="hint">12 OF 78 ROWS · SORTED BY OPEN P&amp;L</span>
+      </header>
+      <table class="ledger-table dense">
+        <thead>
+          <tr>
+            <th class="sy">SYM</th>
+            <th>SIDE</th>
+            <th class="num">QTY</th>
+            <th class="num">AVG</th>
+            <th class="num">MARK</th>
+            <th class="num">DAY %</th>
+            <th class="num">OPEN P&amp;L</th>
+            <th>SECTOR</th>
+            <th>PAIR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td class="sy"><b>NVDA</b></td><td class="up">L</td><td class="num">8,400</td><td class="num">812.40</td><td class="num">884.20</td><td class="num up">+ 1.84</td><td class="num up">+ 602,720</td><td>SEMI</td><td class="dim">AMD</td></tr>
+          <tr><td class="sy"><b>JPM</b></td><td class="up">L</td><td class="num">22,000</td><td class="num">184.20</td><td class="num">198.42</td><td class="num up">+ 0.74</td><td class="num up">+ 312,840</td><td>FIN</td><td class="dim">WFC</td></tr>
+          <tr><td class="sy"><b>WMT</b></td><td class="up">L</td><td class="num">42,000</td><td class="num">58.40</td><td class="num">64.18</td><td class="num up">+ 0.62</td><td class="num up">+ 242,760</td><td>CONS</td><td class="dim">TGT</td></tr>
+          <tr><td class="sy"><b>WFC</b></td><td class="dn">S</td><td class="num">−18,400</td><td class="num">68.20</td><td class="num">64.18</td><td class="num dn">− 0.42</td><td class="num up">+ 73,968</td><td>FIN</td><td class="dim">JPM</td></tr>
+          <tr><td class="sy"><b>CVX</b></td><td class="dn">S</td><td class="num">−9,200</td><td class="num">162.40</td><td class="num">158.40</td><td class="num dn">− 0.84</td><td class="num up">+ 36,800</td><td>ENR</td><td class="dim">XOM</td></tr>
+          <tr><td class="sy"><b>ORCL</b></td><td class="dn">S</td><td class="num">−6,400</td><td class="num">128.20</td><td class="num">124.42</td><td class="num dn">− 0.42</td><td class="num up">+ 24,192</td><td>SW</td><td class="dim">CRM</td></tr>
+          <tr><td class="sy"><b>TGT</b></td><td class="dn">S</td><td class="num">−4,200</td><td class="num">154.20</td><td class="num">148.20</td><td class="num dn">− 0.92</td><td class="num up">+ 25,200</td><td>CONS</td><td class="dim">WMT</td></tr>
+          <tr><td class="sy"><b>AMD</b></td><td class="dn">S</td><td class="num">−3,800</td><td class="num">168.40</td><td class="num">162.84</td><td class="num dn">− 0.42</td><td class="num up">+ 21,128</td><td>SEMI</td><td class="dim">NVDA</td></tr>
+          <tr><td class="sy"><b>META</b></td><td class="up">L</td><td class="num">2,400</td><td class="num">512.40</td><td class="num">484.02</td><td class="num dn">− 1.20</td><td class="num dn">− 68,112</td><td>NET</td><td class="dim">GOOGL</td></tr>
+          <tr><td class="sy"><b>GOOGL</b></td><td class="dn">S</td><td class="num">−6,400</td><td class="num">148.20</td><td class="num">152.40</td><td class="num up">+ 1.04</td><td class="num dn">− 26,880</td><td>NET</td><td class="dim">META</td></tr>
+          <tr><td class="sy"><b>ADBE</b></td><td class="up">L</td><td class="num">1,200</td><td class="num">498.40</td><td class="num">484.40</td><td class="num dn">− 0.84</td><td class="num dn">− 16,800</td><td>SW</td><td class="dim">CRM</td></tr>
+          <tr><td class="sy"><b>PEP</b></td><td class="dn">S</td><td class="num">−2,400</td><td class="num">168.20</td><td class="num">174.20</td><td class="num up">+ 0.82</td><td class="num dn">− 14,400</td><td>CONS</td><td class="dim">KO</td></tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td class="sy"><b>NET</b></td>
+            <td>—</td>
+            <td class="num">78 rows</td>
+            <td class="num">—</td>
+            <td class="num">—</td>
+            <td class="num up">+ 0.42</td>
+            <td class="num up">+ 1,284,407</td>
+            <td>—</td>
+            <td class="dim">39 / 40 intact</td>
+          </tr>
+        </tfoot>
+      </table>
+    </section>
+
+    <section class="grid grid-2 risk-row">
+      <article class="panel risk">
+        <header class="panel-head">
+          <span class="num">05</span>
+          <h2>RISK DASHBOARD</h2>
+          <span class="hint">END-OF-DAY · POST-MARK</span>
+        </header>
+        <div class="risk-grid">
+          <div class="rsk"><span class="k">GROSS</span><span class="v">$ 88.42m</span></div>
+          <div class="rsk"><span class="k">NET</span><span class="v up">+ $ 8.18m</span></div>
+          <div class="rsk"><span class="k">BETA-ADJ NET</span><span class="v">+ $ 4.12m</span></div>
+          <div class="rsk"><span class="k">LONG / SHORT</span><span class="v">48.30 / 40.12</span></div>
+          <div class="rsk"><span class="k">VaR · 1d 95%</span><span class="v dn">− $ 184,402</span></div>
+          <div class="rsk"><span class="k">VaR · 1d 99%</span><span class="v dn">− $ 312,840</span></div>
+          <div class="rsk"><span class="k">STRESS · −5σ</span><span class="v dn">− $ 1.42m</span></div>
+          <div class="rsk"><span class="k">LIQ · T+1</span><span class="v">94.2%</span></div>
+        </div>
+        <div class="greeks">
+          <div class="gk"><span class="k">DELTA</span><span class="v">+ 0.024</span></div>
+          <div class="gk"><span class="k">GAMMA</span><span class="v">+ 0.0084</span></div>
+          <div class="gk"><span class="k">VEGA</span><span class="v dn">− 14,202</span></div>
+          <div class="gk"><span class="k">THETA</span><span class="v dn">− 2,840 / day</span></div>
+          <div class="gk"><span class="k">RHO</span><span class="v">+ 412</span></div>
+          <div class="gk"><span class="k">LAMBDA</span><span class="v">1.84x</span></div>
+        </div>
+      </article>
+
+      <article class="panel exceptions">
+        <header class="panel-head">
+          <span class="num">06</span>
+          <h2>EXCEPTIONS &amp; FLAGS</h2>
+          <span class="hint">REVIEW QUEUE · 4 OPEN</span>
+        </header>
+        <ul class="flag-list">
+          <li class="warn">
+            <span class="tag">SLIPPAGE</span>
+            <span class="msg"><b>AAPL parent #218-04</b> — IOC child sized off stale denominator. Walked the book 18&cent;. Fix deployed.</span>
+            <span class="t">15:59</span>
+          </li>
+          <li class="warn">
+            <span class="tag">SIGMA</span>
+            <span class="msg"><b>NVDA / AMD pair</b> — 1.62σ on the spread, above 1.40 band. Watching into close + 1.</span>
+            <span class="t">15:42</span>
+          </li>
+          <li>
+            <span class="tag">EVENT</span>
+            <span class="msg"><b>FED SPEAKER 11:30 ET</b> — no pair adjustments inside the window. Cleared at 12:04.</span>
+            <span class="t">11:30</span>
+          </li>
+          <li>
+            <span class="tag">ROLL</span>
+            <span class="msg"><b>JUN puts on AAPL</b> — schedule confirms Friday close. Theta carry at − 412 / day.</span>
+            <span class="t">EOD</span>
+          </li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="wraps-list">
+      <header class="section-head">
+        <span class="num">07</span>
+        <h2>RECENT WRAPS</h2>
+        <span class="hint">FILED ONLY ON SESSIONS WORTH WRITING ABOUT</span>
+      </header>
+      <ul class="wraps">
+        {% for post in site.pages | where("section", "wraps") | sort_by("date", reverse=true) %}
+          {% if loop.index <= 4 %}
+          <li>
+            <div class="copy">
+              <a href="{{ post.url }}"><b>{{ post.title }}</b></a>
+              {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+              <div class="tags">
+                {% for t in post.tags %}<span class="t">{{ t }}</span>{% endfor %}
+              </div>
+            </div>
+            <div class="meta">
+              <time>{{ post.date | date("%d %b · %Y") }}</time>
+              {% if post.extra.pnl %}<span class="pnl">{{ post.extra.pnl }}</span>{% endif %}
+              {% if post.extra.trades %}<span class="cnt">{{ post.extra.trades }} fills</span>{% endif %}
+            </div>
+          </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </section>
+
+  </main>
+{% include "footer.html" %}

--- a/examples/eclipse-tape/templates/page.html
+++ b/examples/eclipse-tape/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+  <main class="dash dash-page">
+    <article class="page-card">
+      {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+      <div class="page-meta">
+        {% if page.date %}<time>{{ page.date | date("%d %b · %Y") }}</time>{% endif %}
+        {% if page.extra.session %}<span class="chip">{{ page.extra.session }}</span>{% endif %}
+        {% if page.extra.pnl %}<span class="chip pnl">{{ page.extra.pnl }}</span>{% endif %}
+        {% if page.extra.trades %}<span class="chip">{{ page.extra.trades }} fills</span>{% endif %}
+      </div>
+      {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+      <div class="prose">{{ content }}</div>
+      {% if page.tags %}
+      <footer class="page-tags">
+        {% for t in page.tags %}<a class="t" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}
+      </footer>
+      {% endif %}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/eclipse-tape/templates/section.html
+++ b/examples/eclipse-tape/templates/section.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+  <main class="dash dash-section">
+    <section class="section-cover">
+      {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+      {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+      <div class="section-stat">
+        <span class="k">ENTRIES</span><span class="v">{{ section.pages_count }}</span>
+        <span class="k">CADENCE</span><span class="v">~4-6 / month</span>
+        <span class="k">FEED</span><span class="v"><a href="{{ base_url }}/wraps/rss.xml">RSS</a></span>
+      </div>
+    </section>
+    {{ content }}
+    <ul class="wraps wraps-full">
+      {% for post in section.pages %}
+        <li>
+          <div class="copy">
+            <a href="{{ post.url }}"><b>{{ post.title }}</b></a>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+            <div class="tags">
+              {% for t in post.tags %}<span class="t">{{ t }}</span>{% endfor %}
+            </div>
+          </div>
+          <div class="meta">
+            <time>{{ post.date | date("%d %b · %Y") }}</time>
+            {% if post.extra.pnl %}<span class="pnl">{{ post.extra.pnl }}</span>{% endif %}
+            {% if post.extra.trades %}<span class="cnt">{{ post.extra.trades }} fills</span>{% endif %}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/eclipse-tape/templates/taxonomy.html
+++ b/examples/eclipse-tape/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="dash dash-section">
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">All terms in this taxonomy. Click a term for the matching wraps.</p>
+    <div class="prose">{{ content }}</div>
+  </main>
+{% include "footer.html" %}

--- a/examples/eclipse-tape/templates/taxonomy_term.html
+++ b/examples/eclipse-tape/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="dash dash-section">
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Wraps tagged with this term.</p>
+    <div class="prose">{{ content }}</div>
+  </main>
+{% include "footer.html" %}

--- a/examples/flux-foundry/AGENTS.md
+++ b/examples/flux-foundry/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md - AI Agent Instructions for Flux Foundry
+
+## Project Overview
+
+Static website built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Site-Specific Notes
+
+- Theme: light brutalist steelworks operations console. Paper cream (`#f4efe6`) background, near-black (`#0a0908`) ink, molten-red (`#c8201f`) for critical states, steel blue (`#3b556e`) for nominal indicators.
+- Typography: `Archivo Black` for display numerals, `Inter` for body, `IBM Plex Mono` for tabular data.
+- Signature element: three oversized kiln gauges across the homepage top, each showing live tap temperature, percent of target, and slag/silicon annotations.
+- Content sections: `content/shiftlog/` for shift superintendent writeups; plus `index.md` (console) and `about.md`.
+- CSS lives in `static/css/style.css`.
+- No gradients, no emojis. Solid colours only.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/flux-foundry/archetypes/default.md
+++ b/examples/flux-foundry/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/flux-foundry/config.toml
+++ b/examples/flux-foundry/config.toml
@@ -1,0 +1,217 @@
+title = "Flux Foundry"
+description = "Operations console for an integrated steelworks. Kilns, mills, slab yards, shift logs."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "lines"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["shiftlog"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/flux-foundry/content/about.md
+++ b/examples/flux-foundry/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About the console"
+description = "How to read the Flux Foundry operations console, what the mill makes, and who keeps the line running."
++++
+
+Flux Foundry is the live operations console for **Riverbend Works**, an integrated steelworks on a one-and-a-half kilometre stretch of river upstream of the rolling town that gave the mill its name. The site runs three blast furnaces, two basic-oxygen vessels, a four-strand continuous caster, and a six-stand hot-strip mill. On a good day we tap thirty heats and ship four thousand tonnes of coiled strip to the loading yard. On a great day we tap thirty-two and nobody phones the safety officer.
+
+## What the console is for
+
+The console is the single board the shift superintendent watches from the control room above the caster floor. Everything on the front page is either *now*, *this shift*, or *this week*. Anything older than that lives in the shift log. The console is not a planning tool, it is not a finance tool, and it is not a marketing piece — those things live in other rooms in the office building.
+
+## How to read the kilns
+
+The three blocks across the top of the page are the live tap readings from each of the three blast furnaces — **No. 1 (Aurelia)**, **No. 2 (Brand)**, and **No. 3 (Cinder)**. The giant number is the current hot-metal temperature in degrees Celsius. The vertical bar is the percent of the target tap temperature; we tap between 1480 and 1520 degrees, so anything below 95 percent is amber and anything below 90 is red. The small lines underneath are the basicity ratio of the slag, the silicon content of the iron, and the time since the last cast. If you are reading this and one of the bars is red, the right thing to do is to phone the cast house, not to write a memo about the console.
+
+## How to read the mill
+
+The hot-strip mill panel is the throughput stream for the six stands, in tonnes per hour. The bars are normalised to the nameplate of the train — three thousand four hundred tonnes per hour at full lift. The slab inventory is the live yard count by alloy grade, rendered as a stack of blocks because that is what the yard looks like from the bridge crane. The shift productivity strip is the last twelve shifts; the height of each bar is the tonnes shipped, the colour is whether we hit the shift target.
+
+## Who keeps the line running
+
+Two hundred and forty operators across four shifts, plus the cast house crew, the mill crew, the yard crew, the dispatchers, and the maintenance fitters. The shift log on this site is written by the shift superintendents themselves, in their own words, at the end of each turn. It is not edited.

--- a/examples/flux-foundry/content/index.md
+++ b/examples/flux-foundry/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Operations"
+description = "Flux Foundry — the live operations console for the integrated steelworks at Riverbend Works."
+template = "home"
++++

--- a/examples/flux-foundry/content/shiftlog/_index.md
+++ b/examples/flux-foundry/content/shiftlog/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Shift log"
+description = "Written by the shift superintendents at the end of each turn. Unedited."
+sort_by = "date"
+reverse = true
+paginate = 10
++++
+
+The shift log is the running record of what happened on the line. It is written by the shift superintendents in their own words, at the end of each turn. We publish the long-form entries here — postmortems, record heats, alloy changes, planned maintenance. The short turn-by-turn entries stay on the cast-house board.

--- a/examples/flux-foundry/content/shiftlog/alloy-change-dual-phase-980.md
+++ b/examples/flux-foundry/content/shiftlog/alloy-change-dual-phase-980.md
@@ -1,0 +1,30 @@
++++
+title = "Alloy change · dual-phase 980 for the automotive book"
+date = "2026-05-09"
+description = "We ran our first commercial heat of DP-980 for the automotive book. The chemistry held, the cast ran clean, and the coil passed the metallurgical sample. Here is the writeup."
+tags = ["alloy", "automotive", "dp-980"]
+lines = ["bos", "caster", "hot-strip-mill"]
++++
+
+We ran our first commercial heat of **dual-phase 980** — a high-strength low-alloy grade with a guaranteed minimum tensile of 980 MPa — for the automotive book on the A-shift on Saturday 9 May. The heat was 220 tonnes, ladled out of No. 2 BOS vessel, cast on strand C of the four-strand caster, and rolled on the hot-strip mill at a finishing temperature of 870 °C. The coil passed the metallurgical sample at the cooling-bed survey and was shipped to the automotive customer on the Monday.
+
+## Chemistry
+
+The DP-980 specification we are running for this customer is:
+
+- Carbon: 0.08 to 0.11 percent (heat: 0.094)
+- Manganese: 1.85 to 2.05 percent (heat: 1.96)
+- Silicon: 0.20 to 0.40 percent (heat: 0.31)
+- Chromium: 0.20 to 0.40 percent (heat: 0.28)
+- Sulfur: max 0.005 percent (heat: 0.003)
+- Phosphorus: max 0.015 percent (heat: 0.010)
+
+The sulfur was tight because we ran the heat off a clean scrap mix on No. 2 BOS rather than the standard open mix, and the desulfurisation station gave us another half-decimal point on the way to the caster.
+
+## What was different
+
+DP-980 is a microstructure grade — the strength comes from a controlled mix of ferrite and martensite, not from heavy alloying — and the rolling schedule on the hot-strip mill matters more than the chemistry. The mill was held on a tight finishing temperature window of plus-or-minus eight degrees and the run-out table was on a tailored cooling profile rather than the standard laminar cooling. The cooling-rate window was the part of the run we were least confident about going in, and it is the part we are most confident about now.
+
+## What is next
+
+The customer has placed a follow-on order for 600 tonnes a month for the rest of the year. We will run it on the A-shift cycle for the first three months and then open it up to all four shifts once the cooling-profile recipe is in the standard run book.

--- a/examples/flux-foundry/content/shiftlog/april-maintenance-window.md
+++ b/examples/flux-foundry/content/shiftlog/april-maintenance-window.md
@@ -1,0 +1,23 @@
++++
+title = "April maintenance window · hot-strip mill"
+date = "2026-04-11"
+description = "The hot-strip mill went down for a planned forty-eight-hour maintenance window. Two roll changes, one drive replacement on stand four, and a full descaler rebuild."
+tags = ["maintenance", "hot-strip-mill", "planned"]
+lines = ["hot-strip-mill"]
++++
+
+The hot-strip mill was taken down for a planned forty-eight-hour maintenance window starting at 06:00 on Saturday 11 April and ending at 06:00 on Monday 13 April. The window had been booked since the previous quarter's planning meeting and the order book had been pre-shipped against it. The mill returned to service on the Monday morning shift with a first-piece-good rate of nine in ten and was at the normal coil-on-coil rate by the C-shift.
+
+## What was done
+
+The window was used to do three things that we cannot do during a normal weekly stop:
+
+1. **Work-roll changes on stands one and three.** Both pairs had been on the mill for the maximum recommended campaign and the surface condition was at the limit of what the descaler could compensate for.
+2. **Drive replacement on stand four.** The main drive on stand four had been showing a rising vibration signature on the bearing-temperature trend for the last six weeks. The replacement drive had been on site since the end of March and was pre-aligned on the bench.
+3. **Full descaler rebuild.** The high-pressure descaler ahead of stand one had been on a degraded duty since January with two nozzles isolated. The rebuild brings it back to full capacity and improves the surface quality on the high-end automotive grades.
+
+## What we did not do
+
+We did not change the roughing-mill rolls. They are within campaign and the surface check on the Friday day-shift was clean. We did not change the coiler mandrel — it is on a different campaign cycle and is good through May. We did not run the planned cooling-bed survey, which had been on the optional list — the descaler rebuild ran an hour long and we wanted the start-up time, so the survey has been moved to the next window in June.
+
+The next planned window is in the week of 8 June. The order book is being pre-shipped against it from the end of May.

--- a/examples/flux-foundry/content/shiftlog/record-heat-no-3.md
+++ b/examples/flux-foundry/content/shiftlog/record-heat-no-3.md
@@ -1,0 +1,25 @@
++++
+title = "Record heat on No. 3 blast furnace · 312 tonnes"
+date = "2026-03-22"
+description = "Cinder tapped 312 tonnes of hot metal on a single cast on the B-shift. The previous house record was 298. Here is how it was done and why we are not chasing the number again."
+tags = ["record", "blast-furnace", "no-3-cinder"]
+lines = ["blast-furnace"]
++++
+
+No. 3 blast furnace — **Cinder** — tapped 312 tonnes of hot metal on a single cast at 14:42 on the B-shift on Sunday 22 March. The previous house record on that furnace was 298 tonnes, set in October 2024. The cast ran for eighty-one minutes and the iron arrived at the BOS vessel at 1492 °C. The slag came off at a basicity of 1.21 and the silicon was 0.36 — both inside the comfortable band for a cast of that size.
+
+## How it was done
+
+The blower had been on a slow lift through the morning, taking the wind rate from 4100 to 4400 cubic metres per minute over four hours. The cast house had been on a tight turnaround on the previous two casts and the hearth temperature had been climbing steadily through the shift. The B-shift cast-house leader made the call to extend the cast rather than tap on the normal eighty-minute timer, which is what gave us the extra tonnage.
+
+- Wind rate at tap: 4380 m³/min
+- Coke rate: 312 kg/t
+- Pulverised coal injection: 188 kg/t
+- Top gas temperature: 142 °C
+- Hot blast: 1198 °C
+
+## Why we are not chasing the number
+
+A 312-tonne cast is a fine thing once. It is not a fine thing every cast. The hearth-wear refractory on Cinder is in its fourth campaign and the wall thermocouples on the western quadrant have been creeping up for the last two months. Pushing the furnace harder is the surest way to shorten the campaign, and the cost of a campaign-ending reline is not worth a few tonnes of headline.
+
+The B-shift earned the record. The plan is to bank it, write the leader a letter for the file, and go back to the eighty-minute timer on Monday morning.

--- a/examples/flux-foundry/content/shiftlog/tundish-breakout-postmortem.md
+++ b/examples/flux-foundry/content/shiftlog/tundish-breakout-postmortem.md
@@ -1,0 +1,27 @@
++++
+title = "Tundish breakout on caster strand B · postmortem"
+date = "2026-02-14"
+description = "We lost strand B at 03:17 on the C-shift. The cast was diverted to strand A and we shipped against the order book the next morning. This is what happened and what we changed."
+tags = ["postmortem", "caster", "safety"]
+lines = ["caster"]
++++
+
+We lost strand B of the four-strand caster at 03:17 on the C-shift on the morning of 14 February. The tundish lining on strand B failed at the slag line, hot metal washed through the refractory and into the pit, and the strand was stopped within forty seconds by the cast-house team. No one was hurt. The pit cooled out cleanly and the strand was returned to service forty-one hours later after a full reline.
+
+## What we tapped
+
+We had been on a 1505 °C tap from No. 2 blast furnace, with a basicity of 1.18 and a silicon content of 0.42 percent. The ladle had been on the turret for nineteen minutes when the breakout started — within nominal — and the tundish had been in service for six heats. The lining was the same MgO-C grade we have run for the last eighteen months without an incident.
+
+## What we found
+
+The post-incident inspection found the lining had been thinned at the slag line by an unusually aggressive slag chemistry on the previous heat. The previous heat had been a higher-sulfur charge from the open scrap mix on No. 3 furnace, and the slag had picked up enough FeO to attack the refractory more than usual. The lining wear was within the operating envelope on a per-heat basis but was concentrated on a single band rather than spread across the slag line.
+
+> The breakout was not caused by a single failure. It was caused by a slag chemistry that was not unusual on its own being run on a tundish that was already partway through its life. Both were within spec. Together, they were not.
+
+## What we changed
+
+We have shortened the maximum tundish life on the caster from eight heats to six until we have a better lining-wear model that takes the previous-heat slag chemistry into account. We have also added a slag-chemistry check to the pre-tap board so that the cast-house team can see, at a glance, whether the previous heat was an aggressive one. We have not changed the lining grade.
+
+## What we did not change
+
+We did not change the basicity target, the tap temperature, or the silicon spec. The breakout was a refractory-wear event, not a chemistry event, and we do not want to compensate for a refractory problem by widening the chemistry envelope.

--- a/examples/flux-foundry/static/css/style.css
+++ b/examples/flux-foundry/static/css/style.css
@@ -1,0 +1,871 @@
+/* =============================================================================
+   Flux Foundry — brutalist steelworks operations console
+   Paper cream + near-black ink + molten-red + steel-blue
+   No gradients. No emojis. Solid colours only.
+   ============================================================================= */
+
+:root {
+  --paper:    #f4efe6;
+  --paper-2:  #ebe3d3;
+  --rule:     #d6cfc2;
+  --ink:      #0a0908;
+  --ink-2:    #2a2520;
+  --dim:      #7a6f5c;
+  --red:      #c8201f;
+  --red-deep: #8a1413;
+  --blue:     #3b556e;
+  --blue-2:   #25394d;
+  --warn:     #b87a14;
+
+  --display:  "Archivo Black", "Anton", "Inter", system-ui, sans-serif;
+  --body:     "Inter", system-ui, -apple-system, sans-serif;
+  --mono:     "IBM Plex Mono", "Menlo", "Consolas", monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--body);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--ink); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+a:hover { color: var(--red); }
+
+.works {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 28px 36px 48px;
+  border-left: 1px solid var(--ink);
+  border-right: 1px solid var(--ink);
+  min-height: 100vh;
+  background: var(--paper);
+}
+
+/* ========== masthead ========== */
+.masthead {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 24px;
+  padding-bottom: 18px;
+  border-bottom: 4px solid var(--ink);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.brand .stamp { width: 64px; height: 64px; display: inline-block; }
+.brand .stamp svg { width: 100%; height: 100%; display: block; }
+
+.brand .wordmark { display: flex; flex-direction: column; line-height: 1; }
+.brand .wordmark b {
+  font-family: var(--display);
+  font-size: 38px;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+.brand .wordmark b + b { color: var(--red); }
+.brand .wordmark small {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--dim);
+  margin-top: 8px;
+}
+
+.nav {
+  display: flex;
+  align-items: flex-end;
+  gap: 28px;
+}
+.nav a {
+  font-family: var(--display);
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  padding: 6px 0;
+  border-bottom: 4px solid transparent;
+}
+.nav a:hover { border-bottom-color: var(--red); color: var(--ink); }
+
+/* ========== status bar ========== */
+.status-bar {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-bottom: 1px solid var(--ink);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.status-bar span {
+  padding: 8px 14px;
+  border-right: 1px solid var(--ink);
+  color: var(--ink-2);
+}
+.status-bar span:last-child { border-right: 0; }
+.status-bar b {
+  color: var(--red);
+  margin-right: 8px;
+  font-weight: 700;
+}
+
+/* ========== head row ========== */
+main { display: block; padding-top: 28px; }
+
+.head-row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 48px;
+  align-items: end;
+  padding-bottom: 28px;
+}
+
+.kicker {
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--dim);
+  display: inline-block;
+  margin-bottom: 14px;
+}
+
+h1.display {
+  font-family: var(--display);
+  font-size: 88px;
+  line-height: 0.88;
+  letter-spacing: -0.03em;
+  margin: 0 0 18px;
+  text-transform: uppercase;
+}
+h1.display em {
+  font-style: normal;
+  color: var(--red);
+}
+
+.dek {
+  font-size: 16px;
+  line-height: 1.5;
+  max-width: 56ch;
+  color: var(--ink-2);
+}
+
+.head-right {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.head-right .tally {
+  border: 1px solid var(--ink);
+  padding: 14px 16px 12px;
+  background: var(--paper);
+}
+.head-right .tally:first-child { grid-column: 1 / -1; }
+.head-right .tally.alarm { border: 1px solid var(--red); color: var(--red); }
+.t-num {
+  display: block;
+  font-family: var(--display);
+  font-size: 64px;
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+}
+.head-right .tally:first-child .t-num { font-size: 92px; }
+.t-lbl {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: 8px;
+  color: var(--ink);
+}
+.head-right .tally.alarm .t-lbl { color: var(--red); }
+.t-note {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--dim);
+  margin-top: 4px;
+}
+
+/* ========== rules ========== */
+hr.bar {
+  border: 0;
+  border-top: 1px solid var(--ink);
+  margin: 28px 0;
+}
+hr.bar-thick {
+  border-top: 6px solid var(--ink);
+  margin: 28px 0;
+}
+
+/* ========== kilns ========== */
+.kiln-label {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--dim);
+  margin-bottom: 14px;
+}
+.kiln-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.kiln {
+  border: 3px solid var(--ink);
+  background: var(--paper);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 320px;
+}
+.kiln-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.kiln-head .kiln-tag { font-weight: 700; }
+.kiln-head .kiln-name {
+  font-family: var(--display);
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  color: var(--paper);
+}
+.kiln.alarm .kiln-head { background: var(--red); }
+.kiln-state { color: var(--paper); opacity: 0.8; }
+.kiln.alarm .kiln-state { opacity: 1; font-weight: 700; }
+
+.kiln-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 48px;
+  gap: 16px;
+  padding: 14px 18px;
+  align-items: stretch;
+}
+.kiln-temp {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.kiln-temp .big {
+  font-family: var(--display);
+  font-size: 132px;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+}
+.kiln.alarm .kiln-temp .big { color: var(--red); }
+.kiln-temp .unit {
+  font-family: var(--mono);
+  font-size: 18px;
+  text-transform: uppercase;
+  color: var(--dim);
+  align-self: flex-start;
+  margin-top: 16px;
+}
+
+.kiln-bar {
+  position: relative;
+  width: 100%;
+  background: var(--paper-2);
+  border: 1px solid var(--ink);
+  overflow: hidden;
+}
+.kiln-fill {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  background: var(--blue);
+}
+.kiln-fill.red { background: var(--red); }
+.kiln-tick {
+  position: absolute;
+  left: -3px; right: -3px;
+  height: 0;
+  border-top: 1px solid var(--ink);
+}
+
+.kiln-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid var(--ink);
+}
+.kiln-stats dt {
+  padding: 8px 12px 2px;
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+  border-right: 1px solid var(--rule);
+}
+.kiln-stats dd {
+  padding: 0 12px 10px;
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ink);
+  border-right: 1px solid var(--rule);
+}
+.kiln-stats dt:last-of-type,
+.kiln-stats dd:last-of-type { border-right: 0; }
+.kiln-stats dd.hot { color: var(--red); }
+
+/* ========== generic tile / grid ========== */
+.grid {
+  display: grid;
+  gap: 18px;
+}
+.grid-2-1 { grid-template-columns: 2fr 1fr; }
+.grid-1-1-1 { grid-template-columns: 1fr 1fr 1fr; }
+
+.tile {
+  border: 1px solid var(--ink);
+  padding: 16px 18px 18px;
+  background: var(--paper);
+}
+.tile-head {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  align-items: baseline;
+  gap: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--ink);
+  margin-bottom: 14px;
+}
+.tile-head .folio {
+  font-family: var(--display);
+  font-size: 28px;
+  line-height: 1;
+  color: var(--red);
+}
+.tile-head h2 {
+  font-family: var(--display);
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+.tile-head .caption {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--dim);
+  text-align: right;
+}
+
+/* ========== hot-strip mill bars ========== */
+.mill { display: flex; flex-direction: column; gap: 6px; }
+.m-row {
+  display: grid;
+  grid-template-columns: 180px 1fr 80px;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.m-l { color: var(--ink-2); }
+.m-bar {
+  position: relative;
+  height: 18px;
+  background: var(--paper-2);
+  border: 1px solid var(--ink);
+}
+.m-bar i {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: var(--w);
+  background: var(--ink);
+}
+.m-v {
+  text-align: right;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.m-foot {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--rule);
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--dim);
+  letter-spacing: 0.06em;
+}
+
+/* ========== safety tile ========== */
+.safety { display: flex; flex-direction: column; gap: 14px; }
+.safety-num {
+  border: 2px solid var(--ink);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+.safety-num .big {
+  font-family: var(--display);
+  font-size: 96px;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  color: var(--blue);
+}
+.safety-num .lbl {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+  margin-top: 6px;
+}
+.safety-bd {
+  list-style: none;
+  margin: 0; padding: 0;
+}
+.safety-bd li {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 10px;
+  padding: 6px 0;
+  border-top: 1px solid var(--rule);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.safety-bd li:first-child { border-top: 0; }
+.safety-bd .d { color: var(--ink-2); font-weight: 600; }
+.safety-bd .t { color: var(--ink-2); }
+
+/* ========== tap log table ========== */
+table.tap, table.charge {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+table.tap th, table.tap td,
+table.charge th, table.charge td {
+  padding: 6px 8px;
+  text-align: left;
+  border-bottom: 1px solid var(--rule);
+}
+table.tap th, table.charge th {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--dim);
+  font-weight: 600;
+  border-bottom: 1px solid var(--ink);
+  font-size: 10px;
+}
+table.tap td:nth-child(n+3),
+table.charge td:nth-child(n+2) {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+table.tap th:nth-child(n+3),
+table.charge th:nth-child(n+2) { text-align: right; }
+table.tap tbody tr:hover,
+table.charge tbody tr:hover { background: var(--paper-2); }
+
+/* ========== slab yard ========== */
+.yard {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.yard-stack {
+  border: 1px solid var(--ink);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+.yard-stack .grade {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.blocks {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 2px;
+  width: 100%;
+  height: 110px;
+  justify-content: flex-end;
+}
+.blocks .b {
+  width: 100%;
+  height: 10px;
+  border: 1px solid var(--ink);
+  background: var(--paper);
+}
+.blocks .b.filled { background: var(--ink); }
+.yard-stack .ct {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--dim);
+}
+
+/* ========== productivity ========== */
+.prod {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 4px;
+  align-items: end;
+  height: 160px;
+  border-bottom: 1px solid var(--ink);
+  position: relative;
+  margin-bottom: 6px;
+}
+.prod::before {
+  content: "";
+  position: absolute;
+  left: 0; right: 0;
+  bottom: 75%;
+  border-top: 1px dashed var(--red);
+}
+.p-col { display: flex; flex-direction: column; align-items: center; height: 100%; justify-content: flex-end; }
+.p-col i {
+  display: block;
+  width: 100%;
+  height: var(--h);
+  background: var(--blue);
+}
+.p-col i.under { background: var(--red); }
+.p-col.bold i { background: var(--ink); }
+.p-col span {
+  display: block;
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--dim);
+  margin-top: 4px;
+  text-align: center;
+}
+.p-foot dl {
+  display: grid;
+  grid-template-columns: auto 1fr auto 1fr auto 1fr;
+  gap: 4px 10px;
+  margin: 8px 0 0;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+.p-foot dt {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--dim);
+  font-weight: 600;
+}
+.p-foot dd { margin: 0; }
+
+/* ========== ladle turret ========== */
+.turret {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.turret li {
+  display: grid;
+  grid-template-columns: 44px 92px 1fr;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.turret .pos {
+  font-family: var(--display);
+  font-size: 22px;
+  line-height: 1;
+}
+.turret .state {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+  padding: 4px 6px;
+  background: var(--blue);
+  color: var(--paper);
+  text-align: center;
+}
+.turret li:nth-child(1) .state { background: var(--red); }
+.turret li:nth-child(3) .state { background: var(--paper-2); color: var(--ink); border: 1px solid var(--ink); }
+.turret li:nth-child(4) .state { background: var(--warn); color: var(--paper); }
+.turret .meta { color: var(--ink-2); }
+
+/* ========== shift log feed ========== */
+.logfeed { padding-top: 8px; }
+.lf-head h2 {
+  font-family: var(--display);
+  font-size: 32px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+}
+.lf-head p {
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--dim);
+  margin: 0 0 18px;
+}
+.lf-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-top: 2px solid var(--ink);
+}
+.lf-list li {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 24px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.lf-meta {
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.lf-meta time { display: block; color: var(--ink); font-weight: 600; }
+.lf-line {
+  display: block;
+  margin-top: 4px;
+  color: var(--dim);
+}
+.lf-copy a {
+  font-family: var(--display);
+  font-size: 22px;
+  text-decoration: none;
+  line-height: 1.15;
+  display: inline-block;
+  margin-bottom: 6px;
+}
+.lf-copy a:hover { color: var(--red); }
+.lf-copy p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--ink-2);
+  max-width: 80ch;
+}
+
+/* ========== single-page (about, shiftlog entries) ========== */
+main.single {
+  max-width: 760px;
+  margin: 0 auto;
+  padding-top: 36px;
+}
+.page-title {
+  font-family: var(--display);
+  font-size: 48px;
+  line-height: 1.02;
+  letter-spacing: -0.02em;
+  margin: 0 0 12px;
+  text-transform: uppercase;
+}
+.page-date {
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+  margin-bottom: 4px;
+}
+.page-desc {
+  font-size: 17px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  margin: 0 0 18px;
+  max-width: 64ch;
+}
+.page-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+.chip {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 8px;
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.prose { font-size: 16px; line-height: 1.65; color: var(--ink); }
+.prose h2 {
+  font-family: var(--display);
+  font-size: 26px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  margin: 36px 0 12px;
+  padding-bottom: 6px;
+  border-bottom: 2px solid var(--ink);
+}
+.prose h3 {
+  font-family: var(--display);
+  font-size: 18px;
+  text-transform: uppercase;
+  margin: 24px 0 10px;
+}
+.prose p { margin: 0 0 14px; }
+.prose ul, .prose ol { padding-left: 22px; margin: 0 0 16px; }
+.prose li { margin-bottom: 4px; }
+.prose blockquote {
+  border-left: 4px solid var(--red);
+  margin: 18px 0;
+  padding: 4px 16px;
+  font-family: var(--display);
+  font-size: 18px;
+  text-transform: none;
+  color: var(--ink);
+  background: var(--paper-2);
+}
+.prose code {
+  font-family: var(--mono);
+  font-size: 13px;
+  background: var(--paper-2);
+  padding: 1px 5px;
+}
+.prose strong { color: var(--ink); font-weight: 700; }
+
+/* ========== 404 ========== */
+main.single.fortyfour { text-align: left; }
+.big-num {
+  font-family: var(--display);
+  font-size: 220px;
+  line-height: 0.9;
+  letter-spacing: -0.05em;
+  color: var(--red);
+  display: block;
+  margin-bottom: 12px;
+}
+.cta {
+  display: inline-block;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 10px 16px;
+  font-family: var(--display);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  margin-top: 10px;
+}
+.cta:hover { background: var(--red); color: var(--paper); }
+
+/* ========== colophon / footer ========== */
+.colophon {
+  margin-top: 48px;
+  padding-top: 22px;
+  border-top: 4px solid var(--ink);
+  display: grid;
+  grid-template-columns: 2fr 1fr 1.4fr;
+  gap: 28px;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+.colophon .col strong {
+  display: block;
+  font-family: var(--display);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+  color: var(--ink);
+}
+.colophon .col p { margin: 0; }
+.colophon .col a {
+  display: inline-block;
+  margin-right: 12px;
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+}
+.colophon .col a:hover { border-bottom-color: var(--red); color: var(--red); }
+.colophon .stamp-row {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 12px;
+  padding: 10px 0 0;
+  border-top: 1px solid var(--rule);
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--dim);
+}
+
+/* ========== responsive ========== */
+@media (max-width: 1100px) {
+  .head-row { grid-template-columns: 1fr; }
+  .kiln-grid { grid-template-columns: 1fr; }
+  .kiln-temp .big { font-size: 108px; }
+  .grid-2-1, .grid-1-1-1 { grid-template-columns: 1fr; }
+  .status-bar { grid-template-columns: 1fr 1fr; }
+  .status-bar span:nth-child(2) { border-right: 0; }
+  .status-bar span:nth-child(1),
+  .status-bar span:nth-child(2) { border-bottom: 1px solid var(--ink); }
+  h1.display { font-size: 64px; }
+  .colophon { grid-template-columns: 1fr; }
+  .lf-list li { grid-template-columns: 1fr; gap: 6px; }
+}
+
+@media (max-width: 720px) {
+  .works { padding: 18px 16px 32px; }
+  .masthead { flex-direction: column; align-items: flex-start; }
+  .nav { gap: 18px; }
+  .brand .wordmark b { font-size: 30px; }
+  h1.display { font-size: 48px; }
+  .t-num { font-size: 48px; }
+  .head-right .tally:first-child .t-num { font-size: 64px; }
+  .kiln-temp .big { font-size: 88px; }
+  .page-title { font-size: 34px; }
+  .big-num { font-size: 140px; }
+  .m-row { grid-template-columns: 120px 1fr 64px; }
+  .yard { grid-template-columns: repeat(2, 1fr); }
+  .status-bar { grid-template-columns: 1fr; }
+  .status-bar span { border-right: 0; border-bottom: 1px solid var(--ink); }
+  .status-bar span:last-child { border-bottom: 0; }
+}

--- a/examples/flux-foundry/static/favicon.svg
+++ b/examples/flux-foundry/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f4efe6"/>
+  <rect x="6" y="22" width="20" height="4" fill="#0a0908"/>
+  <path d="M 10 22 L 12 8 L 20 8 L 22 22 Z" fill="none" stroke="#0a0908" stroke-width="1.6" stroke-linejoin="miter"/>
+  <rect x="13" y="3" width="6" height="5" fill="#0a0908"/>
+  <rect x="14" y="13" width="4" height="6" fill="#c8201f"/>
+</svg>

--- a/examples/flux-foundry/templates/404.html
+++ b/examples/flux-foundry/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="single fortyfour">
+    <span class="big-num">404</span>
+    <h1 class="page-title">No such heat in the log.</h1>
+    <p class="page-desc">That page has not been issued. The console is on the front.</p>
+    <p><a href="{{ base_url }}/" class="cta">Return to the console</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/flux-foundry/templates/footer.html
+++ b/examples/flux-foundry/templates/footer.html
@@ -1,0 +1,27 @@
+    <footer class="colophon">
+      <div class="col">
+        <strong>{{ site.title }}</strong>
+        <p>Operations console for the integrated steelworks at Riverbend Works. Three blast furnaces, two BOS vessels, a four-strand caster, a six-stand hot-strip mill. Set in Archivo Black, Inter, and IBM Plex Mono. Built with Hwaro on Crystal.</p>
+      </div>
+      <div class="col">
+        <strong>Sections</strong>
+        <a href="{{ base_url }}/">Console</a>
+        <a href="{{ base_url }}/shiftlog/">Shift log</a>
+        <a href="{{ base_url }}/about/">About the console</a>
+      </div>
+      <div class="col">
+        <strong>Control room · {{ current_year }}</strong>
+        <p>Issued {{ current_date }} · revision r-12 · refresh interval 60 s · for shift superintendents and the works director.</p>
+      </div>
+      <div class="stamp-row">
+        <span>RIVERBEND WORKS</span>
+        <span>EST. 1948</span>
+        <span>HEAT NO. 41822</span>
+        <span>CHARGE C-3-A</span>
+        <span>SIGNED · J. OLAFSSON</span>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/flux-foundry/templates/header.html
+++ b/examples/flux-foundry/templates/header.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="works">
+    <header class="masthead">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="stamp" aria-hidden="true">
+          <svg viewBox="0 0 64 64">
+            <rect x="0" y="0" width="64" height="64" fill="none"/>
+            <rect x="8" y="52" width="48" height="8" fill="#0a0908"/>
+            <path d="M 16 52 L 20 16 L 44 16 L 48 52 Z" fill="none" stroke="#0a0908" stroke-width="3" stroke-linejoin="miter"/>
+            <rect x="26" y="4" width="12" height="12" fill="#0a0908"/>
+            <rect x="28" y="28" width="8" height="14" fill="#c8201f"/>
+            <line x1="16" y1="34" x2="48" y2="34" stroke="#0a0908" stroke-width="1.5"/>
+          </svg>
+        </span>
+        <span class="wordmark">
+          <b>FLUX</b><b>FOUNDRY</b>
+          <small>Riverbend Works · Operations Console · {{ current_date }}</small>
+        </span>
+      </a>
+      <nav class="nav">
+        <a href="{{ base_url }}/">Console</a>
+        <a href="{{ base_url }}/shiftlog/">Shift log</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+    <div class="status-bar">
+      <span><b>STATUS</b> all three furnaces tapping · caster strand B in service</span>
+      <span><b>SHIFT</b> A · turn 3 of 4 · 22:00 — 06:00</span>
+      <span><b>WIND</b> 4280 m³/min combined · hot blast 1192 °C</span>
+      <span><b>YARD</b> 11 cranes assigned · 4 dispatch lanes open</span>
+    </div>

--- a/examples/flux-foundry/templates/home.html
+++ b/examples/flux-foundry/templates/home.html
@@ -1,0 +1,333 @@
+{% include "header.html" %}
+  <main>
+    <section class="head-row">
+      <div class="head-left">
+        <span class="kicker">Operations console · turn 3 · 22:00 — 06:00</span>
+        <h1 class="display">LINE<br>RUNNING<br><em>HOT.</em></h1>
+        <p class="dek">All three blast furnaces tapping on schedule. Caster strand B back in service after the February reline. Hot-strip mill on the 1.4 mm automotive book through the C-shift. The yard is at 78 percent of the cap.</p>
+      </div>
+      <div class="head-right">
+        <div class="tally">
+          <span class="t-num">412</span>
+          <span class="t-lbl">heats this week</span>
+          <span class="t-note">target 408 · plus 4</span>
+        </div>
+        <div class="tally">
+          <span class="t-num">14,820</span>
+          <span class="t-lbl">tonnes shipped · 7d</span>
+          <span class="t-note">target 14,500 · plus 320</span>
+        </div>
+        <div class="tally alarm">
+          <span class="t-num">00</span>
+          <span class="t-lbl">days since last incident</span>
+          <span class="t-note">last: 14 Feb · strand B</span>
+        </div>
+      </div>
+    </section>
+
+    <hr class="bar bar-thick">
+
+    <section class="kilns">
+      <div class="kiln-label">
+        <span>K · KILN BANK · LIVE TAP READINGS · 60 s REFRESH</span>
+        <span>TARGET 1480 — 1520 °C · BASICITY 1.10 — 1.30</span>
+      </div>
+      <div class="kiln-grid">
+        <article class="kiln nominal">
+          <header class="kiln-head">
+            <span class="kiln-tag">No. 1</span>
+            <span class="kiln-name">AURELIA</span>
+            <span class="kiln-state">NOMINAL</span>
+          </header>
+          <div class="kiln-body">
+            <div class="kiln-temp">
+              <span class="big">1504</span>
+              <span class="unit">°C</span>
+            </div>
+            <div class="kiln-bar" aria-hidden="true">
+              <div class="kiln-fill" style="height: 96%"></div>
+              <div class="kiln-tick" style="bottom: 95%"></div>
+              <div class="kiln-tick" style="bottom: 90%"></div>
+              <div class="kiln-tick" style="bottom: 50%"></div>
+            </div>
+          </div>
+          <dl class="kiln-stats">
+            <dt>% of target</dt><dd>96%</dd>
+            <dt>basicity</dt><dd>1.18</dd>
+            <dt>silicon</dt><dd>0.41</dd>
+            <dt>last cast</dt><dd>22 min</dd>
+          </dl>
+        </article>
+
+        <article class="kiln nominal">
+          <header class="kiln-head">
+            <span class="kiln-tag">No. 2</span>
+            <span class="kiln-name">BRAND</span>
+            <span class="kiln-state">NOMINAL</span>
+          </header>
+          <div class="kiln-body">
+            <div class="kiln-temp">
+              <span class="big">1498</span>
+              <span class="unit">°C</span>
+            </div>
+            <div class="kiln-bar" aria-hidden="true">
+              <div class="kiln-fill" style="height: 92%"></div>
+              <div class="kiln-tick" style="bottom: 95%"></div>
+              <div class="kiln-tick" style="bottom: 90%"></div>
+              <div class="kiln-tick" style="bottom: 50%"></div>
+            </div>
+          </div>
+          <dl class="kiln-stats">
+            <dt>% of target</dt><dd>92%</dd>
+            <dt>basicity</dt><dd>1.22</dd>
+            <dt>silicon</dt><dd>0.36</dd>
+            <dt>last cast</dt><dd>41 min</dd>
+          </dl>
+        </article>
+
+        <article class="kiln alarm">
+          <header class="kiln-head">
+            <span class="kiln-tag">No. 3</span>
+            <span class="kiln-name">CINDER</span>
+            <span class="kiln-state">WATCH</span>
+          </header>
+          <div class="kiln-body">
+            <div class="kiln-temp">
+              <span class="big">1462</span>
+              <span class="unit">°C</span>
+            </div>
+            <div class="kiln-bar" aria-hidden="true">
+              <div class="kiln-fill red" style="height: 88%"></div>
+              <div class="kiln-tick" style="bottom: 95%"></div>
+              <div class="kiln-tick" style="bottom: 90%"></div>
+              <div class="kiln-tick" style="bottom: 50%"></div>
+            </div>
+          </div>
+          <dl class="kiln-stats">
+            <dt>% of target</dt><dd class="hot">88%</dd>
+            <dt>basicity</dt><dd>1.14</dd>
+            <dt>silicon</dt><dd>0.52</dd>
+            <dt>last cast</dt><dd>68 min</dd>
+          </dl>
+        </article>
+      </div>
+    </section>
+
+    <hr class="bar">
+
+    <section class="grid grid-2-1">
+      <article class="tile">
+        <header class="tile-head">
+          <span class="folio">M</span>
+          <h2>Hot-strip mill · throughput by stand</h2>
+          <span class="caption">Tonnes per hour · normalised to 3,400 nameplate</span>
+        </header>
+        <div class="mill">
+          <div class="m-row"><span class="m-l">Stand 1 · roughing</span><span class="m-bar"><i style="--w: 88%"></i></span><span class="m-v">2,992</span></div>
+          <div class="m-row"><span class="m-l">Stand 2 · finishing</span><span class="m-bar"><i style="--w: 84%"></i></span><span class="m-v">2,856</span></div>
+          <div class="m-row"><span class="m-l">Stand 3 · finishing</span><span class="m-bar"><i style="--w: 82%"></i></span><span class="m-v">2,788</span></div>
+          <div class="m-row"><span class="m-l">Stand 4 · finishing</span><span class="m-bar"><i style="--w: 80%"></i></span><span class="m-v">2,720</span></div>
+          <div class="m-row"><span class="m-l">Stand 5 · finishing</span><span class="m-bar"><i style="--w: 78%"></i></span><span class="m-v">2,652</span></div>
+          <div class="m-row"><span class="m-l">Stand 6 · finishing</span><span class="m-bar"><i style="--w: 77%"></i></span><span class="m-v">2,618</span></div>
+          <div class="m-foot">
+            <span>Finishing temperature · 868 °C</span>
+            <span>Coiler tension · 14.2 kN</span>
+            <span>Coil-on-coil · 42 s</span>
+          </div>
+        </div>
+      </article>
+
+      <article class="tile">
+        <header class="tile-head">
+          <span class="folio">S</span>
+          <h2>Safety · works incident counter</h2>
+          <span class="caption">Lost-time and recordable events</span>
+        </header>
+        <div class="safety">
+          <div class="safety-num">
+            <span class="big">87</span>
+            <span class="lbl">days · lost-time free</span>
+          </div>
+          <ul class="safety-bd">
+            <li><span class="d">22 May</span><span class="t">First-aid · burn · cast house</span></li>
+            <li><span class="d">19 May</span><span class="t">Near-miss · crane signal · yard</span></li>
+            <li><span class="d">17 May</span><span class="t">Near-miss · scaffold · stand 4</span></li>
+            <li><span class="d">11 May</span><span class="t">First-aid · slip · mill bay</span></li>
+            <li><span class="d">04 May</span><span class="t">Near-miss · hot tap · No. 1</span></li>
+          </ul>
+        </div>
+      </article>
+    </section>
+
+    <hr class="bar">
+
+    <section class="grid grid-1-1-1">
+      <article class="tile">
+        <header class="tile-head">
+          <span class="folio">B</span>
+          <h2>Blast furnace tap log</h2>
+          <span class="caption">Last 6 casts · all furnaces</span>
+        </header>
+        <table class="tap">
+          <thead>
+            <tr><th>Heat</th><th>F.</th><th>°C</th><th>t</th><th>Bas.</th><th>Si</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>41822</td><td>3 · Cinder</td><td>1462</td><td>286</td><td>1.14</td><td>0.52</td></tr>
+            <tr><td>41821</td><td>2 · Brand</td><td>1498</td><td>271</td><td>1.22</td><td>0.36</td></tr>
+            <tr><td>41820</td><td>1 · Aurelia</td><td>1504</td><td>268</td><td>1.18</td><td>0.41</td></tr>
+            <tr><td>41819</td><td>3 · Cinder</td><td>1488</td><td>294</td><td>1.16</td><td>0.48</td></tr>
+            <tr><td>41818</td><td>2 · Brand</td><td>1502</td><td>278</td><td>1.21</td><td>0.34</td></tr>
+            <tr><td>41817</td><td>1 · Aurelia</td><td>1496</td><td>262</td><td>1.19</td><td>0.39</td></tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="tile">
+        <header class="tile-head">
+          <span class="folio">Y</span>
+          <h2>Slab yard · live inventory</h2>
+          <span class="caption">Stacks by alloy grade · max 9 high</span>
+        </header>
+        <div class="yard">
+          <div class="yard-stack">
+            <span class="grade">DP-980</span>
+            <div class="blocks">
+              <span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span>
+            </div>
+            <span class="ct">4 / 9</span>
+          </div>
+          <div class="yard-stack">
+            <span class="grade">HSLA-550</span>
+            <div class="blocks">
+              <span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b"></span><span class="b"></span>
+            </div>
+            <span class="ct">7 / 9</span>
+          </div>
+          <div class="yard-stack">
+            <span class="grade">IF-180</span>
+            <div class="blocks">
+              <span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span>
+            </div>
+            <span class="ct">9 / 9</span>
+          </div>
+          <div class="yard-stack">
+            <span class="grade">S355-J2</span>
+            <div class="blocks">
+              <span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span>
+            </div>
+            <span class="ct">5 / 9</span>
+          </div>
+          <div class="yard-stack">
+            <span class="grade">API-X70</span>
+            <div class="blocks">
+              <span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b"></span><span class="b"></span><span class="b"></span>
+            </div>
+            <span class="ct">6 / 9</span>
+          </div>
+          <div class="yard-stack">
+            <span class="grade">DC-04</span>
+            <div class="blocks">
+              <span class="b filled"></span><span class="b filled"></span><span class="b filled"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span>
+            </div>
+            <span class="ct">3 / 9</span>
+          </div>
+        </div>
+      </article>
+
+      <article class="tile">
+        <header class="tile-head">
+          <span class="folio">P</span>
+          <h2>Shift productivity · last 12</h2>
+          <span class="caption">Tonnes shipped · bar height · target line at 2,400</span>
+        </header>
+        <div class="prod">
+          <div class="p-col"><i style="--h: 84%"></i><span>A · 18</span></div>
+          <div class="p-col"><i style="--h: 78%"></i><span>B · 18</span></div>
+          <div class="p-col"><i style="--h: 88%"></i><span>C · 19</span></div>
+          <div class="p-col"><i style="--h: 92%"></i><span>D · 19</span></div>
+          <div class="p-col"><i style="--h: 72%" class="under"></i><span>A · 19</span></div>
+          <div class="p-col"><i style="--h: 80%"></i><span>B · 19</span></div>
+          <div class="p-col"><i style="--h: 86%"></i><span>C · 20</span></div>
+          <div class="p-col"><i style="--h: 94%"></i><span>D · 20</span></div>
+          <div class="p-col"><i style="--h: 81%"></i><span>A · 20</span></div>
+          <div class="p-col"><i style="--h: 89%"></i><span>B · 20</span></div>
+          <div class="p-col"><i style="--h: 96%"></i><span>C · 21</span></div>
+          <div class="p-col bold"><i style="--h: 91%"></i><span>D · 21</span></div>
+        </div>
+        <div class="p-foot">
+          <dl>
+            <dt>Best</dt><dd>D · 21 May · 2,612 t</dd>
+            <dt>Worst</dt><dd>A · 19 May · 1,948 t</dd>
+            <dt>12-shift mean</dt><dd>2,316 t</dd>
+          </dl>
+        </div>
+      </article>
+    </section>
+
+    <hr class="bar">
+
+    <section class="grid grid-2-1">
+      <article class="tile">
+        <header class="tile-head">
+          <span class="folio">C</span>
+          <h2>Charge mix · last seven heats</h2>
+          <span class="caption">Burden composition by mass · No. 2 Brand</span>
+        </header>
+        <table class="charge">
+          <thead>
+            <tr><th>Heat</th><th>Sinter</th><th>Pellet</th><th>Lump</th><th>Coke</th><th>PCI</th><th>Scrap</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>41822</td><td>58%</td><td>22%</td><td>8%</td><td>320 kg/t</td><td>184 kg/t</td><td>4%</td></tr>
+            <tr><td>41821</td><td>60%</td><td>20%</td><td>8%</td><td>318 kg/t</td><td>186 kg/t</td><td>4%</td></tr>
+            <tr><td>41820</td><td>58%</td><td>22%</td><td>9%</td><td>322 kg/t</td><td>182 kg/t</td><td>4%</td></tr>
+            <tr><td>41819</td><td>56%</td><td>24%</td><td>9%</td><td>324 kg/t</td><td>180 kg/t</td><td>3%</td></tr>
+            <tr><td>41818</td><td>59%</td><td>21%</td><td>8%</td><td>320 kg/t</td><td>184 kg/t</td><td>4%</td></tr>
+            <tr><td>41817</td><td>60%</td><td>20%</td><td>9%</td><td>319 kg/t</td><td>185 kg/t</td><td>4%</td></tr>
+            <tr><td>41816</td><td>58%</td><td>22%</td><td>8%</td><td>321 kg/t</td><td>183 kg/t</td><td>4%</td></tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="tile">
+        <header class="tile-head">
+          <span class="folio">L</span>
+          <h2>Ladle turret · live</h2>
+          <span class="caption">Four positions · BOS to caster</span>
+        </header>
+        <ul class="turret">
+          <li><span class="pos">P1</span><span class="state">CASTING</span><span class="meta">Heat 41822 · strand B · 6 min in</span></li>
+          <li><span class="pos">P2</span><span class="state">WAITING</span><span class="meta">Heat 41823 · ladle on stand · 1496 °C</span></li>
+          <li><span class="pos">P3</span><span class="state">EMPTY</span><span class="meta">Last: 41820 · returned 22 min</span></li>
+          <li><span class="pos">P4</span><span class="state">MAINTAIN</span><span class="meta">Lining check · porous plug · 14 min</span></li>
+        </ul>
+      </article>
+    </section>
+
+    <hr class="bar bar-thick">
+
+    <section class="logfeed">
+      <header class="lf-head">
+        <h2>From the shift log</h2>
+        <p>Written by the shift superintendents at the end of each turn. Unedited.</p>
+      </header>
+      <ul class="lf-list">
+        {% for post in site.pages | where("section", "shiftlog") | sort_by("date", reverse=true) %}
+          {% if loop.index <= 4 %}
+          <li>
+            <div class="lf-meta">
+              <time>{{ post.date | date("%d %b · %Y") }}</time>
+              {% if post.extra.lines %}<span class="lf-line">{{ post.extra.lines | join(" · ") }}</span>{% endif %}
+            </div>
+            <div class="lf-copy">
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+            </div>
+          </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/flux-foundry/templates/page.html
+++ b/examples/flux-foundry/templates/page.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="single">
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.date %}<div class="page-date">{{ page.date | date("%d %B %Y") }}</div>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    {% if page.tags %}
+      <div class="page-tags">
+        {% for tag in page.tags %}<span class="chip">{{ tag }}</span>{% endfor %}
+      </div>
+    {% endif %}
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/flux-foundry/templates/section.html
+++ b/examples/flux-foundry/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+  <main class="single">
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    <article class="prose">{{ content }}</article>
+    <ul class="lf-list">
+      {% for post in section.pages %}
+        <li>
+          <div class="lf-meta">
+            <time>{{ post.date | date("%d %b · %Y") }}</time>
+            {% if post.extra.lines %}<span class="lf-line">{{ post.extra.lines | join(" · ") }}</span>{% endif %}
+          </div>
+          <div class="lf-copy">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/flux-foundry/templates/taxonomy.html
+++ b/examples/flux-foundry/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="single">
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">All terms in this taxonomy.</p>
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/flux-foundry/templates/taxonomy_term.html
+++ b/examples/flux-foundry/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="single">
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Entries tagged with this term.</p>
+    <article class="prose">{{ content }}</article>
+  </main>
+{% include "footer.html" %}

--- a/examples/glyph-orbital/AGENTS.md
+++ b/examples/glyph-orbital/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md — Glyph Orbital
+
+## Project Overview
+
+Static site built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator. Theme: dark, high-density satellite ground-station operations console.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload (default port 3000) |
+| `hwaro new logbook/<slug>.md` | Create new logbook entry from archetype |
+
+## Site-Specific Notes
+
+- Dark theme. Background `#08090e`, foreground `#ece6d6`, single signal-orange accent `#ff7849`, cool cyan `#6ee7ff` for uplink/MEO indicators.
+- Typography: `Space Grotesk` for headings, `Inter` for body, `JetBrains Mono` for numerics and labels.
+- Content sections: `content/logbook/` for pass reports and anomaly post-mortems. Plus `index.md` (console) and `about.md` (manual/colophon).
+- Homepage (`templates/home.html`) is a six-tile dashboard: orbital map (inline SVG), constellation roster, bandwidth budget, pass schedule, telemetry strips, ground-station inventory, plus an open-anomaly block.
+- The orbital map is hand-built inline SVG — three nested ellipses with rotated square satellite glyphs on each arc. No gradients or emojis anywhere.
+- All CSS in `static/css/style.css` (~500 lines).
+- Custom front-matter field: `spacecraft = [...]` on logbook entries, accessed via `page.extra.spacecraft`.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/glyph-orbital/archetypes/default.md
+++ b/examples/glyph-orbital/archetypes/default.md
@@ -1,0 +1,8 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
+spacecraft = []
++++

--- a/examples/glyph-orbital/config.toml
+++ b/examples/glyph-orbital/config.toml
@@ -1,0 +1,217 @@
+title = "Glyph Orbital"
+description = "Ground-station operations console for a small constellation of LEO and MEO birds."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "spacecraft"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["logbook"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/glyph-orbital/content/about.md
+++ b/examples/glyph-orbital/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About this console"
+description = "What the Glyph Orbital console is, who runs it, and how to read what it shows."
++++
+
+Glyph Orbital is the operations console for a small, privately funded constellation of low- and medium-Earth-orbit satellites. The operator is a thirteen-person engineering team based at a single primary ground station in the high desert, with two leased secondary apertures on different continents. The console you are reading is the same one the on-duty controller stares at during a pass.
+
+We publish the console publicly because most of the data on it is already in the open — orbital elements, downlink schedules, vehicle health rollups — and because the kind of operator who would want to fly with us tends to ask for it. The numbers update on a rolling basis. The console is read-only.
+
+## The constellation
+
+The fleet is mixed by design. Six spacecraft sit in sun-synchronous LEO between 450 and 650 kilometres, with the imaging payloads and the inter-satellite links. Two more sit in a medium-Earth orbit near 8,000 kilometres and carry a regional time-transfer payload. The call-signs are assigned in the order the vehicles came off the integration bench — `GLYPH-1A` was the first flight unit, `ARGUS-04` was the fourth of a different bus, and so on. We have lost one spacecraft (`KORE-3B`, deorbited intentionally after a battery-string fault in November 2025).
+
+## How to read the console
+
+The main tile, top-left, is the orbital map. The three nested ellipses are the average altitude shells, drawn flat and not to scale; the small filled squares are spacecraft positions sampled at the timestamp on the masthead. To the right of the map is the constellation roster — one row per bird, with a state dot (green for nominal, amber for caution, red for an open anomaly). Below that, the pass schedule shows the next twelve hours of contacts as bars on a 24-hour grid; the colour of the bar indicates which aperture is committed.
+
+The telemetry strips along the bottom are battery state of charge, downlink signal-to-noise (in decibels), and antenna pointing residual (in millidegrees), sampled at one-minute cadence over the last six hours. The bandwidth-budget block is rolled up from the per-aperture link budget and is the number we pay the most attention to during anomaly response.
+
+## Conventions
+
+All times are UTC. All altitudes are mean above the WGS-84 ellipsoid. Signal-to-noise is reported at the demodulator, after RF chain corrections, not at the antenna feed. We do not redact call-signs of failed birds; they remain in the roster, marked `RETIRED`, until their orbital lifetime expires.

--- a/examples/glyph-orbital/content/index.md
+++ b/examples/glyph-orbital/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Operations"
+description = "Glyph Orbital — live ground-station operations console."
+template = "home"
++++

--- a/examples/glyph-orbital/content/logbook/2026-02-11-argus-04-reaction-wheel-swap.md
+++ b/examples/glyph-orbital/content/logbook/2026-02-11-argus-04-reaction-wheel-swap.md
@@ -1,0 +1,23 @@
++++
+title = "ARGUS-04 reaction wheel swap from RWA-2 to RWA-4"
+date = "2026-02-11"
+description = "Wheel speed bias on RWA-2 crossed the operations threshold during the Tuesday morning pass. We swapped to the spare and re-tuned the attitude controller in the same orbit."
+tags = ["anomaly", "hardware", "attitude"]
+spacecraft = ["ARGUS-04"]
++++
+
+The wheel-speed bias on `ARGUS-04 / RWA-2` had been trending upward at roughly twenty revolutions per minute per week since late January. On 11 February at 06:42 UTC, during the third orbit of the morning support window, the bias crossed the five-hundred-rpm threshold we have written into the attitude-control configuration, and the on-board controller raised the soft fault we expected it to raise.
+
+The swap itself was uneventful. We commanded the spacecraft into safe-pointing mode at 06:51, brought `RWA-4` (the cold spare on the +Y face) out of its parked state, and re-loaded the wheel allocation matrix at 07:08. The vehicle reacquired its science attitude at 07:14, twenty-three minutes earlier than the worst-case timeline in the procedure.
+
+What was less uneventful was the re-tuning. `RWA-4` had been on orbit for fourteen months without being commanded above six hundred rpm, and its friction torque at low speed was higher than the value in the look-up table from acceptance test. We saw the first reaction-control thruster fire two passes later, which is what tipped us off. The fix was to re-fit the friction curve from on-orbit telemetry; the new coefficients are in `cfg/attitude/argus04-rev07.yaml` and the change is propagated to the rest of the bus-type-B fleet as a pending review item.
+
+## Root cause on RWA-2
+
+Vibration spectrum from the last six weeks of telemetry shows the characteristic broadening of a degrading bearing. RWA-2 will not be commanded again. It remains powered down and the attitude controller is configured to treat it as absent. The vehicle now flies on RWA-1, RWA-3, and RWA-4, which is a fully redundant three-axis configuration.
+
+## Follow-ups
+
+- Update the wheel-bias trending alert to fire at three hundred rpm, not five hundred, on bus-type-B vehicles
+- Add the friction-curve re-fit to the spare-activation procedure as a mandatory step
+- Schedule a hardware-in-the-loop run on the engineering model with the new friction model

--- a/examples/glyph-orbital/content/logbook/2026-03-04-glyph-1a-downlink-fade.md
+++ b/examples/glyph-orbital/content/logbook/2026-03-04-glyph-1a-downlink-fade.md
@@ -1,0 +1,19 @@
++++
+title = "GLYPH-1A downlink fade during the 02:18 UTC pass"
+date = "2026-03-04"
+description = "A nine-decibel margin drop on the X-band downlink for the duration of one pass, traced to a partially de-pointed feedhorn on the primary aperture."
+tags = ["anomaly", "ground", "rf"]
+spacecraft = ["GLYPH-1A"]
++++
+
+The 02:18 UTC pass over the primary aperture closed with a measured downlink signal-to-noise of fourteen decibels, against a predicted twenty-three. The bird itself was on its nominal attitude and the on-board transmitter telemetry was within one percent of its calibration. We lost roughly forty percent of the data products from the pass and recovered the rest on the next pass via the secondary aperture.
+
+The fault was on the ground. The primary aperture's feedhorn had drifted approximately one and a half degrees off the boresight, a known failure mode for the feed-mount assembly when the dish has been parked through a sustained high-wind event. The site had logged seventy-five-kilometre-per-hour gusts in the eight hours preceding the pass.
+
+## Resolution
+
+The on-call ground-systems engineer drove out to the site at 04:30 UTC, confirmed the alignment with the boresight laser, and re-clamped the feed-mount. Re-acquisition tests on a known beacon satellite at 06:00 UTC showed twenty-two-decibel margin, which is within tolerance. The feed-mount assembly is on the maintenance list for replacement during the planned April outage; the replacement is a stiffer second-generation mount that we have on the shelf.
+
+## What the console did not show
+
+The console's bandwidth-budget tile is calculated from the predicted link budget, not the measured one, which is why nothing on the homepage went amber until the operator noticed the data-product gap. We have added a measured-vs-predicted divergence alert to the per-pass summary view; it does not yet appear on the public console.

--- a/examples/glyph-orbital/content/logbook/2026-04-19-kore-7b-eclipse-season.md
+++ b/examples/glyph-orbital/content/logbook/2026-04-19-kore-7b-eclipse-season.md
@@ -1,0 +1,25 @@
++++
+title = "KORE-7B entering eclipse season, battery profile review"
+date = "2026-04-19"
+description = "KORE-7B begins its annual eclipse season on 24 April. We reviewed the battery profile against the on-orbit aging model and trimmed two science modes."
+tags = ["planning", "power", "eclipse"]
+spacecraft = ["KORE-7B"]
++++
+
+`KORE-7B` enters its annual eclipse season on 24 April. The vehicle is in a slightly precessed sun-synchronous orbit and sees roughly thirty-five minutes of eclipse per ninety-five minute orbit for the next eleven weeks, peaking at thirty-seven and a half minutes on 7 June.
+
+The battery on `KORE-7B` has accumulated approximately four thousand two hundred charge-discharge cycles since launch and shows the capacity fade we modelled — approximately eleven percent below beginning-of-life capacity, consistent with the analytical model to within one percentage point.
+
+## What we adjusted
+
+We disable two of the higher-power science modes during eclipse this year, where in the previous two eclipse seasons we ran them at reduced duty cycle. Specifically:
+
+- `IMG-WIDE` (the wide-field imager) goes from twenty-five-percent duty during eclipse to fully off
+- `XL-2` (cross-link payload to GLYPH-1A and GLYPH-1B) drops from continuous to opportunity-only during eclipse passes
+- `IMG-NARROW` and the housekeeping radio remain on continuously
+
+The expected depth-of-discharge floor under the new profile is sixty-eight percent, which keeps us a comfortable nine percentage points above the operations limit of seventy-seven percent.
+
+## Why this matters for the next two birds
+
+The next two `KORE`-class vehicles use the same battery line. The on-orbit aging data from `KORE-7B` is the primary input to the operations limit we will set for `KORE-8A` and `KORE-8B` at launch, currently scheduled for late August. The current data suggests we can raise the beginning-of-life depth-of-discharge limit from the conservative fifty-five percent we used at `KORE-7B` launch to sixty-two percent, which buys approximately fourteen percent additional payload-on time per orbit.

--- a/examples/glyph-orbital/content/logbook/2026-05-14-tle-update-cadence.md
+++ b/examples/glyph-orbital/content/logbook/2026-05-14-tle-update-cadence.md
@@ -1,0 +1,21 @@
++++
+title = "Increased TLE update cadence for the LEO sleeve"
+date = "2026-05-14"
+description = "We are now ingesting two-line element sets every four hours for the six LEO vehicles, up from every twelve. The change closes a recurring six-second pointing offset at the start of each pass."
+tags = ["planning", "ground", "pointing"]
+spacecraft = ["GLYPH-1A", "GLYPH-1B", "ARGUS-04", "ARGUS-05"]
++++
+
+Pointing residuals at the start of pass acquisition had been trending consistently positive on the six low-Earth-orbit vehicles — a roughly six-second along-track lag, on average, with a standard deviation of about two seconds. The lag is small enough that the dish track loop closes on the bird within the first ten seconds of horizon, but it shaves real seconds off the usable pass window, and it shows up in the per-pass data-product yield.
+
+The cause was the cadence of our TLE ingest. We pulled the public element sets every twelve hours, and at the worst of the cycle the orbital propagation had drifted by something on the order of two kilometres along-track. That is small in absolute terms but it sits right at the limit of the dish's acquisition pattern, and it explains the consistent direction of the residual.
+
+## The change
+
+We now ingest every four hours, on the hour, against a private commercial feed that we backstop with the public catalogue. The pointing residuals on the LEO sleeve since the change has averaged under one second along-track, which is within the dish's beam half-power point.
+
+## Cost and scope
+
+The commercial feed is around two thousand euros per month for the eight-vehicle subscription tier we are on. The MEO birds are unaffected because their orbits perturb much more slowly and the twelve-hour cadence is still sufficient.
+
+The on-call procedure is updated to ingest a manual TLE when a vehicle has a maneuver in the preceding twenty-four hours, which is the failure mode that the four-hour cadence does not catch.

--- a/examples/glyph-orbital/content/logbook/_index.md
+++ b/examples/glyph-orbital/content/logbook/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Logbook"
+description = "Pass reports, anomaly post-mortems, and hardware-swap notes from the operations floor."
+sort_by = "date"
+reverse = true
+paginate = 12
++++

--- a/examples/glyph-orbital/static/css/style.css
+++ b/examples/glyph-orbital/static/css/style.css
@@ -1,0 +1,860 @@
+:root {
+  --bg: #08090e;
+  --bg-2: #0c0e15;
+  --panel: #11141d;
+  --panel-2: #161922;
+  --ink: #ece6d6;
+  --ink-2: #cfc8b6;
+  --ink-mute: #9aa0b4;
+  --ink-dim: #6a7388;
+  --line: #1f2331;
+  --line-2: #2a2f3e;
+  --line-3: #3a4156;
+  --accent: #ff7849;
+  --cool: #6ee7ff;
+  --warn: #ffb454;
+  --ok: #7bd88f;
+  --off: #4a4e5c;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-size: 14.5px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3, .heading, .doc-title {
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  letter-spacing: -0.01em;
+  font-weight: 600;
+}
+.mono, code, pre, .num, .station-pct, .strip-now { font-family: "JetBrains Mono", ui-monospace, monospace; font-feature-settings: "tnum"; }
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--accent); }
+
+.console {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px 32px 64px;
+}
+
+/* MASTHEAD */
+.masthead {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 32px;
+  align-items: center;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line-2);
+}
+.masthead .brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  color: var(--ink);
+}
+.masthead .brand-mark {
+  width: 52px; height: 52px;
+  color: var(--ink-mute);
+  flex-shrink: 0;
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  padding: 4px;
+}
+.masthead .brand-mark svg { width: 100%; height: 100%; display: block; }
+.masthead .brand-text {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.55rem;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+}
+.masthead .brand-text b { font-weight: 700; color: var(--ink); }
+.masthead .brand-text em {
+  font-style: normal;
+  font-weight: 400;
+  color: var(--accent);
+  letter-spacing: 0.04em;
+}
+.masthead .brand-text small {
+  display: block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-top: 5px;
+}
+
+.primary-nav {
+  display: flex;
+  gap: 26px;
+  justify-self: end;
+}
+.primary-nav a {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  padding-bottom: 3px;
+  border-bottom: 1px solid transparent;
+}
+.primary-nav a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.status-strip {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0 0;
+  margin-top: 8px;
+  border-top: 1px solid var(--line);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.status-strip .status-label { color: var(--ink-dim); }
+.status-strip .status-value { color: var(--ink); }
+.status-strip .sep { color: var(--line-3); margin: 0 4px; }
+
+/* DOTS */
+.dot {
+  display: inline-block;
+  width: 8px; height: 8px;
+  background: var(--off);
+  border-radius: 0;
+  vertical-align: middle;
+}
+.dot-ok { background: var(--ok); }
+.dot-warn { background: var(--warn); }
+.dot-cool { background: var(--cool); }
+.dot-off { background: var(--off); }
+.status-strip .dot { width: 7px; height: 7px; }
+
+/* COVER ROW */
+.cover-row {
+  display: grid;
+  grid-template-columns: 1.1fr 1.05fr;
+  gap: 36px;
+  margin-top: 28px;
+  align-items: start;
+}
+.cover-text .kicker {
+  display: block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+.cover-text h1 {
+  font-size: clamp(2rem, 3.6vw, 3.1rem);
+  line-height: 1.04;
+  letter-spacing: -0.022em;
+  font-weight: 600;
+  margin: 0 0 18px;
+  color: var(--ink);
+}
+.cover-text h1 em {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--accent);
+}
+.cover-text .dek {
+  font-family: "Inter", sans-serif;
+  font-size: 0.98rem;
+  color: var(--ink-mute);
+  line-height: 1.55;
+  max-width: 54ch;
+  margin: 0 0 22px;
+}
+.cover-counters {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--line-2);
+  border: 1px solid var(--line-2);
+}
+.counter {
+  background: var(--panel);
+  padding: 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.counter .num {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.7rem;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -0.02em;
+}
+.counter.caution .num { color: var(--accent); }
+.counter .lbl {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+/* ORBIT FRAME */
+.orbit-frame {
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  padding: 8px;
+}
+.orbit-meta {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 8px 8px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 6px;
+}
+.orbit-meta .mini {
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.orbit-svg { width: 100%; height: auto; display: block; }
+
+/* DIVIDER */
+.divider {
+  border-top: 1px solid var(--line-2);
+  margin: 36px 0;
+}
+.divider.double {
+  border-top: 1px solid var(--line-2);
+  position: relative;
+}
+.divider.double::after {
+  content: "";
+  display: block;
+  border-top: 1px solid var(--line-2);
+  margin-top: 3px;
+}
+
+/* GRID 3x2 */
+.grid-3-2 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+.tile-roster { grid-column: span 2; }
+.tile-pass { grid-column: span 2; }
+
+.tile {
+  background: var(--panel);
+  border: 1px solid var(--line-2);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+}
+.tile-head {
+  margin: 0 0 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 12px;
+}
+.tile-head .tile-num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+}
+.tile-head h2 {
+  font-size: 1.02rem;
+  margin: 0;
+  font-weight: 600;
+  color: var(--ink);
+}
+.tile-head .tile-cap {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  justify-self: end;
+}
+
+/* ROSTER */
+.roster-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+.roster-table thead th {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  text-align: left;
+  padding: 6px 8px 6px 0;
+  border-bottom: 1px solid var(--line-2);
+  font-weight: 500;
+}
+.roster-table thead th.num { text-align: right; }
+.roster-table tbody td {
+  padding: 9px 8px 9px 0;
+  border-bottom: 1px dotted var(--line);
+  vertical-align: middle;
+  color: var(--ink-2);
+}
+.roster-table tbody tr:hover { background: var(--panel-2); }
+.roster-table .cs {
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: 0.04em;
+}
+.roster-table .num {
+  font-family: "JetBrains Mono", monospace;
+  text-align: right;
+  color: var(--ink-2);
+}
+.roster-table .mono { font-size: 11.5px; color: var(--ink-mute); }
+.roster-table .state {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.roster-table .state.caution { color: var(--accent); }
+.roster-table tr.retired td { color: var(--ink-dim); opacity: 0.6; }
+
+/* BUDGET */
+.tile-budget .budget-rows {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.b-row {
+  display: grid;
+  grid-template-columns: 1fr 2fr auto;
+  align-items: center;
+  gap: 12px;
+}
+.b-name {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--ink-mute);
+}
+.b-track {
+  position: relative;
+  height: 8px;
+  background: var(--line);
+  border: 1px solid var(--line-2);
+}
+.b-track i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--ink-2);
+}
+.b-track i.hot { background: var(--accent); }
+.b-track i.cool { background: var(--cool); }
+.b-val {
+  font-size: 10.5px;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.budget-defs {
+  margin: 14px 0 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 5px 14px;
+  font-size: 12px;
+}
+.budget-defs dt {
+  font-family: "Inter", sans-serif;
+  color: var(--ink-mute);
+}
+.budget-defs dd {
+  margin: 0;
+  font-family: "JetBrains Mono", monospace;
+  color: var(--ink);
+  text-align: right;
+}
+
+/* PASS SCHEDULE */
+.pass-axis {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  padding: 0 90px 0 90px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.1em;
+  color: var(--ink-dim);
+  margin-bottom: 6px;
+}
+.pass-axis span {
+  text-align: left;
+}
+.pass-grid {
+  position: relative;
+  border-top: 1px solid var(--line);
+}
+.pass-row {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  align-items: center;
+  gap: 0;
+  padding: 5px 0;
+  border-bottom: 1px dotted var(--line);
+}
+.pr-name {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: 0.04em;
+}
+.pass-row.caution .pr-name { color: var(--accent); }
+.pr-track {
+  position: relative;
+  height: 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+}
+.pr-track .bar {
+  position: absolute;
+  top: 1px;
+  bottom: 1px;
+  background: var(--ink-2);
+}
+.pr-track .bar.hd { background: var(--ink); }
+.pr-track .bar.pt { background: var(--warn); opacity: 0.85; }
+.pr-track .bar.nv { background: var(--ink-mute); }
+.pr-track .bar.cool { background: var(--cool); }
+.pr-track .bar.hot { background: var(--accent); }
+.pass-now {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--accent);
+  margin-left: 90px;
+}
+.pass-now .now-label {
+  position: absolute;
+  top: -16px;
+  left: -10px;
+  font-size: 9px;
+  color: var(--accent);
+  letter-spacing: 0.18em;
+  background: var(--panel);
+  padding: 0 3px;
+}
+.pass-legend {
+  list-style: none;
+  margin: 14px 0 0;
+  padding: 12px 0 0;
+  border-top: 1px solid var(--line);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.pass-legend .sw {
+  display: inline-block;
+  width: 12px;
+  height: 8px;
+  margin-right: 6px;
+  vertical-align: middle;
+  background: var(--ink-2);
+}
+.pass-legend .sw.hd { background: var(--ink); }
+.pass-legend .sw.pt { background: var(--warn); }
+.pass-legend .sw.nv { background: var(--ink-mute); }
+.pass-legend .sw.cool { background: var(--cool); }
+.pass-legend .sw.hot { background: var(--accent); }
+
+/* TELEMETRY STRIPS */
+.tile-telemetry .strip {
+  display: grid;
+  grid-template-columns: 110px 1fr 50px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px dotted var(--line);
+}
+.tile-telemetry .strip:last-child { border-bottom: 0; }
+.strip-label { display: flex; flex-direction: column; gap: 2px; }
+.t-name {
+  font-family: "Inter", sans-serif;
+  font-size: 12px;
+  color: var(--ink);
+}
+.t-unit {
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.strip-svg {
+  width: 100%;
+  height: 44px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+}
+.strip-now {
+  font-size: 13px;
+  color: var(--ink);
+  text-align: right;
+  font-weight: 500;
+}
+
+/* STATION INVENTORY */
+.station-list { list-style: none; margin: 0; padding: 0; }
+.station-list li {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1.2fr 40px;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px dotted var(--line);
+  font-size: 12px;
+}
+.station-list li:last-child { border-bottom: 0; }
+.station-name b { font-weight: 600; color: var(--ink); }
+.station-name { color: var(--ink-mute); font-family: "JetBrains Mono", monospace; font-size: 11px; }
+.station-spec { font-size: 10.5px; color: var(--ink-dim); letter-spacing: 0.06em; }
+.station-bar {
+  position: relative;
+  height: 6px;
+  background: var(--line);
+  border: 1px solid var(--line-2);
+}
+.station-bar i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--ok);
+}
+.station-bar i.warn { background: var(--warn); }
+.station-pct {
+  text-align: right;
+  font-size: 11.5px;
+  color: var(--ink);
+}
+.station-foot {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.station-foot b { color: var(--ink); }
+
+/* ANOMALIES */
+.anom-list {
+  list-style: none;
+  counter-reset: anom;
+  margin: 0;
+  padding: 0;
+}
+.anom-list li {
+  padding: 12px 0;
+  border-bottom: 1px dotted var(--line);
+}
+.anom-list li:last-child { border-bottom: 0; }
+.anom-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.anom-id { font-size: 10.5px; color: var(--ink-dim); letter-spacing: 0.1em; }
+.anom-bird {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: 0.04em;
+}
+.anom-sev {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  padding: 2px 6px;
+  border: 1px solid var(--line-3);
+  color: var(--ink-mute);
+}
+.anom-sev.sev-warn {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.anom-sev.sev-info {
+  border-color: var(--cool);
+  color: var(--cool);
+}
+.anom-list p {
+  margin: 0 0 6px;
+  font-size: 12.5px;
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+.anom-meta {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: var(--ink-dim);
+}
+
+/* LOGBOOK STRIP */
+.logbook-strip { margin-top: 8px; }
+.strip-head { margin-bottom: 22px; }
+.strip-head h2 {
+  font-size: 1.4rem;
+  margin: 0 0 6px;
+  font-weight: 600;
+}
+.strip-head p {
+  font-size: 0.95rem;
+  color: var(--ink-mute);
+  max-width: 60ch;
+  margin: 0;
+}
+.entries { list-style: none; margin: 0; padding: 0; }
+.entry {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 28px;
+  align-items: start;
+  padding: 22px 0;
+  border-top: 1px solid var(--line-2);
+}
+.entry:last-child { border-bottom: 1px solid var(--line-2); }
+.entry-copy a {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  display: inline-block;
+  margin-bottom: 6px;
+}
+.entry-copy a:hover { color: var(--accent); }
+.entry-copy p {
+  margin: 0;
+  color: var(--ink-mute);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  max-width: 64ch;
+}
+.entry-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  white-space: nowrap;
+}
+.entry-meta time { color: var(--ink-mute); }
+
+.cs-chip {
+  display: inline-block;
+  padding: 2px 6px;
+  border: 1px solid var(--line-2);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  color: var(--ink-mute);
+  background: var(--bg-2);
+}
+
+/* DOC PAGES */
+.section-head {
+  padding: 28px 0 20px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--line-2);
+}
+.doc { padding: 28px 0 0; max-width: 720px; }
+.doc-title {
+  font-size: clamp(1.7rem, 3vw, 2.4rem);
+  letter-spacing: -0.02em;
+  margin: 0 0 10px;
+  color: var(--ink);
+  font-weight: 600;
+  line-height: 1.1;
+}
+.doc-desc {
+  color: var(--ink-mute);
+  font-size: 1.02rem;
+  max-width: 60ch;
+  margin: 0 0 14px;
+  line-height: 1.55;
+}
+.doc-date {
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+.doc-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+.doc-body {
+  font-family: "Inter", sans-serif;
+  font-size: 1.02rem;
+  line-height: 1.7;
+  color: var(--ink-2);
+}
+.doc-body h2 {
+  font-size: 1.3rem;
+  margin: 2em 0 0.6em;
+  color: var(--ink);
+  font-weight: 600;
+}
+.doc-body h3 {
+  font-size: 1.1rem;
+  margin: 1.6em 0 0.4em;
+  color: var(--ink);
+  font-weight: 600;
+}
+.doc-body blockquote {
+  border-left: 2px solid var(--accent);
+  padding: 4px 18px;
+  margin: 1.6em 0;
+  color: var(--ink-mute);
+  font-style: italic;
+}
+.doc-body ul li::marker, .doc-body ol li::marker { color: var(--accent); }
+.doc-body ul li, .doc-body ol li { margin: 0.3em 0; }
+.doc-body a { color: var(--accent); border-bottom: 1px solid var(--line-3); }
+.doc-body a:hover { border-color: var(--accent); }
+.doc-body code {
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  padding: 1px 5px;
+  font-size: 0.9em;
+  color: var(--cool);
+}
+.doc-body strong { color: var(--ink); font-weight: 600; }
+.doc-foot {
+  margin-top: 48px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line-2);
+}
+.link-back {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.entries-section .entry-copy a { font-size: 1.3rem; }
+
+/* 404 */
+.doc-404 .err-code {
+  display: inline-block;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 4px 10px;
+  font-size: 10.5px;
+  letter-spacing: 0.22em;
+  margin-bottom: 20px;
+}
+.cta {
+  display: inline-block;
+  padding: 11px 20px;
+  background: var(--accent);
+  color: var(--bg);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  margin-top: 18px;
+}
+.cta:hover { background: var(--ink); color: var(--bg); }
+
+/* FOOTER */
+.colophon {
+  margin-top: 64px;
+  padding-top: 28px;
+  border-top: 1px solid var(--line-2);
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1.3fr 1fr;
+  gap: 32px;
+  font-size: 12.5px;
+  color: var(--ink-mute);
+  line-height: 1.55;
+}
+.colophon .col strong {
+  display: block;
+  margin-bottom: 10px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.colophon p { margin: 0; max-width: 38ch; }
+.colophon a {
+  color: var(--ink-mute);
+  border-bottom: 1px solid var(--line-2);
+  display: inline-block;
+  font-size: 12px;
+  padding-bottom: 1px;
+  margin-bottom: 2px;
+}
+.colophon a:hover { color: var(--accent); border-color: var(--accent); }
+.colophon .mono {
+  display: block;
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--ink-mute);
+  margin-bottom: 2px;
+}
+
+@media (max-width: 1100px) {
+  .grid-3-2 { grid-template-columns: 1fr 1fr; }
+  .tile-roster, .tile-pass { grid-column: span 2; }
+  .cover-row { grid-template-columns: 1fr; }
+  .colophon { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 720px) {
+  .console { padding: 16px 18px 48px; }
+  .masthead { grid-template-columns: 1fr; gap: 14px; }
+  .primary-nav { justify-self: start; flex-wrap: wrap; }
+  .grid-3-2 { grid-template-columns: 1fr; }
+  .tile-roster, .tile-pass { grid-column: span 1; }
+  .cover-counters { grid-template-columns: 1fr 1fr; }
+  .entry { grid-template-columns: 1fr; }
+  .entry-meta { align-items: flex-start; flex-direction: row; flex-wrap: wrap; }
+  .colophon { grid-template-columns: 1fr; }
+  .roster-table thead th:nth-child(3),
+  .roster-table tbody td:nth-child(3) { display: none; }
+}

--- a/examples/glyph-orbital/static/favicon.svg
+++ b/examples/glyph-orbital/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#08090e"/>
+  <ellipse cx="16" cy="16" rx="14" ry="6" fill="none" stroke="#ece6d6" stroke-width="1"/>
+  <ellipse cx="16" cy="16" rx="9" ry="3.8" fill="none" stroke="#6ee7ff" stroke-width="0.8"/>
+  <circle cx="16" cy="16" r="2" fill="#ece6d6"/>
+  <rect x="28" y="14.5" width="3" height="3" fill="#ff7849"/>
+</svg>

--- a/examples/glyph-orbital/templates/404.html
+++ b/examples/glyph-orbital/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="ops">
+    <article class="doc doc-404">
+      <span class="mono err-code">ERR 404 · NO TRACK</span>
+      <h1 class="doc-title">No bird on that vector.</h1>
+      <p class="doc-desc">The page you requested is not in the catalogue. Most things you want are on the console.</p>
+      <p><a href="{{ base_url }}/" class="cta mono">RETURN TO CONSOLE</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/glyph-orbital/templates/footer.html
+++ b/examples/glyph-orbital/templates/footer.html
@@ -1,0 +1,27 @@
+    <footer class="colophon">
+      <div class="col">
+        <strong>{{ site.title }}</strong>
+        <p>Ground-station operations console for a privately funded constellation of eight LEO and MEO spacecraft. Operated from a primary aperture in the high desert, with two leased secondary apertures. Public mirror; the console is read-only.</p>
+      </div>
+      <div class="col">
+        <strong>Sections</strong>
+        <a href="{{ base_url }}/">Console</a><br>
+        <a href="{{ base_url }}/logbook/">Logbook</a><br>
+        <a href="{{ base_url }}/about/">Manual</a><br>
+        <a href="{{ base_url }}/rss.xml">RSS</a>
+      </div>
+      <div class="col">
+        <strong>Apertures</strong>
+        <span class="mono">HD-1  ·  high desert, primary</span><br>
+        <span class="mono">PT-A  ·  leased, southern hemisphere</span><br>
+        <span class="mono">NV-C  ·  leased, polar</span>
+      </div>
+      <div class="col">
+        <strong>Issued {{ current_year }}</strong>
+        <p>All times UTC. Set in Space Grotesk, Inter, and JetBrains Mono. Built with Hwaro on Crystal. No tracking; no third-party scripts.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/glyph-orbital/templates/header.html
+++ b/examples/glyph-orbital/templates/header.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="console">
+    <header class="masthead">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 48 48">
+            <ellipse cx="24" cy="24" rx="22" ry="9" fill="none" stroke="currentColor" stroke-width="1.2"/>
+            <ellipse cx="24" cy="24" rx="14" ry="5.5" fill="none" stroke="currentColor" stroke-width="1"/>
+            <circle cx="24" cy="24" r="3" fill="currentColor"/>
+            <rect x="44" y="22" width="3" height="3" fill="#ff7849"/>
+            <rect x="11" y="28" width="2" height="2" fill="#6ee7ff"/>
+          </svg>
+        </span>
+        <span class="brand-text">
+          <b>GLYPH</b> <em>ORBITAL</em>
+          <small>Ground-station ops · console rev 4.12</small>
+        </span>
+      </a>
+      <nav class="primary-nav">
+        <a href="{{ base_url }}/">Console</a>
+        <a href="{{ base_url }}/logbook/">Logbook</a>
+        <a href="{{ base_url }}/about/">Manual</a>
+      </nav>
+      <div class="status-strip">
+        <span class="dot dot-ok"></span>
+        <span class="status-label">LINK</span>
+        <span class="status-value">NOMINAL</span>
+        <span class="sep">·</span>
+        <span class="status-label">UTC</span>
+        <span class="status-value mono">{{ current_date }} 14:42:08</span>
+        <span class="sep">·</span>
+        <span class="status-label">DUTY</span>
+        <span class="status-value">M. CARDENAS</span>
+      </div>
+    </header>

--- a/examples/glyph-orbital/templates/home.html
+++ b/examples/glyph-orbital/templates/home.html
@@ -1,0 +1,366 @@
+{% include "header.html" %}
+  <main class="ops">
+
+    <section class="cover-row">
+      <div class="cover-text">
+        <span class="kicker">Operations console · 22 May 2026 · 14:42 UTC</span>
+        <h1>Eight birds <em>on station.</em><br>Three contacts in the next hour.<br>One open anomaly.</h1>
+        <p class="dek">Live rollup of the constellation. Orbital state from the 14:00 ingest; telemetry from the on-pass downlinks of the last six hours. Read-only public mirror — controllers fly from the same view.</p>
+        <div class="cover-counters">
+          <div class="counter"><span class="num">8</span><span class="lbl">spacecraft active</span></div>
+          <div class="counter"><span class="num">7</span><span class="lbl">nominal</span></div>
+          <div class="counter caution"><span class="num">1</span><span class="lbl">caution</span></div>
+          <div class="counter"><span class="num">12 h</span><span class="lbl">schedule horizon</span></div>
+        </div>
+      </div>
+      <div class="orbit-frame">
+        <div class="orbit-meta">
+          <span class="mono mini">FRAME ECI · J2000</span>
+          <span class="mono mini">EPOCH 2026-05-22T14:42:08Z</span>
+        </div>
+        <svg class="orbit-svg" viewBox="0 0 520 360" aria-label="Orbital path map">
+          <defs>
+            <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+              <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1a1d28" stroke-width="0.5"/>
+            </pattern>
+          </defs>
+          <rect width="520" height="360" fill="#0c0e15"/>
+          <rect width="520" height="360" fill="url(#grid)"/>
+          <line x1="0" y1="180" x2="520" y2="180" stroke="#2a2f3e" stroke-width="0.5" stroke-dasharray="2 4"/>
+          <line x1="260" y1="0" x2="260" y2="360" stroke="#2a2f3e" stroke-width="0.5" stroke-dasharray="2 4"/>
+
+          <ellipse cx="260" cy="180" rx="230" ry="130" fill="none" stroke="#3a4156" stroke-width="1"/>
+          <ellipse cx="260" cy="180" rx="170" ry="92" fill="none" stroke="#4a5168" stroke-width="1"/>
+          <ellipse cx="260" cy="180" rx="105" ry="55" fill="none" stroke="#6ee7ff" stroke-width="1" stroke-dasharray="3 3" opacity="0.55"/>
+
+          <circle cx="260" cy="180" r="34" fill="#161922" stroke="#3a4156" stroke-width="1"/>
+          <circle cx="260" cy="180" r="22" fill="none" stroke="#2a2f3e" stroke-width="0.5"/>
+          <text x="260" y="184" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6a7388" letter-spacing="1.5">EARTH</text>
+
+          <g transform="translate(490 180) rotate(-22)"><rect x="-4" y="-4" width="8" height="8" fill="#ff7849"/></g>
+          <text x="490" y="160" font-family="JetBrains Mono" font-size="8.5" fill="#ece6d6">GLYPH-1A</text>
+          <text x="490" y="208" font-family="JetBrains Mono" font-size="7.5" fill="#9aa0b4">LEO 612km</text>
+
+          <g transform="translate(75 198) rotate(18)"><rect x="-4" y="-4" width="8" height="8" fill="#ece6d6"/></g>
+          <text x="20" y="218" font-family="JetBrains Mono" font-size="8.5" fill="#ece6d6">GLYPH-1B</text>
+          <text x="20" y="232" font-family="JetBrains Mono" font-size="7.5" fill="#9aa0b4">LEO 598km</text>
+
+          <g transform="translate(308 60) rotate(-62)"><rect x="-4" y="-4" width="8" height="8" fill="#ece6d6"/></g>
+          <text x="316" y="52" font-family="JetBrains Mono" font-size="8.5" fill="#ece6d6">ARGUS-04</text>
+
+          <g transform="translate(190 295) rotate(40)"><rect x="-4" y="-4" width="8" height="8" fill="#ece6d6"/></g>
+          <text x="120" y="312" font-family="JetBrains Mono" font-size="8.5" fill="#ece6d6">ARGUS-05</text>
+
+          <g transform="translate(420 100) rotate(-48)"><rect x="-4" y="-4" width="8" height="8" fill="#ff7849"/></g>
+          <text x="372" y="92" font-family="JetBrains Mono" font-size="8.5" fill="#ff7849">ARGUS-06 *</text>
+
+          <g transform="translate(140 100) rotate(56)"><rect x="-4" y="-4" width="8" height="8" fill="#ece6d6"/></g>
+          <text x="80" y="92" font-family="JetBrains Mono" font-size="8.5" fill="#ece6d6">GLYPH-1C</text>
+
+          <g transform="translate(365 240) rotate(-10)"><rect x="-4" y="-4" width="8" height="8" fill="#6ee7ff"/></g>
+          <text x="372" y="262" font-family="JetBrains Mono" font-size="8.5" fill="#6ee7ff">KORE-7A</text>
+          <text x="372" y="274" font-family="JetBrains Mono" font-size="7.5" fill="#9aa0b4">MEO 8240km</text>
+
+          <g transform="translate(150 240) rotate(28)"><rect x="-4" y="-4" width="8" height="8" fill="#6ee7ff"/></g>
+          <text x="90" y="262" font-family="JetBrains Mono" font-size="8.5" fill="#6ee7ff">KORE-7B</text>
+
+          <text x="14" y="22" font-family="JetBrains Mono" font-size="8" fill="#6a7388" letter-spacing="1.5">ALT SHELLS</text>
+          <text x="14" y="34" font-family="JetBrains Mono" font-size="7.5" fill="#9aa0b4">450-650 km · 8000 km · cross-link mesh</text>
+          <text x="14" y="346" font-family="JetBrains Mono" font-size="7.5" fill="#6a7388">* ARGUS-06 — open anomaly, reaction wheel bias drift</text>
+        </svg>
+      </div>
+    </section>
+
+    <div class="divider"></div>
+
+    <section class="grid-3-2">
+
+      <article class="tile tile-roster">
+        <header class="tile-head">
+          <span class="tile-num">01</span>
+          <h2>Constellation roster</h2>
+          <span class="tile-cap">eight active · one retired</span>
+        </header>
+        <table class="roster-table">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Call-sign</th>
+              <th>Bus</th>
+              <th class="num">Alt</th>
+              <th class="num">SoC</th>
+              <th>Last contact</th>
+              <th>State</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td><span class="dot dot-ok"></span></td><td class="cs">GLYPH-1A</td><td>B-II</td><td class="num">612</td><td class="num">88%</td><td class="mono">+12m</td><td class="state">nominal</td></tr>
+            <tr><td><span class="dot dot-ok"></span></td><td class="cs">GLYPH-1B</td><td>B-II</td><td class="num">598</td><td class="num">84%</td><td class="mono">+04m</td><td class="state">nominal</td></tr>
+            <tr><td><span class="dot dot-ok"></span></td><td class="cs">GLYPH-1C</td><td>B-II</td><td class="num">604</td><td class="num">91%</td><td class="mono">+18m</td><td class="state">nominal</td></tr>
+            <tr><td><span class="dot dot-ok"></span></td><td class="cs">ARGUS-04</td><td>B-III</td><td class="num">472</td><td class="num">77%</td><td class="mono">+02m</td><td class="state">nominal</td></tr>
+            <tr><td><span class="dot dot-ok"></span></td><td class="cs">ARGUS-05</td><td>B-III</td><td class="num">468</td><td class="num">79%</td><td class="mono">+09m</td><td class="state">nominal</td></tr>
+            <tr><td><span class="dot dot-warn"></span></td><td class="cs">ARGUS-06</td><td>B-III</td><td class="num">466</td><td class="num">72%</td><td class="mono">+22m</td><td class="state caution">RWA drift</td></tr>
+            <tr><td><span class="dot dot-cool"></span></td><td class="cs">KORE-7A</td><td>M-I</td><td class="num">8240</td><td class="num">82%</td><td class="mono">+38m</td><td class="state">nominal</td></tr>
+            <tr><td><span class="dot dot-cool"></span></td><td class="cs">KORE-7B</td><td>M-I</td><td class="num">8118</td><td class="num">86%</td><td class="mono">+41m</td><td class="state">nominal</td></tr>
+            <tr class="retired"><td><span class="dot dot-off"></span></td><td class="cs">KORE-3B</td><td>M-I</td><td class="num">—</td><td class="num">—</td><td class="mono">deorb 25-11-14</td><td class="state">retired</td></tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="tile tile-budget">
+        <header class="tile-head">
+          <span class="tile-num">02</span>
+          <h2>Bandwidth budget</h2>
+          <span class="tile-cap">aperture-hours · next 12h</span>
+        </header>
+        <div class="budget-rows">
+          <div class="b-row">
+            <span class="b-name">HD-1 · primary</span>
+            <span class="b-track">
+              <i style="width:78%"></i>
+            </span>
+            <span class="b-val mono">7.8 / 10 h</span>
+          </div>
+          <div class="b-row">
+            <span class="b-name">PT-A · southern</span>
+            <span class="b-track">
+              <i style="width:52%"></i>
+            </span>
+            <span class="b-val mono">5.2 / 10 h</span>
+          </div>
+          <div class="b-row">
+            <span class="b-name">NV-C · polar</span>
+            <span class="b-track">
+              <i style="width:91%" class="hot"></i>
+            </span>
+            <span class="b-val mono">9.1 / 10 h</span>
+          </div>
+          <div class="b-row">
+            <span class="b-name">X-link mesh</span>
+            <span class="b-track">
+              <i style="width:34%" class="cool"></i>
+            </span>
+            <span class="b-val mono">3.4 / 10 h</span>
+          </div>
+        </div>
+        <dl class="budget-defs">
+          <dt>Total scheduled</dt><dd>25.5 h</dd>
+          <dt>Margin · 12h</dt><dd>14.5 h</dd>
+          <dt>Predicted yield</dt><dd>92.8%</dd>
+          <dt>SLA floor</dt><dd>85.0%</dd>
+        </dl>
+      </article>
+
+      <article class="tile tile-pass">
+        <header class="tile-head">
+          <span class="tile-num">03</span>
+          <h2>Pass schedule · next 12 h</h2>
+          <span class="tile-cap">contacts on a 24-hour grid</span>
+        </header>
+        <div class="pass-axis">
+          <span>15Z</span><span>17Z</span><span>19Z</span><span>21Z</span><span>23Z</span><span>01Z</span><span>03Z</span>
+        </div>
+        <div class="pass-grid">
+          <div class="pass-row"><span class="pr-name">GLYPH-1A</span>
+            <span class="pr-track">
+              <i class="bar hd" style="left:6%; width:5.5%"></i>
+              <i class="bar pt" style="left:38%; width:5%"></i>
+              <i class="bar hd" style="left:72%; width:6%"></i>
+            </span>
+          </div>
+          <div class="pass-row"><span class="pr-name">GLYPH-1B</span>
+            <span class="pr-track">
+              <i class="bar hd" style="left:14%; width:5%"></i>
+              <i class="bar nv" style="left:46%; width:5%"></i>
+              <i class="bar hd" style="left:80%; width:5%"></i>
+            </span>
+          </div>
+          <div class="pass-row"><span class="pr-name">GLYPH-1C</span>
+            <span class="pr-track">
+              <i class="bar pt" style="left:22%; width:5%"></i>
+              <i class="bar hd" style="left:54%; width:5%"></i>
+              <i class="bar hd" style="left:88%; width:4%"></i>
+            </span>
+          </div>
+          <div class="pass-row"><span class="pr-name">ARGUS-04</span>
+            <span class="pr-track">
+              <i class="bar hd" style="left:2%; width:5%"></i>
+              <i class="bar hd" style="left:34%; width:5%"></i>
+              <i class="bar nv" style="left:66%; width:5%"></i>
+            </span>
+          </div>
+          <div class="pass-row"><span class="pr-name">ARGUS-05</span>
+            <span class="pr-track">
+              <i class="bar pt" style="left:10%; width:5%"></i>
+              <i class="bar hd" style="left:42%; width:5%"></i>
+              <i class="bar hd" style="left:74%; width:5%"></i>
+            </span>
+          </div>
+          <div class="pass-row caution"><span class="pr-name">ARGUS-06</span>
+            <span class="pr-track">
+              <i class="bar hd hot" style="left:18%; width:5%"></i>
+              <i class="bar hd hot" style="left:50%; width:5%"></i>
+              <i class="bar hd hot" style="left:82%; width:5%"></i>
+            </span>
+          </div>
+          <div class="pass-row"><span class="pr-name">KORE-7A</span>
+            <span class="pr-track">
+              <i class="bar cool" style="left:8%; width:14%"></i>
+              <i class="bar cool" style="left:60%; width:14%"></i>
+            </span>
+          </div>
+          <div class="pass-row"><span class="pr-name">KORE-7B</span>
+            <span class="pr-track">
+              <i class="bar cool" style="left:28%; width:14%"></i>
+              <i class="bar cool" style="left:78%; width:14%"></i>
+            </span>
+          </div>
+          <div class="pass-now" style="left:8%"><span class="now-label mono">NOW</span></div>
+        </div>
+        <ul class="pass-legend">
+          <li><i class="sw hd"></i> HD-1</li>
+          <li><i class="sw pt"></i> PT-A</li>
+          <li><i class="sw nv"></i> NV-C</li>
+          <li><i class="sw cool"></i> X-link</li>
+          <li><i class="sw hot"></i> caution</li>
+        </ul>
+      </article>
+
+      <article class="tile tile-telemetry">
+        <header class="tile-head">
+          <span class="tile-num">04</span>
+          <h2>Telemetry strips · last 6 h</h2>
+          <span class="tile-cap">battery · downlink · pointing</span>
+        </header>
+        <div class="strip">
+          <div class="strip-label">
+            <span class="t-name">Battery SoC</span>
+            <span class="t-unit mono">% · 60-sec</span>
+          </div>
+          <svg class="strip-svg" viewBox="0 0 320 60" preserveAspectRatio="none">
+            <line x1="0" y1="20" x2="320" y2="20" stroke="#2a2f3e" stroke-width="0.5" stroke-dasharray="2 4"/>
+            <line x1="0" y1="40" x2="320" y2="40" stroke="#2a2f3e" stroke-width="0.5" stroke-dasharray="2 4"/>
+            <polyline fill="none" stroke="#ece6d6" stroke-width="1.4" points="0,28 20,26 40,29 60,34 80,40 100,46 120,48 140,42 160,32 180,22 200,16 220,14 240,18 260,22 280,20 300,16 320,14"/>
+          </svg>
+          <span class="strip-now mono">88.3</span>
+        </div>
+        <div class="strip">
+          <div class="strip-label">
+            <span class="t-name">Downlink SNR</span>
+            <span class="t-unit mono">dB · X-band</span>
+          </div>
+          <svg class="strip-svg" viewBox="0 0 320 60" preserveAspectRatio="none">
+            <line x1="0" y1="20" x2="320" y2="20" stroke="#2a2f3e" stroke-width="0.5" stroke-dasharray="2 4"/>
+            <line x1="0" y1="40" x2="320" y2="40" stroke="#2a2f3e" stroke-width="0.5" stroke-dasharray="2 4"/>
+            <polyline fill="none" stroke="#6ee7ff" stroke-width="1.4" points="0,42 18,38 36,30 54,22 72,18 90,14 108,10 126,12 144,18 162,24 180,22 198,16 216,14 234,18 252,22 270,28 288,24 306,18 320,14"/>
+          </svg>
+          <span class="strip-now mono">22.4</span>
+        </div>
+        <div class="strip">
+          <div class="strip-label">
+            <span class="t-name">Pointing residual</span>
+            <span class="t-unit mono">millideg · az</span>
+          </div>
+          <svg class="strip-svg" viewBox="0 0 320 60" preserveAspectRatio="none">
+            <line x1="0" y1="30" x2="320" y2="30" stroke="#2a2f3e" stroke-width="0.5"/>
+            <polyline fill="none" stroke="#ff7849" stroke-width="1.4" points="0,30 18,32 36,28 54,34 72,30 90,38 108,34 126,28 144,24 162,30 180,36 198,32 216,28 234,26 252,30 270,34 288,30 306,28 320,30"/>
+          </svg>
+          <span class="strip-now mono">3.1</span>
+        </div>
+      </article>
+
+      <article class="tile tile-station">
+        <header class="tile-head">
+          <span class="tile-num">05</span>
+          <h2>Ground-station inventory</h2>
+          <span class="tile-cap">apertures · sub-systems · health</span>
+        </header>
+        <ul class="station-list">
+          <li>
+            <span class="station-name"><b>HD-1</b> high desert</span>
+            <span class="station-spec mono">7.3m · X+S band</span>
+            <span class="station-bar"><i style="width:96%"></i></span>
+            <span class="station-pct mono">96</span>
+          </li>
+          <li>
+            <span class="station-name"><b>PT-A</b> southern (leased)</span>
+            <span class="station-spec mono">5.4m · X band</span>
+            <span class="station-bar"><i style="width:88%"></i></span>
+            <span class="station-pct mono">88</span>
+          </li>
+          <li>
+            <span class="station-name"><b>NV-C</b> polar (leased)</span>
+            <span class="station-spec mono">9.0m · X+Ka band</span>
+            <span class="station-bar"><i style="width:74%" class="warn"></i></span>
+            <span class="station-pct mono">74</span>
+          </li>
+          <li>
+            <span class="station-name"><b>OBS-1</b> beacon range</span>
+            <span class="station-spec mono">2.4m · cal only</span>
+            <span class="station-bar"><i style="width:100%"></i></span>
+            <span class="station-pct mono">100</span>
+          </li>
+          <li>
+            <span class="station-name"><b>HD-2</b> backup</span>
+            <span class="station-spec mono">3.7m · S band</span>
+            <span class="station-bar"><i style="width:62%" class="warn"></i></span>
+            <span class="station-pct mono">62</span>
+          </li>
+        </ul>
+        <div class="station-foot mono">avg fleet health · <b>84.0%</b> · 30d trend · steady</div>
+      </article>
+
+      <article class="tile tile-anom">
+        <header class="tile-head">
+          <span class="tile-num">06</span>
+          <h2>Open anomalies</h2>
+          <span class="tile-cap">tracked at the duty-controller level</span>
+        </header>
+        <ol class="anom-list">
+          <li>
+            <div class="anom-head"><span class="anom-id mono">A-26-014</span><span class="anom-bird">ARGUS-06</span><span class="anom-sev sev-warn">CAUTION</span></div>
+            <p>Reaction wheel RWA-2 bias drift, 380 rpm and trending. Spare RWA-4 activation procedure staged; awaiting next sun-side pass to execute.</p>
+            <div class="anom-meta mono">opened 21-05 18:04Z · owner: J. AHN</div>
+          </li>
+          <li>
+            <div class="anom-head"><span class="anom-id mono">A-26-013</span><span class="anom-bird">NV-C aperture</span><span class="anom-sev sev-info">INFO</span></div>
+            <p>Feed-mount stiffness below target after April high-wind event. Replacement part on site; outage scheduled for the next maintenance window.</p>
+            <div class="anom-meta mono">opened 14-05 06:20Z · owner: L. PARK</div>
+          </li>
+          <li>
+            <div class="anom-head"><span class="anom-id mono">A-26-011</span><span class="anom-bird">KORE-7B</span><span class="anom-sev sev-info">INFO</span></div>
+            <p>Eclipse-season battery profile in effect through 7 June. IMG-WIDE disabled during eclipse, XL-2 opportunity-only.</p>
+            <div class="anom-meta mono">opened 24-04 00:00Z · owner: M. CARDENAS</div>
+          </li>
+        </ol>
+      </article>
+
+    </section>
+
+    <div class="divider double"></div>
+
+    <section class="logbook-strip">
+      <header class="strip-head">
+        <h2>From the logbook</h2>
+        <p>Pass reports, post-mortems, and hardware-swap notes — written by the engineer on duty, lightly edited.</p>
+      </header>
+      <ul class="entries">
+        {% for post in site.pages | where("section", "logbook") | sort_by("date", reverse=true) %}
+          {% if loop.index <= 4 %}
+          <li class="entry">
+            <div class="entry-copy">
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+            </div>
+            <div class="entry-meta">
+              <time class="mono">{{ post.date | date("%d %b %Y") }}</time>
+              {% if post.extra.spacecraft %}{% for cs in post.extra.spacecraft %}<span class="cs-chip mono">{{ cs }}</span>{% endfor %}{% endif %}
+            </div>
+          </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </section>
+
+  </main>
+{% include "footer.html" %}

--- a/examples/glyph-orbital/templates/page.html
+++ b/examples/glyph-orbital/templates/page.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="ops">
+    <article class="doc">
+      {% if page.title is present %}<h1 class="doc-title">{{ page.title | e }}</h1>{% endif %}
+      {% if page.description %}<p class="doc-desc">{{ page.description }}</p>{% endif %}
+      {% if page.date %}<div class="doc-date mono">{{ page.date | date("%d %b %Y") }} · UTC</div>{% endif %}
+      {% if page.extra.spacecraft %}
+        <div class="doc-chips">
+          {% for cs in page.extra.spacecraft %}<span class="cs-chip mono">{{ cs }}</span>{% endfor %}
+        </div>
+      {% endif %}
+      <div class="doc-body">{{ content }}</div>
+      <div class="doc-foot">
+        <a href="{{ base_url }}/logbook/" class="link-back mono">&larr; back to logbook</a>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/glyph-orbital/templates/section.html
+++ b/examples/glyph-orbital/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="ops">
+    <header class="section-head">
+      {% if page.title is present %}<h1 class="doc-title">{{ page.title | e }}</h1>{% endif %}
+      {% if page.description %}<p class="doc-desc">{{ page.description }}</p>{% endif %}
+    </header>
+    {{ content }}
+    <ul class="entries entries-section">
+      {% for post in section.pages %}
+        <li class="entry">
+          <div class="entry-copy">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+          </div>
+          <div class="entry-meta">
+            <time class="mono">{{ post.date | date("%d %b %Y") }}</time>
+            {% if post.extra.spacecraft %}{% for cs in post.extra.spacecraft %}<span class="cs-chip mono">{{ cs }}</span>{% endfor %}{% endif %}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/glyph-orbital/templates/taxonomy.html
+++ b/examples/glyph-orbital/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="ops">
+    <header class="section-head">
+      <h1 class="doc-title">{{ page.title | e }}</h1>
+      <p class="doc-desc">Index of taxonomy terms.</p>
+    </header>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/glyph-orbital/templates/taxonomy_term.html
+++ b/examples/glyph-orbital/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="ops">
+    <header class="section-head">
+      <h1 class="doc-title">{{ page.title | e }}</h1>
+      <p class="doc-desc">Entries tagged with this term.</p>
+    </header>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/mosaic-bionics/AGENTS.md
+++ b/examples/mosaic-bionics/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md - AI Agent Instructions for Mosaic Bionics
+
+## Project Overview
+
+Static website built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator. This site is a fermentation and strain-engineering control console — a wet-lab dashboard for an industrial biotech operation.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Site-Specific Notes
+
+- Theme: dark biotech wet-lab dashboard. Ink-purple (`#0b0a14`) background, bone-white (`#e8e4dd`) foreground, on-spec accent green (`#7df59f`).
+- Signature element: a 96-well hexagonal heatmap mosaic (12 cols x 8 rows) with five discrete bin colors — never gradients.
+- Typography: IBM Plex Sans for body/headings, IBM Plex Mono for tabular numerics, IBM Plex Serif for captions.
+- Content sections: `content/runlog/` for batch run logs; `index.md` (console) and `about.md` (lab colophon).
+- CSS lives in `static/css/style.css`.
+- No gradients, no emojis.
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/mosaic-bionics/archetypes/default.md
+++ b/examples/mosaic-bionics/archetypes/default.md
@@ -1,0 +1,11 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
+[extra]
+batch_id = ""
+strain = ""
+reactor = ""
++++

--- a/examples/mosaic-bionics/config.toml
+++ b/examples/mosaic-bionics/config.toml
@@ -1,0 +1,217 @@
+title = "Mosaic Bionics"
+description = "Fermentation and strain-engineering control console for the bench-to-pilot pipeline."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "strains"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/private"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["runlog"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/mosaic-bionics/content/about.md
+++ b/examples/mosaic-bionics/content/about.md
@@ -1,0 +1,39 @@
++++
+title = "About the lab"
+description = "The team behind Mosaic Bionics, what the console shows, and how to read it during a shift handover."
++++
+
+Mosaic Bionics is a small, vertically integrated fermentation house operating out of a
+converted dairy in the lower Hudson Valley. We run three pilot-scale stirred-tank
+bioreactors (one 30 L, two 200 L) and a 96-well screening deck wired to an in-house
+control plane. The bench team is five people: two strain engineers, one media chemist,
+one process engineer, and a lab manager who refuses to be called anything other than
+"the lab manager." The console you are reading is the artifact we stare at during shift
+handover at 07:00 and 19:00 every day.
+
+## What the console shows
+
+The signature element at the top is the **96-well expression mosaic** — twelve columns,
+eight rows of hexagonal cells representing the active screening plate. Each cell is
+filled with one of five discrete saturation bins, mapped from the strain's measured
+relative fluorescence at the most recent timepoint. The bins are bucketed, not
+interpolated: a cell either crosses a threshold or it does not. We do this deliberately,
+because the human eye is better at counting bins than at reading continuous color, and
+because a faint gradient hides the cells that just barely cleared the cutoff. The four
+strip charts immediately below the mosaic are the live state of the pilot reactors —
+**pH, dissolved oxygen, OD600,** and **temperature** — captured at one-minute resolution
+over the trailing six hours. The batch-yield ledger lists the last twelve fermentations
+in reverse chronological order, with strain identifier, final titer in g/L, yield
+against the theoretical maximum, and an out-of-spec flag if any control loop tripped.
+
+## How to read it during handover
+
+Start at the mosaic. If you see clustering — a column or row of high-bin cells — that is
+almost always a plate effect (an edge well evaporated, a media stock was miscounted)
+and not real signal. Move to the strip charts: anything pH below 6.4 or DO under 25
+percent during exponential phase needs eyes on it. Then read the anomaly log at the
+bottom of the console, oldest first, and clear what you can before the next shift
+inherits it.
+
+The lab is open to visitors on the first Friday of each month. Mind the autoclave room
+and do not eat the agar.

--- a/examples/mosaic-bionics/content/index.md
+++ b/examples/mosaic-bionics/content/index.md
@@ -3,7 +3,3 @@ title = "Console"
 template = "home"
 description = "Live fermentation console for Mosaic Bionics — plate readouts, bioreactor strip charts, batch yield ledger, and the next 48 hours of inoculations."
 +++
-
-The shift handover board for the Mosaic Bionics fermentation floor. All numbers are
-captured at the latest control loop tick; out-of-spec values are flagged in the anomaly
-strip at the bottom of the console.

--- a/examples/mosaic-bionics/content/index.md
+++ b/examples/mosaic-bionics/content/index.md
@@ -1,0 +1,9 @@
++++
+title = "Console"
+template = "home"
+description = "Live fermentation console for Mosaic Bionics — plate readouts, bioreactor strip charts, batch yield ledger, and the next 48 hours of inoculations."
++++
+
+The shift handover board for the Mosaic Bionics fermentation floor. All numbers are
+captured at the latest control loop tick; out-of-spec values are flagged in the anomaly
+strip at the bottom of the console.

--- a/examples/mosaic-bionics/content/runlog/2026-02-14-contamination-postmortem-bx2104.md
+++ b/examples/mosaic-bionics/content/runlog/2026-02-14-contamination-postmortem-bx2104.md
@@ -1,0 +1,57 @@
++++
+title = "Postmortem: contamination event on R-200B, batch 2026-031"
+date = "2026-02-14"
+description = "Foaming, off-spec pH, and a Bacillus subtilis bloom that took out a 200 L fed-batch of BX-2104.7 at hour 38."
+tags = ["postmortem", "contamination", "fed-batch"]
+[extra]
+batch_id = "2026-031"
+strain = "BX-2104.7"
+reactor = "R-200B"
+status = "scrapped"
++++
+
+## Summary
+
+Batch 2026-031 was a 200 L fed-batch of **BX-2104.7** on **R-200B**, intended to extend
+the titer record we set in late January. The run was terminated at hour 38 after the
+on-line OD600 climbed past 38 — roughly 12 OD higher than the expected exponential
+trajectory — and the off-gas analyzer reported an unexplained jump in CO2 evolution
+rate that did not correlate with the feed schedule. The plate count we pulled at hour
+40 came back at 4.2 × 10^7 CFU/mL of a contaminating organism that ribotyped as
+**Bacillus subtilis**, most likely from the inoculum prep line. The batch was scrapped,
+the reactor was CIP'd twice, and we steamed the transfer line for ninety minutes
+before re-qualifying.
+
+## Timeline
+
+- **Hour 00:00** — inoculation from a 2 L seed at OD 4.1. Initial pH 6.8, DO 78%.
+- **Hour 06:00** — exponential phase confirmed. OD 5.6, doubling time on track at 1.8h.
+- **Hour 18:00** — induction at OD 14.2. Feed schedule advanced to phase II.
+- **Hour 30:00** — DO crash to 18% despite max stir + max sparge. Foam spike.
+- **Hour 36:00** — pH excursion to 5.9, antifoam #2 dosed. CER + 22%.
+- **Hour 38:00** — terminated. Plate pulled.
+- **Hour 40:00** — plate count confirms contamination at 4.2 × 10^7 CFU/mL.
+
+## Root cause
+
+The inoculum was prepared in **shake flask SF-19**, which had been autoclaved on the
+same morning as a media-prep run that used unfiltered tap water — a violation of our
+SOP. The autoclave cycle completed normally (123 °C, 28 min, F0 verified) so the flask
+itself was sterile when it came out. The contamination most likely entered during the
+transfer to the seed bioreactor: the sterile filter on the transfer line had been in
+service for 41 days, past our 30-day rotation. A post-mortem integrity test on that
+filter failed at 18 psi forward flow.
+
+## Corrective actions
+
+1. Filter rotation cadence cut from 30 days to **21 days**, tracked in the maintenance
+   board.
+2. **Two-person sign-off** added to the inoculum transfer SOP. The receiving engineer
+   must verify the filter integrity card before opening the transfer valve.
+3. The shake-flask rack has been moved out of the media-prep room entirely. New rack
+   lives in the dedicated inoculum room, behind the second airlock.
+4. We are evaluating an in-line bioburden sensor for the transfer line. Two vendors
+   under quote, decision expected by end of March.
+
+No personnel exposure. The contaminating organism is BSL-1 and was disposed of through
+the normal autoclave-and-bleach waste stream.

--- a/examples/mosaic-bionics/content/runlog/2026-03-22-titer-record-bx2188.md
+++ b/examples/mosaic-bionics/content/runlog/2026-03-22-titer-record-bx2188.md
@@ -1,0 +1,52 @@
++++
+title = "Titer record: BX-2188.2 closes batch 2026-058 at 41.8 g/L"
+date = "2026-03-22"
+description = "A new house record for the malonyl-CoA shunt strain. 41.8 g/L at hour 96 on a 30 L fed-batch with the redesigned glucose feed profile."
+tags = ["record", "fed-batch", "strain-engineering"]
+[extra]
+batch_id = "2026-058"
+strain = "BX-2188.2"
+reactor = "R-030A"
+status = "on-spec"
+titer_g_l = 41.8
+yield_pct = 64.2
++++
+
+## Summary
+
+Batch 2026-058 — a 30 L fed-batch of **BX-2188.2** on **R-030A** — closed at **41.8 g/L**
+of the target dicarboxylic acid at hour 96, setting a new house record. The previous
+best for this strain lineage was 38.4 g/L (batch 2025-244, December). The improvement
+is attributable to the redesigned glucose feed profile we trialed this run, which
+holds the residual glucose closer to 1.2 g/L instead of the 0.3–0.5 g/L window we used
+through Q4.
+
+## Run snapshot
+
+- **Strain:** BX-2188.2 (lineage from BX-2104.7, two rounds of MAGE on the malonyl-CoA
+  shunt regulators).
+- **Media:** MB-21 defined, with the magnesium step we trialed in January.
+- **Induction:** IPTG at OD 28, hour 21.
+- **Specific productivity (peak):** 142 mg/g/h between hours 34 and 50.
+- **Yield on glucose:** 64.2% of theoretical max.
+- **Final pH:** 6.74 (target 6.70 ± 0.10).
+- **DO floor:** 31% (target 30%).
+
+## What changed
+
+The new feed profile uses a sigmoidal ramp from hour 18 to hour 32, holding residual
+glucose at **1.2 g/L** through the exponential phase before throttling back to 0.6 g/L
+for the production phase. The hypothesis was that the higher residual glucose during
+exponential growth would let the cells build more biomass before we redirect carbon
+to the product pathway. The hypothesis held: peak OD reached 84.6, compared to 71.2
+on the last record-setting run.
+
+## What we are watching
+
+The specific productivity curve has a noticeable dip between hours 50 and 56 that
+correlates with a brief DO excursion. We are not sure yet whether this is causal or
+coincidental — the next two runs will hold DO tighter to find out. If it is causal,
+there may be another 2–3 g/L on the table.
+
+The strain library entry for BX-2188.2 has been updated. The seed bank has been
+expanded to ten cryovials.

--- a/examples/mosaic-bionics/content/runlog/2026-04-09-strain-swap-bx2191.md
+++ b/examples/mosaic-bionics/content/runlog/2026-04-09-strain-swap-bx2191.md
@@ -1,0 +1,54 @@
++++
+title = "Strain swap: retiring BX-2104.7, promoting BX-2191.1 to working stock"
+date = "2026-04-09"
+description = "After eighteen months as the workhorse, BX-2104.7 is retired to the long-term seed bank. BX-2191.1 takes the working stock slot."
+tags = ["strain-engineering", "library", "process"]
+[extra]
+batch_id = "—"
+strain = "BX-2191.1"
+reactor = "—"
+status = "library"
++++
+
+## Summary
+
+Effective today, **BX-2104.7** moves from working stock to the long-term cryopreserved
+seed bank. **BX-2191.1** — the auxotrophy-rescued descendant with the rebuilt acetyl-CoA
+node — is promoted to working stock and becomes the default strain for new fed-batch
+campaigns on the dicarboxylic-acid product line.
+
+## Why
+
+BX-2104.7 has been the workhorse since October 2024 and has run more than 240 batches
+across the three pilot reactors. It is a known, well-characterized strain, and it will
+continue to live in the long-term bank as our reference. But BX-2191.1 has now cleared
+the bar in three independent 30 L runs:
+
+- Titer parity with BX-2104.7 within ±4% on identical media (n = 3).
+- Specific productivity 8–11% higher in the exponential phase.
+- No detectable byproduct accumulation above the BX-2104.7 baseline.
+- Auxotrophy rescue is stable through twelve generations on minimal media, including
+  one round at 200 L (batch 2026-049).
+
+The auxotrophy rescue is the important change. BX-2104.7 required a leucine
+supplementation step that complicated media prep and added a recurring sterility risk
+at the supplementation port. BX-2191.1 does not need it. That should simplify the SOP
+and remove one of the more failure-prone steps from the inoculation protocol.
+
+## What changes for the floor
+
+- New working-stock cryovials have been pulled from the bank and indexed in the
+  library: rack 4, positions A1 through A10.
+- Media MB-21 stays the same. The leucine supplementation step is removed from the
+  SOP — please update your benchsheet.
+- The next two campaigns on the pilot line will still be run on BX-2104.7 to clear the
+  scheduled work and the customer's qualification lots. After that, default to
+  BX-2191.1.
+- Seed-train protocols are unchanged.
+
+## What we are watching
+
+The first 200 L run on BX-2191.1 was clean but the foam profile was slightly higher
+than we are used to. We have ordered a small lot of antifoam #3 for comparison
+testing. If the new strain needs a different antifoam, we will document the change
+and add it to the SOP before the qualification lots.

--- a/examples/mosaic-bionics/content/runlog/2026-05-11-media-optimization-scan.md
+++ b/examples/mosaic-bionics/content/runlog/2026-05-11-media-optimization-scan.md
@@ -1,0 +1,52 @@
++++
+title = "Media optimization: 96-well scan of the magnesium and trace-metal axes"
+date = "2026-05-11"
+description = "A factorial scan across magnesium sulfate and the trace-metal mix on the 96-well screening deck. Two clear hits, one suspected plate effect."
+tags = ["screening", "media", "doe"]
+[extra]
+batch_id = "scan-2026-018"
+strain = "BX-2191.1"
+reactor = "96-well deck"
+status = "on-spec"
++++
+
+## Summary
+
+A two-factor screening DOE on **BX-2191.1**, varying **MgSO4** concentration (six
+levels, 0.4 to 2.4 g/L) and the **trace-metal mix TM-4** dosage (eight levels, 0.5×
+to 4.0× nominal). The full 6 × 8 grid plus 48 reference wells ran on the 96-well
+screening deck for 36 hours under the standard exponential-phase protocol. Endpoint
+fluorescence was read at 36 h; the heatmap mosaic in the front of the console is
+this scan.
+
+## Hits
+
+Two cells in the high bin that survive replication:
+
+- **Column 7, Row B** (MgSO4 1.6 g/L, TM-4 2.0×): endpoint fluorescence 1.42× over
+  the 1.0 g/L Mg, 1.0× TM reference. Reproduced in two of two replicate wells on the
+  same plate.
+- **Column 9, Row C** (MgSO4 2.0 g/L, TM-4 2.5×): endpoint fluorescence 1.31× over
+  reference. One replicate, one well at the next-bin-down. Worth chasing.
+
+The MgSO4 effect is the dominant axis. The TM-4 axis matters much less than we
+expected — the response above 1.0× is flat within noise except where it interacts
+with the magnesium step.
+
+## Suspected plate effect
+
+Row A on columns 1 through 4 read uniformly high. This is the corner of the plate
+nearest the heater block and we have seen this pattern before — almost certainly an
+evaporation-driven concentration effect, not a real signal. Those wells are excluded
+from the response surface fit.
+
+## Next steps
+
+- Confirm the column-7 hit in a 1 L bioreactor scale-down run, planned for next week.
+- Re-fit the response surface excluding the Row A corner and use it to set the
+  starting point for a tighter scan around MgSO4 1.4 to 1.8 g/L.
+- The 96-well deck is booked through Friday for the antifoam comparison scan, so
+  the follow-up DOE pushes to the week of May 18th.
+
+Raw fluorescence data is in `data/scans/scan-2026-018.csv`. Plate map and well
+assignments are pinned to the lab board.

--- a/examples/mosaic-bionics/content/runlog/_index.md
+++ b/examples/mosaic-bionics/content/runlog/_index.md
@@ -1,0 +1,14 @@
++++
+title = "Run log"
+description = "Postmortems, records, swap notes, and scan summaries from the fermentation floor."
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "section"
+generate_feeds = true
++++
+
+The shared notebook of the Mosaic Bionics fermentation team. Entries are written by
+the engineer on shift and reviewed at the next standup. Out-of-spec batches always
+get a postmortem; record-setting batches always get a writeup; everything else gets
+a short note so the next shift knows what happened.

--- a/examples/mosaic-bionics/static/css/style.css
+++ b/examples/mosaic-bionics/static/css/style.css
@@ -1,0 +1,906 @@
+/* =============================================================
+   Mosaic Bionics — fermentation console
+   Dark wet-lab dashboard. No gradients. No emojis.
+   ============================================================= */
+
+:root {
+  --ink:          #0b0a14;
+  --ink-2:        #14122080;
+  --panel:        #15132080;
+  --panel-solid:  #161325;
+  --panel-edge:   #2a2640;
+  --bone:         #e8e4dd;
+  --bone-dim:     #b9b3a6;
+  --bone-mute:    #7c7766;
+  --rule:         #3a334d;
+  --rule-soft:    #25213a;
+
+  --bin0:         #1c2d3d;
+  --bin1:         #1f6b7a;
+  --bin2:         #3aa39e;
+  --bin3:         #c14f8a;
+  --bin4:         #e3cca0;
+
+  --on:           #7df59f;
+  --warn:         #e3cca0;
+  --bad:          #c14f8a;
+
+  --fs-sans:      "IBM Plex Sans", system-ui, sans-serif;
+  --fs-mono:      "IBM Plex Mono", ui-monospace, monospace;
+  --fs-serif:     "IBM Plex Serif", Georgia, serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--ink);
+  color: var(--bone);
+  font-family: var(--fs-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--bone); text-decoration: none; }
+a:hover { color: var(--on); }
+
+.console {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 28px 32px 64px;
+}
+
+/* ---------- Masthead ---------- */
+.masthead {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 32px;
+  align-items: center;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.brand {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  color: var(--bone);
+}
+
+.brand .petri { color: var(--bone); display: block; line-height: 0; }
+.brand .petri svg { display: block; }
+
+.brand .title { display: flex; flex-direction: column; line-height: 1.15; }
+.brand .title b {
+  font-family: var(--fs-sans);
+  font-weight: 700;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+.brand .title em {
+  font-family: var(--fs-serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 20px;
+  color: var(--bin2);
+}
+.brand .title small {
+  display: block;
+  font-family: var(--fs-mono);
+  font-size: 10.5px;
+  color: var(--bone-dim);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+.nav {
+  display: flex;
+  gap: 22px;
+  justify-self: center;
+}
+.nav a {
+  font-family: var(--fs-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bone-dim);
+  padding-bottom: 4px;
+  border-bottom: 1px solid transparent;
+}
+.nav a:hover { color: var(--on); border-bottom-color: var(--on); }
+
+.status-strip {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  font-family: var(--fs-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+}
+.status-strip .dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--on);
+  display: inline-block;
+}
+.status-strip .kv {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--rule);
+  padding-left: 10px;
+}
+.status-strip .kv:first-of-type { border-left: none; padding-left: 0; }
+.status-strip .kv b {
+  color: var(--bone-dim);
+  font-weight: 400;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+.status-strip .kv i {
+  color: var(--bone);
+  font-style: normal;
+  font-weight: 500;
+  font-size: 11px;
+}
+
+/* ---------- Cover ---------- */
+.cover {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 56px;
+  padding: 40px 0 32px;
+}
+
+.cover .kicker {
+  font-family: var(--fs-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--bin2);
+  display: block;
+  margin-bottom: 18px;
+}
+
+.cover h1 {
+  font-family: var(--fs-sans);
+  font-weight: 700;
+  font-size: 38px;
+  line-height: 1.12;
+  letter-spacing: -0.018em;
+  margin: 0 0 18px;
+  color: var(--bone);
+}
+
+.cover .dek {
+  font-family: var(--fs-serif);
+  font-size: 15.5px;
+  line-height: 1.55;
+  color: var(--bone-dim);
+  max-width: 52ch;
+  margin: 0;
+}
+
+.cover-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  align-content: start;
+}
+
+.stat {
+  background: var(--panel);
+  border: 1px solid var(--panel-edge);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.stat .lbl {
+  font-family: var(--fs-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bone-dim);
+}
+.stat .val {
+  font-family: var(--fs-mono);
+  font-size: 26px;
+  font-weight: 500;
+  color: var(--bone);
+  letter-spacing: -0.01em;
+}
+.stat .val.on { color: var(--on); }
+.stat .val small {
+  font-size: 13px;
+  color: var(--bone-mute);
+  margin-left: 2px;
+}
+.stat .note {
+  font-family: var(--fs-mono);
+  font-size: 10.5px;
+  color: var(--bone-mute);
+  letter-spacing: 0.04em;
+}
+
+/* ---------- Rules ---------- */
+.rule {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 26px 0;
+}
+.rule-double {
+  border: none;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  height: 4px;
+  margin: 26px 0;
+}
+
+/* ---------- Block heads ---------- */
+.block { margin: 8px 0; }
+.block-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 18px;
+  align-items: baseline;
+  margin-bottom: 18px;
+}
+.block-head .folio-num {
+  font-family: var(--fs-serif);
+  font-style: italic;
+  font-size: 28px;
+  color: var(--bin2);
+  line-height: 1;
+}
+.block-head h2 {
+  font-family: var(--fs-sans);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.005em;
+  color: var(--bone);
+}
+.block-head .caption {
+  font-family: var(--fs-serif);
+  font-style: italic;
+  font-size: 12.5px;
+  color: var(--bone-mute);
+  text-align: right;
+}
+
+/* ---------- Mosaic ---------- */
+.mosaic-block { padding: 4px 0 8px; }
+.mosaic-wrap {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 32px;
+  align-items: start;
+  background: var(--panel-solid);
+  border: 1px solid var(--panel-edge);
+  padding: 24px 28px;
+}
+.mosaic-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.mosaic-svg .hex {
+  stroke: var(--ink);
+  stroke-width: 1;
+}
+.mosaic-svg .hex.bin0 { fill: var(--bin0); }
+.mosaic-svg .hex.bin1 { fill: var(--bin1); }
+.mosaic-svg .hex.bin2 { fill: var(--bin2); }
+.mosaic-svg .hex.bin3 { fill: var(--bin3); }
+.mosaic-svg .hex.bin4 { fill: var(--bin4); }
+
+.mosaic-svg .hex-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 7px;
+  fill: var(--ink);
+  fill-opacity: 0.72;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+/* light text on the darker bins for legibility */
+.mosaic-svg .hex.bin0 + .hex-label,
+.mosaic-svg .hex.bin1 + .hex-label {
+  fill: var(--bone);
+  fill-opacity: 0.7;
+}
+
+.mosaic-legend {
+  font-family: var(--fs-mono);
+  font-size: 11px;
+}
+.mosaic-legend .legend-head {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--rule);
+}
+.legend-title {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--bone);
+}
+.legend-sub {
+  font-family: var(--fs-serif);
+  font-style: italic;
+  font-size: 12px;
+  color: var(--bone-mute);
+  margin-top: 4px;
+}
+.legend-list {
+  list-style: none;
+  margin: 0 0 14px;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+.legend-list li {
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  font-size: 11.5px;
+}
+.legend-list .swatch {
+  display: inline-block;
+  width: 18px;
+  height: 14px;
+  border: 1px solid var(--ink);
+}
+.legend-list .swatch.bin0 { background: var(--bin0); }
+.legend-list .swatch.bin1 { background: var(--bin1); }
+.legend-list .swatch.bin2 { background: var(--bin2); }
+.legend-list .swatch.bin3 { background: var(--bin3); }
+.legend-list .swatch.bin4 { background: var(--bin4); }
+.legend-list .lab { color: var(--bone); text-transform: uppercase; letter-spacing: 0.14em; font-size: 10.5px; }
+.legend-list .rng { color: var(--bone-dim); }
+
+.legend-foot {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 12px;
+  border-top: 1px solid var(--rule);
+  font-size: 11px;
+  color: var(--bone-dim);
+}
+.legend-foot b { color: var(--bone); font-weight: 500; }
+
+/* ---------- Strip charts ---------- */
+.strip-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 16px;
+}
+.strip {
+  background: var(--panel-solid);
+  border: 1px solid var(--panel-edge);
+  padding: 14px 14px 10px;
+}
+.strip-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  margin-bottom: 8px;
+  row-gap: 1px;
+}
+.strip-lbl {
+  font-family: var(--fs-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bone-dim);
+}
+.strip-val {
+  font-family: var(--fs-mono);
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--bone);
+}
+.strip-set {
+  grid-column: 1 / -1;
+  font-family: var(--fs-serif);
+  font-style: italic;
+  font-size: 11.5px;
+  color: var(--bone-mute);
+}
+
+.strip-svg {
+  width: 100%;
+  height: 100px;
+  display: block;
+  background: var(--ink);
+  border: 1px solid var(--rule-soft);
+}
+.strip-svg .grid line { stroke: var(--rule-soft); stroke-width: 0.5; }
+.strip-svg .setpoint { stroke: var(--bin2); stroke-width: 0.8; stroke-dasharray: 3 3; opacity: 0.55; }
+.strip-svg .setpoint.warn { stroke: var(--warn); }
+.strip-svg .trace { fill: none; stroke-width: 1.5; }
+.strip-svg .trace.ok { stroke: var(--on); }
+.strip-svg .trace.accent { stroke: var(--bin3); }
+.strip-svg .trace.warn { stroke: var(--warn); }
+
+.strip-foot {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--fs-mono);
+  font-size: 9.5px;
+  color: var(--bone-mute);
+  margin-top: 6px;
+  letter-spacing: 0.08em;
+}
+
+/* ---------- Ledger table ---------- */
+.ledger-wrap {
+  background: var(--panel-solid);
+  border: 1px solid var(--panel-edge);
+  padding: 4px 16px;
+  overflow-x: auto;
+}
+
+.ledger {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--fs-mono);
+  font-size: 12px;
+}
+.ledger thead th {
+  text-align: left;
+  padding: 12px 8px;
+  font-weight: 500;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bone-dim);
+  border-bottom: 1px solid var(--rule);
+}
+.ledger thead th.num { text-align: right; }
+.ledger thead th small {
+  display: block;
+  font-size: 9px;
+  color: var(--bone-mute);
+  letter-spacing: 0.1em;
+  margin-top: 1px;
+  text-transform: none;
+}
+.ledger td {
+  padding: 9px 8px;
+  border-bottom: 1px solid var(--rule-soft);
+  vertical-align: top;
+  color: var(--bone);
+}
+.ledger td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.ledger tbody tr:hover { background: rgba(58, 163, 158, 0.06); }
+.ledger tbody tr.hi td { color: var(--bin4); }
+.ledger tbody tr.hi td.num { color: var(--bin4); }
+.ledger tbody tr.oos td { color: var(--bone-mute); }
+.ledger tfoot td {
+  padding: 12px 8px;
+  border-top: 1px solid var(--rule);
+  border-bottom: none;
+  color: var(--bone-dim);
+  font-size: 11px;
+}
+
+.tag {
+  display: inline-block;
+  font-family: var(--fs-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 3px 7px;
+  border: 1px solid currentColor;
+}
+.tag.on { color: var(--on); }
+.tag.record { color: var(--bin4); }
+.tag.oos { color: var(--bad); }
+
+/* ---------- Folio split rows ---------- */
+.folio-row.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+}
+
+/* ---------- Strain grid ---------- */
+.strain-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.strain {
+  position: relative;
+  background: var(--panel-solid);
+  border: 1px solid var(--panel-edge);
+  padding: 10px 12px 10px 22px;
+  font-family: var(--fs-mono);
+  font-size: 11.5px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.strain::before {
+  content: "";
+  position: absolute;
+  left: 10px;
+  top: 14px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--bone-mute);
+}
+.strain.on::before { background: var(--on); }
+.strain.warn::before { background: var(--warn); }
+.strain.off::before { background: var(--bad); }
+
+.strain b {
+  font-weight: 600;
+  color: var(--bone);
+  font-size: 12.5px;
+}
+.strain .line {
+  color: var(--bone-dim);
+  font-size: 11px;
+}
+.strain .meta {
+  color: var(--bone-mute);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  margin-top: 2px;
+}
+
+/* ---------- Schedule timeline ---------- */
+.schedule {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.schedule li {
+  display: grid;
+  grid-template-columns: 110px 1fr auto;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule-soft);
+  position: relative;
+}
+.schedule li:last-child { border-bottom: none; }
+.schedule li.now {
+  border-left: 2px solid var(--on);
+  padding-left: 12px;
+  margin-left: -14px;
+  background: rgba(125, 245, 159, 0.04);
+}
+.schedule .t {
+  font-family: var(--fs-mono);
+  font-size: 11px;
+  color: var(--bin2);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.schedule .what {
+  font-family: var(--fs-sans);
+  font-size: 12.5px;
+  color: var(--bone);
+  line-height: 1.4;
+}
+.schedule .what b { font-weight: 600; }
+.schedule .what i {
+  font-family: var(--fs-mono);
+  font-style: normal;
+  font-size: 10.5px;
+  color: var(--bone-mute);
+  letter-spacing: 0.04em;
+}
+.schedule .who {
+  font-family: var(--fs-mono);
+  font-size: 10.5px;
+  color: var(--bone-dim);
+}
+
+/* ---------- Anomaly log ---------- */
+.anomaly-block { margin-top: 8px; }
+.anomaly {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: var(--panel-solid);
+  border: 1px solid var(--panel-edge);
+}
+.anomaly li {
+  display: grid;
+  grid-template-columns: 70px 110px 1fr 80px;
+  gap: 18px;
+  padding: 11px 16px;
+  border-bottom: 1px solid var(--rule-soft);
+  font-family: var(--fs-mono);
+  font-size: 11.5px;
+  align-items: baseline;
+}
+.anomaly li:last-child { border-bottom: none; }
+.anomaly .when {
+  color: var(--bin2);
+  letter-spacing: 0.04em;
+}
+.anomaly .src {
+  color: var(--bone);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 10.5px;
+}
+.anomaly .msg {
+  font-family: var(--fs-sans);
+  color: var(--bone-dim);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+.anomaly .lvl {
+  justify-self: end;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  padding: 3px 7px;
+  border: 1px solid currentColor;
+}
+.anomaly .lvl-info .lvl { color: var(--bin2); }
+.anomaly .lvl-warn .lvl { color: var(--warn); }
+.anomaly .lvl-bad .lvl { color: var(--bad); }
+
+/* ---------- Essay list / notes ---------- */
+.essay-list { margin: 16px 0 0; }
+.essay-h {
+  font-family: var(--fs-sans);
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0 0 4px;
+  letter-spacing: -0.005em;
+}
+.essay-d {
+  font-family: var(--fs-serif);
+  font-style: italic;
+  color: var(--bone-mute);
+  margin: 0 0 18px;
+}
+
+.notes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.notes li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 28px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--rule-soft);
+}
+.notes li:last-child { border-bottom: none; }
+.notes .copy a {
+  font-family: var(--fs-sans);
+  font-weight: 600;
+  font-size: 15.5px;
+  color: var(--bone);
+  display: inline-block;
+  margin-bottom: 4px;
+}
+.notes .copy a:hover { color: var(--on); }
+.notes .copy p {
+  margin: 0 0 8px;
+  color: var(--bone-dim);
+  font-size: 13px;
+  max-width: 70ch;
+}
+.notes .meta time {
+  font-family: var(--fs-mono);
+  font-size: 11px;
+  color: var(--bone-mute);
+  letter-spacing: 0.1em;
+}
+
+.badge {
+  display: inline-block;
+  font-family: var(--fs-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border: 1px solid var(--rule);
+  color: var(--bone-dim);
+  margin-right: 6px;
+}
+.badge.stat-on-spec { color: var(--on); border-color: var(--on); }
+.badge.stat-scrapped { color: var(--bad); border-color: var(--bad); }
+.badge.stat-library { color: var(--bin2); border-color: var(--bin2); }
+
+/* ---------- Page / prose ---------- */
+.page-title {
+  font-family: var(--fs-sans);
+  font-weight: 700;
+  font-size: 30px;
+  letter-spacing: -0.015em;
+  margin: 24px 0 6px;
+}
+.page-meta {
+  font-family: var(--fs-mono);
+  font-size: 11.5px;
+  color: var(--bone-mute);
+  margin-bottom: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+.page-desc {
+  font-family: var(--fs-serif);
+  font-style: italic;
+  font-size: 16px;
+  color: var(--bone-dim);
+  margin: 0 0 24px;
+  max-width: 70ch;
+}
+
+.prose,
+.prose-body {
+  max-width: 70ch;
+}
+.prose-body h2 {
+  font-family: var(--fs-sans);
+  font-weight: 600;
+  font-size: 18px;
+  margin: 28px 0 8px;
+  color: var(--bone);
+}
+.prose-body h3 {
+  font-family: var(--fs-sans);
+  font-weight: 600;
+  font-size: 14.5px;
+  margin: 22px 0 6px;
+  color: var(--bone-dim);
+}
+.prose-body p {
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: var(--bone-dim);
+  margin: 0 0 14px;
+}
+.prose-body strong { color: var(--bone); font-weight: 600; }
+.prose-body em { color: var(--bin2); font-style: italic; }
+.prose-body ul, .prose-body ol {
+  padding-left: 22px;
+  margin: 0 0 16px;
+  color: var(--bone-dim);
+}
+.prose-body li { margin-bottom: 6px; line-height: 1.6; }
+.prose-body code {
+  font-family: var(--fs-mono);
+  font-size: 12.5px;
+  background: var(--panel-solid);
+  border: 1px solid var(--panel-edge);
+  padding: 1px 5px;
+  color: var(--bin2);
+}
+.prose-body a { color: var(--bin2); border-bottom: 1px solid var(--rule); }
+.prose-body a:hover { color: var(--on); }
+
+.page-tags {
+  margin-top: 28px;
+  padding-top: 14px;
+  border-top: 1px solid var(--rule);
+}
+.tag-chip {
+  display: inline-block;
+  font-family: var(--fs-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 4px 9px;
+  border: 1px solid var(--rule);
+  color: var(--bone-dim);
+  margin: 0 6px 6px 0;
+}
+.tag-chip:hover { color: var(--on); border-color: var(--on); }
+
+/* ---------- Section index ---------- */
+.section-head { margin-bottom: 18px; }
+.notes.plain li .copy .badges { margin-top: 6px; }
+
+/* ---------- 404 ---------- */
+.not-found {
+  text-align: center;
+  padding: 80px 0;
+}
+.not-found .big-num {
+  font-family: var(--fs-mono);
+  font-size: 90px;
+  color: var(--bin3);
+  letter-spacing: -0.04em;
+  display: block;
+  line-height: 1;
+}
+.cta {
+  display: inline-block;
+  font-family: var(--fs-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border: 1px solid var(--bone-dim);
+  padding: 9px 16px;
+  color: var(--bone);
+  margin: 8px 4px;
+}
+.cta:hover { color: var(--on); border-color: var(--on); }
+
+/* ---------- Colophon / footer ---------- */
+.colophon {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 32px;
+  margin-top: 56px;
+  padding-top: 24px;
+  border-top: 1px solid var(--rule);
+  font-size: 12px;
+  color: var(--bone-mute);
+}
+.colophon strong {
+  display: block;
+  font-family: var(--fs-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bone);
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+.colophon p {
+  margin: 0;
+  line-height: 1.55;
+  max-width: 50ch;
+}
+.colophon a {
+  color: var(--bone-dim);
+  border-bottom: 1px solid var(--rule);
+}
+.colophon a:hover { color: var(--on); }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 960px) {
+  .masthead {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+  .nav, .status-strip {
+    justify-self: start;
+    flex-wrap: wrap;
+  }
+  .cover { grid-template-columns: 1fr; gap: 28px; }
+  .mosaic-wrap { grid-template-columns: 1fr; }
+  .strip-grid { grid-template-columns: 1fr 1fr; }
+  .folio-row.split { grid-template-columns: 1fr; }
+  .colophon { grid-template-columns: 1fr; }
+  .anomaly li { grid-template-columns: 1fr; gap: 4px; }
+  .schedule li { grid-template-columns: 1fr; gap: 4px; }
+}
+
+@media (max-width: 560px) {
+  .console { padding: 18px 18px 40px; }
+  .cover h1 { font-size: 28px; }
+  .strip-grid { grid-template-columns: 1fr; }
+  .strain-grid { grid-template-columns: 1fr; }
+  .ledger { font-size: 11px; }
+  .block-head { grid-template-columns: auto 1fr; }
+  .block-head .caption { grid-column: 1 / -1; text-align: left; }
+}

--- a/examples/mosaic-bionics/static/favicon.svg
+++ b/examples/mosaic-bionics/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#0b0a14"/>
+  <polygon points="32,8 52,20 52,44 32,56 12,44 12,20" fill="none" stroke="#e8e4dd" stroke-width="2"/>
+  <polygon points="32,18 44,25 44,39 32,46 20,39 20,25" fill="#3aa39e"/>
+  <polygon points="32,26 38,29.5 38,36.5 32,40 26,36.5 26,29.5" fill="#c14f8a"/>
+  <circle cx="32" cy="33" r="3" fill="#e8e4dd"/>
+</svg>

--- a/examples/mosaic-bionics/templates/404.html
+++ b/examples/mosaic-bionics/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main>
+    <div class="not-found">
+      <span class="big-num">404</span>
+      <h1 class="page-title">No batch by that ID</h1>
+      <p class="page-desc">That page is not on the floor. Check the run log, or return to the console.</p>
+      <p><a href="{{ base_url }}/" class="cta">Return to console</a> · <a href="{{ base_url }}/runlog/" class="cta">Browse run log</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/mosaic-bionics/templates/footer.html
+++ b/examples/mosaic-bionics/templates/footer.html
@@ -1,0 +1,23 @@
+    <footer class="colophon">
+      <div>
+        <strong>{{ site.title }}</strong>
+        <p>Fermentation and strain-engineering control console for the bench-to-pilot pipeline. Set in IBM Plex Sans, Mono, and Serif. Built with Hwaro on Crystal.</p>
+      </div>
+      <div>
+        <strong>Sections</strong>
+        <p>
+          <a href="{{ base_url }}/">Console</a> ·
+          <a href="{{ base_url }}/runlog/">Run log</a> ·
+          <a href="{{ base_url }}/about/">Lab</a> ·
+          <a href="{{ base_url }}/tags/">Tags</a>
+        </p>
+      </div>
+      <div>
+        <strong>Mosaic Bionics · {{ current_year }}</strong>
+        <p>Console build r-217 · console tick 07:14:02 EDT · BSL-1 floor · no part of this page constitutes a release decision. Issued {{ current_date }}.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/mosaic-bionics/templates/header.html
+++ b/examples/mosaic-bionics/templates/header.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Serif:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="console">
+    <header class="masthead">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="petri" aria-hidden="true">
+          <svg viewBox="0 0 44 44" width="44" height="44">
+            <circle cx="22" cy="22" r="20" fill="none" stroke="currentColor" stroke-width="1.2"/>
+            <circle cx="22" cy="22" r="14" fill="none" stroke="currentColor" stroke-width="0.8" opacity="0.6"/>
+            <polygon points="22,10 30,15 30,25 22,30 14,25 14,15" fill="none" stroke="currentColor" stroke-width="1"/>
+            <polygon points="22,15 27,18 27,24 22,27 17,24 17,18" fill="currentColor" opacity="0.85"/>
+          </svg>
+        </span>
+        <span class="title">
+          <b>Mosaic</b> <em>Bionics</em>
+          <small>Fermentation console · shift {{ current_date }}</small>
+        </span>
+      </a>
+      <nav class="nav">
+        <a href="{{ base_url }}/">Console</a>
+        <a href="{{ base_url }}/runlog/">Run log</a>
+        <a href="{{ base_url }}/about/">Lab</a>
+      </nav>
+      <div class="status-strip">
+        <span class="dot ok"></span>
+        <span class="kv"><b>R-030A</b><i>on-spec</i></span>
+        <span class="kv"><b>R-200A</b><i>on-spec</i></span>
+        <span class="kv"><b>R-200B</b><i>CIP</i></span>
+        <span class="kv"><b>96-well</b><i>scanning</i></span>
+        <span class="kv timestamp"><b>tick</b><i>07:14:02 EDT</i></span>
+      </div>
+    </header>

--- a/examples/mosaic-bionics/templates/home.html
+++ b/examples/mosaic-bionics/templates/home.html
@@ -1,0 +1,383 @@
+{% include "header.html" %}
+  <main>
+    {# ============================================================== #}
+    {# Cover strip                                                    #}
+    {# ============================================================== #}
+    <section class="cover">
+      <div class="cover-text">
+        <span class="kicker">Console · shift 07:00 — 19:00 EDT · build r-217</span>
+        <h1>The floor at a glance,<br>by cell, by reactor, by batch.</h1>
+        <p class="dek">Ninety-six screening wells against the magnesium and trace-metal axes. Three pilot reactors holding their setpoints. Twelve closed fed-batches in the ledger. One contamination on a cleared CIP. Read the mosaic top-down, the strip charts left-to-right, and clear the anomaly log before the next shift.</p>
+      </div>
+      <div class="cover-stats">
+        <div class="stat"><span class="lbl">Active batches</span><span class="val">3</span><span class="note">2 fed-batch · 1 seed</span></div>
+        <div class="stat"><span class="lbl">Plate scan</span><span class="val">96<small>w</small></span><span class="note">DOE 2026-018</span></div>
+        <div class="stat"><span class="lbl">Library strains</span><span class="val">218</span><span class="note">14 working stock</span></div>
+        <div class="stat"><span class="lbl">Anomalies</span><span class="val on">2</span><span class="note">none critical</span></div>
+      </div>
+    </section>
+
+    <hr class="rule rule-double">
+
+    {# ============================================================== #}
+    {# I — 96-well hexagonal mosaic                                   #}
+    {# ============================================================== #}
+    <section class="block mosaic-block">
+      <header class="block-head">
+        <span class="folio-num">I</span>
+        <h2>96-well plate · expression mosaic</h2>
+        <span class="caption">Scan 2026-018 · BX-2191.1 · endpoint fluorescence at 36 h · five discrete bins</span>
+      </header>
+
+      <div class="mosaic-wrap">
+        <svg class="mosaic-svg" viewBox="0 0 540 320" preserveAspectRatio="xMidYMid meet" role="img" aria-label="96-well hexagonal heatmap">
+          {# Eight rows of 12 hexagonal cells. Bin strings rendered per row. #}
+          {% set row_a = "443312231210" %}
+          {% set row_b = "013212342321" %}
+          {% set row_c = "102123334421" %}
+          {% set row_d = "011223322310" %}
+          {% set row_e = "101223323211" %}
+          {% set row_f = "010122322101" %}
+          {% set row_g = "101122212110" %}
+          {% set row_h = "010112211010" %}
+          {% for row_pair in "A,B,C,D,E,F,G,H" | split(pat=",") %}
+            {% set row_idx = loop.index0 %}
+            {% set y_base = 30 + row_idx * 31 %}
+            {% if row_pair == "A" %}{% set bins = row_a %}{% endif %}
+            {% if row_pair == "B" %}{% set bins = row_b %}{% endif %}
+            {% if row_pair == "C" %}{% set bins = row_c %}{% endif %}
+            {% if row_pair == "D" %}{% set bins = row_d %}{% endif %}
+            {% if row_pair == "E" %}{% set bins = row_e %}{% endif %}
+            {% if row_pair == "F" %}{% set bins = row_f %}{% endif %}
+            {% if row_pair == "G" %}{% set bins = row_g %}{% endif %}
+            {% if row_pair == "H" %}{% set bins = row_h %}{% endif %}
+            {% for b in bins | split(pat="") %}
+              {% set col = loop.index0 %}
+              {% set cx = 30 + col * 27 %}
+              {% if col % 2 == 1 %}{% set cy = y_base + 16 %}{% else %}{% set cy = y_base %}{% endif %}
+              <polygon class="hex bin{{ b }}" points="{{ cx + 18 }},{{ cy }} {{ cx + 9 }},{{ cy - 16 }} {{ cx - 9 }},{{ cy - 16 }} {{ cx - 18 }},{{ cy }} {{ cx - 9 }},{{ cy + 16 }} {{ cx + 9 }},{{ cy + 16 }}"><title>{{ row_pair }}{{ col + 1 }} · bin {{ b }}</title></polygon>
+              <text class="hex-label" x="{{ cx }}" y="{{ cy + 3 }}" text-anchor="middle">{{ row_pair }}{{ col + 1 }}</text>
+            {% endfor %}
+          {% endfor %}
+        </svg>
+
+        <aside class="mosaic-legend">
+          <div class="legend-head">
+            <span class="legend-title">Bin scale</span>
+            <span class="legend-sub">relative fluorescence vs. reference</span>
+          </div>
+          <ul class="legend-list">
+            <li><i class="swatch bin0"></i><span class="lab">bin 0</span><span class="rng">&lt; 0.50&times;</span></li>
+            <li><i class="swatch bin1"></i><span class="lab">bin 1</span><span class="rng">0.50 — 0.85&times;</span></li>
+            <li><i class="swatch bin2"></i><span class="lab">bin 2</span><span class="rng">0.85 — 1.05&times;</span></li>
+            <li><i class="swatch bin3"></i><span class="lab">bin 3</span><span class="rng">1.05 — 1.25&times;</span></li>
+            <li><i class="swatch bin4"></i><span class="lab">bin 4</span><span class="rng">&ge; 1.25&times;</span></li>
+          </ul>
+          <div class="legend-foot">
+            <span><b>Hits</b> · B7, C9</span>
+            <span><b>Suspect plate effect</b> · A1 — A4 corner</span>
+            <span><b>Reference wells</b> · 48 of 96</span>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    {# ============================================================== #}
+    {# II — Bioreactor strip charts                                   #}
+    {# ============================================================== #}
+    <section class="block">
+      <header class="block-head">
+        <span class="folio-num">II</span>
+        <h2>Bioreactor strip charts</h2>
+        <span class="caption">R-030A · trailing 6 h · 1-minute resolution · setpoints overlaid</span>
+      </header>
+
+      <div class="strip-grid">
+        {# pH chart 6.5-7.0 setpoint 6.7 #}
+        <div class="strip">
+          <div class="strip-head">
+            <span class="strip-lbl">pH</span>
+            <span class="strip-val">6.72</span>
+            <span class="strip-set">setpoint 6.70 &plusmn; 0.10</span>
+          </div>
+          <svg class="strip-svg" viewBox="0 0 320 100" preserveAspectRatio="none" aria-hidden="true">
+            <g class="grid">
+              <line x1="0" y1="20" x2="320" y2="20"/>
+              <line x1="0" y1="50" x2="320" y2="50"/>
+              <line x1="0" y1="80" x2="320" y2="80"/>
+              {%- for i in range(7) -%}
+              <line x1="{{ i * 53 }}" y1="0" x2="{{ i * 53 }}" y2="100"/>
+              {%- endfor -%}
+            </g>
+            <line class="setpoint" x1="0" y1="50" x2="320" y2="50"/>
+            <polyline class="trace ok" points="0,52 12,51 24,49 36,48 48,50 60,52 72,55 84,53 96,50 108,48 120,46 132,47 144,49 156,52 168,54 180,52 192,49 204,47 216,48 228,50 240,52 252,53 264,51 276,49 288,48 300,50 312,51 320,50"/>
+          </svg>
+          <div class="strip-foot">
+            <span>+6h</span><span>+4</span><span>+2</span><span>now</span>
+          </div>
+        </div>
+
+        {# DO chart #}
+        <div class="strip">
+          <div class="strip-head">
+            <span class="strip-lbl">DO%</span>
+            <span class="strip-val">34.1</span>
+            <span class="strip-set">floor 30.0</span>
+          </div>
+          <svg class="strip-svg" viewBox="0 0 320 100" preserveAspectRatio="none" aria-hidden="true">
+            <g class="grid">
+              <line x1="0" y1="20" x2="320" y2="20"/>
+              <line x1="0" y1="50" x2="320" y2="50"/>
+              <line x1="0" y1="80" x2="320" y2="80"/>
+              {%- for i in range(7) -%}
+              <line x1="{{ i * 53 }}" y1="0" x2="{{ i * 53 }}" y2="100"/>
+              {%- endfor -%}
+            </g>
+            <line class="setpoint warn" x1="0" y1="70" x2="320" y2="70"/>
+            <polyline class="trace ok" points="0,30 12,32 24,36 36,42 48,48 60,52 72,55 84,58 96,60 108,62 120,64 132,62 144,58 156,55 168,53 180,55 192,58 204,60 216,62 228,60 240,58 252,55 264,54 276,52 288,51 300,52 312,54 320,55"/>
+          </svg>
+          <div class="strip-foot">
+            <span>+6h</span><span>+4</span><span>+2</span><span>now</span>
+          </div>
+        </div>
+
+        {# OD600 chart - sigmoidal growth #}
+        <div class="strip">
+          <div class="strip-head">
+            <span class="strip-lbl">OD600</span>
+            <span class="strip-val">42.6</span>
+            <span class="strip-set">exponential phase</span>
+          </div>
+          <svg class="strip-svg" viewBox="0 0 320 100" preserveAspectRatio="none" aria-hidden="true">
+            <g class="grid">
+              <line x1="0" y1="20" x2="320" y2="20"/>
+              <line x1="0" y1="50" x2="320" y2="50"/>
+              <line x1="0" y1="80" x2="320" y2="80"/>
+              {%- for i in range(7) -%}
+              <line x1="{{ i * 53 }}" y1="0" x2="{{ i * 53 }}" y2="100"/>
+              {%- endfor -%}
+            </g>
+            <polyline class="trace accent" points="0,88 16,86 32,83 48,80 64,76 80,71 96,65 112,58 128,50 144,43 160,37 176,32 192,28 208,25 224,22 240,20 256,19 272,18 288,17 304,16 320,16"/>
+          </svg>
+          <div class="strip-foot">
+            <span>+6h</span><span>+4</span><span>+2</span><span>now</span>
+          </div>
+        </div>
+
+        {# Temperature chart #}
+        <div class="strip">
+          <div class="strip-head">
+            <span class="strip-lbl">Temp &deg;C</span>
+            <span class="strip-val">30.02</span>
+            <span class="strip-set">setpoint 30.00 &plusmn; 0.05</span>
+          </div>
+          <svg class="strip-svg" viewBox="0 0 320 100" preserveAspectRatio="none" aria-hidden="true">
+            <g class="grid">
+              <line x1="0" y1="20" x2="320" y2="20"/>
+              <line x1="0" y1="50" x2="320" y2="50"/>
+              <line x1="0" y1="80" x2="320" y2="80"/>
+              {%- for i in range(7) -%}
+              <line x1="{{ i * 53 }}" y1="0" x2="{{ i * 53 }}" y2="100"/>
+              {%- endfor -%}
+            </g>
+            <line class="setpoint" x1="0" y1="50" x2="320" y2="50"/>
+            <polyline class="trace ok" points="0,51 16,50 32,51 48,49 64,50 80,52 96,51 112,49 128,48 144,50 160,51 176,52 192,50 208,49 224,51 240,52 256,50 272,49 288,50 304,51 320,50"/>
+          </svg>
+          <div class="strip-foot">
+            <span>+6h</span><span>+4</span><span>+2</span><span>now</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    {# ============================================================== #}
+    {# III — Batch yield ledger                                       #}
+    {# ============================================================== #}
+    <section class="block">
+      <header class="block-head">
+        <span class="folio-num">III</span>
+        <h2>Batch yield ledger</h2>
+        <span class="caption">Trailing twelve fed-batches · titer in g/L · yield against theoretical max</span>
+      </header>
+
+      <div class="ledger-wrap">
+        <table class="ledger">
+          <thead>
+            <tr>
+              <th>Batch</th>
+              <th>Closed</th>
+              <th>Strain</th>
+              <th>Reactor</th>
+              <th class="num">Titer<small>g/L</small></th>
+              <th class="num">Yield<small>%</small></th>
+              <th class="num">Spec. prod.<small>mg/g/h</small></th>
+              <th>Flag</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>2026-074</td><td>15 May</td><td>BX-2191.1</td><td>R-030A</td><td class="num">39.4</td><td class="num">61.8</td><td class="num">128</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr><td>2026-071</td><td>11 May</td><td>BX-2191.1</td><td>R-200A</td><td class="num">36.2</td><td class="num">58.4</td><td class="num">119</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr class="hi"><td>2026-058</td><td>22 Mar</td><td>BX-2188.2</td><td>R-030A</td><td class="num">41.8</td><td class="num">64.2</td><td class="num">142</td><td><span class="tag record">record</span></td></tr>
+            <tr><td>2026-054</td><td>16 Mar</td><td>BX-2188.2</td><td>R-200A</td><td class="num">38.9</td><td class="num">61.1</td><td class="num">131</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr><td>2026-049</td><td>02 Mar</td><td>BX-2191.1</td><td>R-200B</td><td class="num">34.6</td><td class="num">56.2</td><td class="num">112</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr><td>2026-045</td><td>26 Feb</td><td>BX-2104.7</td><td>R-030A</td><td class="num">36.1</td><td class="num">58.0</td><td class="num">118</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr><td>2026-041</td><td>20 Feb</td><td>BX-2188.2</td><td>R-200A</td><td class="num">37.4</td><td class="num">59.6</td><td class="num">122</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr class="oos"><td>2026-031</td><td>14 Feb</td><td>BX-2104.7</td><td>R-200B</td><td class="num">—</td><td class="num">—</td><td class="num">—</td><td><span class="tag oos">scrapped</span></td></tr>
+            <tr><td>2026-026</td><td>09 Feb</td><td>BX-2104.7</td><td>R-030A</td><td class="num">35.8</td><td class="num">57.4</td><td class="num">116</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr><td>2026-019</td><td>02 Feb</td><td>BX-2104.7</td><td>R-200A</td><td class="num">36.0</td><td class="num">57.8</td><td class="num">117</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr><td>2026-013</td><td>26 Jan</td><td>BX-2104.7</td><td>R-030A</td><td class="num">38.4</td><td class="num">60.2</td><td class="num">124</td><td><span class="tag on">on-spec</span></td></tr>
+            <tr><td>2026-008</td><td>18 Jan</td><td>BX-2104.7</td><td>R-200A</td><td class="num">35.4</td><td class="num">57.0</td><td class="num">115</td><td><span class="tag on">on-spec</span></td></tr>
+          </tbody>
+          <tfoot>
+            <tr><td colspan="4"><b>Trailing 12 · mean (excl. scrap)</b></td><td class="num">37.3</td><td class="num">59.2</td><td class="num">122</td><td>11 / 12 on-spec</td></tr>
+          </tfoot>
+        </table>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    {# ============================================================== #}
+    {# IV — Strain library + inoculation schedule (split)            #}
+    {# ============================================================== #}
+    <section class="folio-row split">
+      <article class="block">
+        <header class="block-head">
+          <span class="folio-num">IV</span>
+          <h2>Strain library · working stock</h2>
+          <span class="caption">14 strains currently qualified for fed-batch work</span>
+        </header>
+
+        <div class="strain-grid">
+          <div class="strain on"><b>BX-2191.1</b><span class="line">acetyl-CoA rebuild · auxo-rescue</span><span class="meta">working · 10 vials</span></div>
+          <div class="strain on"><b>BX-2188.2</b><span class="line">malonyl-CoA shunt · v2</span><span class="meta">working · 14 vials</span></div>
+          <div class="strain on"><b>BX-2104.7</b><span class="line">parental workhorse</span><span class="meta">retired · long-term bank</span></div>
+          <div class="strain on"><b>BX-2167.4</b><span class="line">PHB knockout</span><span class="meta">working · 8 vials</span></div>
+          <div class="strain on"><b>BX-2172.0</b><span class="line">codon-optimized lacI</span><span class="meta">working · 6 vials</span></div>
+          <div class="strain on"><b>BX-2180.3</b><span class="line">tetR swap</span><span class="meta">working · 4 vials</span></div>
+          <div class="strain warn"><b>BX-2183.1</b><span class="line">trc::lacIq variant</span><span class="meta">drift suspected</span></div>
+          <div class="strain on"><b>BX-2185.2</b><span class="line">arabinose induction</span><span class="meta">working · 6 vials</span></div>
+          <div class="strain on"><b>BX-2189.0</b><span class="line">low-foam chassis</span><span class="meta">working · 5 vials</span></div>
+          <div class="strain on"><b>BX-2190.1</b><span class="line">temperature-shifted</span><span class="meta">working · 7 vials</span></div>
+          <div class="strain on"><b>BX-2193.0</b><span class="line">membrane lipid trim</span><span class="meta">qualifying</span></div>
+          <div class="strain on"><b>BX-2194.1</b><span class="line">stress-tolerant chassis</span><span class="meta">qualifying</span></div>
+          <div class="strain off"><b>BX-2160.9</b><span class="line">deprecated · poor yield</span><span class="meta">long-term bank</span></div>
+          <div class="strain off"><b>BX-2155.2</b><span class="line">deprecated · plasmid loss</span><span class="meta">long-term bank</span></div>
+        </div>
+      </article>
+
+      <article class="block">
+        <header class="block-head">
+          <span class="folio-num">V</span>
+          <h2>Inoculation schedule · next 48 h</h2>
+          <span class="caption">All times local · EDT · seed-train owner in brackets</span>
+        </header>
+
+        <ol class="schedule">
+          <li class="now">
+            <span class="t">today · 09:30</span>
+            <span class="what"><b>Seed flask transfer</b> · BX-2191.1 to SF-22<br><i>SOP-INO-04 · 2 L MB-21 · induction window OD 26 — 30</i></span>
+            <span class="who">[A. Reyes]</span>
+          </li>
+          <li>
+            <span class="t">today · 14:00</span>
+            <span class="what"><b>Inoculate R-030A</b> · batch 2026-076<br><i>BX-2188.2 · 30 L fed-batch · pH 6.70 · target 96 h</i></span>
+            <span class="who">[J. Park]</span>
+          </li>
+          <li>
+            <span class="t">today · 22:00</span>
+            <span class="what"><b>CIP cycle · R-200B</b><br><i>caustic + acid · steam sterilize at 06:00</i></span>
+            <span class="who">[night shift]</span>
+          </li>
+          <li>
+            <span class="t">tomorrow · 06:30</span>
+            <span class="what"><b>Inoculate R-200A</b> · batch 2026-077<br><i>BX-2191.1 · 200 L · qualification lot 03</i></span>
+            <span class="who">[L. Okafor]</span>
+          </li>
+          <li>
+            <span class="t">tomorrow · 11:00</span>
+            <span class="what"><b>96-well scan setup</b> · TM-4 follow-up DOE<br><i>tight grid 1.4 — 1.8 g/L MgSO4 · 4 replicates</i></span>
+            <span class="who">[A. Reyes]</span>
+          </li>
+          <li>
+            <span class="t">+48 h · 07:00</span>
+            <span class="what"><b>Inoculate R-200B</b> · batch 2026-078<br><i>BX-2188.2 · 200 L · standard fed-batch</i></span>
+            <span class="who">[J. Park]</span>
+          </li>
+        </ol>
+      </article>
+    </section>
+
+    <hr class="rule">
+
+    {# ============================================================== #}
+    {# VI — Anomaly log strip                                         #}
+    {# ============================================================== #}
+    <section class="block anomaly-block">
+      <header class="block-head">
+        <span class="folio-num">VI</span>
+        <h2>Anomaly log · last 24 h</h2>
+        <span class="caption">Oldest first · clear before next shift handover</span>
+      </header>
+
+      <ul class="anomaly">
+        <li class="lvl-info">
+          <span class="when">22:14</span>
+          <span class="src">R-200A</span>
+          <span class="msg">Foam sensor reading elevated for 4 min during phase II ramp. Antifoam #2 auto-dose triggered, returned to baseline within 90 s.</span>
+          <span class="lvl">info</span>
+        </li>
+        <li class="lvl-warn">
+          <span class="when">02:48</span>
+          <span class="src">96-well deck</span>
+          <span class="msg">Row A columns 1 — 4 reading uniformly high. Suspected evaporation effect at heater-block corner. Exclude from response surface fit.</span>
+          <span class="lvl">watch</span>
+        </li>
+        <li class="lvl-info">
+          <span class="when">05:02</span>
+          <span class="src">R-030A</span>
+          <span class="msg">Brief DO dip to 28% at hour 34 of batch 2026-074. Within tolerance band; flagged for postrun review.</span>
+          <span class="lvl">info</span>
+        </li>
+        <li class="lvl-info">
+          <span class="when">06:55</span>
+          <span class="src">library</span>
+          <span class="msg">BX-2183.1 vial 7 thawed for QC after suspected drift. Plate streak in progress, results expected by 12:00.</span>
+          <span class="lvl">info</span>
+        </li>
+      </ul>
+    </section>
+
+    <hr class="rule rule-double">
+
+    {# ============================================================== #}
+    {# VII — Recent run-log entries                                   #}
+    {# ============================================================== #}
+    <section class="essay-list">
+      <h2 class="essay-h">From the run log</h2>
+      <p class="essay-d">Postmortems, records, swap notes, and scan summaries. New entries land within 24 h of close.</p>
+      <ul class="notes">
+        {% for post in site.pages | where("section", "runlog") | sort_by("date", reverse=true) %}
+          {% if loop.index <= 4 %}
+          <li>
+            <div class="copy">
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+              {% if post.extra.batch_id %}<span class="badge">batch {{ post.extra.batch_id }}</span>{% endif %}
+              {% if post.extra.strain %}<span class="badge">{{ post.extra.strain }}</span>{% endif %}
+              {% if post.extra.reactor %}<span class="badge">{{ post.extra.reactor }}</span>{% endif %}
+            </div>
+            <div class="meta">
+              <time>{{ post.date | date("%d %b · %Y") }}</time>
+            </div>
+          </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/examples/mosaic-bionics/templates/page.html
+++ b/examples/mosaic-bionics/templates/page.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main>
+    <article class="prose">
+      {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+      {% if page.date %}<div class="page-meta">
+        <time>{{ page.date | date("%d %B %Y") }}</time>
+        {% if page.extra.batch_id %}<span class="badge">batch {{ page.extra.batch_id }}</span>{% endif %}
+        {% if page.extra.strain %}<span class="badge">{{ page.extra.strain }}</span>{% endif %}
+        {% if page.extra.reactor %}<span class="badge">{{ page.extra.reactor }}</span>{% endif %}
+        {% if page.extra.status %}<span class="badge stat-{{ page.extra.status }}">{{ page.extra.status }}</span>{% endif %}
+      </div>{% endif %}
+      {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+      <div class="prose-body">{{ content }}</div>
+      {% if page.tags %}
+      <div class="page-tags">
+        {% for t in page.tags %}<a class="tag-chip" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}
+      </div>
+      {% endif %}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/mosaic-bionics/templates/section.html
+++ b/examples/mosaic-bionics/templates/section.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+  <main>
+    <header class="section-head">
+      {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+      {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+      <div class="prose-body">{{ content }}</div>
+    </header>
+    <ul class="notes plain">
+      {% for post in section.pages %}
+        <li>
+          <div class="copy">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+            <div class="badges">
+              {% if post.extra.batch_id %}<span class="badge">batch {{ post.extra.batch_id }}</span>{% endif %}
+              {% if post.extra.strain %}<span class="badge">{{ post.extra.strain }}</span>{% endif %}
+              {% if post.extra.reactor %}<span class="badge">{{ post.extra.reactor }}</span>{% endif %}
+              {% if post.extra.status %}<span class="badge stat-{{ post.extra.status }}">{{ post.extra.status }}</span>{% endif %}
+            </div>
+          </div>
+          <div class="meta">
+            <time>{{ post.date | date("%d %b · %Y") }}</time>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/mosaic-bionics/templates/taxonomy.html
+++ b/examples/mosaic-bionics/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Browse all terms in this taxonomy.</p>
+    <div class="prose-body">{{ content }}</div>
+  </main>
+{% include "footer.html" %}

--- a/examples/mosaic-bionics/templates/taxonomy_term.html
+++ b/examples/mosaic-bionics/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Run-log entries tagged with this term.</p>
+    <div class="prose-body">{{ content }}</div>
+  </main>
+{% include "footer.html" %}

--- a/examples/vertex-prism/AGENTS.md
+++ b/examples/vertex-prism/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md - AI Agent Instructions for Vertex Prism
+
+## Project Overview
+
+Static website built with [Hwaro](https://github.com/hahwul/hwaro), a Crystal-based static site generator.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` |
+| `hwaro serve` | Dev server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Site-Specific Notes
+
+- Theme: an isometric BI / data-exploration deck. Warm paper bg (`#f7f4ee`), near-black ink (`#181613`). Four hard poster accents — cadmium red `#d23f2a`, prussian blue `#234a76`, mustard `#d4a02f`, forest green `#2f6e3f`. Each tile uses one accent dominantly.
+- Signature element: a CSS-3D isometric cube-tower bar chart on the deck home, built with stacked divs using `::before`/`::after` for side faces and three discrete shade steps (no gradients).
+- Typography: Space Grotesk (headings), Inter (body), JetBrains Mono (numerics).
+- Content: `content/memos/` for analytics memos; `index.md` for the deck home; `about.md` for the colophon.
+- CSS lives in `static/css/style.css`.
+- **No gradients. No emojis. Anywhere.**
+
+## Full Reference
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)

--- a/examples/vertex-prism/archetypes/default.md
+++ b/examples/vertex-prism/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/vertex-prism/config.toml
+++ b/examples/vertex-prism/config.toml
@@ -1,0 +1,217 @@
+title = "Vertex Prism"
+description = "An isometric data-exploration deck for product, growth, and finance analytics."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "website"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "domains"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["memos"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/examples/vertex-prism/content/about.md
+++ b/examples/vertex-prism/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About the deck"
+description = "Who Vertex Prism is for, who maintains it, and how the views are intended to be read."
++++
+
+Vertex Prism is the shared analytics deck for **Cuboid Software**, a 140-person SaaS business that sells design-collaboration tools to product, design, and engineering teams. The deck is reviewed every Monday morning by the operating committee and is also published, in slightly redacted form, to every employee on Wednesday.
+
+## Who maintains it
+
+The deck is owned jointly by three small teams. The **analytics engineering** team owns the underlying models — they live in a single dbt project, are tested on every commit, and are documented in plain English on the same page as the SQL. The **growth science** team owns the dashboards on the marketing and conversion side. The **finance** team owns the ARR bridge, the cohort retention surface, and the contribution-margin views.
+
+Each tile on the deck is signed at the bottom with the name of the maintainer team and the freshness of the underlying query. If a number on the deck is wrong, there is exactly one person we ask first; if a definition is unclear, there is exactly one team we ask first.
+
+## How to read the views
+
+The deck is intentionally drawn in **isometric projection**. We have found that flat bar charts hide the texture of the data — a month that is technically "up" can be hiding a single very large enterprise deal — and we have found that the third dimension on the cube tower makes the texture obvious without needing a footnote. The cubes are read like a poster, not like a 3D plot: tall stack means a strong month, color-coded by the dominant deal segment.
+
+The ribbon-stack area chart is read left-to-right; each ribbon is a customer segment, stacked from bottom to top in the order of self-serve, mid-market, enterprise, strategic. The cohort retention table is read row-by-row; the four shade steps per row are the four quarters of retention, with the darkest cell being the freshest.
+
+## What this deck is not
+
+It is not a dashboard for the board, who get a separate, much shorter pack each quarter. It is not a real-time view, either; everything on the deck is computed from the warehouse at 4 AM and is intentionally stale during the day. We have found that real-time numbers invite real-time decisions, and we do not want to make real-time decisions about retention.

--- a/examples/vertex-prism/content/index.md
+++ b/examples/vertex-prism/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Deck"
+description = "Vertex Prism — an isometric data-exploration deck for product, growth, and finance analytics."
+template = "home"
++++

--- a/examples/vertex-prism/content/memos/_index.md
+++ b/examples/vertex-prism/content/memos/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Memos"
+description = "Long-form analytics memos from the operating committee. One memo per month, intentionally slow."
+sort_by = "date"
+reverse = true
+paginate = 10
++++

--- a/examples/vertex-prism/content/memos/arr-bridge-q1-2026.md
+++ b/examples/vertex-prism/content/memos/arr-bridge-q1-2026.md
@@ -1,0 +1,34 @@
++++
+title = "ARR bridge — Q1 2026"
+date = "2026-03-22"
+description = "Reconciling the move in ARR from $42.1M to $46.8M during Q1, with a careful look at the three lines that surprised us."
+tags = ["arr", "bridge", "finance"]
+domains = ["finance"]
++++
+
+We closed Q1-26 at $46.8M of annualized recurring revenue, up from $42.1M at the end of Q4-25. That is a $4.7M gross move in a quarter, which is a strong number; the more interesting question is the composition.
+
+## The bridge
+
+| Component | Amount | Note |
+|---|---|---|
+| Starting ARR (31 Dec 25) | $42.1M | as reported |
+| New logo | +$3.8M | 142 new logos, ASP $26.8K |
+| Expansion | +$2.4M | seats + tier upgrades |
+| Contraction | −$0.5M | seat reductions, no tier downgrades |
+| Gross churn | −$1.0M | 31 logos lost |
+| **Ending ARR (31 Mar 26)** | **$46.8M** | |
+
+The headline number, $4.7M net, is fine. The composition has two surprises worth a paragraph each.
+
+## Surprise one — new logo ASP
+
+New-logo average selling price came in at $26.8K, against a plan of $22.0K. That is a 22 percent beat. We initially read this as a strong quarter for the sales team, and it partially is. But on closer inspection, **84 percent of the beat is one customer** — a Series-C fintech that signed a three-year $410K contract in early March. Adjusting for that one deal, ASP was $22.4K, almost exactly on plan. We have updated the deck to show both the headline number and the "excluding largest" number side by side.
+
+## Surprise two — gross churn
+
+Gross churn came in at $1.0M, against a plan of $1.4M. Half of the favorable variance is a single enterprise customer who was forecast to churn at end of Q1 and has signed a one-quarter extension while they evaluate a competitor. We have **not** removed them from the at-risk list. The deck flags this as a one-quarter timing benefit, not a structural improvement.
+
+## What this means for Q2
+
+We are holding the Q2 plan at $50.5M ending ARR. The new-logo line is at plan once the single large deal is stripped out, and the gross-churn line has a clear one-quarter timing component that is likely to land in Q2 rather than Q1. We see no reason to raise the year.

--- a/examples/vertex-prism/content/memos/cac-payback-note.md
+++ b/examples/vertex-prism/content/memos/cac-payback-note.md
@@ -1,0 +1,32 @@
++++
+title = "CAC payback note — the paid-social bid is too high"
+date = "2026-02-08"
+description = "Self-serve CAC payback has crept from 3.6 months to 4.9 months over two quarters. The blended number is fine; the marginal number is not."
+tags = ["cac", "paid-social"]
+domains = ["growth"]
++++
+
+A short memo on customer-acquisition cost. We want to flag a trend that does not yet show up on the headline page but that the growth team is acting on.
+
+## The blended number is fine
+
+Blended CAC payback across all paid channels is 4.9 months. That is a touch worse than the 4.6-month plan, but well inside the band we care about, and over a 12-month window it is essentially flat.
+
+## The marginal number is not fine
+
+The blended number is misleading because it averages across channels with very different yields. When we look at **marginal CAC** — the cost of the last dollar of spend, not the average dollar — paid social has crept from 3.6 months at the start of Q4-25 to 6.8 months at the start of Q1-26. That is an 88 percent increase in three months. The cause is not mysterious: we doubled the paid-social budget over the same period.
+
+Marginal CAC payback by channel, current quarter:
+
+- Paid search: 4.1 months (steady)
+- Paid social: 6.8 months (deteriorating)
+- Content / SEO: 2.4 months (improving)
+- Outbound SDR: 14.7 months (mid-market only, on plan)
+
+The contribution margin on a customer with a 6.8-month payback is still positive over our 11-month self-serve half-life, but the cushion has gone from comfortable to thin.
+
+## What we are doing
+
+The growth team has cut the paid-social daily budget by 35 percent for the next four weeks. We expect marginal CAC to fall back toward 5 months and blended toward 4.4. We are reallocating about half of the savings into the content surface, where the marginal CAC is the best of any channel we run, and holding the rest in reserve until the May read.
+
+We have added a **marginal-CAC tile** to the deck. The blended number stays on the headline page; the marginal number sits one click in.

--- a/examples/vertex-prism/content/memos/cohort-comparison-self-serve-vs-mid-market.md
+++ b/examples/vertex-prism/content/memos/cohort-comparison-self-serve-vs-mid-market.md
@@ -1,0 +1,25 @@
++++
+title = "Self-serve vs. mid-market — two different businesses"
+date = "2026-04-12"
+description = "The self-serve and mid-market cohorts behave so differently that, for planning purposes, we are going to start treating them as two distinct businesses."
+tags = ["cohorts", "segmentation"]
+domains = ["growth", "finance"]
++++
+
+For four years we have measured the company as a single SaaS business with a long-tail of segments. We are giving up on that framing. The self-serve and mid-market motions have diverged enough that planning them together makes the planning worse, not better.
+
+## The numbers that pushed us
+
+Three numbers, taken across the last four quarterly cohorts:
+
+- **Net revenue retention.** Self-serve sits at 96 percent, with very little expansion. Mid-market sits at 118 percent, with most of the expansion coming from seat-count growth within the first nine months.
+- **CAC payback.** Self-serve pays back in 4.1 months, almost entirely from paid social. Mid-market pays back in 14.7 months, with the dominant channel being outbound SDR plus content.
+- **Cohort half-life.** Self-serve, 11 months. Mid-market, 38 months.
+
+Treating these two motions as one number — a blended NRR of 109, a blended payback of 9.3 months — is misleading in both directions. The self-serve motion looks healthier than it is, because the mid-market expansion is propping up the blended retention. The mid-market motion looks slower than it is, because the self-serve churn is dragging the blended half-life down.
+
+## What changes operationally
+
+Starting with the May deck, every tile on the dashboard will have a **segment toggle** — self-serve, mid-market, blended. The default view is the segmented one. The blended view will still exist for continuity, but the operating committee has agreed to talk about the segments separately.
+
+We are also splitting the contribution-margin view. The self-serve motion is a 78-percent gross-margin business with a 4-month payback. The mid-market motion is a 71-percent gross-margin business with a 15-month payback. Those are two different capital allocations, and they should look like two different capital allocations on the page.

--- a/examples/vertex-prism/content/memos/retention-deep-dive.md
+++ b/examples/vertex-prism/content/memos/retention-deep-dive.md
@@ -1,0 +1,28 @@
++++
+title = "Retention deep-dive — the Q1 cohorts are bending"
+date = "2026-05-18"
+description = "The Q1-26 cohorts are showing a different retention shape than every prior quarter. Here is what we think it is, and what we are doing about it."
+tags = ["retention", "cohorts"]
+domains = ["growth"]
++++
+
+The Q1-26 cohorts — the customers who first paid us between January and March of this year — have a visibly different retention shape than every prior quarter we have shipped a memo about. We want to walk through what the shape is, what we think is causing it, and what we are doing in the product to push back.
+
+## The shape
+
+For Q4-25 and earlier, the customer's first-month retention sits at around 92 percent and the curve flattens out near 81 percent by month six. The shape is concave from above — the bulk of the churn happens in the first 30 days, and the curve is well-approximated by an exponential decay with a half-life around 18 months.
+
+For Q1-26, the first-month retention is **higher** than the previous baseline — about 94 percent — but the curve does *not* flatten in the same place. Instead, the second and third month retentions are softer, sitting at 88 and 84 percent respectively, against a baseline of 89 and 86. By the time we look at month six, the curves cross and the new cohort is **two points below** the trailing baseline.
+
+## What we think it is
+
+We launched a 14-day free trial in late December that materially lowered the activation friction. The first-month numbers look stronger because we are letting more lukewarm customers convert; the third-month numbers look softer because those same lukewarm customers churn as soon as they hit a real billing cycle. The net cohort half-life has dropped from 18 months to 15.4 months, which is a meaningful enough move that we want to be careful before we extrapolate it.
+
+## What we are doing
+
+The growth team has shipped two interventions:
+
+- A **payment-method-on-file** prompt during the trial. Early A/B reads suggest a 6.4 point lift in trial-to-paid conversion among the lukewarm population.
+- A **30-day check-in** email sequence that surfaces three specific activation events. We are reading conversion and ignoring open rates.
+
+We will reread the cohort surface in the June memo. We are not changing the trial back; the gross-add lift is too large to give up on a three-month read.

--- a/examples/vertex-prism/static/css/style.css
+++ b/examples/vertex-prism/static/css/style.css
@@ -1,0 +1,1006 @@
+/* =============================================================================
+   Vertex Prism — isometric data-exploration deck
+   Light, poster-block palette · no gradients · no emojis
+   ========================================================================== */
+
+:root {
+  --paper: #f7f4ee;
+  --paper-2: #efeae0;
+  --paper-3: #e6dfd0;
+  --ink: #181613;
+  --ink-2: #3a342c;
+  --ink-3: #6b6357;
+  --rule: #181613;
+
+  --red: #d23f2a;
+  --red-2: #b53321;
+  --red-3: #8a2515;
+
+  --blue: #234a76;
+  --blue-2: #1a3a5e;
+  --blue-3: #122a47;
+
+  --mustard: #d4a02f;
+  --mustard-2: #b08522;
+  --mustard-3: #7d5d14;
+
+  --green: #2f6e3f;
+  --green-2: #245530;
+  --green-3: #173d20;
+
+  --grid: #d8d0bf;
+
+  /* isometric geometry */
+  --cube: 26px;
+  --cube-half: 13px;
+
+  --serif: "Inter", system-ui, sans-serif;
+  --display: "Space Grotesk", "Inter", sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--ink); text-decoration: none; border-bottom: 1.5px solid var(--ink); }
+a:hover { color: var(--red); border-color: var(--red); }
+
+.deck {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 28px 36px 64px;
+  border-left: 1.5px solid var(--ink);
+  border-right: 1.5px solid var(--ink);
+  background: var(--paper);
+  min-height: 100vh;
+}
+
+/* ---------- masthead ---------- */
+
+.masthead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0 18px;
+  border-bottom: 3px solid var(--ink);
+}
+
+.brand {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  border: none;
+}
+.brand:hover { color: var(--ink); }
+
+.cube-mark { width: 52px; height: 52px; display: block; }
+.cube-mark svg { width: 100%; height: 100%; display: block; }
+
+.wordmark {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.05;
+  font-family: var(--display);
+}
+.wordmark em { font-style: normal; color: var(--red); font-weight: 700; font-size: 22px; letter-spacing: -0.01em; }
+.wordmark b { font-weight: 700; font-size: 22px; letter-spacing: -0.01em; }
+.wordmark small {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-top: 4px;
+}
+
+.masthead nav {
+  display: flex;
+  gap: 22px;
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 14.5px;
+  letter-spacing: 0.01em;
+}
+.masthead nav a { border: none; padding-bottom: 3px; border-bottom: 2px solid transparent; }
+.masthead nav a:hover { border-color: var(--red); }
+
+.meta-strip {
+  display: flex;
+  gap: 32px;
+  flex-wrap: wrap;
+  padding: 10px 0 24px;
+  border-bottom: 1.5px solid var(--ink);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+.meta-strip b { color: var(--red); font-weight: 600; margin-right: 6px; }
+
+/* ---------- rules ---------- */
+
+.rule {
+  border: none;
+  border-top: 1.5px solid var(--ink);
+  margin: 28px 0;
+}
+.rule-double {
+  border: none;
+  border-top: 1.5px solid var(--ink);
+  border-bottom: 1.5px solid var(--ink);
+  height: 5px;
+  margin: 36px 0;
+}
+
+/* ---------- cover & KPIs ---------- */
+
+.cover {
+  padding: 28px 0 12px;
+}
+.kicker {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 5px 10px;
+  margin-bottom: 18px;
+}
+.cover h1 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 56px;
+  line-height: 1.04;
+  letter-spacing: -0.025em;
+  margin: 0 0 12px;
+  max-width: 880px;
+}
+.cover h1 em { font-style: normal; color: var(--red); }
+.cover .dek {
+  font-size: 17px;
+  line-height: 1.5;
+  max-width: 720px;
+  color: var(--ink-2);
+  margin: 0 0 28px;
+}
+
+.kpi-band {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border: 1.5px solid var(--ink);
+  background: var(--paper);
+}
+.kpi {
+  padding: 18px 20px;
+  border-right: 1.5px solid var(--ink);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  position: relative;
+}
+.kpi:last-child { border-right: none; }
+.kpi::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 6px;
+  background: var(--red);
+}
+.kpi[data-accent="blue"]::before { background: var(--blue); }
+.kpi[data-accent="mustard"]::before { background: var(--mustard); }
+.kpi[data-accent="green"]::before { background: var(--green); }
+.kpi[data-accent="red"]::before { background: var(--red); }
+
+.kpi .lbl {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-top: 6px;
+}
+.kpi .val {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 36px;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.kpi .val small {
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--ink-3);
+  margin-left: 2px;
+}
+.kpi .delta {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.03em;
+  margin-top: 2px;
+}
+.delta.pos { color: var(--green); }
+.delta.neg { color: var(--red); }
+
+/* ---------- tile structure ---------- */
+
+.tile {
+  border: 1.5px solid var(--ink);
+  background: var(--paper);
+  padding: 22px 24px 26px;
+  margin: 0;
+}
+.tile-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  flex-wrap: wrap;
+  padding-bottom: 14px;
+  margin-bottom: 18px;
+  border-bottom: 1.5px solid var(--ink);
+}
+.folio-num {
+  display: inline-block;
+  font-family: var(--mono);
+  font-weight: 600;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 4px 8px;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+.tile-head h2 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: -0.015em;
+  margin: 0;
+  flex: 0 1 auto;
+}
+.tile-head .caption {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-left: auto;
+}
+
+.tile-row {
+  display: grid;
+  gap: 24px;
+}
+.tile-row-split { grid-template-columns: 1.05fr 1fr; }
+.tile-row-third { grid-template-columns: 1fr 1fr 0.85fr; }
+
+/* ---------- ISOMETRIC CUBE TOWER (signature) ---------- */
+
+.iso-stage {
+  padding: 36px 0 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+  overflow: hidden;
+}
+
+.iso-floor {
+  position: relative;
+  width: 880px;
+  max-width: 100%;
+  height: 380px;
+  transform-style: preserve-3d;
+  perspective: 1400px;
+}
+
+.iso-grid {
+  position: absolute;
+  inset: 0;
+  transform: rotateX(60deg) rotateZ(-45deg);
+  transform-origin: center bottom;
+  pointer-events: none;
+}
+.iso-grid .g-line {
+  position: absolute;
+  background: var(--grid);
+  left: 50%;
+  top: 70%;
+  width: 380px;
+  height: 1px;
+  margin-left: -190px;
+}
+.iso-grid .g-line:nth-child(1) { transform: translateY(-90px); }
+.iso-grid .g-line:nth-child(2) { transform: translateY(-60px); }
+.iso-grid .g-line:nth-child(3) { transform: translateY(-30px); }
+.iso-grid .g-line:nth-child(4) { transform: translateY(0); }
+.iso-grid .g-line:nth-child(5) { transform: translateY(30px); }
+.iso-grid .g-line:nth-child(6) { transform: translateY(60px); }
+.iso-grid .g-line.v {
+  width: 1px;
+  height: 200px;
+  margin-left: 0;
+  top: 50%;
+  margin-top: -100px;
+}
+.iso-grid .g-line.v:nth-child(7)  { transform: translateX(-150px); }
+.iso-grid .g-line.v:nth-child(8)  { transform: translateX(-90px); }
+.iso-grid .g-line.v:nth-child(9)  { transform: translateX(-30px); }
+.iso-grid .g-line.v:nth-child(10) { transform: translateX(30px); }
+.iso-grid .g-line.v:nth-child(11) { transform: translateX(90px); }
+.iso-grid .g-line.v:nth-child(12) { transform: translateX(150px); }
+
+.iso-towers {
+  position: absolute;
+  inset: 0;
+  transform: rotateX(60deg) rotateZ(-45deg);
+  transform-origin: center bottom;
+  transform-style: preserve-3d;
+  display: grid;
+  grid-template-columns: repeat(12, var(--cube));
+  gap: 12px;
+  width: max-content;
+  left: 50%;
+  top: 55%;
+  margin-left: -240px;
+}
+
+.tower {
+  position: relative;
+  width: var(--cube);
+  height: var(--cube);
+  transform-style: preserve-3d;
+  align-self: end;
+}
+
+/* per-tower lift: stack n cubes upward */
+.tower i.cube {
+  position: absolute;
+  left: 0; bottom: 0;
+  width: var(--cube);
+  height: var(--cube);
+  transform-style: preserve-3d;
+  /* TOP face — drawn flat on this rotated plane */
+  background: var(--red);
+  border: 1px solid var(--ink);
+}
+.tower i.cube::before,
+.tower i.cube::after {
+  content: "";
+  position: absolute;
+  border: 1px solid var(--ink);
+}
+/* RIGHT face — rotate up out of the plane */
+.tower i.cube::before {
+  width: var(--cube);
+  height: var(--cube);
+  right: 0;
+  top: 0;
+  transform-origin: right top;
+  transform: rotateY(-90deg) translateZ(0);
+  background: var(--red-2);
+}
+/* FRONT face */
+.tower i.cube::after {
+  width: var(--cube);
+  height: var(--cube);
+  left: 0;
+  bottom: 0;
+  transform-origin: left bottom;
+  transform: rotateX(90deg) translateZ(0);
+  background: var(--red-3);
+}
+
+/* stack cubes vertically (Z axis in rotated space = translateZ) */
+.tower i.cube:nth-of-type(1)  { transform: translateZ(0); }
+.tower i.cube:nth-of-type(2)  { transform: translateZ(var(--cube)); }
+.tower i.cube:nth-of-type(3)  { transform: translateZ(calc(var(--cube) * 2)); }
+.tower i.cube:nth-of-type(4)  { transform: translateZ(calc(var(--cube) * 3)); }
+.tower i.cube:nth-of-type(5)  { transform: translateZ(calc(var(--cube) * 4)); }
+.tower i.cube:nth-of-type(6)  { transform: translateZ(calc(var(--cube) * 5)); }
+.tower i.cube:nth-of-type(7)  { transform: translateZ(calc(var(--cube) * 6)); }
+.tower i.cube:nth-of-type(8)  { transform: translateZ(calc(var(--cube) * 7)); }
+.tower i.cube:nth-of-type(9)  { transform: translateZ(calc(var(--cube) * 8)); }
+.tower i.cube:nth-of-type(10) { transform: translateZ(calc(var(--cube) * 9)); }
+
+/* color by accent — top / right / front are three discrete shade steps of the same hue */
+.tower[data-accent="blue"]   i.cube                { background: var(--blue); }
+.tower[data-accent="blue"]   i.cube::before        { background: var(--blue-2); }
+.tower[data-accent="blue"]   i.cube::after         { background: var(--blue-3); }
+
+.tower[data-accent="red"]    i.cube                { background: var(--red); }
+.tower[data-accent="red"]    i.cube::before        { background: var(--red-2); }
+.tower[data-accent="red"]    i.cube::after         { background: var(--red-3); }
+
+.tower[data-accent="mustard"] i.cube               { background: var(--mustard); }
+.tower[data-accent="mustard"] i.cube::before       { background: var(--mustard-2); }
+.tower[data-accent="mustard"] i.cube::after        { background: var(--mustard-3); }
+
+.tower[data-accent="green"]  i.cube                { background: var(--green); }
+.tower[data-accent="green"]  i.cube::before        { background: var(--green-2); }
+.tower[data-accent="green"]  i.cube::after         { background: var(--green-3); }
+
+.tower .m, .tower .v {
+  position: absolute;
+  font-family: var(--mono);
+  font-size: 10px;
+  white-space: nowrap;
+  color: var(--ink-2);
+  letter-spacing: 0.04em;
+  /* un-rotate so labels read flat */
+  transform: rotateZ(45deg) rotateX(-60deg) translateY(20px);
+  transform-origin: left top;
+  pointer-events: none;
+}
+.tower .m {
+  bottom: -28px;
+  left: 0;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink);
+}
+.tower .v {
+  bottom: -44px;
+  left: 0;
+  color: var(--ink-3);
+}
+.tower.mark .m { color: var(--red); }
+.tower.mark .v { color: var(--red); font-weight: 600; }
+
+.iso-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 22px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.iso-legend li { display: flex; align-items: center; gap: 8px; color: var(--ink-2); }
+.iso-legend i {
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--ink);
+  display: inline-block;
+}
+
+/* ---------- ribbon-stack area ---------- */
+
+.ribbon-stage {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 22px;
+  align-items: center;
+}
+.ribbon-svg {
+  width: 100%;
+  height: 220px;
+  display: block;
+  border: 1.5px solid var(--ink);
+  background: var(--paper-2);
+}
+.ribbon-labels {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ribbon-labels li {
+  display: grid;
+  grid-template-columns: 14px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1.5px solid var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--paper);
+}
+.ribbon-labels i {
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--ink);
+}
+.ribbon-labels b {
+  font-family: var(--display);
+  font-weight: 700;
+  margin-left: 6px;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+.ribbon-labels span:last-child {
+  font-family: var(--mono);
+  color: var(--ink-3);
+}
+
+/* ---------- cohort grid ---------- */
+
+.cohort-grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+.cohort-grid th,
+.cohort-grid td {
+  padding: 8px 10px;
+  border: 1px solid var(--ink);
+  text-align: center;
+}
+.cohort-grid thead th {
+  background: var(--ink);
+  color: var(--paper);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 10.5px;
+}
+.cohort-grid tbody td:first-child {
+  text-align: left;
+  font-weight: 600;
+  background: var(--paper-2);
+}
+.cohort-grid .num { text-align: right; }
+.cohort-grid .cell {
+  font-weight: 600;
+  color: var(--paper);
+}
+/* 4 discrete shade steps, no gradients */
+tr[data-accent="blue"] .cell.s1 { background: #c6d2e0; color: var(--ink); }
+tr[data-accent="blue"] .cell.s2 { background: #7a96b8; color: var(--paper); }
+tr[data-accent="blue"] .cell.s3 { background: var(--blue); }
+tr[data-accent="blue"] .cell.s4 { background: var(--blue-3); }
+
+tr[data-accent="mustard"] .cell.s1 { background: #efd9a4; color: var(--ink); }
+tr[data-accent="mustard"] .cell.s2 { background: #d9b660; color: var(--ink); }
+tr[data-accent="mustard"] .cell.s3 { background: var(--mustard); color: var(--ink); }
+tr[data-accent="mustard"] .cell.s4 { background: var(--mustard-3); }
+
+tr[data-accent="red"] .cell.s1 { background: #ecbeb4; color: var(--ink); }
+tr[data-accent="red"] .cell.s2 { background: #d97a6a; color: var(--paper); }
+tr[data-accent="red"] .cell.s3 { background: var(--red); }
+tr[data-accent="red"] .cell.s4 { background: var(--red-3); }
+
+tr[data-accent="green"] .cell.s1 { background: #bcd2c2; color: var(--ink); }
+tr[data-accent="green"] .cell.s2 { background: #6a9479; color: var(--paper); }
+tr[data-accent="green"] .cell.s3 { background: var(--green); }
+tr[data-accent="green"] .cell.s4 { background: var(--green-3); }
+
+.cohort-grid tr.hl td:first-child {
+  background: var(--red);
+  color: var(--paper);
+}
+.caption-foot {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  letter-spacing: 0.04em;
+  margin: 12px 0 0;
+  text-transform: uppercase;
+}
+.caption-foot a { color: var(--red); border-color: var(--red); }
+
+/* ---------- funnel (rhombi) ---------- */
+
+.funnel-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 0;
+  align-items: center;
+}
+.rhom {
+  width: var(--w);
+  height: 38px;
+  position: relative;
+  transform: skewX(-22deg);
+  background: var(--blue);
+  border: 1.5px solid var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  color: var(--paper);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  transition: filter .15s ease;
+}
+.rhom > * { transform: skewX(22deg); display: inline-block; }
+.rhom .rh-lbl { text-transform: uppercase; font-weight: 600; }
+.rhom .rh-v { font-family: var(--display); font-weight: 700; letter-spacing: -0.01em; font-size: 14px; }
+.rhom.r1 { background: var(--blue); }
+.rhom.r2 { background: var(--blue-2); }
+.rhom.r3 { background: var(--red); }
+.rhom.r4 { background: var(--mustard); color: var(--ink); }
+.rhom.r5 { background: var(--green); }
+.rhom:hover { filter: brightness(1.05); }
+
+/* ---------- bridge table ---------- */
+
+.bridge-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.bridge-table td {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--paper-3);
+  vertical-align: middle;
+}
+.bridge-table td:first-child { font-weight: 500; }
+.bridge-table .num { text-align: right; width: 25%; }
+.bridge-table .num.pos { color: var(--green); font-weight: 600; }
+.bridge-table .num.neg { color: var(--red); font-weight: 600; }
+.bridge-table .bar { width: 40%; padding-left: 14px; position: relative; height: 28px; }
+.bridge-table .bar i {
+  position: absolute;
+  top: 50%;
+  margin-top: -8px;
+  height: 16px;
+  width: var(--w);
+  left: var(--o, 0%);
+  border: 1px solid var(--ink);
+}
+.bridge-table .b-base { background: var(--ink); }
+.bridge-table .b-pos { background: var(--green); }
+.bridge-table .b-neg { background: var(--red); }
+.bridge-table tr.ttl td { border-top: 2px solid var(--ink); border-bottom: none; padding-top: 12px; }
+.bridge-table tr.ttl td:first-child { font-family: var(--display); font-size: 15px; }
+
+/* ---------- unit economics list ---------- */
+
+.ue-list {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px 14px;
+  margin: 0;
+  padding: 0;
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+.ue-list dt {
+  color: var(--ink-2);
+  border-bottom: 1px dotted var(--paper-3);
+  padding-bottom: 6px;
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.ue-list dd {
+  margin: 0;
+  font-family: var(--display);
+  font-weight: 700;
+  text-align: right;
+  border-bottom: 1px dotted var(--paper-3);
+  padding-bottom: 6px;
+  letter-spacing: -0.01em;
+  font-size: 16px;
+}
+.ue-list dd small {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ink-3);
+  margin-left: 2px;
+  font-family: var(--mono);
+}
+
+/* ---------- segment explorer ---------- */
+
+.seg-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.seg-list li {
+  display: grid;
+  grid-template-columns: 36px 1.4fr 2fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 4px;
+  border-bottom: 1px solid var(--paper-3);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.seg-list .rank {
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--ink-3);
+  font-size: 14px;
+}
+.seg-list .seg {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--ink);
+}
+.seg-list .bar {
+  height: 14px;
+  background: var(--paper-2);
+  border: 1px solid var(--ink);
+  position: relative;
+}
+.seg-list .bar i {
+  display: block;
+  height: 100%;
+  width: var(--w);
+  background: var(--red);
+}
+.seg-list li[data-accent="blue"]    .bar i { background: var(--blue); }
+.seg-list li[data-accent="mustard"] .bar i { background: var(--mustard); }
+.seg-list li[data-accent="green"]   .bar i { background: var(--green); }
+.seg-list li[data-accent="red"]     .bar i { background: var(--red); }
+.seg-list .num {
+  font-family: var(--display);
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+
+/* ---------- memo list ---------- */
+
+.memo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.memo-list li {
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
+  gap: 18px;
+  padding: 18px 6px;
+  border-bottom: 1px solid var(--paper-3);
+  align-items: start;
+}
+.memo-list .num { padding-top: 2px; }
+.memo-list .copy a {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 19px;
+  letter-spacing: -0.01em;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--ink);
+}
+.memo-list .copy a:hover { border-bottom-color: var(--red); color: var(--red); }
+.memo-list .copy p {
+  margin: 6px 0 6px;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.5;
+  max-width: 64ch;
+}
+.memo-list .meta {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  white-space: nowrap;
+}
+.row-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
+
+.chip {
+  display: inline-block;
+  border: 1.2px solid var(--ink);
+  padding: 2px 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink);
+  background: var(--paper);
+}
+.chip:hover { background: var(--ink); color: var(--paper); }
+.chip.sm { font-size: 10px; padding: 1px 6px; border-width: 1px; }
+
+/* ---------- page (single post) ---------- */
+
+.page {
+  padding: 32px 0;
+  max-width: 760px;
+  margin: 0 auto;
+}
+.page-title {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 44px;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  margin: 0 0 10px;
+}
+.page-date {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0 0 14px;
+}
+.page-desc {
+  font-size: 17px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  margin: 0 0 30px;
+  padding-bottom: 22px;
+  border-bottom: 1.5px solid var(--ink);
+}
+
+.prose {
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--ink);
+}
+.prose h2 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 26px;
+  letter-spacing: -0.01em;
+  margin: 38px 0 14px;
+  padding-top: 18px;
+  border-top: 1px solid var(--paper-3);
+}
+.prose h3 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 19px;
+  margin: 26px 0 8px;
+}
+.prose p { margin: 0 0 18px; }
+.prose ul, .prose ol { padding-left: 22px; margin: 0 0 18px; }
+.prose li { margin-bottom: 4px; }
+.prose strong { color: var(--red); font-weight: 600; }
+.prose blockquote {
+  border-left: 4px solid var(--ink);
+  padding: 4px 18px;
+  margin: 22px 0;
+  font-family: var(--display);
+  font-style: normal;
+  font-size: 18px;
+  line-height: 1.45;
+  color: var(--ink-2);
+}
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 22px 0;
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.prose th, .prose td {
+  border-bottom: 1px solid var(--paper-3);
+  padding: 8px 10px;
+  text-align: left;
+}
+.prose th {
+  background: var(--ink);
+  color: var(--paper);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 11px;
+  border-bottom: none;
+}
+.prose code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  background: var(--paper-2);
+  padding: 1px 5px;
+  border: 1px solid var(--paper-3);
+}
+.prose a { color: var(--red); border-color: var(--red); }
+.prose a:hover { background: var(--red); color: var(--paper); }
+
+.page-foot {
+  margin-top: 40px;
+  padding-top: 18px;
+  border-top: 1.5px solid var(--ink);
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.page-foot .lbl {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-right: 6px;
+}
+
+.cta {
+  display: inline-block;
+  font-family: var(--display);
+  font-weight: 600;
+  background: var(--red);
+  color: var(--paper);
+  padding: 10px 18px;
+  border: 1.5px solid var(--ink);
+}
+.cta:hover { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+
+/* ---------- colophon ---------- */
+
+.colophon {
+  margin-top: 50px;
+  padding-top: 22px;
+  border-top: 3px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1.2fr;
+  gap: 36px;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+.colophon .col strong {
+  display: block;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  margin-bottom: 8px;
+}
+.colophon a {
+  display: inline-block;
+  margin-right: 14px;
+  border-bottom: 1.5px solid var(--ink);
+}
+.colophon p { margin: 0; line-height: 1.55; }
+.colophon code {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  background: var(--paper-2);
+  border: 1px solid var(--paper-3);
+  padding: 1px 4px;
+}
+
+/* ---------- responsive ---------- */
+
+@media (max-width: 1080px) {
+  .tile-row-split,
+  .tile-row-third { grid-template-columns: 1fr; }
+  .kpi-band { grid-template-columns: repeat(2, 1fr); }
+  .kpi:nth-child(2) { border-right: none; }
+  .kpi:nth-child(1), .kpi:nth-child(2) { border-bottom: 1.5px solid var(--ink); }
+  .ribbon-stage { grid-template-columns: 1fr; }
+  .colophon { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 720px) {
+  .deck { padding: 18px 18px 36px; border-left: none; border-right: none; }
+  .cover h1 { font-size: 38px; }
+  .kpi-band { grid-template-columns: 1fr; }
+  .kpi { border-right: none; border-bottom: 1.5px solid var(--ink); }
+  .kpi:last-child { border-bottom: none; }
+  .iso-floor { transform: scale(0.7); transform-origin: top center; height: 280px; }
+  .masthead { flex-direction: column; align-items: flex-start; gap: 14px; }
+  .meta-strip { font-size: 10.5px; gap: 14px; }
+  .seg-list li { grid-template-columns: 28px 1fr auto; }
+  .seg-list .bar { display: none; }
+  .memo-list li { grid-template-columns: 1fr; }
+  .memo-list .meta { margin-top: 4px; }
+}

--- a/examples/vertex-prism/static/favicon.svg
+++ b/examples/vertex-prism/static/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f7f4ee"/>
+  <polygon points="16,4 28,10 28,22 16,28 4,22 4,10" fill="none" stroke="#181613" stroke-width="1.4"/>
+  <polygon points="16,4 28,10 16,16 4,10" fill="#d4a02f"/>
+  <polygon points="4,10 16,16 16,28 4,22" fill="#234a76"/>
+  <polygon points="28,10 16,16 16,28 28,22" fill="#d23f2a"/>
+  <line x1="16" y1="4" x2="16" y2="16" stroke="#181613" stroke-width="1"/>
+  <line x1="4" y1="10" x2="16" y2="16" stroke="#181613" stroke-width="1"/>
+  <line x1="28" y1="10" x2="16" y2="16" stroke="#181613" stroke-width="1"/>
+  <line x1="16" y1="16" x2="16" y2="28" stroke="#181613" stroke-width="1"/>
+</svg>

--- a/examples/vertex-prism/templates/404.html
+++ b/examples/vertex-prism/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="page">
+    <h1 class="page-title">404 — tile not materialized</h1>
+    <p class="page-desc">That view is not in the deck. The query may have failed at 4 AM, or the page may never have existed.</p>
+    <p><a href="{{ base_url }}/" class="cta">Back to the deck</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/vertex-prism/templates/footer.html
+++ b/examples/vertex-prism/templates/footer.html
@@ -1,0 +1,20 @@
+    <footer class="colophon">
+      <div class="col">
+        <strong>{{ site.title }}</strong>
+        <p>An isometric analytics deck for Cuboid Software. Reviewed Mondays. Published Wednesdays. Set in Space Grotesk, Inter, and JetBrains Mono. Built with Hwaro on Crystal.</p>
+      </div>
+      <div class="col">
+        <strong>Surfaces</strong>
+        <a href="{{ base_url }}/">Deck</a>
+        <a href="{{ base_url }}/memos/">Memos</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </div>
+      <div class="col">
+        <strong>Office of analytics · {{ current_year }}</strong>
+        <p>All numbers in this deck are computed at 04:00 UTC from the warehouse. Tickets to <code>#data-help</code>.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/examples/vertex-prism/templates/header.html
+++ b/examples/vertex-prism/templates/header.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} — {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="deck">
+    <header class="masthead">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="cube-mark" aria-hidden="true">
+          <svg viewBox="0 0 60 60">
+            <polygon points="30,6 54,18 54,42 30,54 6,42 6,18" fill="none" stroke="#181613" stroke-width="2"/>
+            <polygon points="30,6 54,18 30,30 6,18" fill="#d4a02f"/>
+            <polygon points="6,18 30,30 30,54 6,42" fill="#234a76"/>
+            <polygon points="54,18 30,30 30,54 54,42" fill="#d23f2a"/>
+            <line x1="30" y1="6" x2="30" y2="30" stroke="#181613" stroke-width="1.4"/>
+            <line x1="6" y1="18" x2="30" y2="30" stroke="#181613" stroke-width="1.4"/>
+            <line x1="54" y1="18" x2="30" y2="30" stroke="#181613" stroke-width="1.4"/>
+            <line x1="30" y1="30" x2="30" y2="54" stroke="#181613" stroke-width="1.4"/>
+          </svg>
+        </span>
+        <span class="wordmark">
+          <em>Vertex</em><b>Prism</b>
+          <small>Deck v.04 · {{ current_date }}</small>
+        </span>
+      </a>
+      <nav>
+        <a href="{{ base_url }}/">Deck</a>
+        <a href="{{ base_url }}/memos/">Memos</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+    <div class="meta-strip">
+      <span><b>warehouse</b> snowflake-prod · materialized 04:00 UTC</span>
+      <span><b>owners</b> analytics · growth-science · finance</span>
+      <span><b>refresh</b> daily · gated weekly</span>
+    </div>

--- a/examples/vertex-prism/templates/home.html
+++ b/examples/vertex-prism/templates/home.html
@@ -1,0 +1,284 @@
+{% include "header.html" %}
+  <main class="dashboard">
+
+    <section class="cover">
+      <div class="cover-text">
+        <span class="kicker">Operating deck · W21 · 18 May 2026</span>
+        <h1>The cubes are <em>up</em>. The cohorts are <em>bending</em>.</h1>
+        <p class="dek">A Monday operating review for Cuboid Software. Eight tiles, one cube tower, four memos. Drawn in isometric so the texture of the data is hard to ignore.</p>
+        <div class="kpi-band">
+          <div class="kpi" data-accent="blue">
+            <span class="lbl">ARR</span>
+            <span class="val">$ 46.8<small>m</small></span>
+            <span class="delta pos">+ 11.2% QoQ</span>
+          </div>
+          <div class="kpi" data-accent="red">
+            <span class="lbl">NRR · TTM</span>
+            <span class="val">112<small>%</small></span>
+            <span class="delta neg">− 2.4 pts QoQ</span>
+          </div>
+          <div class="kpi" data-accent="mustard">
+            <span class="lbl">GMV · monthly</span>
+            <span class="val">$ 18.4<small>m</small></span>
+            <span class="delta pos">+ 6.1% MoM</span>
+          </div>
+          <div class="kpi" data-accent="green">
+            <span class="lbl">CAC payback</span>
+            <span class="val">4.9<small>mo</small></span>
+            <span class="delta neg">+ 0.3 mo QoQ</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section class="tile tile-tower">
+      <header class="tile-head">
+        <span class="folio-num">01</span>
+        <h2>Monthly revenue, twelve months</h2>
+        <span class="caption">Cube-tower bar chart · one cube = $ 500K of new MRR · colored by dominant segment</span>
+      </header>
+      <div class="iso-stage">
+        <div class="iso-floor">
+          <div class="iso-grid">
+            <div class="g-line"></div><div class="g-line"></div><div class="g-line"></div>
+            <div class="g-line"></div><div class="g-line"></div><div class="g-line"></div>
+            <div class="g-line v"></div><div class="g-line v"></div><div class="g-line v"></div>
+            <div class="g-line v"></div><div class="g-line v"></div><div class="g-line v"></div>
+          </div>
+          <div class="iso-towers">
+            {# 12 towers, 1 per month — stacked cubes, height = MRR. Accents cycle by dominant segment. #}
+            <div class="tower" style="--h:6;" data-accent="blue"><span class="m">May</span><span class="v">$ 3.0m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:5;" data-accent="blue"><span class="m">Jun</span><span class="v">$ 2.5m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:4;" data-accent="mustard"><span class="m">Jul</span><span class="v">$ 2.0m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:7;" data-accent="red"><span class="m">Aug</span><span class="v">$ 3.5m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:8;" data-accent="blue"><span class="m">Sep</span><span class="v">$ 4.0m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:6;" data-accent="green"><span class="m">Oct</span><span class="v">$ 3.0m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:5;" data-accent="mustard"><span class="m">Nov</span><span class="v">$ 2.5m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:9;" data-accent="red"><span class="m">Dec</span><span class="v">$ 4.5m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:7;" data-accent="blue"><span class="m">Jan</span><span class="v">$ 3.5m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:8;" data-accent="green"><span class="m">Feb</span><span class="v">$ 4.0m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower" style="--h:10;" data-accent="red"><span class="m">Mar</span><span class="v">$ 5.0m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+            <div class="tower mark" style="--h:9;" data-accent="mustard"><span class="m">Apr</span><span class="v">$ 4.5m</span>
+              <i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i><i class="cube"></i>
+            </div>
+          </div>
+        </div>
+        <ul class="iso-legend">
+          <li><i style="background:#234a76"></i> self-serve</li>
+          <li><i style="background:#d23f2a"></i> mid-market</li>
+          <li><i style="background:#d4a02f"></i> enterprise</li>
+          <li><i style="background:#2f6e3f"></i> strategic</li>
+        </ul>
+      </div>
+    </section>
+
+    <hr class="rule rule-double">
+
+    <section class="tile-row tile-row-split">
+
+      <article class="tile tile-ribbon">
+        <header class="tile-head">
+          <span class="folio-num">02</span>
+          <h2>ARR composition · ribbon</h2>
+          <span class="caption">Isometric ribbon-stack · self-serve · mid-market · enterprise · strategic</span>
+        </header>
+        <div class="ribbon-stage">
+          <svg viewBox="0 0 480 220" preserveAspectRatio="none" class="ribbon-svg" aria-hidden="true">
+            <g transform="matrix(1,-0.32,1,0.32,-120,160)">
+              <polygon points="0,180 60,170 120,164 180,150 240,144 300,130 360,118 420,108 420,180 0,180" fill="#234a76"/>
+              <polygon points="0,140 60,130 120,118 180,100 240,88 300,72 360,54 420,38 420,108 360,118 300,130 240,144 180,150 120,164 60,170 0,180 0,140" fill="#d23f2a"/>
+              <polygon points="0,100 60,86 120,72 180,52 240,38 300,18 360,2 420,-12 420,38 360,54 300,72 240,88 180,100 120,118 60,130 0,140 0,100" fill="#d4a02f"/>
+              <polygon points="0,70 60,52 120,38 180,18 240,4 300,-14 360,-30 420,-44 420,-12 360,2 300,18 240,38 180,52 120,72 60,86 0,100 0,70" fill="#2f6e3f"/>
+              <line x1="0" y1="180" x2="420" y2="108" stroke="#181613" stroke-width="0.6"/>
+              <line x1="0" y1="140" x2="420" y2="38" stroke="#181613" stroke-width="0.6"/>
+              <line x1="0" y1="100" x2="420" y2="-12" stroke="#181613" stroke-width="0.6"/>
+            </g>
+          </svg>
+          <ul class="ribbon-labels">
+            <li><i style="background:#2f6e3f"></i> strategic <b>$ 8.2m</b><span>17.5%</span></li>
+            <li><i style="background:#d4a02f"></i> enterprise <b>$ 14.6m</b><span>31.2%</span></li>
+            <li><i style="background:#d23f2a"></i> mid-market <b>$ 16.4m</b><span>35.0%</span></li>
+            <li><i style="background:#234a76"></i> self-serve <b>$ 7.6m</b><span>16.3%</span></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="tile tile-cohort">
+        <header class="tile-head">
+          <span class="folio-num">03</span>
+          <h2>Cohort retention · half-life</h2>
+          <span class="caption">Weekly cohorts by quarter · 4 discrete shade steps · darker = freshest</span>
+        </header>
+        <table class="cohort-grid">
+          <thead>
+            <tr>
+              <th>Cohort</th>
+              <th>Size</th>
+              <th>M1</th><th>M2</th><th>M3</th><th>M6</th><th>M12</th>
+              <th>Half-life</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-accent="blue">
+              <td>Q1 25</td><td class="num">1,124</td>
+              <td class="cell s4">96</td><td class="cell s3">93</td><td class="cell s3">91</td><td class="cell s2">86</td><td class="cell s1">81</td>
+              <td class="num">19.2 mo</td>
+            </tr>
+            <tr data-accent="blue">
+              <td>Q2 25</td><td class="num">1,288</td>
+              <td class="cell s4">95</td><td class="cell s3">92</td><td class="cell s3">90</td><td class="cell s2">85</td><td class="cell s1">80</td>
+              <td class="num">18.6 mo</td>
+            </tr>
+            <tr data-accent="mustard">
+              <td>Q3 25</td><td class="num">1,402</td>
+              <td class="cell s4">94</td><td class="cell s3">91</td><td class="cell s2">88</td><td class="cell s2">83</td><td class="cell s1">78</td>
+              <td class="num">17.4 mo</td>
+            </tr>
+            <tr data-accent="red">
+              <td>Q4 25</td><td class="num">1,538</td>
+              <td class="cell s4">93</td><td class="cell s3">90</td><td class="cell s2">87</td><td class="cell s1">82</td><td class="cell s1">—</td>
+              <td class="num">16.8 mo</td>
+            </tr>
+            <tr data-accent="red" class="hl">
+              <td>Q1 26</td><td class="num">1,712</td>
+              <td class="cell s4">94</td><td class="cell s2">88</td><td class="cell s1">84</td><td class="cell s1">—</td><td class="cell s1">—</td>
+              <td class="num">15.4 mo</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="caption-foot">Read row-by-row · the Q1-26 row bends earlier · see <a href="{{ base_url }}/memos/retention-deep-dive/">memo 01</a></p>
+      </article>
+
+    </section>
+
+    <hr class="rule">
+
+    <section class="tile-row tile-row-third">
+
+      <article class="tile tile-funnel">
+        <header class="tile-head">
+          <span class="folio-num">04</span>
+          <h2>Acquisition funnel</h2>
+          <span class="caption">Rhombi · April · self-serve</span>
+        </header>
+        <div class="funnel-stage">
+          <div class="rhom r1" style="--w:100%"><span class="rh-lbl">Visit</span><span class="rh-v">218,400</span></div>
+          <div class="rhom r2" style="--w:72%"><span class="rh-lbl">Trial</span><span class="rh-v">52,416</span></div>
+          <div class="rhom r3" style="--w:46%"><span class="rh-lbl">Activate</span><span class="rh-v">24,112</span></div>
+          <div class="rhom r4" style="--w:24%"><span class="rh-lbl">Paid</span><span class="rh-v">5,786</span></div>
+          <div class="rhom r5" style="--w:16%"><span class="rh-lbl">M3 retained</span><span class="rh-v">4,860</span></div>
+        </div>
+      </article>
+
+      <article class="tile tile-bridge">
+        <header class="tile-head">
+          <span class="folio-num">05</span>
+          <h2>ARR bridge · Q1 26</h2>
+          <span class="caption">From $ 42.1m to $ 46.8m</span>
+        </header>
+        <table class="bridge-table">
+          <tbody>
+            <tr><td>Starting</td><td class="num">$ 42.1m</td><td class="bar"><i class="b-base" style="--w:84%"></i></td></tr>
+            <tr><td>+ New logo</td><td class="num pos">+ 3.8</td><td class="bar"><i class="b-pos" style="--w:8%; --o:84%"></i></td></tr>
+            <tr><td>+ Expansion</td><td class="num pos">+ 2.4</td><td class="bar"><i class="b-pos" style="--w:5%; --o:92%"></i></td></tr>
+            <tr><td>− Contraction</td><td class="num neg">− 0.5</td><td class="bar"><i class="b-neg" style="--w:1%; --o:96%"></i></td></tr>
+            <tr><td>− Gross churn</td><td class="num neg">− 1.0</td><td class="bar"><i class="b-neg" style="--w:2%; --o:94%"></i></td></tr>
+            <tr class="ttl"><td><b>Ending</b></td><td class="num"><b>$ 46.8m</b></td><td class="bar"><i class="b-base" style="--w:94%"></i></td></tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="tile tile-kpis">
+        <header class="tile-head">
+          <span class="folio-num">06</span>
+          <h2>Unit economics</h2>
+          <span class="caption">Trailing 12 months</span>
+        </header>
+        <dl class="ue-list">
+          <dt>MRR</dt><dd class="num">$ 3.9<small>m</small></dd>
+          <dt>ARR</dt><dd class="num">$ 46.8<small>m</small></dd>
+          <dt>Gross margin</dt><dd class="num">74.2<small>%</small></dd>
+          <dt>Contribution margin</dt><dd class="num">38.1<small>%</small></dd>
+          <dt>NRR</dt><dd class="num">112<small>%</small></dd>
+          <dt>GRR</dt><dd class="num">94<small>%</small></dd>
+          <dt>CAC payback · self-serve</dt><dd class="num">4.9 mo</dd>
+          <dt>CAC payback · mid-market</dt><dd class="num">14.7 mo</dd>
+          <dt>Cohort half-life</dt><dd class="num">15.4 mo</dd>
+          <dt>Magic number</dt><dd class="num">1.21</dd>
+        </dl>
+      </article>
+
+    </section>
+
+    <hr class="rule rule-double">
+
+    <section class="tile tile-segments">
+      <header class="tile-head">
+        <span class="folio-num">07</span>
+        <h2>Segment explorer · top ten</h2>
+        <span class="caption">By contribution to net new ARR · April · bar = share · color = motion</span>
+      </header>
+      <ul class="seg-list">
+        <li data-accent="red"><span class="rank">01</span><span class="seg">Design agencies · 25 — 100 seats</span><span class="bar"><i style="--w:92%"></i></span><span class="num">$ 612K</span></li>
+        <li data-accent="blue"><span class="rank">02</span><span class="seg">Product teams · self-serve</span><span class="bar"><i style="--w:74%"></i></span><span class="num">$ 488K</span></li>
+        <li data-accent="mustard"><span class="rank">03</span><span class="seg">Fintech · enterprise</span><span class="bar"><i style="--w:64%"></i></span><span class="num">$ 426K</span></li>
+        <li data-accent="green"><span class="rank">04</span><span class="seg">Engineering platforms · strategic</span><span class="bar"><i style="--w:58%"></i></span><span class="num">$ 384K</span></li>
+        <li data-accent="red"><span class="rank">05</span><span class="seg">Design studios · 10 — 25 seats</span><span class="bar"><i style="--w:48%"></i></span><span class="num">$ 318K</span></li>
+        <li data-accent="blue"><span class="rank">06</span><span class="seg">Solo designers · self-serve</span><span class="bar"><i style="--w:42%"></i></span><span class="num">$ 278K</span></li>
+        <li data-accent="mustard"><span class="rank">07</span><span class="seg">Healthcare IT · enterprise</span><span class="bar"><i style="--w:36%"></i></span><span class="num">$ 240K</span></li>
+        <li data-accent="red"><span class="rank">08</span><span class="seg">Consultancies · 5 — 10 seats</span><span class="bar"><i style="--w:30%"></i></span><span class="num">$ 198K</span></li>
+        <li data-accent="green"><span class="rank">09</span><span class="seg">Government · strategic</span><span class="bar"><i style="--w:24%"></i></span><span class="num">$ 162K</span></li>
+        <li data-accent="blue"><span class="rank">10</span><span class="seg">Education · self-serve</span><span class="bar"><i style="--w:18%"></i></span><span class="num">$ 118K</span></li>
+      </ul>
+    </section>
+
+    <hr class="rule">
+
+    <section class="tile tile-memos">
+      <header class="tile-head">
+        <span class="folio-num">08</span>
+        <h2>Memos</h2>
+        <span class="caption">Long-form notes from the operating committee · one per month</span>
+      </header>
+      <ul class="memo-list">
+        {% for post in site.pages | where("section", "memos") | sort_by("date", reverse=true) %}
+          {% if loop.index <= 4 %}
+          <li>
+            <div class="num"><span class="folio-num">{{ loop.index }}</span></div>
+            <div class="copy">
+              <a href="{{ post.url }}">{{ post.title }}</a>
+              {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+            </div>
+            <div class="meta"><time>{{ post.date | date("%d %b · %Y") }}</time></div>
+          </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </section>
+
+  </main>
+{% include "footer.html" %}

--- a/examples/vertex-prism/templates/page.html
+++ b/examples/vertex-prism/templates/page.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="page">
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.date %}<div class="page-date"><span class="folio-num">M</span>{{ page.date | date("%d %B %Y") }}</div>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    <article class="prose">{{ content }}</article>
+    {% if page.tags %}
+    <footer class="page-foot">
+      <span class="lbl">tagged</span>
+      {% for t in page.tags %}<a class="chip" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t }}</a>{% endfor %}
+    </footer>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/examples/vertex-prism/templates/section.html
+++ b/examples/vertex-prism/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+  <main class="page">
+    {% if page.title is present %}<h1 class="page-title">{{ page.title | e }}</h1>{% endif %}
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+    {{ content }}
+    <ul class="memo-list">
+      {% for post in section.pages %}
+        <li>
+          <div class="num"><span class="folio-num">{{ loop.index }}</span></div>
+          <div class="copy">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+            {% if post.tags %}
+              <div class="row-tags">
+                {% for t in post.tags %}<span class="chip sm">{{ t }}</span>{% endfor %}
+              </div>
+            {% endif %}
+          </div>
+          <div class="meta">
+            <time>{{ post.date | date("%d %b · %Y") }}</time>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/vertex-prism/templates/taxonomy.html
+++ b/examples/vertex-prism/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="page">
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">All terms in this taxonomy.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/vertex-prism/templates/taxonomy_term.html
+++ b/examples/vertex-prism/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="page">
+    <h1 class="page-title">{{ page.title | e }}</h1>
+    <p class="page-desc">Memos and pages tagged with this term.</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2436,6 +2436,12 @@
     "celestial",
     "dramatic"
   ],
+  "eclipse-tape": [
+    "dark",
+    "dashboard",
+    "trading",
+    "monospace"
+  ],
   "editorial-letter": [
     "paper",
     "light",
@@ -2890,6 +2896,12 @@
     "neon",
     "pop-art"
   ],
+  "flux-foundry": [
+    "light",
+    "dashboard",
+    "brutalist",
+    "industrial"
+  ],
   "folio": [
     "light",
     "portfolio"
@@ -3323,6 +3335,12 @@
     "blog",
     "glassmorphism",
     "minimal"
+  ],
+  "glyph-orbital": [
+    "dark",
+    "dashboard",
+    "scientific",
+    "monospace"
   ],
   "glyphic": [
     "dark",
@@ -5091,6 +5109,12 @@
     "light",
     "blog",
     "magazine"
+  ],
+  "mosaic-bionics": [
+    "dark",
+    "dashboard",
+    "scientific",
+    "lab"
   ],
   "mosaic-wall": [
     "structured",
@@ -8473,6 +8497,12 @@
     "spread",
     "contrast",
     "editorial"
+  ],
+  "vertex-prism": [
+    "light",
+    "dashboard",
+    "isometric",
+    "geometric"
   ],
   "vertigo": [
     "dark",


### PR DESCRIPTION
## Summary

Adds five new dashboard-tagged example sites, each committed to a distinct visual stance:

- **glyph-orbital** (dark) — satellite ground-station ops console with inline-SVG nested orbital arcs and a 12-hour pass schedule
- **flux-foundry** (light) — brutalist steelworks ops console anchored by three 132px kiln gauges in Archivo Black
- **mosaic-bionics** (dark) — biotech wet-lab dashboard with a 96-well hex heatmap rendered in five *discrete* color bins (no gradient)
- **vertex-prism** (light) — isometric BI exploration deck built from CSS-3D cube towers in a Memphis/Constructivist palette
- **eclipse-tape** (dark) — trading desk tape and Level-2 order book anchored by a 200px monospace P&L

Each site ships with a dense homepage console, an about/manual page, a four-entry archive section, full template set, and an entry in `tags.json`.

## Compliance

- **No gradients**: verified zero `linear-gradient` / `radial-gradient` / `conic-gradient` declarations across all five sites.
- **No emojis**: verified zero emoji codepoints in templates and CSS.
- **CSS sizes**: 860–1006 lines per site, externalized per the AGENTS.md convention.
- **Crinja-safe**: no array-literal `in` operators; `{{ content }}` (not `page.content`); custom metadata via `page.extra.*`.

## Test plan

- [x] \`hwaro doctor --fix\` on each new site (added the standard set of optional commented-out config sections)
- [x] \`hwaro build\` on each new site — all 5 build cleanly, 7 pages each, no warnings
- [x] \`tags.json\` validates as JSON (1433 entries) with all 5 new keys present
- [ ] CI build of the full \`examples/\` set passes
- [ ] Screenshots on the deployed index page look as intended