### PR TITLE
Add five bold docs example sites with distinct typographic systems

### DIFF
--- a/examples/dictation-log/AGENTS.md
+++ b/examples/dictation-log/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/dictation-log/archetypes/default.md
+++ b/examples/dictation-log/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/dictation-log/config.toml
+++ b/examples/dictation-log/config.toml
@@ -1,0 +1,190 @@
+title = "Dictation Log"
+description = "Documentation laid out as audio transcripts — timestamps in the gutter, solid waveform bars in the margin."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+heading_ids = true
+footnotes = true
+task_lists = true
+admonitions = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/dictation-log/content/about.md
+++ b/examples/dictation-log/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "Studio Notes"
+description = "How the log is recorded, transcribed, and filed."
++++
+
+Recordings are made on a single SM7B through a Cloudlifter into a Universal Audio Apollo. Sample rate is 48 kHz, bit depth is 16, channels are mono. The signal chain is the same for every episode — a discipline that makes diffs between recordings honest.
+
+Transcripts are generated locally with Whisper Large v3, then hand-edited for accuracy. Speaker tags are added on the second pass. Timestamps are accurate to the second; do not trust them at sub-second resolution.
+
+Tapes are stored as `.flac` in a flat directory keyed by date. The filing system has been the same since 2019 and is the most important infrastructure decision documented in this log.

--- a/examples/dictation-log/content/episodes/_index.md
+++ b/examples/dictation-log/content/episodes/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Episodes"
+description = "Six tapes on file. Read in order, or jump to whichever session calls you."
+sort_by = "weight"
+template = "section"
++++

--- a/examples/dictation-log/content/episodes/annotation-passes.md
+++ b/examples/dictation-log/content/episodes/annotation-passes.md
@@ -1,0 +1,33 @@
++++
+title = "Annotation Passes"
+description = "The second listen, where you add the marginalia."
+date = "2026-01-29"
+weight = 4
+template = "doc"
+[extra]
+episode_num = 4
+runtime = "11:20"
+operator = "OPER-7"
+tape = "T-04-A"
+kind = "editing"
++++
+
+The first pass is the recording. The second pass is the annotation — and the annotation is where most of the value of the log comes from. A raw transcript is data. An annotated transcript is documentation.
+
+## When to annotate
+
+Annotate within a week of the recording, never the same day. Same-day annotation reproduces what you already said. Week-old annotation adds what you forgot to say, what you now understand differently, and what the team has corrected you on.
+
+A month is too long. By a month, your memory of the session has hardened into your transcript-as-truth, and you will not see the gaps.
+
+## What an annotation looks like
+
+An annotation is one paragraph, set apart from the original transcript, marked with a date and an operator code. Never edit the original transcript. Never delete a transcript line. The annotation sits beside the original, both available to the reader.
+
+> Two truths. The original truth at recording time. The corrected truth at annotation time. Both visible. The reader chooses what to believe.
+
+## What not to annotate
+
+Do not annotate typos. Do not annotate misspeaks that were obvious in context. Do not annotate to remove embarrassment. The transcript is a record of how you thought, and editing for embarrassment is editing for vanity — not for the reader.
+
+Annotate to *clarify*, to *correct factual error*, and to *add the thing you forgot*. Nothing else.

--- a/examples/dictation-log/content/episodes/archive-protocol.md
+++ b/examples/dictation-log/content/episodes/archive-protocol.md
@@ -1,0 +1,46 @@
++++
+title = "Archive Protocol"
+description = "How a tape becomes a record."
+date = "2026-02-05"
+weight = 5
+template = "doc"
+[extra]
+episode_num = 5
+runtime = "07:34"
+operator = "OPER-7"
+tape = "T-05-A"
+kind = "archive"
++++
+
+A tape becomes a record when three things are true: it has a slate, it has a transcript, and it has at least one annotation pass. Until all three exist, the recording is a draft. After all three exist, it is permanent.
+
+## The flat-file principle
+
+Every archived tape lives in a single flat directory, keyed by date. No nesting. No taxonomy. No project folders. The taxonomy comes from the tag system inside the transcript — not from the filesystem.
+
+```
+archive/
+  2026-01-08-session-zero/
+    tape.flac
+    transcript.md
+    annotations.md
+  2026-01-15-transcript-format/
+    tape.flac
+    transcript.md
+    annotations.md
+  ...
+```
+
+Flat directories survive software changes. Nested taxonomies do not. Every nesting scheme this archive has tried in seven years has been migrated to flat, and the flat version has stayed.
+
+## Retention
+
+Tapes are retained indefinitely. Transcripts are retained indefinitely. Annotations are retained indefinitely. Deletion happens only on legal request, and is logged in a public record that survives the deletion.
+
+This is the *one* place where the archive is heavier than it needs to be — and the place where the archive is most worth its weight.
+
+## Destruction protocol
+
+In the rare case that a tape must be destroyed, three signatures are required: the operator who made the recording, the archivist on duty, and the legal officer who approved the destruction. The destruction is logged with the date, the reason, and the three signatures. The tape is then deleted.
+
+Nothing else is deleted. The record of the deletion remains.

--- a/examples/dictation-log/content/episodes/operator-vocabulary.md
+++ b/examples/dictation-log/content/episodes/operator-vocabulary.md
@@ -1,0 +1,49 @@
++++
+title = "Operator Vocabulary"
+description = "The forty-odd terms an operator uses on tape."
+date = "2026-02-12"
+weight = 6
+template = "doc"
+[extra]
+episode_num = 6
+runtime = "06:18"
+operator = "OPER-7"
+tape = "T-06-A"
+kind = "glossary"
++++
+
+If you have read through to episode six, you have heard most of these terms in context. This is the reference. Listed in the order an operator encounters them on a normal session.
+
+## Pre-recording
+
+**Slate** — the opening ten seconds of any session, naming the date, the session number, and the intent.
+
+**Cold check** — the thirty seconds of silence recorded before the first word, to confirm the chain is clean.
+
+**Gain ride** — adjusting the preamp gain during the session to keep the signal level steady. A discipline. Not a luxury.
+
+## During recording
+
+**Mid-tape check** — the third-of-the-way pause, where the operator listens back to confirm the recording is live.
+
+**Side flip** — the moment between side A and side B. Always slated.
+
+**Annotation cue** — a verbal marker the operator says aloud ("note for later") that flags a moment for the second pass.
+
+## Post-recording
+
+**Pass** — a complete listen-through of a session. The first pass is recording; the second is annotation; the third is finalization.
+
+**Marginalia** — what annotations are. Notes set beside the original line, never replacing it.
+
+**Permanent** — the state of a tape after three passes. Once permanent, the tape is added to the archive and cannot be edited.
+
+## The archive
+
+**Flat file** — the principle that every tape lives in a single directory, keyed by date, with no nesting.
+
+**Destruction protocol** — the three-signature process for removing a tape from the archive.
+
+**Tombstone** — the record that remains after a tape is destroyed.
+
+Return to the [Log](/) when you have read enough.

--- a/examples/dictation-log/content/episodes/recording-rituals.md
+++ b/examples/dictation-log/content/episodes/recording-rituals.md
@@ -1,0 +1,45 @@
++++
+title = "Recording Rituals"
+description = "The opening slate, the mid-tape check, the closing sign-off."
+date = "2026-01-22"
+weight = 3
+template = "doc"
+[extra]
+episode_num = 3
+runtime = "09:55"
+operator = "OPER-7"
+tape = "T-03-A"
+kind = "practice"
++++
+
+Every studio has rituals. Some are technical, some are theatrical, all of them are useful. A ritual is what you do without thinking, so the thing you should be thinking about gets your full attention.
+
+## The opening slate
+
+A slate is the first ten seconds of any recording. Three pieces of information, in order, every time:
+
+1. The date, full year first.
+2. The session number and side.
+3. A one-sentence intent for the session.
+
+The slate is not for the listener. The slate is for the *archivist*, who six months from now will be sorting through unmarked recordings and trying to figure out which one is which.
+
+```
+OPER: Two thousand twenty-six,
+      session four, side A.
+      Today we're documenting the rollback procedure.
+```
+
+That's the slate. Stop the recording, listen back, confirm the slate is audible, then start session four.
+
+## The mid-tape check
+
+About a third of the way through a session, stop. Say "Mid-tape check," and listen back to the last thirty seconds. You are checking three things: that the recording is still live, that the levels are still good, that the room has not turned into a fan.
+
+If anything is wrong, you have caught it at the third, not at the end. If everything is right, you have a checkpoint you can find in the transcript later.
+
+## The closing sign-off
+
+A session ends with a sentence that names what was accomplished and a sentence that names what was not. Always in that order. The temptation is to end on what's left, because that is what's on your mind — but the *accomplishment* is what an archivist needs to find this tape in five years.
+
+> Sign off, then stop the recording. Not the other way around. A clipped sign-off is a corrupted tape.

--- a/examples/dictation-log/content/episodes/session-zero.md
+++ b/examples/dictation-log/content/episodes/session-zero.md
@@ -1,0 +1,40 @@
++++
+title = "Session Zero — Setting Up The Studio"
+description = "What's in the box, how to plug it in, and what to record first."
+date = "2026-01-08"
+weight = 1
+template = "doc"
+[extra]
+episode_num = 1
+runtime = "08:42"
+operator = "OPER-7"
+tape = "T-01-A"
+kind = "setup"
++++
+
+OK, recording. Session zero. Today's job is to get the studio working — not to record anything useful yet, just to make sure the next recording will be useful.
+
+The microphone needs to be six inches from your mouth, no closer, no further. Closer and the plosives blow out the diaphragm. Further and the room takes over the signal. Six inches. Tape a mark to the desk if you have to.
+
+## What you need on the bench
+
+The minimum kit is smaller than people think. One microphone, one preamp, one interface, one cable per stage. If you already have a laptop, that's the fifth piece.
+
+- Dynamic microphone, broadcast style.
+- A clean preamp with at least 60 dB of gain.
+- An interface with a real headphone output.
+- One XLR cable per stage. Not three. One.
+
+You do not need a mixer for session zero. A mixer is for sessions four and onward, when you start cutting between sources. For session zero, every signal goes straight from microphone to interface, and you listen to your own voice on a single channel.
+
+## Plug it in
+
+Power the interface first. Always. Phantom power going into an unpowered interface can damage the microphone. Once the interface is awake, plug in the microphone. Once the microphone is plugged in, enable phantom — unless you are running a dynamic microphone like the SM7B, in which case do not enable phantom at all.
+
+> Phantom power on a dynamic does nothing useful and risks damaging older capsules. Read the microphone's spec sheet once. Then read it again.
+
+## Record thirty seconds of nothing
+
+Before you say anything, record thirty seconds of silence. Listen back. If you hear hum, the cable is the suspect. If you hear hiss, the gain is too high. If you hear room tone, you've passed.
+
+Now you can start session one.

--- a/examples/dictation-log/content/episodes/transcript-format.md
+++ b/examples/dictation-log/content/episodes/transcript-format.md
@@ -1,0 +1,42 @@
++++
+title = "The Transcript Format"
+description = "Why every paragraph carries a timestamp and what the operator tags mean."
+date = "2026-01-15"
+weight = 2
+template = "doc"
+[extra]
+episode_num = 2
+runtime = "12:08"
+operator = "OPER-7"
+tape = "T-02-A"
+kind = "reference"
++++
+
+The transcript format is opinionated. Every paragraph carries a numeric stamp on the left. Every block of code, every quoted line, every list is offset to the right so the timeline stays visible. This is not decoration — it is how a transcript stays navigable.
+
+If you are reading this episode in the player, the stamps line up to the audio. If you are reading the printed page, the stamps tell you where you are inside the document.
+
+## Why timestamps in the margin
+
+A long-form document without internal addresses is a lost document. You can quote a section, but you cannot point to a moment. Timestamps in the margin give every paragraph a unique address you can link to, cite, and return to.
+
+Section anchors solve the same problem in conventional documentation, but at a coarser grain. A section anchor points to a heading. A timestamp points to a *sentence*.
+
+## What the operator tags mean
+
+The transcripts mark up four kinds of speech:
+
+| Tag | What it means |
+|-----|---------------|
+| OPER | The primary operator speaking |
+| ANN | An annotation added after the fact |
+| QUOTE | Someone the operator is quoting |
+| TAPE | A break, side flip, or signal change |
+
+The annotations are the most useful tag for readers — they let the operator come back to a session a week later and add what they were too distracted to say in the moment. Annotations never overwrite the original transcript; they sit beside it.
+
+## How to read out loud
+
+If you are recording your own transcript, talk *slowly* and *finish sentences*. Reading the transcript back later, you will notice that what felt like a slow pace on tape sounds like a normal pace on the page. People speak faster than they read.
+
+> The transcript is a *gift to your future self*. Speak to that person the way you would write to them — with respect for their time.

--- a/examples/dictation-log/content/index.md
+++ b/examples/dictation-log/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Dictation Log"
+description = "Documentation, spoken into a microphone."
++++
+
+The fastest way to capture knowledge is to talk through what you're doing while you do it. The slowest way to find that knowledge again is to leave the recording in a folder labeled *random_audio*.
+
+This log is what happens when you treat the recording as the document. Every page below is a transcript, time-stamped and indexed. Start at [Episode 01](/episodes/session-zero/), or read the [Studio Notes](/about/) first.

--- a/examples/dictation-log/static/css/style.css
+++ b/examples/dictation-log/static/css/style.css
@@ -1,0 +1,613 @@
+:root {
+  --bg: #0d0f12;
+  --bg-soft: #14171c;
+  --bg-deep: #1c2128;
+  --line: #2a313c;
+  --ink: #e8e3d7;
+  --ink-soft: #a8a298;
+  --margin: #6c6a63;
+  --amber: #f0a04b;
+  --record: #e25444;
+  --green: #6fc28a;
+  --cyan: #65b7d4;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
+body {
+  background: var(--bg);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='4'><rect width='4' height='1' fill='%23ffffff' fill-opacity='0.018'/></svg>");
+  color: var(--ink);
+  font-family: 'IBM Plex Mono', 'JetBrains Mono', monospace;
+  font-size: 15px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--amber); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; text-decoration-color: rgba(240,160,75,0.4); }
+a:hover { color: var(--ink); text-decoration-color: var(--ink); }
+
+.shell { max-width: 1320px; margin: 0 auto; padding: 0 32px; }
+
+/* ---- transport bar (masthead) ---- */
+.transport {
+  border-bottom: 1px solid var(--line);
+  padding: 16px 0;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 28px;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  background: rgba(13,15,18,0.96);
+  backdrop-filter: blur(8px);
+  z-index: 20;
+}
+.t-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  color: var(--ink);
+}
+.t-brand .rec-dot {
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--record);
+  box-shadow: 0 0 0 3px rgba(226,84,68,0.18);
+  flex-shrink: 0;
+}
+.t-brand .name {
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+.t-brand .name .meta { color: var(--margin); font-weight: 400; letter-spacing: 0.18em; margin-left: 10px; font-size: 11px; }
+
+.t-mid {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.waveform {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  height: 28px;
+  padding: 0 8px;
+  border-left: 1px solid var(--line);
+  border-right: 1px solid var(--line);
+  flex: 1;
+  min-width: 0;
+  max-width: 380px;
+  overflow: hidden;
+}
+.waveform i {
+  display: block;
+  width: 3px;
+  background: var(--ink-soft);
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+.waveform i.amber { background: var(--amber); }
+.waveform i.dim { background: var(--margin); }
+
+.t-counter {
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  color: var(--ink);
+}
+.t-counter b { color: var(--amber); font-weight: 700; }
+
+.t-right {
+  display: flex;
+  gap: 14px;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.t-right a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+.t-right a:hover, .t-right a.active { color: var(--bg); background: var(--ink); border-color: var(--ink); }
+
+/* ---- home ---- */
+.cover {
+  padding: 60px 0 50px;
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 56px;
+  align-items: start;
+}
+.cover .stamp {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--margin);
+  margin-bottom: 22px;
+}
+.cover h1 {
+  font-size: 76px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  font-weight: 700;
+  margin-bottom: 26px;
+  color: var(--ink);
+}
+.cover h1 .amber { color: var(--amber); }
+.cover .lede {
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  max-width: 580px;
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+}
+
+.cover .session-card {
+  background: var(--bg-soft);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 22px 24px;
+  font-size: 13px;
+}
+.cover .session-card h4 {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 16px;
+  border-bottom: 1px dashed var(--line);
+  padding-bottom: 10px;
+}
+.cover .session-card .row { display: flex; justify-content: space-between; padding: 4px 0; }
+.cover .session-card .row span:first-child { color: var(--margin); text-transform: uppercase; font-size: 11px; letter-spacing: 0.12em; }
+.cover .session-card .row b { color: var(--ink); }
+.cover .session-card .bar {
+  height: 6px;
+  background: var(--bg-deep);
+  border-radius: 2px;
+  margin: 14px 0 6px;
+  position: relative;
+  overflow: hidden;
+}
+.cover .session-card .bar i {
+  display: block;
+  height: 100%;
+  width: 64%;
+  background: var(--amber);
+}
+
+/* ---- episode list ---- */
+.episodes {
+  padding: 50px 0;
+}
+.episodes h2 {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.episodes h2::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+
+.ep-row {
+  display: grid;
+  grid-template-columns: 60px 80px 1fr auto auto;
+  gap: 24px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--line);
+  text-decoration: none;
+  color: var(--ink);
+  align-items: center;
+  transition: background 0.15s ease;
+}
+.ep-row:hover { background: var(--bg-soft); }
+.ep-row .ep-num {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--amber);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+.ep-row .ep-mini-wave {
+  display: flex;
+  gap: 1px;
+  align-items: center;
+  height: 28px;
+}
+.ep-row .ep-mini-wave i {
+  display: block;
+  width: 2px;
+  background: var(--ink-soft);
+}
+.ep-row .ep-title {
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 1.3;
+}
+.ep-row .ep-title .desc {
+  display: block;
+  font-size: 13px;
+  color: var(--ink-soft);
+  font-family: 'IBM Plex Sans', sans-serif;
+  margin-top: 4px;
+  font-weight: 400;
+}
+.ep-row .ep-tag {
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--margin);
+  border: 1px solid var(--line);
+  padding: 4px 10px;
+  border-radius: 100px;
+}
+.ep-row .ep-len {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink-soft);
+}
+
+/* ---- doc layout ---- */
+.doc-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 48px;
+  padding: 36px 0 80px;
+}
+.tracklist {
+  position: sticky;
+  top: 90px;
+  align-self: start;
+  max-height: calc(100vh - 130px);
+  overflow-y: auto;
+  border-right: 1px solid var(--line);
+  padding-right: 24px;
+}
+.tracklist h4 {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.tracklist h4::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+.tracklist a {
+  display: grid;
+  grid-template-columns: 26px 1fr auto;
+  gap: 10px;
+  padding: 10px 6px;
+  text-decoration: none;
+  color: var(--ink-soft);
+  border-radius: 4px;
+  font-size: 13px;
+  align-items: center;
+}
+.tracklist a:hover { background: var(--bg-soft); color: var(--ink); }
+.tracklist a.active { background: var(--bg-deep); color: var(--ink); }
+.tracklist a.active .num { color: var(--amber); }
+.tracklist a .num { color: var(--margin); font-variant-numeric: tabular-nums; font-weight: 700; }
+.tracklist a .ttl { line-height: 1.3; }
+.tracklist a .len { font-size: 11px; color: var(--margin); font-variant-numeric: tabular-nums; }
+
+article.doc { min-width: 0; }
+.episode-head {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 28px 30px 24px;
+  margin-bottom: 36px;
+  background: var(--bg-soft);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 30px;
+  align-items: end;
+}
+.episode-head .pre {
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 14px;
+}
+.episode-head h1 {
+  font-size: 40px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  margin-bottom: 12px;
+  color: var(--ink);
+}
+.episode-head .desc {
+  font-size: 15px;
+  font-family: 'IBM Plex Sans', sans-serif;
+  color: var(--ink-soft);
+  line-height: 1.5;
+  max-width: 600px;
+}
+.episode-head .meta-block {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--margin);
+  text-align: right;
+  line-height: 1.9;
+}
+.episode-head .meta-block b { color: var(--ink); font-weight: 700; }
+
+.transcript-strip {
+  height: 56px;
+  background: var(--bg-deep);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 12px 14px;
+  margin-bottom: 30px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.transcript-strip .play {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--amber);
+  color: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.transcript-strip .full-wave {
+  flex: 1;
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  height: 28px;
+  overflow: hidden;
+  min-width: 0;
+}
+.transcript-strip .full-wave i {
+  display: block;
+  width: 2px;
+  flex-shrink: 0;
+  background: var(--ink-soft);
+}
+.transcript-strip .full-wave i.amber { background: var(--amber); }
+.transcript-strip .time { font-size: 12px; font-variant-numeric: tabular-nums; color: var(--ink-soft); flex-shrink: 0; }
+.transcript-strip .time b { color: var(--ink); }
+
+/* doc body in transcript style */
+.doc-body { font-size: 15px; line-height: 1.75; max-width: 760px; }
+.doc-body h2 {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 48px 0 18px;
+  padding-left: 12px;
+  border-left: 4px solid var(--amber);
+  color: var(--ink);
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+.doc-body h2::before {
+  content: "[ " counter(h2-counter, decimal-leading-zero) " ]";
+  counter-increment: h2-counter;
+  color: var(--amber);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+}
+.doc-body { counter-reset: h2-counter; }
+.doc-body h3 {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 28px 0 8px;
+  color: var(--cyan);
+}
+
+/* paragraphs as transcript entries */
+.doc-body p {
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  gap: 18px;
+  margin: 18px 0;
+  padding: 6px 0;
+  border-left: 1px solid var(--line);
+  padding-left: 16px;
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+  font-size: 15.5px;
+  line-height: 1.65;
+  color: var(--ink);
+}
+.doc-body { counter-reset: h2-counter ts-counter; }
+.doc-body p { counter-increment: ts-counter; }
+.doc-body p::before {
+  content: "[ " counter(ts-counter, decimal-leading-zero) " ]";
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--amber);
+  font-variant-numeric: tabular-nums;
+  padding-top: 3px;
+  font-weight: 600;
+}
+
+.doc-body strong { color: var(--amber); font-weight: 700; }
+.doc-body em { color: var(--cyan); font-style: normal; }
+
+.doc-body ul, .doc-body ol {
+  margin: 12px 0 16px 100px;
+  font-family: 'IBM Plex Sans', sans-serif;
+}
+.doc-body li { margin: 8px 0; }
+.doc-body ul li::marker { color: var(--amber); content: "▶ "; }
+.doc-body ol li::marker { color: var(--cyan); font-family: 'IBM Plex Mono', monospace; }
+
+.doc-body code {
+  font-family: 'IBM Plex Mono', monospace;
+  background: var(--bg-deep);
+  padding: 2px 6px;
+  font-size: 13px;
+  color: var(--amber);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+.doc-body pre {
+  background: var(--bg-deep);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--amber);
+  padding: 18px 22px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  overflow-x: auto;
+  margin: 22px 0 22px 100px;
+  border-radius: 0 4px 4px 0;
+}
+.doc-body pre code { background: none; border: none; padding: 0; color: var(--ink); }
+
+.doc-body blockquote {
+  margin: 24px 0 24px 100px;
+  padding: 16px 22px;
+  background: var(--bg-soft);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--cyan);
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-style: italic;
+  color: var(--ink);
+  border-radius: 0 4px 4px 0;
+  font-size: 15px;
+}
+.doc-body blockquote::before {
+  content: "ANNOTATION";
+  display: block;
+  font-family: 'IBM Plex Mono', monospace;
+  font-style: normal;
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  color: var(--cyan);
+  margin-bottom: 8px;
+}
+
+.doc-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 22px 0 22px 100px;
+  width: calc(100% - 100px);
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 14px;
+  border: 1px solid var(--line);
+}
+.doc-body th {
+  background: var(--bg-deep);
+  text-align: left;
+  padding: 8px 12px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--amber);
+  border-bottom: 1px solid var(--line);
+}
+.doc-body td { padding: 8px 12px; border-bottom: 1px solid var(--line); color: var(--ink-soft); }
+.doc-body tr:hover td { color: var(--ink); background: var(--bg-soft); }
+
+.doc-body hr {
+  border: 0;
+  text-align: center;
+  margin: 30px 0;
+  position: relative;
+  color: var(--margin);
+}
+.doc-body hr::after {
+  content: "— END OF SIDE A · TURN TAPE —";
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.3em;
+}
+
+/* nav */
+.doc-nav {
+  margin-top: 60px;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+.doc-nav a {
+  text-decoration: none;
+  border: 1px solid var(--line);
+  padding: 16px 18px;
+  background: var(--bg-soft);
+  color: var(--ink);
+  border-radius: 6px;
+  display: block;
+  transition: border-color 0.15s ease;
+}
+.doc-nav a:hover { border-color: var(--amber); }
+.doc-nav .label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--amber);
+  display: block;
+  margin-bottom: 4px;
+}
+.doc-nav .title { font-weight: 700; font-size: 15px; line-height: 1.3; }
+.doc-nav .next { text-align: right; }
+
+/* footer */
+.colophon {
+  border-top: 1px solid var(--line);
+  padding: 32px 0 44px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 30px;
+  font-size: 12px;
+  color: var(--margin);
+}
+.colophon h5 {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 8px;
+}
+.colophon a { color: var(--ink); }
+
+@media (max-width: 960px) {
+  .shell { padding: 0 18px; }
+  .transport { grid-template-columns: 1fr auto; }
+  .t-mid { display: none; }
+  .cover { grid-template-columns: 1fr; gap: 30px; }
+  .cover h1 { font-size: 50px; }
+  .doc-shell { grid-template-columns: 1fr; }
+  .tracklist { position: static; max-height: none; border-right: 0; border-bottom: 1px solid var(--line); padding-bottom: 18px; }
+  .episode-head { grid-template-columns: 1fr; }
+  .episode-head .meta-block { text-align: left; }
+  .doc-body p { grid-template-columns: 60px 1fr; gap: 10px; }
+  .doc-body ul, .doc-body ol, .doc-body pre, .doc-body blockquote, .doc-body table { margin-left: 0; width: 100%; }
+  .colophon { grid-template-columns: 1fr; }
+  .ep-row { grid-template-columns: 40px 1fr auto; }
+  .ep-row .ep-mini-wave, .ep-row .ep-tag { display: none; }
+}

--- a/examples/dictation-log/static/favicon.svg
+++ b/examples/dictation-log/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/dictation-log/templates/404.html
+++ b/examples/dictation-log/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main style="padding:100px 0;text-align:center;">
+  <div style="font-size:11px;letter-spacing:0.3em;text-transform:uppercase;color:var(--amber);margin-bottom:20px;">— SIGNAL LOST —</div>
+  <div style="font-size:160px;font-weight:700;letter-spacing:-0.05em;color:var(--ink);">404</div>
+  <h1 style="font-size:32px;font-weight:700;margin:24px 0 14px;letter-spacing:-0.02em;">Dead Tape</h1>
+  <p style="max-width:480px;margin:0 auto 28px;font-family:'IBM Plex Sans',sans-serif;color:var(--ink-soft);font-size:16px;line-height:1.5;">The recording exists in the index but the tape itself is blank. The signal was lost between session and archive.</p>
+  <a href="{{ base_url }}/" style="font-size:11px;letter-spacing:0.22em;text-transform:uppercase;border:1px solid var(--line);padding:12px 22px;text-decoration:none;color:var(--ink);display:inline-block;border-radius:4px;">↩ Return to Log</a>
+</main>
+{% include "footer.html" %}

--- a/examples/dictation-log/templates/doc.html
+++ b/examples/dictation-log/templates/doc.html
@@ -1,0 +1,64 @@
+{% include "header.html" %}
+<main class="doc-shell">
+  <aside class="tracklist">
+    <h4>Tracklist</h4>
+    {% if section.pages %}
+      {% for doc in section.pages %}
+      <a href="{{ base_url }}{{ doc.url }}" {% if doc.url == page.url %}class="active"{% endif %}>
+        <span class="num">{{ "%02d" | format(loop.index) }}</span>
+        <span class="ttl">{{ doc.title }}</span>
+        <span class="len">{{ doc.extra.runtime | default(value="—") }}</span>
+      </a>
+      {% endfor %}
+    {% endif %}
+
+    <h4 style="margin-top:24px;">Studio</h4>
+    <a href="{{ base_url }}/"><span class="num">▶</span><span class="ttl">Log</span><span></span></a>
+    <a href="{{ base_url }}/about/"><span class="num">▶</span><span class="ttl">Studio Notes</span><span></span></a>
+    <a href="{{ base_url }}/tags/"><span class="num">▶</span><span class="ttl">Topic Index</span><span></span></a>
+  </aside>
+
+  <article class="doc">
+    <header class="episode-head">
+      <div>
+        <div class="pre">EPISODE {{ "%02d" | format(page.extra.episode_num | default(value=1)) }} · {{ page.date | date(format="%d %b %Y") | upper }}</div>
+        <h1>{{ page.title }}</h1>
+        {% if page.description %}<p class="desc">{{ page.description }}</p>{% endif %}
+      </div>
+      <div class="meta-block">
+        <div>RUNTIME · <b>{{ page.extra.runtime | default(value="—") }}</b></div>
+        <div>OPERATOR · <b>{{ page.extra.operator | default(value="OPER-7") }}</b></div>
+        <div>TAPE · <b>{{ page.extra.tape | default(value="T-04-A") }}</b></div>
+        <div>READ · <b>{{ page.reading_time | default(value="—") }} MIN</b></div>
+      </div>
+    </header>
+
+    <div class="transcript-strip">
+      <div class="play">▶</div>
+      <div class="full-wave">
+        <i style="height:6px"></i><i style="height:14px"></i><i style="height:8px"></i><i style="height:18px"></i><i style="height:22px;background:var(--amber)"></i><i style="height:11px"></i><i style="height:9px"></i><i style="height:14px"></i><i style="height:6px"></i><i style="height:18px;background:var(--amber)"></i><i style="height:22px"></i><i style="height:8px"></i><i style="height:14px"></i><i style="height:11px"></i><i style="height:6px;background:var(--amber)"></i><i style="height:18px"></i><i style="height:22px"></i><i style="height:14px"></i><i style="height:8px"></i><i style="height:6px;background:var(--amber)"></i><i style="height:11px"></i><i style="height:18px"></i><i style="height:9px"></i><i style="height:14px;background:var(--amber)"></i><i style="height:22px"></i><i style="height:6px"></i><i style="height:11px"></i><i style="height:18px;background:var(--amber)"></i><i style="height:8px"></i><i style="height:14px"></i><i style="height:22px"></i><i style="height:9px"></i><i style="height:6px;background:var(--amber)"></i><i style="height:11px"></i><i style="height:18px"></i><i style="height:14px"></i><i style="height:22px"></i><i style="height:8px;background:var(--amber)"></i><i style="height:6px"></i><i style="height:11px"></i><i style="height:18px"></i><i style="height:9px;background:var(--amber)"></i><i style="height:22px"></i><i style="height:14px"></i><i style="height:6px"></i><i style="height:18px"></i><i style="height:11px;background:var(--amber)"></i><i style="height:9px"></i><i style="height:22px"></i><i style="height:8px"></i><i style="height:14px;background:var(--amber)"></i><i style="height:6px"></i><i style="height:18px"></i><i style="height:11px"></i><i style="height:9px"></i><i style="height:22px;background:var(--amber)"></i><i style="height:14px"></i><i style="height:8px"></i><i style="height:18px"></i><i style="height:11px"></i><i style="height:6px;background:var(--amber)"></i>
+      </div>
+      <div class="time"><b>00:00</b> / {{ page.extra.runtime | default(value="—") }}</div>
+    </div>
+
+    <div class="doc-body">
+      {{ content }}
+    </div>
+
+    <nav class="doc-nav">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}">
+        <span class="label">◀ PREV TAPE</span>
+        <span class="title">{{ page.lower.title }}</span>
+      </a>
+      {% else %}<span></span>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="next">
+        <span class="label">NEXT TAPE ▶</span>
+        <span class="title">{{ page.higher.title }}</span>
+      </a>
+      {% else %}<span></span>{% endif %}
+    </nav>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/dictation-log/templates/footer.html
+++ b/examples/dictation-log/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="colophon">
+      <div>
+        <h5>{{ site.title }}</h5>
+        <p>Documentation as field recording. Every page is an episode of someone working through a problem out loud, time-stamped and annotated for the reader who arrives later.</p>
+      </div>
+      <div>
+        <h5>Studio</h5>
+        <p>Recording chain<br>SM7B → Cloudlifter → Apollo<br>16-bit / 48 kHz / mono</p>
+      </div>
+      <div>
+        <h5>Subscribe</h5>
+        <p><a href="{{ base_url }}/feeds/rss.xml">RSS</a> · <a href="{{ base_url }}/about/">Studio Notes</a><br>&copy; {{ current_year }} {{ site.title }}</p>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/dictation-log/templates/header.html
+++ b/examples/dictation-log/templates/header.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} — {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="shell">
+    <header class="transport">
+      <a class="t-brand" href="{{ base_url }}/">
+        <span class="rec-dot"></span>
+        <div class="name">{{ site.title | upper }} <span class="meta">·  REC</span></div>
+      </a>
+      <div class="t-mid">
+        <span>WAVE</span>
+        <span class="waveform">
+          <i style="height:6px"></i><i style="height:10px"></i><i style="height:18px"></i><i style="height:22px;" class="amber"></i><i style="height:14px"></i><i style="height:9px"></i><i style="height:24px"></i><i style="height:18px;" class="amber"></i><i style="height:11px"></i><i style="height:6px;" class="dim"></i><i style="height:14px"></i><i style="height:20px"></i><i style="height:8px"></i><i style="height:16px;" class="amber"></i><i style="height:9px"></i><i style="height:11px"></i><i style="height:6px;" class="dim"></i><i style="height:20px"></i><i style="height:24px"></i><i style="height:18px"></i><i style="height:7px"></i><i style="height:14px;" class="amber"></i><i style="height:9px"></i><i style="height:11px"></i><i style="height:22px"></i><i style="height:18px"></i><i style="height:8px;" class="dim"></i><i style="height:14px"></i><i style="height:6px"></i><i style="height:12px"></i><i style="height:24px;" class="amber"></i><i style="height:16px"></i><i style="height:8px"></i><i style="height:11px"></i><i style="height:18px"></i><i style="height:6px;" class="dim"></i><i style="height:14px"></i><i style="height:22px"></i><i style="height:9px"></i><i style="height:11px"></i><i style="height:14px"></i><i style="height:18px;" class="amber"></i>
+        </span>
+        <span class="t-counter"><b>00:42</b> / 12:08</span>
+      </div>
+      <div class="t-right">
+        <a href="{{ base_url }}/" {% if page.url == "/" %}class="active"{% endif %}>Log</a>
+        <a href="{{ base_url }}/episodes/" {% if page.section == "episodes" %}class="active"{% endif %}>Episodes</a>
+        <a href="{{ base_url }}/about/">Studio</a>
+      </div>
+    </header>

--- a/examples/dictation-log/templates/page.html
+++ b/examples/dictation-log/templates/page.html
@@ -1,0 +1,83 @@
+{% include "header.html" %}
+<main>
+  <section class="cover">
+    <div>
+      <div class="stamp">SESSION 04 · TAPE LOG · {{ current_year }}</div>
+      <h1>Documentation,<br>spoken<br><span class="amber">into a microphone.</span></h1>
+      <p class="lede">A documentation system built on the idea that the best engineers think out loud. Every page is a recorded session — time-stamped, transcribed, annotated, and indexed. You can read it like a transcript, or read it like a manual. Both work.</p>
+    </div>
+    <aside class="session-card">
+      <h4>Current Session</h4>
+      <div class="row"><span>Tape</span><b>T-04-A</b></div>
+      <div class="row"><span>Channel</span><b>Mono · 48k</b></div>
+      <div class="row"><span>Operator</span><b>OPER-7</b></div>
+      <div class="row"><span>Length</span><b>12:08</b></div>
+      <div class="bar"><i></i></div>
+      <div style="font-size:11px;letter-spacing:0.18em;text-transform:uppercase;color:var(--margin);">08:14 / 12:08 · 64% complete</div>
+      <div class="row" style="margin-top:14px;border-top:1px dashed var(--line);padding-top:10px;"><span>Saved</span><b>02:14 AM</b></div>
+    </aside>
+  </section>
+
+  <section class="episodes">
+    <h2>Episodes On File</h2>
+    <a class="ep-row" href="{{ base_url }}/episodes/session-zero/">
+      <span class="ep-num">01</span>
+      <span class="ep-mini-wave">
+        <i style="height:8px;background:var(--amber)"></i><i style="height:14px"></i><i style="height:6px"></i><i style="height:18px;background:var(--amber)"></i><i style="height:11px"></i><i style="height:22px"></i><i style="height:9px"></i><i style="height:14px"></i><i style="height:18px"></i><i style="height:6px"></i><i style="height:11px;background:var(--amber)"></i><i style="height:8px"></i>
+      </span>
+      <span class="ep-title">Session Zero — Setting Up The Studio<span class="desc">What's in the box, how to plug it in, and what to record first. The introduction to the rest of the log.</span></span>
+      <span class="ep-tag">SETUP</span>
+      <span class="ep-len">08:42</span>
+    </a>
+    <a class="ep-row" href="{{ base_url }}/episodes/transcript-format/">
+      <span class="ep-num">02</span>
+      <span class="ep-mini-wave">
+        <i style="height:14px"></i><i style="height:6px"></i><i style="height:11px;background:var(--amber)"></i><i style="height:18px"></i><i style="height:8px"></i><i style="height:22px"></i><i style="height:14px;background:var(--amber)"></i><i style="height:6px"></i><i style="height:18px"></i><i style="height:11px"></i><i style="height:9px"></i><i style="height:14px;background:var(--amber)"></i>
+      </span>
+      <span class="ep-title">The Transcript Format<span class="desc">Why every paragraph carries a timestamp and what the operator tags mean. Read this before episode three.</span></span>
+      <span class="ep-tag">REFERENCE</span>
+      <span class="ep-len">12:08</span>
+    </a>
+    <a class="ep-row" href="{{ base_url }}/episodes/recording-rituals/">
+      <span class="ep-num">03</span>
+      <span class="ep-mini-wave">
+        <i style="height:9px"></i><i style="height:14px;background:var(--amber)"></i><i style="height:22px"></i><i style="height:6px"></i><i style="height:18px"></i><i style="height:11px"></i><i style="height:14px"></i><i style="height:9px;background:var(--amber)"></i><i style="height:18px"></i><i style="height:22px"></i><i style="height:6px"></i><i style="height:11px"></i>
+      </span>
+      <span class="ep-title">Recording Rituals<span class="desc">The opening slate, the mid-tape check, the closing sign-off. The cadence that makes a session sound like a session.</span></span>
+      <span class="ep-tag">PRACTICE</span>
+      <span class="ep-len">09:55</span>
+    </a>
+    <a class="ep-row" href="{{ base_url }}/episodes/annotation-passes/">
+      <span class="ep-num">04</span>
+      <span class="ep-mini-wave">
+        <i style="height:22px;background:var(--amber)"></i><i style="height:6px"></i><i style="height:14px"></i><i style="height:11px"></i><i style="height:18px"></i><i style="height:9px;background:var(--amber)"></i><i style="height:14px"></i><i style="height:22px"></i><i style="height:6px"></i><i style="height:11px"></i><i style="height:18px"></i><i style="height:8px;background:var(--amber)"></i>
+      </span>
+      <span class="ep-title">Annotation Passes<span class="desc">The second listen, where you add the marginalia. How to mark a moment without overwriting it.</span></span>
+      <span class="ep-tag">EDITING</span>
+      <span class="ep-len">11:20</span>
+    </a>
+    <a class="ep-row" href="{{ base_url }}/episodes/archive-protocol/">
+      <span class="ep-num">05</span>
+      <span class="ep-mini-wave">
+        <i style="height:11px"></i><i style="height:18px"></i><i style="height:6px;background:var(--amber)"></i><i style="height:14px"></i><i style="height:22px"></i><i style="height:9px"></i><i style="height:14px;background:var(--amber)"></i><i style="height:18px"></i><i style="height:11px"></i><i style="height:6px"></i><i style="height:14px"></i><i style="height:22px;background:var(--amber)"></i>
+      </span>
+      <span class="ep-title">Archive Protocol<span class="desc">How a tape becomes a record. Filing, retention, and the questions you ask before destroying anything.</span></span>
+      <span class="ep-tag">ARCHIVE</span>
+      <span class="ep-len">07:34</span>
+    </a>
+    <a class="ep-row" href="{{ base_url }}/episodes/operator-vocabulary/">
+      <span class="ep-num">06</span>
+      <span class="ep-mini-wave">
+        <i style="height:14px"></i><i style="height:11px"></i><i style="height:18px;background:var(--amber)"></i><i style="height:8px"></i><i style="height:22px"></i><i style="height:11px"></i><i style="height:14px;background:var(--amber)"></i><i style="height:9px"></i><i style="height:18px"></i><i style="height:22px"></i><i style="height:6px"></i><i style="height:11px;background:var(--amber)"></i>
+      </span>
+      <span class="ep-title">Operator Vocabulary<span class="desc">The forty-odd terms an operator uses on tape. Glossary for newcomers, refresher for everyone else.</span></span>
+      <span class="ep-tag">GLOSSARY</span>
+      <span class="ep-len">06:18</span>
+    </a>
+  </section>
+
+  <div class="doc-body" style="max-width:720px;padding:40px 0 60px;">
+    {{ content }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/dictation-log/templates/section.html
+++ b/examples/dictation-log/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<main>
+  <section class="cover">
+    <div>
+      <div class="stamp">{{ section.pages | length }} EPISODES ON FILE · {{ current_year }}</div>
+      <h1>{{ section.title }}</h1>
+      {% if section.description %}<p class="lede">{{ section.description }}</p>{% endif %}
+    </div>
+  </section>
+  <section class="episodes">
+    <h2>Tape Index</h2>
+    {% for doc in section.pages %}
+    <a class="ep-row" href="{{ base_url }}{{ doc.url }}">
+      <span class="ep-num">{{ "%02d" | format(loop.index) }}</span>
+      <span class="ep-mini-wave">
+        <i style="height:8px"></i><i style="height:14px;background:var(--amber)"></i><i style="height:6px"></i><i style="height:18px"></i><i style="height:11px"></i><i style="height:22px;background:var(--amber)"></i><i style="height:9px"></i><i style="height:14px"></i><i style="height:18px"></i><i style="height:6px;background:var(--amber)"></i><i style="height:11px"></i><i style="height:8px"></i>
+      </span>
+      <span class="ep-title">{{ doc.title }}{% if doc.description %}<span class="desc">{{ doc.description }}</span>{% endif %}</span>
+      <span class="ep-tag">{{ doc.extra.kind | default(value="LOG") | upper }}</span>
+      <span class="ep-len">{{ doc.extra.runtime | default(value="—") }}</span>
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/dictation-log/templates/shortcodes/alert.html
+++ b/examples/dictation-log/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/dictation-log/templates/taxonomy.html
+++ b/examples/dictation-log/templates/taxonomy.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<main style="padding:50px 0 80px;">
+  <div style="font-size:11px;letter-spacing:0.3em;text-transform:uppercase;color:var(--margin);margin-bottom:16px;">Topic Index</div>
+  <h1 style="font-size:48px;font-weight:700;letter-spacing:-0.02em;margin-bottom:32px;">All Tags</h1>
+  <ul style="list-style:none;padding:0;display:flex;flex-wrap:wrap;gap:10px;">
+    {% for term in taxonomy_terms %}
+    <li><a href="{{ base_url }}{{ term.url }}" style="text-decoration:none;color:var(--ink);font-size:12px;letter-spacing:0.15em;text-transform:uppercase;padding:8px 14px;border:1px solid var(--line);border-radius:100px;display:inline-block;background:var(--bg-soft);">#{{ term.name }} <span style="color:var(--amber);">{{ term.pages | length }}</span></a></li>
+    {% endfor %}
+  </ul>
+</main>
+{% include "footer.html" %}

--- a/examples/dictation-log/templates/taxonomy_term.html
+++ b/examples/dictation-log/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<main>
+  <section class="cover" style="border-bottom:1px solid var(--line);">
+    <div>
+      <div class="stamp">Filed Under</div>
+      <h1 style="font-size:60px;">#{{ taxonomy_term }}</h1>
+      <p class="lede">{{ taxonomy_pages | length }} episode{% if taxonomy_pages | length != 1 %}s{% endif %} tagged.</p>
+    </div>
+  </section>
+  <section class="episodes">
+    <h2>Filtered Index</h2>
+    {% for doc in taxonomy_pages %}
+    <a class="ep-row" href="{{ base_url }}{{ doc.url }}">
+      <span class="ep-num">{{ "%02d" | format(loop.index) }}</span>
+      <span class="ep-mini-wave"></span>
+      <span class="ep-title">{{ doc.title }}{% if doc.description %}<span class="desc">{{ doc.description }}</span>{% endif %}</span>
+      <span class="ep-tag">{{ doc.extra.kind | default(value="LOG") | upper }}</span>
+      <span class="ep-len">{{ doc.date | date(format="%d %b") | upper }}</span>
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/dieter-docs/AGENTS.md
+++ b/examples/dieter-docs/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/dieter-docs/archetypes/default.md
+++ b/examples/dieter-docs/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/dieter-docs/config.toml
+++ b/examples/dieter-docs/config.toml
@@ -1,0 +1,190 @@
+title = "Dieter Docs"
+description = "Documentation in the Rams tradition — ultra-functional, single orange accent, nothing without a purpose."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+heading_ids = true
+footnotes = true
+task_lists = true
+admonitions = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/dieter-docs/content/about.md
+++ b/examples/dieter-docs/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "Imprint"
+description = "Who wrote this manual and why."
++++
+
+This manual exists because most documentation is too long. The principles below are adapted from a tradition of industrial design that prized restraint above novelty.
+
+The manual is set in Inter, with code in JetBrains Mono. The only color other than black, white, and gray is a single shade of orange used to mark the principle numerals and the one element the reader must not miss on any page.
+
+If you find a page that violates one of its own principles, file an issue. The maintainers consider that the strongest form of feedback this manual can receive.

--- a/examples/dieter-docs/content/index.md
+++ b/examples/dieter-docs/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Manual"
+description = "Documentation in the Rams tradition."
++++
+
+A documentation manual that practices what it preaches. Six principles, each one a short page, none of them decorative.
+
+Begin at [Principle 01](/principles/one/). Read in order on a first pass.

--- a/examples/dieter-docs/content/principles/_index.md
+++ b/examples/dieter-docs/content/principles/_index.md
@@ -1,0 +1,6 @@
++++
+title = "The Principles"
+description = "Six entries. Read in order on a first pass."
+sort_by = "weight"
+template = "section"
++++

--- a/examples/dieter-docs/content/principles/five.md
+++ b/examples/dieter-docs/content/principles/five.md
@@ -1,0 +1,39 @@
++++
+title = "Good docs are thorough."
+description = "They do not stop at the first paragraph. They cover the edge case the reader will hit at 02:00."
+date = "2026-02-02"
+weight = 5
+template = "doc"
+toc = true
+[extra]
+number = 5
++++
+
+Thorough is not the same as long. A thorough page is one that has been examined for every reasonable reader-question and either answers it or names where the answer lives. Length is the side effect, not the goal.
+
+## What thorough means
+
+A thorough page has been *read* by people other than the writer. Specifically: someone who knows the system well enough to catch errors, and someone who does not know the system at all and reads the page from scratch. Both reviews matter. Skipping the second is the most common cause of documentation that *feels* thorough but isn't.
+
+```
+review 1: domain expert  → catches inaccuracies
+review 2: fresh reader   → catches confusions
+```
+
+The two reviews surface different kinds of failure. The expert finds *wrong*. The fresh reader finds *unclear*. Both should pass before a page is considered thorough.
+
+## Edge cases
+
+Edge cases earn their own section, not their own scattered notes. A page that handles edge cases inline becomes harder to scan for the common case. A page that names a *Failure modes* or *Edge cases* section keeps the common path clean and gives the rare path a home.
+
+- Common path stays at the top.
+- Edge cases stay in their own section near the bottom.
+- The reader can choose where to invest their attention.
+
+## The 02:00 test
+
+The most demanding reader of any documentation page is the person who reaches it at 02:00 because their system is broken. That reader does not have time to read four paragraphs of background. They need the relevant fact, fast.
+
+A thorough page passes the 02:00 test when the relevant fact is findable in under thirty seconds — and the surrounding context is still there for the reader who arrives at 14:00 with time to read.
+
+> Thoroughness without findability is just length.

--- a/examples/dieter-docs/content/principles/four.md
+++ b/examples/dieter-docs/content/principles/four.md
@@ -1,0 +1,37 @@
++++
+title = "Good docs are long-lasting."
+description = "They are written to age well. They survive a rewrite of the underlying system."
+date = "2026-01-26"
+weight = 4
+template = "doc"
+toc = true
+[extra]
+number = 4
++++
+
+Documentation written for the next six months is documentation that will need to be rewritten in six months. Write for two years. Write so that the page is still useful when the codebase underneath has been refactored twice.
+
+## What ages well
+
+Concepts age better than code. A page that explains *why* a feature exists ages better than a page that explains *how* to call it. The how can be regenerated from the source code. The why has to be written by a human who remembers the original decision.
+
+| Layer | Half-life |
+|-------|-----------|
+| Why (motivation) | Years |
+| What (concepts) | Years |
+| How (API surface) | Months |
+| Examples | Weeks |
+
+Write the long half-life material yourself. Generate the short half-life material from the source.
+
+## How to test for staleness
+
+Once a quarter, read every page in the manual. If a page describes something that no longer exists or works differently than described, mark it for revision. If a page describes something that has not changed, leave it alone.
+
+The discipline is to *not edit* what does not need editing. A page that survives three quarters untouched has earned its place.
+
+> Stable documentation is the highest compliment a system can pay its documentation.
+
+## When to deprecate
+
+Deprecate a page when the system it describes has been retired, not when the system has been improved. Improvement updates the page. Retirement deprecates it. Confusing the two is how manuals turn into archives.

--- a/examples/dieter-docs/content/principles/one.md
+++ b/examples/dieter-docs/content/principles/one.md
@@ -1,0 +1,32 @@
++++
+title = "Good docs are useful."
+description = "A page that does not help a reader do something does not belong in the manual."
+date = "2026-01-05"
+weight = 1
+template = "doc"
+toc = true
+[extra]
+number = 1
++++
+
+The first test is the strictest. Pick any page in the manual. Ask the reader of that page what they wanted from it. If their answer is *information*, the page may still belong. If their answer is *a task*, and the page does not help them do that task, the page does not belong.
+
+## What counts as useful
+
+A page is useful when it shortens the distance between a reader's intent and a reader's outcome. It does not need to be comprehensive. It needs to be *load-bearing* on the path the reader is walking.
+
+- A *task guide* is useful when it answers the reader's "how do I."
+- A *reference* is useful when it answers the reader's "what is this called."
+- A *concept piece* is useful when it answers the reader's "why does this exist."
+
+A page that answers none of these is decoration, and decoration is the enemy of the manual.
+
+## The test you can run
+
+Read the page. List, in order, the three questions the page answers. If you cannot list three, the page is not yet ready. If your three questions are not also the three questions the reader will ask, you have written the wrong page.
+
+> The test is severe by design. Documentation that fails the test is what makes other documentation feel long.
+
+## What about background?
+
+Background belongs in *concept pages*, and concept pages must justify their length the same way task pages do. A background section that does not eventually serve a task is background that does not belong.

--- a/examples/dieter-docs/content/principles/six.md
+++ b/examples/dieter-docs/content/principles/six.md
@@ -1,0 +1,35 @@
++++
+title = "Good docs are as little as possible."
+description = "Subtract everything that is not necessary. Subtract again."
+date = "2026-02-09"
+weight = 6
+template = "doc"
+toc = true
+[extra]
+number = 6
++++
+
+The final principle, and the hardest. Every page you write should be examined for what can be removed. After the first pass, examine it again. After the second pass, ship it — but mark it for one more review in a month.
+
+## What to subtract
+
+Words that restate. Sentences that summarize what just came before. Paragraphs that exist to make the page feel complete. Code examples that repeat a pattern already shown. Diagrams that visualize what the paragraph already said.
+
+Every one of these has a defender. The defender's argument is always *some readers will need this*. The argument is sometimes right. The discipline is to ask, of every defended element, whether *most* readers need it. If they do not, the element is friction for the many in service of the few — and the documentation has chosen the wrong side.
+
+## Subtraction is not minimalism
+
+Minimalism removes for the sake of removal. Subtraction removes for the sake of clarity. The two look similar in a finished page and are completely different in process.
+
+- Subtraction asks: *does this earn its place?*
+- Minimalism asks: *can this be removed?*
+
+Subtraction yields documentation that is exactly as long as it needs to be. Minimalism yields documentation that has been hollowed out for style. The reader can tell the difference.
+
+> Subtract until the next subtraction would remove something the reader needs. Then stop.
+
+## The final test
+
+Print the page. Read it aloud. The places where you stumble are the places to subtract. The places where you slow down are the places to leave alone. Your voice will tell you what your eyes will not.
+
+Return to the [Manual](/) when you have read enough.

--- a/examples/dieter-docs/content/principles/three.md
+++ b/examples/dieter-docs/content/principles/three.md
@@ -1,0 +1,33 @@
++++
+title = "Good docs are unobtrusive."
+description = "They are tools, not statements. They serve attention, they do not compete for it."
+date = "2026-01-19"
+weight = 3
+template = "doc"
+toc = true
+[extra]
+number = 3
++++
+
+The manual exists to be useful. It does not exist to be *admired*. A page that draws attention to its own design has failed at this principle, no matter how beautiful that design is.
+
+## What unobtrusive looks like
+
+Unobtrusive does not mean ugly. It means *quiet*. A page can be carefully composed, well-typeset, easy to read, and still be quiet. The opposite of unobtrusive is *clever* — a page that asks the reader to admire how it presents the information before they get to the information.
+
+- One typeface for the body.
+- One accent color, used sparingly.
+- Headings that look like headings, not like decoration.
+- Code that looks like code, not like art.
+
+## Removing what fights the reader
+
+Every visual element on a page either helps the reader or competes with the reader. There is no neutral element. The discipline is to remove anything that competes.
+
+Animations. Hover effects that move things. Background patterns. Drop shadows. Colored backgrounds for emphasis. Each of these may have a justification, but the burden of proof is on the element, not on the reader.
+
+> The reader has limited attention. Documentation that spends that attention on its own appearance has less left for what it came to communicate.
+
+## The single accent
+
+This manual uses one accent color — a single orange, applied only to principle numerals and to the rare element the reader must not miss. That is the entire color palette beyond black, white, and gray. The discipline is *not* about minimalism for its own sake. It is about reserving every visual signal for a single, legible purpose.

--- a/examples/dieter-docs/content/principles/two.md
+++ b/examples/dieter-docs/content/principles/two.md
@@ -1,0 +1,35 @@
++++
+title = "Good docs are honest."
+description = "They do not overstate capability. They do not hide failure modes."
+date = "2026-01-12"
+weight = 2
+template = "doc"
+toc = true
+[extra]
+number = 2
++++
+
+Honest documentation describes the system as it is, not as the engineer wishes it were. This is harder than it sounds, because the engineer wrote both the system and the documentation, and the writing happens while the wishing is still warm.
+
+## Overstating capability
+
+The temptation to overstate is real. A feature ships at 80%; the documentation describes the 100% the engineer intends to reach next quarter. The reader trusts the documentation. The reader hits the 80% reality. The trust is gone.
+
+The discipline is to write what is *true today*. Not what was true last week. Not what will be true next quarter. Today.
+
+| Phase | Document |
+|-------|----------|
+| Planned | Nothing yet |
+| Shipped at 80% | The 80% that works |
+| Shipped at 100% | The 100% |
+| Deprecated | The deprecation |
+
+## Hiding failure modes
+
+Every system fails. Honest documentation names the failure modes the reader is likely to encounter. The temptation here is the inverse of overstating: to omit the failures because they look bad. The reader will hit them anyway. The documentation should warn them first.
+
+> A failure mode the reader discovers alone is twice as expensive as a failure mode the manual named.
+
+## What about marketing?
+
+Marketing has its own honesty discipline. The manual is not marketing. The two should be reviewed by different people, written under different incentives, and never substituted for each other.

--- a/examples/dieter-docs/static/css/style.css
+++ b/examples/dieter-docs/static/css/style.css
@@ -1,0 +1,509 @@
+:root {
+  --white: #ffffff;
+  --paper: #fafaf8;
+  --gray-50: #f4f4f1;
+  --gray-100: #e6e6e0;
+  --gray-300: #cfcfc7;
+  --gray-500: #87877e;
+  --gray-700: #4a4a44;
+  --ink: #0a0a08;
+  --orange: #ff5a00;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
+body {
+  background: var(--white);
+  color: var(--ink);
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: -0.005em;
+}
+
+a { color: var(--ink); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; text-decoration-color: var(--gray-300); }
+a:hover { color: var(--orange); text-decoration-color: var(--orange); }
+
+.shell { max-width: 1280px; margin: 0 auto; padding: 0 40px; }
+
+/* ---- masthead ---- */
+.masthead {
+  padding: 24px 0;
+  border-bottom: 1px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 30px;
+  align-items: center;
+}
+.brand-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.brand-mark {
+  width: 18px; height: 18px;
+  background: var(--orange);
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.brand {
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+  color: var(--ink);
+}
+.brand .sub { color: var(--gray-500); font-weight: 400; margin-left: 8px; }
+
+.topnav {
+  display: flex;
+  gap: 26px;
+  font-size: 13px;
+  font-weight: 500;
+}
+.topnav a {
+  text-decoration: none;
+  color: var(--gray-700);
+  position: relative;
+  padding-bottom: 4px;
+}
+.topnav a:hover { color: var(--ink); }
+.topnav a.active { color: var(--ink); }
+.topnav a.active::after {
+  content: "";
+  position: absolute;
+  bottom: -25px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--orange);
+}
+
+/* ---- home hero ---- */
+.hero {
+  padding: 120px 0 110px;
+  border-bottom: 1px solid var(--ink);
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 60px;
+}
+.hero .num {
+  font-size: 14px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--gray-500);
+  letter-spacing: 0.02em;
+  padding-top: 18px;
+}
+.hero .num b { color: var(--orange); font-weight: 700; display: block; font-size: 60px; line-height: 1; letter-spacing: -0.03em; margin-bottom: 6px; }
+.hero h1 {
+  font-size: 72px;
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+  font-weight: 600;
+  margin-bottom: 28px;
+  max-width: 740px;
+}
+.hero h1 .o { color: var(--orange); }
+.hero .lede {
+  max-width: 600px;
+  font-size: 19px;
+  line-height: 1.5;
+  color: var(--gray-700);
+}
+
+/* ---- principles list ---- */
+.principles {
+  padding: 80px 0;
+  border-bottom: 1px solid var(--ink);
+}
+.principles .header {
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  gap: 60px;
+  margin-bottom: 48px;
+  align-items: end;
+}
+.principles .header .num {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gray-500);
+  font-variant-numeric: tabular-nums;
+}
+.principles .header h2 {
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+}
+.principles .header .count {
+  font-size: 13px;
+  color: var(--gray-500);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 80px 1fr 200px auto;
+  gap: 60px;
+  padding: 26px 0;
+  border-top: 1px solid var(--gray-300);
+  text-decoration: none;
+  color: var(--ink);
+  align-items: baseline;
+  transition: background 0.15s ease;
+}
+.row:hover { background: var(--paper); }
+.row:last-child { border-bottom: 1px solid var(--gray-300); }
+.row:hover .row-num { color: var(--orange); }
+.row .row-num {
+  font-variant-numeric: tabular-nums;
+  font-size: 42px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.row h3 {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.018em;
+  line-height: 1.15;
+}
+.row p {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--gray-700);
+}
+.row .meta {
+  font-size: 12px;
+  color: var(--gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+/* ---- doc layout ---- */
+.doc-shell {
+  display: grid;
+  grid-template-columns: 220px 1fr 220px;
+  gap: 60px;
+  padding: 60px 0 100px;
+}
+.doc-side {
+  position: sticky;
+  top: 24px;
+  align-self: start;
+  max-height: calc(100vh - 60px);
+  overflow-y: auto;
+}
+.doc-side h4 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--gray-500);
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--ink);
+}
+.doc-side a {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 10px;
+  padding: 8px 0;
+  text-decoration: none;
+  color: var(--gray-700);
+  font-size: 14px;
+  line-height: 1.3;
+  border-top: 1px solid var(--gray-100);
+}
+.doc-side a:first-of-type { border-top: 0; }
+.doc-side a:hover { color: var(--ink); }
+.doc-side a.active { color: var(--ink); font-weight: 600; }
+.doc-side a.active .num { color: var(--orange); }
+.doc-side a .num {
+  font-variant-numeric: tabular-nums;
+  color: var(--gray-500);
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.doc-side .grp { margin-bottom: 32px; }
+
+article.doc { min-width: 0; max-width: 720px; }
+
+.crumb {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--gray-500);
+  margin-bottom: 32px;
+}
+.crumb a { color: var(--gray-700); text-decoration: none; }
+.crumb a:hover { color: var(--ink); }
+.crumb .sep { color: var(--gray-300); margin: 0 8px; }
+
+.doc-head {
+  margin-bottom: 60px;
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 30px;
+  align-items: start;
+}
+.doc-head .principle-num {
+  font-size: 64px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  color: var(--orange);
+}
+.doc-head .principle-num small {
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-bottom: 6px;
+}
+.doc-head h1 {
+  font-size: 46px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  margin-bottom: 14px;
+}
+.doc-head .desc {
+  font-size: 19px;
+  line-height: 1.45;
+  color: var(--gray-700);
+  max-width: 580px;
+}
+.doc-head .rule {
+  margin-top: 24px;
+  height: 1px;
+  background: var(--ink);
+}
+
+/* doc body */
+.doc-body { font-size: 17px; line-height: 1.68; color: var(--ink); }
+.doc-body p { margin: 16px 0; }
+.doc-body h2 {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 56px 0 12px;
+  padding-top: 28px;
+  border-top: 1px solid var(--ink);
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+}
+.doc-body h2::before {
+  content: counter(h2-counter, decimal-leading-zero);
+  counter-increment: h2-counter;
+  color: var(--orange);
+  font-weight: 500;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+.doc-body { counter-reset: h2-counter; }
+.doc-body h3 {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 32px 0 8px;
+}
+
+.doc-body strong { font-weight: 700; }
+.doc-body em { font-style: normal; color: var(--orange); }
+
+.doc-body ul, .doc-body ol { margin: 12px 0 16px 0; padding-left: 0; list-style: none; }
+.doc-body li {
+  margin: 10px 0;
+  padding-left: 24px;
+  position: relative;
+}
+.doc-body ul li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 12px;
+  width: 10px;
+  height: 1px;
+  background: var(--orange);
+}
+.doc-body ol { counter-reset: ol-c; }
+.doc-body ol li { counter-increment: ol-c; }
+.doc-body ol li::before {
+  content: counter(ol-c, decimal-leading-zero);
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--orange);
+  font-weight: 500;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+
+.doc-body code {
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  background: var(--gray-50);
+  padding: 2px 6px;
+  font-size: 14px;
+  border-radius: 2px;
+  color: var(--ink);
+}
+.doc-body pre {
+  background: var(--gray-50);
+  padding: 22px 24px;
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-size: 13.5px;
+  line-height: 1.6;
+  overflow-x: auto;
+  margin: 26px 0;
+  border-left: 3px solid var(--orange);
+  border-radius: 2px;
+}
+.doc-body pre code { background: none; padding: 0; }
+
+.doc-body blockquote {
+  margin: 30px 0;
+  padding: 4px 0 4px 24px;
+  border-left: 3px solid var(--orange);
+  font-size: 20px;
+  line-height: 1.45;
+  font-weight: 500;
+  color: var(--ink);
+  letter-spacing: -0.012em;
+}
+.doc-body blockquote p { margin: 8px 0; }
+
+.doc-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 26px 0;
+  font-size: 14px;
+}
+.doc-body th {
+  text-align: left;
+  padding: 10px 12px 10px 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.doc-body td { padding: 10px 12px 10px 0; border-bottom: 1px solid var(--gray-100); color: var(--gray-700); }
+.doc-body td:first-child { color: var(--ink); font-weight: 500; }
+
+.doc-body hr {
+  border: 0;
+  border-top: 1px solid var(--gray-300);
+  margin: 36px 0;
+}
+
+/* TOC */
+.toc-side h4 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--gray-500);
+  margin-bottom: 14px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--ink);
+}
+.toc-side ul { list-style: none; padding: 0; }
+.toc-side ul ul { padding-left: 12px; }
+.toc-side a {
+  display: block;
+  text-decoration: none;
+  color: var(--gray-700);
+  font-size: 13px;
+  padding: 4px 0;
+  line-height: 1.3;
+}
+.toc-side a:hover { color: var(--ink); }
+
+.toc-side .stats {
+  margin-top: 30px;
+  padding-top: 18px;
+  border-top: 1px solid var(--gray-300);
+}
+.toc-side .stats h5 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--gray-500);
+  font-weight: 500;
+  margin-bottom: 8px;
+}
+.toc-side .stats dl { font-size: 13px; }
+.toc-side .stats dt { color: var(--gray-500); margin-top: 8px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; }
+.toc-side .stats dd { color: var(--ink); font-weight: 500; }
+
+/* nav */
+.doc-nav {
+  margin-top: 70px;
+  padding-top: 26px;
+  border-top: 1px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+}
+.doc-nav a { text-decoration: none; color: var(--ink); display: block; padding: 14px 0; }
+.doc-nav .label {
+  display: block;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--gray-500);
+  margin-bottom: 4px;
+}
+.doc-nav a:hover .label { color: var(--orange); }
+.doc-nav .title { font-weight: 600; font-size: 18px; letter-spacing: -0.015em; line-height: 1.2; }
+.doc-nav .next { text-align: right; }
+
+/* footer */
+.colophon {
+  padding: 50px 0 60px;
+  border-top: 1px solid var(--ink);
+  display: grid;
+  grid-template-columns: 80px 1fr 1fr 1fr;
+  gap: 60px;
+  font-size: 13px;
+  color: var(--gray-700);
+  line-height: 1.6;
+}
+.colophon .mark { width: 12px; height: 12px; background: var(--orange); border-radius: 50%; }
+.colophon h5 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink);
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+.colophon a { color: var(--ink); }
+
+@media (max-width: 1080px) {
+  .doc-shell { grid-template-columns: 1fr; gap: 30px; }
+  .doc-side, .toc-side { position: static; max-height: none; }
+}
+@media (max-width: 760px) {
+  .shell { padding: 0 20px; }
+  .hero { grid-template-columns: 1fr; gap: 16px; padding: 60px 0; }
+  .hero h1 { font-size: 44px; }
+  .hero .num b { font-size: 36px; }
+  .row { grid-template-columns: 50px 1fr; }
+  .row p, .row .meta { grid-column: 2 / -1; }
+  .doc-head { grid-template-columns: 1fr; gap: 12px; }
+  .doc-head .principle-num { font-size: 44px; }
+  .doc-head h1 { font-size: 32px; }
+  .colophon { grid-template-columns: 1fr; gap: 20px; }
+  .colophon .mark { display: none; }
+}

--- a/examples/dieter-docs/static/favicon.svg
+++ b/examples/dieter-docs/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/dieter-docs/templates/404.html
+++ b/examples/dieter-docs/templates/404.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+<main style="padding:140px 0;">
+  <div style="display:grid;grid-template-columns:80px 1fr;gap:60px;max-width:760px;">
+    <div style="font-size:64px;font-weight:500;line-height:0.9;letter-spacing:-0.04em;color:var(--orange);font-variant-numeric:tabular-nums;">404</div>
+    <div>
+      <p style="font-size:11px;font-weight:500;color:var(--gray-500);text-transform:uppercase;letter-spacing:0.15em;margin-bottom:14px;">Not in the manual</p>
+      <h1 style="font-size:42px;font-weight:600;letter-spacing:-0.03em;line-height:1.05;margin-bottom:18px;">This page has no entry.</h1>
+      <p style="font-size:18px;color:var(--gray-700);line-height:1.5;max-width:520px;margin-bottom:28px;">The manual contains exactly the pages it needs to contain. This is not one of them.</p>
+      <a href="{{ base_url }}/" style="font-size:13px;font-weight:500;text-decoration:none;color:var(--ink);border-bottom:2px solid var(--orange);padding-bottom:4px;">↩ Return to the manual</a>
+    </div>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/dieter-docs/templates/doc.html
+++ b/examples/dieter-docs/templates/doc.html
@@ -1,0 +1,80 @@
+{% include "header.html" %}
+<main class="doc-shell">
+  <aside class="doc-side">
+    <div class="grp">
+      <h4>Principles</h4>
+      {% if section.pages %}
+        {% for doc in section.pages %}
+        <a href="{{ base_url }}{{ doc.url }}" {% if doc.url == page.url %}class="active"{% endif %}>
+          <span class="num">{{ "%02d" | format(loop.index) }}</span>
+          <span>{{ doc.title }}</span>
+        </a>
+        {% endfor %}
+      {% endif %}
+    </div>
+    <div class="grp">
+      <h4>Pages</h4>
+      <a href="{{ base_url }}/"><span class="num">→</span><span>Manual</span></a>
+      <a href="{{ base_url }}/about/"><span class="num">→</span><span>Imprint</span></a>
+      <a href="{{ base_url }}/tags/"><span class="num">→</span><span>Tag Index</span></a>
+    </div>
+  </aside>
+
+  <article class="doc">
+    <div class="crumb">
+      <a href="{{ base_url }}/">Manual</a>
+      <span class="sep">/</span>
+      <a href="{{ base_url }}/principles/">Principles</a>
+      <span class="sep">/</span>
+      <span>{{ page.title }}</span>
+    </div>
+
+    <header class="doc-head">
+      <div class="principle-num">
+        <small>Principle</small>
+        {{ "%02d" | format(page.extra.number | default(value=1)) }}
+      </div>
+      <div>
+        <h1>{{ page.title }}</h1>
+        {% if page.description %}<p class="desc">{{ page.description }}</p>{% endif %}
+        <div class="rule"></div>
+      </div>
+    </header>
+
+    <div class="doc-body">
+      {{ content }}
+    </div>
+
+    <nav class="doc-nav">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}">
+        <span class="label">← Previous principle</span>
+        <span class="title">{{ page.lower.title }}</span>
+      </a>
+      {% else %}<span></span>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="next">
+        <span class="label">Next principle →</span>
+        <span class="title">{{ page.higher.title }}</span>
+      </a>
+      {% else %}<span></span>{% endif %}
+    </nav>
+  </article>
+
+  <aside class="toc-side">
+    {% if page.toc %}
+    <h4>On this page</h4>
+    {{ page.toc }}
+    {% endif %}
+    <div class="stats">
+      <h5>Metadata</h5>
+      <dl>
+        <dt>Principle</dt><dd>{{ "%02d" | format(page.extra.number | default(value=1)) }}</dd>
+        <dt>Date</dt><dd>{{ page.date | date(format="%Y-%m-%d") }}</dd>
+        <dt>Reading</dt><dd>{{ page.reading_time | default(value="—") }} min</dd>
+        <dt>Words</dt><dd>{{ page.word_count | default(value="—") }}</dd>
+      </dl>
+    </div>
+  </aside>
+</main>
+{% include "footer.html" %}

--- a/examples/dieter-docs/templates/footer.html
+++ b/examples/dieter-docs/templates/footer.html
@@ -1,0 +1,18 @@
+    <footer class="colophon">
+      <div class="mark"></div>
+      <div>
+        <h5>{{ site.title }}</h5>
+        <p>{{ site.description }}</p>
+      </div>
+      <div>
+        <h5>System</h5>
+        <p>Edition {{ current_year }}<br>Six principles, indexed.<br>Single accent color.</p>
+      </div>
+      <div>
+        <h5>Read further</h5>
+        <p><a href="{{ base_url }}/feeds/rss.xml">Subscribe</a><br><a href="{{ base_url }}/about/">Imprint</a><br><a href="{{ base_url }}/tags/">Index</a></p>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/dieter-docs/templates/header.html
+++ b/examples/dieter-docs/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} — {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="shell">
+    <header class="masthead">
+      <div class="brand-row">
+        <span class="brand-mark"></span>
+        <a class="brand" href="{{ base_url }}/">{{ site.title }}<span class="sub">— a documentation manual</span></a>
+      </div>
+      <nav class="topnav">
+        <a href="{{ base_url }}/" {% if page.url == "/" %}class="active"{% endif %}>Manual</a>
+        <a href="{{ base_url }}/principles/" {% if page.section == "principles" %}class="active"{% endif %}>Principles</a>
+        <a href="{{ base_url }}/principles/six/">Reference</a>
+        <a href="{{ base_url }}/about/">Imprint</a>
+      </nav>
+    </header>

--- a/examples/dieter-docs/templates/page.html
+++ b/examples/dieter-docs/templates/page.html
@@ -1,0 +1,74 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <div class="num"><b>00</b>Manual<br>Edition · {{ current_year }}</div>
+    <div>
+      <h1>Good documentation is as little documentation <span class="o">as possible.</span></h1>
+      <p class="lede">A manual in the Dieter Rams tradition. Six principles, written without ornament, indexed without ceremony. Every rule earns its line. Nothing in this house is decorative.</p>
+    </div>
+  </section>
+
+  <section class="principles">
+    <div class="header">
+      <div class="num">01</div>
+      <h2>The six principles, in order.</h2>
+      <div class="count">06 entries</div>
+    </div>
+
+    <a class="row" href="{{ base_url }}/principles/one/">
+      <div class="row-num">01</div>
+      <div>
+        <h3>Good docs are useful.</h3>
+      </div>
+      <p>The first test. If a page does not help a reader do something, the page does not belong in the manual.</p>
+      <div class="meta">5 min</div>
+    </a>
+    <a class="row" href="{{ base_url }}/principles/two/">
+      <div class="row-num">02</div>
+      <div>
+        <h3>Good docs are honest.</h3>
+      </div>
+      <p>They do not overstate capability. They do not hide failure modes. They name what is true now, not what was once true.</p>
+      <div class="meta">6 min</div>
+    </a>
+    <a class="row" href="{{ base_url }}/principles/three/">
+      <div class="row-num">03</div>
+      <div>
+        <h3>Good docs are unobtrusive.</h3>
+      </div>
+      <p>They are tools, not statements. They serve the reader's attention rather than competing for it.</p>
+      <div class="meta">5 min</div>
+    </a>
+    <a class="row" href="{{ base_url }}/principles/four/">
+      <div class="row-num">04</div>
+      <div>
+        <h3>Good docs are long-lasting.</h3>
+      </div>
+      <p>They are written to age well. They survive a rewrite of the underlying system without requiring a rewrite of themselves.</p>
+      <div class="meta">7 min</div>
+    </a>
+    <a class="row" href="{{ base_url }}/principles/five/">
+      <div class="row-num">05</div>
+      <div>
+        <h3>Good docs are thorough.</h3>
+      </div>
+      <p>They do not stop at the first paragraph. They cover the edge case the reader will hit at 02:00.</p>
+      <div class="meta">6 min</div>
+    </a>
+    <a class="row" href="{{ base_url }}/principles/six/">
+      <div class="row-num">06</div>
+      <div>
+        <h3>Good docs are as little as possible.</h3>
+      </div>
+      <p>The final principle, and the hardest. Subtract everything that is not necessary. Subtract again.</p>
+      <div class="meta">4 min</div>
+    </a>
+  </section>
+
+  <section style="padding:60px 0;">
+    <div class="doc-body" style="max-width:680px;margin-left:140px;">
+      {{ content }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/dieter-docs/templates/section.html
+++ b/examples/dieter-docs/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <div class="num"><b>{{ "%02d" | format(section.pages | length) }}</b>Entries</div>
+    <div>
+      <h1>{{ section.title }}</h1>
+      {% if section.description %}<p class="lede">{{ section.description }}</p>{% endif %}
+    </div>
+  </section>
+  <section class="principles">
+    <div class="header">
+      <div class="num">All</div>
+      <h2>Index, in numerical order.</h2>
+      <div class="count">{{ section.pages | length }} entries</div>
+    </div>
+    {% for doc in section.pages %}
+    <a class="row" href="{{ base_url }}{{ doc.url }}">
+      <div class="row-num">{{ "%02d" | format(loop.index) }}</div>
+      <div><h3>{{ doc.title }}</h3></div>
+      {% if doc.description %}<p>{{ doc.description }}</p>{% else %}<p></p>{% endif %}
+      <div class="meta">{{ doc.reading_time | default(value="—") }} min</div>
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/dieter-docs/templates/shortcodes/alert.html
+++ b/examples/dieter-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/dieter-docs/templates/taxonomy.html
+++ b/examples/dieter-docs/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <div class="num"><b>{{ "%02d" | format(taxonomy_terms | length) }}</b>Tags</div>
+    <div>
+      <h1>Tag index.</h1>
+      <p class="lede">Every term filed in the manual, in order of frequency.</p>
+    </div>
+  </section>
+  <section class="principles">
+    {% for term in taxonomy_terms %}
+    <a class="row" href="{{ base_url }}{{ term.url }}">
+      <div class="row-num">{{ "%02d" | format(loop.index) }}</div>
+      <div><h3>#{{ term.name }}</h3></div>
+      <p></p>
+      <div class="meta">{{ term.pages | length }} entries</div>
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/dieter-docs/templates/taxonomy_term.html
+++ b/examples/dieter-docs/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <div class="num"><b>#</b>{{ taxonomy_term }}</div>
+    <div>
+      <h1>{{ taxonomy_pages | length }} entries tagged.</h1>
+    </div>
+  </section>
+  <section class="principles">
+    {% for doc in taxonomy_pages %}
+    <a class="row" href="{{ base_url }}{{ doc.url }}">
+      <div class="row-num">{{ "%02d" | format(loop.index) }}</div>
+      <div><h3>{{ doc.title }}</h3></div>
+      {% if doc.description %}<p>{{ doc.description }}</p>{% else %}<p></p>{% endif %}
+      <div class="meta">{{ doc.date | date(format="%Y-%m") }}</div>
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/risograph-codex/AGENTS.md
+++ b/examples/risograph-codex/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/risograph-codex/archetypes/default.md
+++ b/examples/risograph-codex/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/risograph-codex/config.toml
+++ b/examples/risograph-codex/config.toml
@@ -1,0 +1,190 @@
+title = "Risograph Codex"
+description = "Two-color riso print documentation with halftone dots and offset registration marks."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+heading_ids = true
+footnotes = true
+task_lists = true
+admonitions = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/risograph-codex/content/about.md
+++ b/examples/risograph-codex/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "Colophon"
+description = "How this codex was set, printed, and assembled."
++++
+
+This codex is printed in two passes on a Risograph SF5230 — fluorescent red first, marine blue second, on warm cream 80gsm stock. Body type is set in PT Serif. Display type is Space Grotesk. All numerals, lots, and registration marks are set in Space Mono.
+
+The cover stock is hand-trimmed to 148×210mm. The interior signatures are saddle-stitched with cotton thread in a small workshop in Hapjeong, Seoul.
+
+No bleed exceeds 3mm. No ink mixes on press. Every value you read between red and blue is built from optical blending of two solid screens — never from a gradient.

--- a/examples/risograph-codex/content/docs/_index.md
+++ b/examples/risograph-codex/content/docs/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Chapters"
+description = "The full table of contents for the Risograph Codex — six chapters, one appendix."
+sort_by = "weight"
+template = "section"
++++
+
+Six bound chapters, one loose appendix. Read in order on a first pass — the press behavior in Chapter One sets up everything that follows. Once you have a sheet on the line, you can dip into individual chapters as reference.

--- a/examples/risograph-codex/content/docs/color-system.md
+++ b/examples/risograph-codex/content/docs/color-system.md
@@ -1,0 +1,36 @@
++++
+title = "The Color System"
+description = "Why only two inks can build twenty values."
+date = "2026-01-19"
+weight = 2
+template = "doc"
+[extra]
+kind = "theory"
++++
+
+A riso has one job at a time. It prints one solid color, lays down a screen, and stops. Every value beyond solid is built by your eye, not by the press. That single rule is the foundation of the system.
+
+## Two inks, twenty values
+
+When red ink lays down 50% halftone over blue 50% halftone, the eye reads a third color that exists nowhere on the page. Stack three densities (10, 50, 90) for each ink and you have nine combinations, plus paper white and full overprint — eleven distinct values from two drums.
+
+Push the screens to five densities and the same math gives you twenty-six. That is the working palette of most riso publications you have ever held.
+
+## Overprint and the optical mixing problem
+
+Overprint is where the press stops cooperating. A red square on top of a blue square does not produce a uniform purple — it produces a *dirty* purple, because the riso ink is translucent and oxidizes on contact. Plan your overprints. Do not discover them after binding.
+
+- **Solid + solid**: muddy, oxidizes within 48 hours.
+- **Halftone + solid**: the cleanest overprint — use this whenever possible.
+- **Halftone + halftone**: the most flexible, hardest to register.
+
+## Color separations
+
+Build the separations in two layers, both as solid black on white. The press does not need your color preview. The press needs to know which dots come off which drum.
+
+```
+layer-01-red.png    → drum 1 (red)
+layer-02-blue.png   → drum 2 (blue)
+```
+
+Save both at 300dpi, grayscale, and never premultiply. The press driver is older than you think — it does not handle alpha gracefully.

--- a/examples/risograph-codex/content/docs/getting-started.md
+++ b/examples/risograph-codex/content/docs/getting-started.md
@@ -1,0 +1,49 @@
++++
+title = "Getting Started"
+description = "Prime the drums, load paper, and pull your first two-color test sheet."
+date = "2026-01-12"
+weight = 1
+template = "doc"
+[extra]
+kind = "presswork"
+notice = "RUN A WARM-UP OF 20 BLANK SHEETS BEFORE ANY PRODUCTION PASS. INK MUST FLOW."
++++
+
+Before you touch the first sheet, learn what the machine wants from you. A riso is a contradiction — it looks like a copier, behaves like a press, and forgives like neither.
+
+## What you will need
+
+- A duplicator with at least two color drums installed.
+- 80–100gsm uncoated paper in a single batch (mix batches and registration drifts).
+- A master sheet for each color separation.
+- Patience for the first ten misregistered prints.
+
+The list is small because the variables are large. You will spend more time tuning the four items above than on any software step.
+
+## Priming the drums
+
+Drums that have sat overnight produce streaks. Cycle each drum through 8–10 blanks before the production run. If the streak does not clear, swap the master and run another five. Never run production until the test sheet is clean to the corner.
+
+```
+> drum 1 (red)    : warm 8 sheets
+> drum 2 (blue)   : warm 8 sheets
+> registration    : ±0.3mm vertical, ±0.2mm horizontal
+> stock           : single batch, grain long
+```
+
+## Pulling the first proof
+
+Print the red drum first. Inspect the proof on the press, not under the light box — the paper will pick up oil from your hands and the registration will appear to shift in the strong light. Once the red is clean, load the blue drum and run the same stack again.
+
+> A second pass is never just a second pass. Every sheet now carries the topography of the first. Calibrate to that, not to your monitor.
+
+The first proof is rarely your final proof. Expect to discard the first sheet, keep the next ten as references, and start counting your production run from sheet eleven.
+
+## Common first-pass mistakes
+
+1. Loading paper from two different batches into the same tray.
+2. Running production before the warm-up sheets clear.
+3. Trusting the monitor preview as final color.
+4. Skipping the registration calibration after a drum swap.
+
+Move on to [The Color System](/docs/color-system/) once your first proof comes off the press clean.

--- a/examples/risograph-codex/content/docs/glossary.md
+++ b/examples/risograph-codex/content/docs/glossary.md
@@ -1,0 +1,39 @@
++++
+title = "Glossary"
+description = "The vocabulary of two-color riso."
+date = "2026-02-16"
+weight = 6
+template = "doc"
+[extra]
+kind = "reference"
++++
+
+A working vocabulary. Every term here is one you will hear in a riso studio at some point, often shouted across the room while a drum is being changed.
+
+## Press terms
+
+**Drum** — the rotating cylinder that holds a single ink. A two-color riso has two drums. A four-color has four. The drum itself does not move on press; the paper moves past it.
+
+**Master** — the thermal stencil burned for each separation. A new master is created for every color of every print run. Masters degrade after about 500 impressions.
+
+**Pass** — one drum's worth of printing. A two-color print has two passes.
+
+## Color terms
+
+**Spot color** — a single ink at full strength. Each riso ink is a spot color.
+
+**Overprint** — where two spot colors land on the same sheet position. Adds, does not mix.
+
+**Knockout** — the inverse of overprint: where one color is removed so the other can sit alone on paper.
+
+## Defects
+
+**Streaking** — vertical lines on the print, usually from an under-warmed drum.
+
+**Crawling** — ink that has not dried and migrates between stacked sheets. Cured by drying time, not by speed.
+
+**Drift** — registration that changes mid-run, almost always caused by mixed paper batches.
+
+## End notes
+
+Read [Imprint & Output](/docs/imprint/) if you have not yet trimmed your first run. Return to [Getting Started](/docs/getting-started/) if any of the terms above were new to you.

--- a/examples/risograph-codex/content/docs/halftones.md
+++ b/examples/risograph-codex/content/docs/halftones.md
@@ -1,0 +1,29 @@
++++
+title = "Halftones & Dots"
+description = "Dot pitch, line screens, and visible grain."
+date = "2026-02-02"
+weight = 4
+template = "doc"
+[extra]
+kind = "film"
++++
+
+The halftone is the only tool you have for building tone on a riso. There is no continuous tone, no gradient ramp inside the machine — only dots, lined up in patterns you choose.
+
+## Line screen and dot pitch
+
+A line screen is how many rows of dots fit in an inch. Common riso values are 65, 85, and 100 lpi. Below 65 lpi the dots become visible at arm's length. Above 100 lpi the riso struggles to resolve them — drum lint and master fade start to swallow the fine pattern.
+
+| LPI | Reads as | Best for |
+|-----|----------|----------|
+| 65  | Visible dot pattern | Posters, large display work |
+| 85  | Subtle grain        | Editorial, body images |
+| 100 | Near-continuous     | Fine illustration, small detail |
+
+## Angle and moiré
+
+Two halftones at the same angle moiré badly. Offset the angles between drums — 15° red, 75° blue is a common starting pair. The exact values depend on your design, but the rule holds: same angle = moiré, different angle = clean overprint.
+
+## Dot patterns beyond round
+
+The default is a round dot, but you can use line, square, or diamond patterns for texture. Line screens make every image read as if it had been scanned from a print magazine. Diamonds add a soft architectural grid. Choose the pattern before you build the separations — switching mid-process re-renders every image.

--- a/examples/risograph-codex/content/docs/imprint.md
+++ b/examples/risograph-codex/content/docs/imprint.md
@@ -1,0 +1,37 @@
++++
+title = "Imprint & Output"
+description = "Trim, fold, bind, and declare."
+date = "2026-02-09"
+weight = 5
+template = "doc"
+[extra]
+kind = "finish"
++++
+
+The press work is done. What comes next is finishing — and finishing is where most amateur runs lose their character.
+
+## Trim and grain
+
+Always trim with the paper grain. A perpendicular cut tears the fibers and leaves a ragged edge that does not improve with sanding. Test a single sheet from each batch — grain direction varies between mills more than you would expect.
+
+The standard trim for this codex is 148×210mm, A5. Bleed three millimeters on every edge so the trim catches type that runs to the edge.
+
+## Saddle stitch or perfect bound
+
+For runs of 16 pages or less, saddle stitch with cotton thread. Above 32 pages, perfect bind with a flexible PUR glue — the riso ink will crack on a stiff spine if the book is opened past 180°.
+
+```
+pages  | binding
+-------|----------
+4-16   | saddle stitch (thread)
+20-32  | side stitch
+32+    | perfect bound (PUR glue)
+```
+
+## The colophon
+
+Every printed object should declare what it is. The colophon belongs on the back inside cover and should include: paper, ink, press, run size, and date. If you cannot fit all five, drop the date — the others matter more.
+
+> A book without a colophon is a book that refuses to take responsibility for itself.
+
+Read the [Glossary](/docs/glossary/) for the full vocabulary, or return to [the index](/).

--- a/examples/risograph-codex/content/docs/registration.md
+++ b/examples/risograph-codex/content/docs/registration.md
@@ -1,0 +1,29 @@
++++
+title = "Registration"
+description = "Crosshairs, corner marks, and calibrated misalignment."
+date = "2026-01-26"
+weight = 3
+template = "doc"
+[extra]
+kind = "craft"
++++
+
+Registration on a riso is never perfect, and you should never want it to be. The hand-printed feel comes from a tolerance — usually ±0.3mm — that the eye reads as warmth, not as error.
+
+## The corner mark system
+
+Every page in this codex carries four corner marks. Each is a small crosshair with a circle. The marks let the press operator align two color passes by eye before pulling production. They also stay on the proof — they are part of the visual language.
+
+> A page without corner marks is a page that was never meant to be on press. Even if your final trim removes them, design the file with them present.
+
+## Tuning the offset
+
+A clean offset between two colors is somewhere between 0.2mm and 0.5mm. Below 0.2mm the work reads as digital. Above 0.5mm the eye starts to register it as a printing error, not as a style.
+
+Calibrate by printing a single 5×5 grid of solid squares in red, then in blue, with each square 5mm on a side. Measure the corner-to-corner offset with a loupe. Adjust the paper tray, not the file, until the offset sits where you want it.
+
+## When misregistration is wrong
+
+There is a difference between *characteristic* misregistration and *broken* misregistration. The first is consistent across the run — every sheet looks the same. The second drifts mid-run, usually because the paper batch changed humidity overnight.
+
+If sheet 1 and sheet 200 look different, stop. Re-tune. Discard the drifting sheets — do not bind them into a finished run.

--- a/examples/risograph-codex/content/index.md
+++ b/examples/risograph-codex/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Risograph Codex"
+description = "A field manual for two-color riso publishing."
++++
+
+This is a working notebook on the riso process — written by people who pulled the prints, not who watched the videos. Every page in this codex has been on press at least twice. The misregistration you see is the proof.
+
+Start at [Chapter One](/docs/getting-started/), or pull a single sheet from the [Glossary](/docs/glossary/) if you already know your way around a drum.

--- a/examples/risograph-codex/static/css/style.css
+++ b/examples/risograph-codex/static/css/style.css
@@ -1,0 +1,521 @@
+/* ----- riso palette ----- */
+:root {
+  --paper: #f1e8d1;
+  --paper-deep: #e7dcbd;
+  --ink: #1a1a1a;
+  --ink-soft: #2d2d2d;
+  --red: #ff3b3b;
+  --blue: #2c45d6;
+  --rule: #1a1a1a;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { height: 100%; }
+body {
+  background-color: var(--paper);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12'><circle cx='2' cy='2' r='0.9' fill='%231a1a1a' fill-opacity='0.18'/></svg>");
+  color: var(--ink);
+  font-family: 'PT Serif', Georgia, serif;
+  font-size: 17px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--blue); text-decoration: underline; text-decoration-thickness: 1.5px; text-underline-offset: 3px; }
+a:hover { color: var(--red); }
+
+/* ----- registration corners ----- */
+.reg-mark {
+  position: fixed;
+  width: 28px;
+  height: 28px;
+  z-index: 100;
+  pointer-events: none;
+}
+.reg-mark.tl { top: 14px; left: 14px; }
+.reg-mark.tr { top: 14px; right: 14px; }
+.reg-mark.bl { bottom: 14px; left: 14px; }
+.reg-mark.br { bottom: 14px; right: 14px; }
+
+/* ----- layout ----- */
+.shell { max-width: 1240px; margin: 0 auto; padding: 0 64px; }
+
+.masthead {
+  border-bottom: 3px double var(--ink);
+  padding: 36px 0 22px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 28px;
+  align-items: end;
+}
+.masthead .brand {
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 44px;
+  letter-spacing: -0.02em;
+  line-height: 0.95;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-decoration: none;
+  position: relative;
+  display: inline-block;
+}
+.masthead .brand::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: var(--red);
+  mix-blend-mode: multiply;
+  transform: translate(3px, 3px);
+  z-index: -1;
+}
+.masthead .meta {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  text-align: right;
+  color: var(--ink-soft);
+  line-height: 1.7;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.masthead .meta b { color: var(--red); font-weight: 700; }
+
+.topnav {
+  display: flex;
+  gap: 26px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--ink);
+  font-family: 'Space Mono', monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.topnav a { text-decoration: none; color: var(--ink); }
+.topnav a:hover { color: var(--red); }
+.topnav a.active { color: var(--blue); border-bottom: 2px solid var(--blue); padding-bottom: 4px; }
+
+/* ----- home grid ----- */
+.hero {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 64px;
+  padding: 60px 0 50px;
+  border-bottom: 1px solid var(--ink);
+}
+.hero h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 76px;
+  line-height: 0.92;
+  letter-spacing: -0.035em;
+  text-transform: uppercase;
+}
+.hero h1 .red { color: var(--red); }
+.hero h1 .blue { color: var(--blue); }
+.hero .lede {
+  font-family: 'PT Serif', serif;
+  font-size: 20px;
+  line-height: 1.45;
+  font-style: italic;
+  border-left: 3px solid var(--red);
+  padding-left: 18px;
+  margin-top: 12px;
+}
+.hero .stamp {
+  background: var(--paper-deep);
+  border: 2px solid var(--ink);
+  padding: 18px 20px;
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  line-height: 1.8;
+  align-self: start;
+  transform: rotate(-1.5deg);
+  box-shadow: 4px 4px 0 var(--ink);
+}
+.hero .stamp .row { display: flex; justify-content: space-between; gap: 18px; border-bottom: 1px dashed var(--ink); padding: 4px 0; }
+.hero .stamp .row:last-child { border-bottom: 0; }
+.hero .stamp .row b { color: var(--red); }
+
+/* ----- chapter cards ----- */
+.chapters {
+  padding: 50px 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 28px;
+}
+.chapter {
+  display: block;
+  text-decoration: none;
+  color: var(--ink);
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  padding: 28px 26px 22px;
+  position: relative;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.chapter:hover { transform: translate(-3px, -3px); box-shadow: 6px 6px 0 var(--blue); }
+.chapter .num {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  color: var(--red);
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.chapter h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 28px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  margin-bottom: 12px;
+}
+.chapter p { font-size: 15px; line-height: 1.5; color: var(--ink-soft); }
+.chapter .tag {
+  display: inline-block;
+  margin-top: 14px;
+  background: var(--blue);
+  color: var(--paper);
+  padding: 3px 9px;
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+/* ----- divider ----- */
+.divider {
+  text-align: center;
+  border-top: 1px dashed var(--ink);
+  border-bottom: 1px dashed var(--ink);
+  padding: 14px 0;
+  margin: 50px 0;
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+}
+
+/* ----- doc layout ----- */
+.doc-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 56px;
+  padding: 40px 0 80px;
+}
+.doc-side {
+  border-right: 1px dashed var(--ink);
+  padding-right: 28px;
+  position: sticky;
+  top: 24px;
+  align-self: start;
+  max-height: calc(100vh - 60px);
+  overflow-y: auto;
+}
+.doc-side h4 {
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--red);
+  margin-bottom: 14px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--ink);
+}
+.doc-side ul { list-style: none; }
+.doc-side li { margin: 6px 0; }
+.doc-side a {
+  display: block;
+  text-decoration: none;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 14px;
+  color: var(--ink);
+  padding: 4px 0 4px 14px;
+  border-left: 2px solid transparent;
+  line-height: 1.35;
+}
+.doc-side a:hover { color: var(--blue); border-left-color: var(--blue); }
+.doc-side a.active {
+  border-left-color: var(--red);
+  color: var(--red);
+  font-weight: 700;
+  background: var(--paper-deep);
+}
+
+.doc-side .group-label {
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin: 18px 0 6px 0;
+}
+
+article.doc {
+  min-width: 0;
+}
+article.doc .crumb {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 18px;
+  color: var(--ink-soft);
+}
+article.doc .crumb a { color: var(--ink); }
+article.doc .crumb .sep { color: var(--red); margin: 0 8px; }
+
+article.doc h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 64px;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  position: relative;
+  display: inline-block;
+}
+article.doc h1::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: var(--blue);
+  transform: translate(4px, 4px);
+  z-index: -1;
+}
+article.doc .desc {
+  font-family: 'PT Serif', serif;
+  font-style: italic;
+  font-size: 19px;
+  color: var(--ink-soft);
+  margin: 22px 0 28px;
+  padding-left: 18px;
+  border-left: 4px solid var(--red);
+}
+
+.doc-body { font-size: 17px; line-height: 1.75; }
+.doc-body h2 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 30px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  margin: 48px 0 16px;
+  padding-bottom: 6px;
+  border-bottom: 3px solid var(--ink);
+  color: var(--red);
+}
+.doc-body h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 21px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin: 32px 0 10px;
+  color: var(--blue);
+}
+.doc-body p { margin: 14px 0; }
+.doc-body strong { background: var(--red); color: var(--paper); padding: 0 4px; font-weight: 700; }
+.doc-body em { color: var(--blue); }
+.doc-body ul, .doc-body ol { margin: 14px 0 14px 26px; }
+.doc-body li { margin: 8px 0; }
+.doc-body ul li::marker { color: var(--red); content: "▣ "; }
+.doc-body ol li::marker { color: var(--blue); font-family: 'Space Mono', monospace; }
+
+.doc-body code {
+  font-family: 'Space Mono', monospace;
+  background: var(--paper-deep);
+  border: 1px solid var(--ink);
+  padding: 1px 6px;
+  font-size: 14px;
+  color: var(--red);
+}
+.doc-body pre {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 22px 24px;
+  font-family: 'Space Mono', monospace;
+  font-size: 14px;
+  line-height: 1.55;
+  overflow-x: auto;
+  margin: 22px 0;
+  border: none;
+  position: relative;
+  box-shadow: 6px 6px 0 var(--red);
+}
+.doc-body pre code { background: none; border: none; padding: 0; color: var(--paper); }
+
+.doc-body blockquote {
+  margin: 24px 0;
+  padding: 18px 22px;
+  background: var(--paper-deep);
+  border-left: 4px solid var(--blue);
+  font-style: italic;
+  position: relative;
+}
+.doc-body blockquote::before {
+  content: "❝";
+  position: absolute;
+  top: 4px;
+  right: 14px;
+  font-size: 36px;
+  color: var(--red);
+  font-family: 'PT Serif', serif;
+  line-height: 1;
+}
+
+.doc-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 24px 0;
+  border: 2px solid var(--ink);
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 15px;
+}
+.doc-body th {
+  background: var(--ink);
+  color: var(--paper);
+  text-align: left;
+  padding: 8px 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+}
+.doc-body td { padding: 8px 12px; border-top: 1px dashed var(--ink); }
+.doc-body tr:nth-child(even) td { background: var(--paper-deep); }
+
+.doc-body hr {
+  border: 0;
+  border-top: 1px dashed var(--ink);
+  margin: 36px 0;
+  position: relative;
+  text-align: center;
+}
+.doc-body hr::after {
+  content: "✶";
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--paper);
+  padding: 0 12px;
+  color: var(--red);
+}
+
+/* doc-nav */
+.doc-nav {
+  margin-top: 60px;
+  padding-top: 24px;
+  border-top: 3px double var(--ink);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+.doc-nav a {
+  text-decoration: none;
+  border: 2px solid var(--ink);
+  padding: 14px 18px;
+  background: var(--paper);
+  display: block;
+  color: var(--ink);
+  font-family: 'Space Grotesk', sans-serif;
+}
+.doc-nav a:hover { background: var(--paper-deep); }
+.doc-nav .label {
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--red);
+  display: block;
+  margin-bottom: 4px;
+}
+.doc-nav .title { font-weight: 700; font-size: 17px; }
+.doc-nav .next { text-align: right; }
+.doc-nav .next .label { color: var(--blue); }
+
+/* footer */
+.colophon {
+  margin-top: 60px;
+  padding: 30px 0 40px;
+  border-top: 3px double var(--ink);
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 28px;
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-soft);
+}
+.colophon b { color: var(--red); display: block; margin-bottom: 8px; font-size: 12px; }
+.colophon a { color: var(--ink); }
+
+.section-intro {
+  padding: 40px 0 30px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: 26px;
+  border-bottom: 1px solid var(--ink);
+  margin-bottom: 36px;
+}
+.section-intro h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 84px;
+  line-height: 0.9;
+  text-transform: uppercase;
+  letter-spacing: -0.035em;
+  color: var(--ink);
+  position: relative;
+  display: inline-block;
+}
+.section-intro h1::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: var(--red);
+  transform: translate(4px, 4px);
+  z-index: -1;
+}
+.section-intro .signal {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  text-align: right;
+  line-height: 1.8;
+}
+.section-intro .signal b { color: var(--blue); display: block; font-size: 13px; }
+
+.notice {
+  background: var(--red);
+  color: var(--paper);
+  padding: 12px 18px;
+  font-family: 'Space Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin: 22px 0;
+  border: 2px solid var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+}
+
+@media (max-width: 900px) {
+  .shell { padding: 0 24px; }
+  .doc-shell { grid-template-columns: 1fr; }
+  .doc-side { border-right: 0; border-bottom: 1px dashed var(--ink); padding-bottom: 18px; position: static; max-height: none; }
+  .hero { grid-template-columns: 1fr; }
+  .hero h1 { font-size: 52px; }
+  .chapters { grid-template-columns: 1fr; }
+  .colophon { grid-template-columns: 1fr; }
+  article.doc h1 { font-size: 42px; }
+  .section-intro { grid-template-columns: 1fr; }
+  .section-intro h1 { font-size: 56px; }
+}

--- a/examples/risograph-codex/static/favicon.svg
+++ b/examples/risograph-codex/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/risograph-codex/templates/404.html
+++ b/examples/risograph-codex/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<main style="padding:120px 0;text-align:center;">
+  <div style="display:inline-block;position:relative;">
+    <h1 style="font-family:'Space Grotesk',sans-serif;font-size:180px;font-weight:700;letter-spacing:-0.04em;line-height:0.9;color:#1a1a1a;">404</h1>
+    <h1 style="font-family:'Space Grotesk',sans-serif;font-size:180px;font-weight:700;letter-spacing:-0.04em;line-height:0.9;color:#ff3b3b;position:absolute;inset:0;transform:translate(6px,6px);z-index:-1;">404</h1>
+  </div>
+  <p style="font-family:'Space Mono',monospace;font-size:14px;letter-spacing:0.2em;text-transform:uppercase;margin:20px 0 10px;">— SHEET MISFEED —</p>
+  <p style="max-width:480px;margin:0 auto 26px;font-style:italic;font-size:18px;">This page never made it past the second drum. The ink was loaded, the paper queued, but the registration failed.</p>
+  <a href="{{ base_url }}/" style="font-family:'Space Mono',monospace;font-size:12px;letter-spacing:0.15em;text-transform:uppercase;border:2px solid #1a1a1a;padding:10px 20px;text-decoration:none;color:#1a1a1a;background:#e7dcbd;display:inline-block;">↩ Back to Index</a>
+</main>
+{% include "footer.html" %}

--- a/examples/risograph-codex/templates/doc.html
+++ b/examples/risograph-codex/templates/doc.html
@@ -1,0 +1,63 @@
+{% include "header.html" %}
+<main class="doc-shell">
+  <aside class="doc-side">
+    <h4>{{ section.title | default(value="Chapters") }}</h4>
+    {% if section.pages %}
+    <ul>
+      {% for doc in section.pages %}
+      <li>
+        <a href="{{ base_url }}{{ doc.url }}" {% if doc.url == page.url %}class="active"{% endif %}>
+          {{ "%02d" | format(loop.index) }} &middot; {{ doc.title }}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    <div class="group-label">— Loose Sheets —</div>
+    <ul>
+      <li><a href="{{ base_url }}/">Cover</a></li>
+      <li><a href="{{ base_url }}/about/">Colophon</a></li>
+      <li><a href="{{ base_url }}/tags/">Index of Tags</a></li>
+    </ul>
+  </aside>
+
+  <article class="doc">
+    <div class="crumb">
+      <a href="{{ base_url }}/">INDEX</a>
+      <span class="sep">/</span>
+      <a href="{{ base_url }}/docs/">CHAPTERS</a>
+      <span class="sep">/</span>
+      <span>{{ page.title | upper }}</span>
+    </div>
+
+    <h1 data-text="{{ page.title }}">{{ page.title }}</h1>
+    {% if page.description %}
+      <p class="desc">{{ page.description }}</p>
+    {% endif %}
+
+    {% if page.extra.notice %}
+      <div class="notice">{{ page.extra.notice }}</div>
+    {% endif %}
+
+    <div class="doc-body">
+      {{ content }}
+    </div>
+
+    <nav class="doc-nav">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}">
+        <span class="label">← Previous Chapter</span>
+        <span class="title">{{ page.lower.title }}</span>
+      </a>
+      {% else %}<span></span>{% endif %}
+
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="next">
+        <span class="label">Next Chapter →</span>
+        <span class="title">{{ page.higher.title }}</span>
+      </a>
+      {% else %}<span></span>{% endif %}
+    </nav>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/risograph-codex/templates/footer.html
+++ b/examples/risograph-codex/templates/footer.html
@@ -1,0 +1,21 @@
+    <footer class="colophon">
+      <div>
+        <b>The Press</b>
+        Two-pass riso printed on warm cream stock at 800 dpi.
+        Misregistration is intentional.
+      </div>
+      <div>
+        <b>Ink</b>
+        Fluorescent Red 022 &middot; Marine Blue 354<br>
+        Mixed with ink black for tonal sections.
+      </div>
+      <div>
+        <b>Distribution</b>
+        Mailed in glassine envelopes.<br>
+        &copy; {{ current_year }} {{ site.title }} —
+        <a href="{{ base_url }}/feeds/rss.xml">RSS</a>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/risograph-codex/templates/header.html
+++ b/examples/risograph-codex/templates/header.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} — {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=PT+Serif:ital,wght@0,400;0,700;1,400&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <svg class="reg-mark tl" viewBox="0 0 28 28" aria-hidden="true">
+    <circle cx="14" cy="14" r="11" fill="none" stroke="#ff3b3b" stroke-width="1.4"/>
+    <line x1="0" y1="14" x2="28" y2="14" stroke="#2c45d6" stroke-width="1"/>
+    <line x1="14" y1="0" x2="14" y2="28" stroke="#2c45d6" stroke-width="1"/>
+  </svg>
+  <svg class="reg-mark tr" viewBox="0 0 28 28" aria-hidden="true">
+    <circle cx="14" cy="14" r="11" fill="none" stroke="#ff3b3b" stroke-width="1.4"/>
+    <line x1="0" y1="14" x2="28" y2="14" stroke="#2c45d6" stroke-width="1"/>
+    <line x1="14" y1="0" x2="14" y2="28" stroke="#2c45d6" stroke-width="1"/>
+  </svg>
+  <svg class="reg-mark bl" viewBox="0 0 28 28" aria-hidden="true">
+    <circle cx="14" cy="14" r="11" fill="none" stroke="#ff3b3b" stroke-width="1.4"/>
+    <line x1="0" y1="14" x2="28" y2="14" stroke="#2c45d6" stroke-width="1"/>
+    <line x1="14" y1="0" x2="14" y2="28" stroke="#2c45d6" stroke-width="1"/>
+  </svg>
+  <svg class="reg-mark br" viewBox="0 0 28 28" aria-hidden="true">
+    <circle cx="14" cy="14" r="11" fill="none" stroke="#ff3b3b" stroke-width="1.4"/>
+    <line x1="0" y1="14" x2="28" y2="14" stroke="#2c45d6" stroke-width="1"/>
+    <line x1="14" y1="0" x2="14" y2="28" stroke="#2c45d6" stroke-width="1"/>
+  </svg>
+
+  <div class="shell">
+    <header class="masthead">
+      <a class="brand" href="{{ base_url }}/" data-text="{{ site.title | upper }}">{{ site.title | upper }}</a>
+      <div class="meta">
+        <div>VOL. <b>IV</b> &middot; ISSUE <b>002</b></div>
+        <div>RUN OF <b>500</b> &middot; TWO COLOR</div>
+        <div>PRINTED ON RECYCLED STOCK</div>
+      </div>
+    </header>
+    <nav class="topnav">
+      <a href="{{ base_url }}/" {% if page.url == "/" %}class="active"{% endif %}>INDEX</a>
+      <a href="{{ base_url }}/docs/" {% if page.section == "docs" %}class="active"{% endif %}>CHAPTERS</a>
+      <a href="{{ base_url }}/docs/imprint/">IMPRINT</a>
+      <a href="{{ base_url }}/docs/glossary/">GLOSSARY</a>
+      <a href="{{ base_url }}/about/">COLOPHON</a>
+    </nav>

--- a/examples/risograph-codex/templates/page.html
+++ b/examples/risograph-codex/templates/page.html
@@ -1,0 +1,71 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <div>
+      <h1>The <span class="red">Codex</span><br>of <span class="blue">Two</span> Inks</h1>
+      <p class="lede">A field manual for two-color riso publishing — how to coax depth, texture, and tactile presence from a printer that refuses to mix.</p>
+    </div>
+    <aside class="stamp">
+      <div class="row"><span>STOCK</span><span><b>Cream 80gsm</b></span></div>
+      <div class="row"><span>PASSES</span><span><b>02</b></span></div>
+      <div class="row"><span>DRUMS</span><span><b>Red &middot; Blue</b></span></div>
+      <div class="row"><span>BLEED</span><span><b>3mm</b></span></div>
+      <div class="row"><span>LOT</span><span><b>RX-0042</b></span></div>
+    </aside>
+  </section>
+
+  <div class="section-intro" style="border-bottom:0;padding-bottom:0;margin-bottom:0;">
+    <h1 data-text="Chapters" style="font-size:56px;">Chapters</h1>
+    <div class="signal">
+      <b>5 ENTRIES</b>
+      LAST REVISED MAR 2026<br>
+      OFFSETS WITHIN ±0.3MM
+    </div>
+  </div>
+
+  <section class="chapters">
+    <a class="chapter" href="{{ base_url }}/docs/getting-started/">
+      <div class="num">CHAPTER ONE</div>
+      <h3>Getting Started</h3>
+      <p>Prime the drums, load paper, and pull your first two-color test sheet without ruining the registration.</p>
+      <span class="tag">PRESSWORK</span>
+    </a>
+    <a class="chapter" href="{{ base_url }}/docs/color-system/">
+      <div class="num">CHAPTER TWO</div>
+      <h3>The Color System</h3>
+      <p>Why only two inks can build twenty values. A primer on overprint, halftone, and the optical mixing that does the rest.</p>
+      <span class="tag">THEORY</span>
+    </a>
+    <a class="chapter" href="{{ base_url }}/docs/registration/">
+      <div class="num">CHAPTER THREE</div>
+      <h3>Registration</h3>
+      <p>Crosshairs, corner marks, and the calibrated misalignment that gives every riso its hand-printed signature.</p>
+      <span class="tag">CRAFT</span>
+    </a>
+    <a class="chapter" href="{{ base_url }}/docs/halftones/">
+      <div class="num">CHAPTER FOUR</div>
+      <h3>Halftones &amp; Dots</h3>
+      <p>Dot pitch, line screens, and how to thread the needle between solid color and visible grain.</p>
+      <span class="tag">FILM</span>
+    </a>
+    <a class="chapter" href="{{ base_url }}/docs/imprint/">
+      <div class="num">CHAPTER FIVE</div>
+      <h3>Imprint &amp; Output</h3>
+      <p>Trimming, folding, binding — and what the back-page colophon should always declare.</p>
+      <span class="tag">FINISH</span>
+    </a>
+    <a class="chapter" href="{{ base_url }}/docs/glossary/">
+      <div class="num">APPENDIX</div>
+      <h3>Glossary</h3>
+      <p>The vocabulary of riso, set in the only two colors this book has ever owned.</p>
+      <span class="tag">REFERENCE</span>
+    </a>
+  </section>
+
+  <div class="divider">— BOUND BY HAND · NO. {{ current_year }} —</div>
+
+  <div class="doc-body" style="max-width:760px;">
+    {{ content }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/risograph-codex/templates/section.html
+++ b/examples/risograph-codex/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+<main>
+  <div class="section-intro">
+    <h1 data-text="{{ section.title }}">{{ section.title }}</h1>
+    <div class="signal">
+      <b>{{ section.pages | length }} CHAPTERS</b>
+      INDEXED BY HAND<br>
+      TWO-COLOR PROCESS
+    </div>
+  </div>
+
+  {% if section.description %}
+    <p class="lede" style="max-width:680px;margin-bottom:30px;">{{ section.description }}</p>
+  {% endif %}
+
+  <section class="chapters">
+    {% for doc in section.pages %}
+    <a class="chapter" href="{{ base_url }}{{ doc.url }}">
+      <div class="num">No. {{ loop.index }} — {{ doc.date | date(format="%b %Y") | upper }}</div>
+      <h3>{{ doc.title }}</h3>
+      {% if doc.description %}<p>{{ doc.description }}</p>{% endif %}
+      {% if doc.extra.kind %}<span class="tag">{{ doc.extra.kind | upper }}</span>{% endif %}
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/risograph-codex/templates/shortcodes/alert.html
+++ b/examples/risograph-codex/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/risograph-codex/templates/taxonomy.html
+++ b/examples/risograph-codex/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+<main>
+  <div class="section-intro">
+    <h1 data-text="Tag Index">Tag Index</h1>
+    <div class="signal"><b>{{ taxonomy_terms | length }} TERMS</b>INDEXED BY HAND</div>
+  </div>
+  <ul style="list-style:none;padding:0;display:flex;flex-wrap:wrap;gap:14px;">
+    {% for term in taxonomy_terms %}
+    <li><a href="{{ base_url }}{{ term.url }}" style="display:inline-block;border:2px solid #1a1a1a;padding:8px 14px;text-decoration:none;color:#1a1a1a;font-family:'Space Mono',monospace;font-size:12px;text-transform:uppercase;letter-spacing:0.1em;background:#e7dcbd;">{{ term.name }} <b style="color:#ff3b3b;">{{ term.pages | length }}</b></a></li>
+    {% endfor %}
+  </ul>
+</main>
+{% include "footer.html" %}

--- a/examples/risograph-codex/templates/taxonomy_term.html
+++ b/examples/risograph-codex/templates/taxonomy_term.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<main>
+  <div class="section-intro">
+    <h1 data-text="{{ taxonomy_term }}">#{{ taxonomy_term }}</h1>
+    <div class="signal"><b>{{ taxonomy_pages | length }} PAGES</b>FILED UNDER &laquo;{{ taxonomy_term | upper }}&raquo;</div>
+  </div>
+  <section class="chapters">
+    {% for doc in taxonomy_pages %}
+    <a class="chapter" href="{{ base_url }}{{ doc.url }}">
+      <div class="num">{{ doc.date | date(format="%b %Y") | upper }}</div>
+      <h3>{{ doc.title }}</h3>
+      {% if doc.description %}<p>{{ doc.description }}</p>{% endif %}
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/slab-cathedral/AGENTS.md
+++ b/examples/slab-cathedral/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/slab-cathedral/archetypes/default.md
+++ b/examples/slab-cathedral/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/slab-cathedral/config.toml
+++ b/examples/slab-cathedral/config.toml
@@ -1,0 +1,190 @@
+title = "Slab Cathedral"
+description = "A documentation cathedral set in monumental slab serif."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+heading_ids = true
+footnotes = true
+task_lists = true
+admonitions = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/slab-cathedral/content/about.md
+++ b/examples/slab-cathedral/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "Colophon"
+description = "How this cathedral was built."
++++
+
+Body text is set in Source Serif 4, opsz 24, designed by Frank Grießhammer. Display text is set in Roboto Slab Black, designed by Christian Robertson. Codes, captions, and the mason's notes are set in JetBrains Mono.
+
+The cathedral runs on Hwaro, a static site generator written in Crystal. The build is reproducible to the byte. The font files are served from Google Fonts in subset form to keep the cold-load under thirty kilobytes.
+
+If you find a missing stone — a broken link, a misspelled term — the [Restoration canon](/canons/restoration/) describes how this house handles repairs. Leave a note on the maintenance board; a mason will see to it within the next observance.

--- a/examples/slab-cathedral/content/canons/_index.md
+++ b/examples/slab-cathedral/content/canons/_index.md
@@ -1,0 +1,8 @@
++++
+title = "The Canons"
+description = "Six chapters, set in stone."
+sort_by = "weight"
+template = "section"
++++
+
+Six canons, in numbered order. Read in sequence on a first visit. After that, return to whichever chapel calls you.

--- a/examples/slab-cathedral/content/canons/foundations.md
+++ b/examples/slab-cathedral/content/canons/foundations.md
@@ -1,0 +1,36 @@
++++
+title = "Foundations"
+description = "The first canon. What the cathedral is, and what it is not."
+date = "2026-01-06"
+weight = 1
+template = "doc"
+toc = true
+[extra]
+roman = "I"
++++
+
+This is not the documentation system you are used to. There are no tabs across the top, no expanding sidebars, no animated arrows urging you onward to the next twelve pages. There is a nave, a chapel, and a single canon at a time.
+
+The cathedral asks for the same patience a long-form essay does. It rewards a reader who arrives, sits in one place, and finishes what they started.
+
+## What the cathedral is
+
+A cathedral is a single building that performs three functions at once: a place to gather, a place to read, and a place to teach. This documentation is built the same way. The Nave is where you arrive. The Canons are where you read. The Glossary is where you teach yourself the vocabulary you missed.
+
+The architecture is the curriculum. You cannot lose your place because every chapter is named, numbered, and ordered. You cannot drown in tabs because there are no tabs.
+
+## What the cathedral is not
+
+It is not an API reference. It is not a knowledge base. It is not the search bar you reach for when the deploy is on fire and the build is broken. Those tools exist, and they should — but they are different tools.
+
+Use the cathedral for the things that deserve to be read slowly. Use a search bar for the things you need to find in three seconds.
+
+> A documentation system that tries to be both a reference and a teaching is neither. The cathedral picks teaching.
+
+## Why slab
+
+The slab serif is not nostalgia. It is the typographic voice that reads cleanly at any size, on any screen, in any language with a Latin set. The slab carries weight, but it does not shout. It says *this matters* without ever raising its voice.
+
+You will read this canon in slab. You will read every canon in slab. The voice does not change, because the voice is the building.
+
+Continue to [Canon II, Proportions](/canons/proportions/).

--- a/examples/slab-cathedral/content/canons/glossary.md
+++ b/examples/slab-cathedral/content/canons/glossary.md
@@ -1,0 +1,50 @@
++++
+title = "Glossary"
+description = "The vocabulary of the order."
+date = "2026-02-10"
+weight = 6
+template = "doc"
+toc = true
+[extra]
+roman = "VI"
++++
+
+Every order has its terms. The cathedral is small enough that a glossary fits in a single canon — forty-three terms, set in alphabetical order, none of them invented for their own sake.
+
+## A — F
+
+**Aisle** — one of the two narrow columns flanking the nave. The left aisle holds the canon index; the right aisle holds the table of contents.
+
+**Annotation** — a dated, signed note appended to an older canon. Annotations never overwrite; they sit beneath the original line.
+
+**Canon** — a single chapter. Numbered with a Roman numeral, given a name, written under the discipline of the observance.
+
+**Chapel** — a place inside a canon where a single sub-topic lives. A chapel is what other documentation systems call a *section*.
+
+**Deprecation** — the closing of a canon to new readers without removing it from the cathedral.
+
+## G — M
+
+**Glossary** — this canon. A glossary is the only canon that may be expanded without re-versioning the whole cathedral.
+
+**Heading** — the slab-set name of a chapel or a canon. Headings always begin a new line of attention.
+
+**Lede** — the single italic line beneath the canon's name. The lede is a promise; the canon is its honoring.
+
+**Maintainer** — a person with the standing to deprecate, re-cast, or delete a canon. Every canon has at least one.
+
+## N — S
+
+**Nave** — the homepage of the cathedral. The nave is where every reader arrives.
+
+**Observance** — the body of rituals described in Canon IV. The observance is the writing discipline, not the architecture.
+
+**Restoration** — the craft of repair described in Canon V.
+
+## T — Z
+
+**Tombstone** — the record left when a canon is deleted. A tombstone names the canon, dates the deletion, and links to whatever replaced it.
+
+**Typography** — the building material of the cathedral, described in Canon III.
+
+Return to the [Nave](/) when you have read enough.

--- a/examples/slab-cathedral/content/canons/observance.md
+++ b/examples/slab-cathedral/content/canons/observance.md
@@ -1,0 +1,34 @@
++++
+title = "Observance"
+description = "The rituals of writing in this house."
+date = "2026-01-27"
+weight = 4
+template = "doc"
+toc = true
+[extra]
+roman = "IV"
++++
+
+Every cathedral has rituals — the small habits of attention that distinguish a sacred space from a warehouse. The cathedral of documentation is no different. These are the observances you keep when you write a canon for this house.
+
+## How a canon is opened
+
+Every canon opens with the same structure. A Roman numeral, two hundred and twenty pixels tall, carved at the head of the page. Below it, the canon's name in seventy-pixel slab. Below that, a single italic line of context, the *lede*, that frames what is to follow.
+
+The lede is not a summary. The lede is a *promise*. It tells the reader what the canon will give them by the end. If the lede cannot be honored, the canon is not yet ready to be written.
+
+## How a paragraph is written
+
+A paragraph in this house carries one idea. Not two, not half. One. When the idea is complete, the paragraph ends. There is no minimum length, no maximum length. The discipline is conceptual, not metric.
+
+> The shortest paragraph in this entire cathedral is a single word. The longest is one hundred and forty-three. Both honor the rule.
+
+## How a section is closed
+
+Every section closes with a sentence that gives the reader either a *next step* or a *settlement*. A next step points forward: "Continue to Canon V." A settlement makes peace with the section: "There is nothing more to say here." Either is acceptable. Trailing off without one or the other is not.
+
+## How silence is held
+
+White space is not absence. It is part of the writing. A canon with too little white space exhausts the reader. A canon with too much wastes their time. The discipline is balance — and balance is learned by listening.
+
+Continue to [Canon V, Restoration](/canons/restoration/).

--- a/examples/slab-cathedral/content/canons/proportions.md
+++ b/examples/slab-cathedral/content/canons/proportions.md
@@ -1,0 +1,36 @@
++++
+title = "Proportions"
+description = "On the discipline of single-column reading."
+date = "2026-01-13"
+weight = 2
+template = "doc"
+toc = true
+[extra]
+roman = "II"
++++
+
+Width is a virtue of restraint. A line of text 720 pixels wide reads twice as cleanly as a line 1200 pixels wide, and four times as cleanly as a line that spans the whole window. The cathedral commits to this number — 720, no exceptions, no responsive widening.
+
+## The measure
+
+The optimal line length for reading sits between 50 and 75 characters. Below 50 the eye snaps too often to the next line. Above 75 it loses its place between sweep and return. Source Serif 4 at 19px, set on a 720px column, lands inside that window for every paragraph in this house.
+
+You may resent the unused white space on a 1920px monitor. The space is part of the design. The space is what makes the reading feel like reading.
+
+| Width | Reads as |
+|-------|----------|
+| Under 50ch | Choppy, telegraphic |
+| 50–75ch | Calm, sustained |
+| Over 75ch | Strained, easily lost |
+
+## The aisles
+
+The narrow side aisles at left and right are not decoration. The left aisle holds the canon index — your map. The right aisle holds the table of contents for the open canon — your bookmark. Together they make the cathedral navigable without ever interrupting the central column.
+
+On a phone, the aisles fold up onto the top of the page. The nave stays exactly the same width — fluid below a breakpoint, never wider above it.
+
+## Margins are not negotiable
+
+A wide margin is not a luxury. It is the discipline that keeps the eye where it belongs. If your screen is large, the cathedral floats in the middle, surrounded by paper. That is correct. Do not maximize.
+
+Continue to [Canon III, Typography](/canons/typography/).

--- a/examples/slab-cathedral/content/canons/restoration.md
+++ b/examples/slab-cathedral/content/canons/restoration.md
@@ -1,0 +1,34 @@
++++
+title = "Restoration"
+description = "How the cathedral is repaired."
+date = "2026-02-03"
+weight = 5
+template = "doc"
+toc = true
+[extra]
+roman = "V"
++++
+
+Cathedrals age. Stones crack. Glass yellows. Lines that read well in one decade read oddly in the next. The cathedral of documentation has a craft for these moments, and the craft is restoration — never replacement.
+
+## Deprecation as a craft
+
+A canon that no longer serves is not deleted. It is *deprecated* — marked, dated, and quietly closed to new readers. The page remains in the index, with a deprecation notice at the top that links to the canon that replaced it. Old links keep working. The history stays legible.
+
+Deletion is a last resort. The only canons that are deleted are ones that contained an active harm — a factual error that misled, a security mistake that wounded. Even then, the deletion leaves a tombstone behind.
+
+## The three categories of repair
+
+1. **Surface** — typos, broken links, outdated screenshots. Fixed within the week.
+2. **Structural** — a section that no longer holds together, a heading that misnames what follows. Re-cast within the quarter.
+3. **Foundational** — a canon whose central premise has changed. Deprecated, replaced, and the old canon kept as a tombstone.
+
+The category is decided by the maintainer, not by the reader. A reader who flags an issue is heard, then a maintainer decides the tier.
+
+## Erasure as a last resort
+
+Some traditions hold that all history must remain visible. Others hold that wrong information should be removed at any cost. The cathedral takes a middle position: history remains visible, *with annotation*. A canon that contained an error keeps the error, struck through, with a corrective note dated and signed.
+
+> A struck-through error is more honest than a silent correction.
+
+Continue to [Canon VI, Glossary](/canons/glossary/).

--- a/examples/slab-cathedral/content/canons/typography.md
+++ b/examples/slab-cathedral/content/canons/typography.md
@@ -1,0 +1,38 @@
++++
+title = "Typography"
+description = "The slab serif and its lineage."
+date = "2026-01-20"
+weight = 3
+template = "doc"
+toc = true
+[extra]
+roman = "III"
++++
+
+A typeface is a building material. You do not choose it the way you choose a paint color — you choose it the way an architect chooses the stone for a façade. Slab serif is the cathedral's stone, and there are reasons.
+
+## The lineage
+
+Slab serifs were born in industrial London in 1815, designed to shout across a printed handbill. They were never quiet typefaces. The modern slab — Roboto Slab, Bree, Zilla — inherits the muscular silhouette and softens the contrast for screen reading.
+
+The cathedral uses Roboto Slab at three weights: 400 for the rare display run-in, 700 for the chapter names, 900 for the canon numerals. The 900 weight is the only place where slab is allowed to shout.
+
+## The pairing
+
+Slab does not read well as body type at 19px. The strokes are too uniform; the eye tires. So the body is set in **Source Serif 4** — a serif designed by Frank Grießhammer for sustained reading on screens. The two voices share a temperament: both rooted in industrial tradition, both reformed for the present.
+
+```
+display:  Roboto Slab 900   — 64–220px
+body:     Source Serif 4    — 18–22px
+caption:  JetBrains Mono    — 10–13px
+```
+
+The mono is for the mason's notes — the timestamps, the run codes, the things that are not the reading but exist to support it.
+
+## The voice
+
+A typeface has a voice the same way a person does. The cathedral picks a voice that is *deliberate, calm, certain*. Not friendly. Not playful. Not nostalgic. Deliberate.
+
+You can hear the voice in any line you read. If you cannot, the typography has failed and the canon should be re-cast.
+
+Continue to [Canon IV, Observance](/canons/observance/).

--- a/examples/slab-cathedral/content/index.md
+++ b/examples/slab-cathedral/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "The Nave"
+description = "A documentation cathedral set in monumental slab serif."
++++
+
+Welcome to the cathedral. Take your time inside. Read one canon, then sit with it before moving to the next. The architecture is meant to slow you down — that is the point.
+
+Enter through [Canon I, Foundations](/canons/foundations/), or sit in the [Nave](/) a while longer.

--- a/examples/slab-cathedral/static/css/style.css
+++ b/examples/slab-cathedral/static/css/style.css
@@ -1,0 +1,595 @@
+:root {
+  --paper: #f0eadc;
+  --paper-deep: #e6dec9;
+  --ink: #0b0a08;
+  --ink-soft: #2c2924;
+  --rule: #1a1815;
+  --accent: #a73826;
+  --accent-soft: #c66648;
+  --margin: #756c5a;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: 'Source Serif 4', 'Source Serif Pro', Georgia, serif;
+  font-size: 18px;
+  line-height: 1.62;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 4px; text-decoration-color: rgba(167,56,38,0.4); }
+a:hover { color: var(--ink); text-decoration-color: var(--ink); }
+
+.shell { max-width: 1200px; margin: 0 auto; padding: 0 48px; }
+
+/* ---- masthead: double-rule cathedral entrance ---- */
+.masthead {
+  border-top: 8px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding: 14px 0 8px;
+  margin-top: 4px;
+  position: relative;
+}
+.masthead::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 0;
+  right: 0;
+  height: 4px;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+.mast-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 32px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+.mast-row .left, .mast-row .right { color: var(--ink-soft); }
+.mast-row .right { text-align: right; }
+.brand {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--ink);
+}
+.topnav {
+  padding: 16px 0 18px;
+  border-bottom: 1px solid var(--ink);
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+}
+.topnav a { text-decoration: none; color: var(--ink); }
+.topnav a:hover { color: var(--accent); }
+.topnav a.active { color: var(--accent); }
+
+/* ---- nave: home hero ---- */
+.nave {
+  padding: 100px 0 90px;
+  text-align: center;
+  border-bottom: 1px solid var(--ink);
+}
+.nave .pre {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  color: var(--margin);
+  margin-bottom: 32px;
+}
+.nave h1 {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 168px;
+  line-height: 0.86;
+  letter-spacing: -0.045em;
+  margin-bottom: 40px;
+  color: var(--ink);
+}
+.nave h1 .ampersand {
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-style: italic;
+  font-weight: 400;
+  color: var(--accent);
+}
+.nave .lede {
+  max-width: 640px;
+  margin: 0 auto;
+  font-size: 22px;
+  line-height: 1.45;
+  font-style: italic;
+  color: var(--ink-soft);
+}
+.nave .rule {
+  margin: 36px auto 0;
+  width: 60px;
+  border-top: 2px solid var(--ink);
+}
+
+/* ---- chapter list (home) ---- */
+.chapter-list {
+  padding: 80px 0;
+  display: grid;
+  grid-template-columns: minmax(0, 760px);
+  justify-content: center;
+}
+.chapter-list h2 {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  text-align: center;
+  margin-bottom: 50px;
+  color: var(--margin);
+}
+.chapter {
+  display: grid;
+  grid-template-columns: 140px 1fr auto;
+  gap: 30px;
+  padding: 28px 0;
+  border-top: 1px solid var(--ink);
+  align-items: baseline;
+  text-decoration: none;
+  color: var(--ink);
+  transition: background 0.2s ease;
+}
+.chapter:hover { background: var(--paper-deep); }
+.chapter:last-child { border-bottom: 1px solid var(--ink); }
+.chapter .num {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 96px;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  color: var(--accent);
+  text-align: right;
+}
+.chapter h3 {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 700;
+  font-size: 34px;
+  line-height: 1;
+  letter-spacing: -0.015em;
+  margin-bottom: 8px;
+}
+.chapter p {
+  font-size: 16px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  font-style: italic;
+}
+.chapter .meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--margin);
+  white-space: nowrap;
+  align-self: center;
+}
+
+/* ---- doc layout: nave + side aisles ---- */
+.doc-shell {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 720px) 220px;
+  gap: 40px;
+  padding: 60px 0 80px;
+  justify-content: center;
+}
+.aisle-left, .aisle-right {
+  position: sticky;
+  top: 24px;
+  align-self: start;
+  max-height: calc(100vh - 60px);
+  overflow-y: auto;
+}
+.aisle-left {
+  text-align: right;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.aisle-left .group { margin-bottom: 22px; }
+.aisle-left .label { color: var(--margin); margin-bottom: 8px; display: block; font-size: 10px; }
+.aisle-left a {
+  display: block;
+  text-decoration: none;
+  color: var(--ink-soft);
+  padding: 4px 0;
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-size: 14px;
+  letter-spacing: 0;
+  text-transform: none;
+  line-height: 1.35;
+}
+.aisle-left a:hover { color: var(--accent); }
+.aisle-left a.active {
+  color: var(--accent);
+  font-weight: 700;
+  font-style: italic;
+}
+.aisle-left a .num {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 13px;
+  margin-right: 8px;
+  color: var(--margin);
+}
+
+.aisle-right {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.aisle-right .label { color: var(--margin); margin-bottom: 10px; display: block; }
+.aisle-right .toc a {
+  display: block;
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-size: 13px;
+  letter-spacing: 0;
+  text-transform: none;
+  text-decoration: none;
+  color: var(--ink-soft);
+  padding: 4px 0 4px 14px;
+  border-left: 1px solid var(--margin);
+  line-height: 1.35;
+}
+.aisle-right .toc a:hover { color: var(--accent); border-left-color: var(--accent); }
+.aisle-right .toc ul { list-style: none; padding: 0; }
+.aisle-right .toc ul ul { padding-left: 14px; border-left: 1px dashed var(--margin); margin-left: 4px; }
+
+/* article */
+article.doc { min-width: 0; }
+article.doc .crumb {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  text-align: center;
+  color: var(--margin);
+  margin-bottom: 50px;
+}
+article.doc .crumb a { color: var(--ink); text-decoration: none; }
+article.doc .crumb a:hover { color: var(--accent); }
+article.doc .crumb .sep { margin: 0 10px; color: var(--margin); }
+
+.doc-head {
+  text-align: center;
+  margin-bottom: 70px;
+}
+.doc-head .chapter-mark {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: var(--margin);
+  margin-bottom: 24px;
+}
+.doc-head .chapter-num {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 220px;
+  line-height: 0.82;
+  letter-spacing: -0.06em;
+  color: var(--accent);
+  margin-bottom: 20px;
+}
+.doc-head h1 {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 64px;
+  line-height: 0.96;
+  letter-spacing: -0.025em;
+  margin-bottom: 24px;
+  color: var(--ink);
+}
+.doc-head .desc {
+  max-width: 540px;
+  margin: 0 auto;
+  font-size: 20px;
+  font-style: italic;
+  color: var(--ink-soft);
+  line-height: 1.45;
+}
+.doc-head .rule {
+  margin: 36px auto 0;
+  width: 60px;
+  border-top: 2px solid var(--ink);
+}
+
+/* body */
+.doc-body { font-size: 19px; line-height: 1.72; }
+.doc-body > p:first-of-type::first-letter {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 92px;
+  line-height: 0.85;
+  float: left;
+  margin: 6px 14px 0 -2px;
+  color: var(--accent);
+}
+.doc-body h2 {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 42px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin: 70px 0 22px;
+  text-align: center;
+  color: var(--ink);
+  position: relative;
+}
+.doc-body h2::before {
+  content: "";
+  display: block;
+  width: 40px;
+  height: 2px;
+  background: var(--accent);
+  margin: 0 auto 24px;
+}
+.doc-body h3 {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 700;
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+  margin: 40px 0 12px;
+  color: var(--ink);
+}
+.doc-body h3::before {
+  content: counter(h3-counter, decimal-leading-zero) "  ";
+  counter-increment: h3-counter;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 400;
+  font-size: 14px;
+  color: var(--accent);
+  letter-spacing: 0.1em;
+  vertical-align: middle;
+}
+.doc-body { counter-reset: h3-counter; }
+.doc-body p { margin: 16px 0; }
+.doc-body strong { font-weight: 700; color: var(--ink); }
+.doc-body em { font-style: italic; color: var(--accent); }
+.doc-body ul, .doc-body ol { margin: 16px 0 18px 26px; }
+.doc-body li { margin: 8px 0; }
+.doc-body ul li::marker { color: var(--accent); content: "❧ "; font-size: 0.85em; }
+.doc-body ol { list-style: none; counter-reset: ol-counter; padding-left: 0; }
+.doc-body ol li { counter-increment: ol-counter; position: relative; padding-left: 56px; }
+.doc-body ol li::before {
+  content: counter(ol-counter, upper-roman) ".";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 44px;
+  text-align: right;
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  color: var(--accent);
+  font-size: 17px;
+}
+
+.doc-body code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--paper-deep);
+  padding: 1px 6px;
+  font-size: 15px;
+  color: var(--accent);
+  border: 1px solid var(--margin);
+}
+.doc-body pre {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 24px 28px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14.5px;
+  line-height: 1.6;
+  overflow-x: auto;
+  margin: 30px -20px;
+  border-top: 4px solid var(--accent);
+  border-bottom: 1px solid var(--accent);
+}
+.doc-body pre code { background: none; border: none; padding: 0; color: var(--paper); }
+
+.doc-body blockquote {
+  margin: 36px -40px;
+  padding: 28px 40px;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-style: italic;
+  font-size: 24px;
+  line-height: 1.45;
+  text-align: center;
+  color: var(--ink);
+  position: relative;
+}
+.doc-body blockquote::before {
+  content: "❝";
+  display: block;
+  font-style: normal;
+  font-size: 48px;
+  line-height: 1;
+  color: var(--accent);
+  margin-bottom: 14px;
+  font-family: 'Source Serif 4', Georgia, serif;
+}
+.doc-body blockquote p { margin: 0; }
+
+.doc-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 28px 0;
+  font-size: 16px;
+}
+.doc-body th {
+  text-align: left;
+  padding: 12px 14px;
+  border-top: 2px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.doc-body td { padding: 12px 14px; border-bottom: 1px solid var(--paper-deep); }
+.doc-body tr:last-child td { border-bottom: 2px solid var(--ink); }
+
+.doc-body hr {
+  border: 0;
+  text-align: center;
+  margin: 40px 0;
+  position: relative;
+}
+.doc-body hr::after {
+  content: "✦   ✦   ✦";
+  font-family: 'Source Serif 4', Georgia, serif;
+  color: var(--accent);
+  letter-spacing: 1em;
+  font-size: 14px;
+}
+
+/* footer of article */
+.doc-end {
+  margin: 90px auto 0;
+  text-align: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--margin);
+  padding: 30px 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 8px solid var(--ink);
+  position: relative;
+}
+.doc-end::after {
+  content: "";
+  position: absolute;
+  bottom: -12px;
+  left: 0;
+  right: 0;
+  height: 4px;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+.doc-end .em { color: var(--accent); font-size: 18px; letter-spacing: 0.3em; }
+
+.doc-nav {
+  margin-top: 60px;
+  padding-top: 24px;
+  border-top: 1px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+}
+.doc-nav a {
+  text-decoration: none;
+  color: var(--ink);
+  display: block;
+}
+.doc-nav .label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--margin);
+  display: block;
+  margin-bottom: 6px;
+}
+.doc-nav .title {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+.doc-nav .title:hover { color: var(--accent); }
+.doc-nav .next { text-align: right; }
+
+/* colophon */
+.colophon {
+  padding: 60px 0 80px;
+  text-align: center;
+  border-top: 1px solid var(--ink);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: var(--margin);
+  line-height: 2;
+}
+.colophon a { color: var(--ink); }
+.colophon .mono-rule {
+  width: 36px;
+  height: 1px;
+  background: var(--ink);
+  margin: 22px auto;
+}
+
+/* section page */
+.section-head {
+  padding: 80px 0;
+  text-align: center;
+  border-bottom: 1px solid var(--ink);
+}
+.section-head .pre {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  color: var(--margin);
+  margin-bottom: 28px;
+}
+.section-head h1 {
+  font-family: 'Roboto Slab', Georgia, serif;
+  font-weight: 900;
+  font-size: 132px;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+  margin-bottom: 24px;
+}
+.section-head .lede {
+  max-width: 600px;
+  margin: 0 auto;
+  font-size: 21px;
+  line-height: 1.45;
+  font-style: italic;
+  color: var(--ink-soft);
+}
+
+@media (max-width: 1080px) {
+  .doc-shell { grid-template-columns: 1fr; gap: 30px; }
+  .aisle-left, .aisle-right { position: static; max-height: none; text-align: left; }
+  .aisle-left a, .aisle-left .label { text-align: left; }
+}
+@media (max-width: 720px) {
+  .shell { padding: 0 22px; }
+  .nave h1 { font-size: 84px; }
+  .doc-head .chapter-num { font-size: 120px; }
+  .doc-head h1 { font-size: 38px; }
+  .section-head h1 { font-size: 72px; }
+  .chapter { grid-template-columns: 80px 1fr; }
+  .chapter .meta { display: none; }
+  .chapter .num { font-size: 56px; }
+  .doc-body pre, .doc-body blockquote { margin-left: 0; margin-right: 0; }
+}

--- a/examples/slab-cathedral/static/favicon.svg
+++ b/examples/slab-cathedral/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/slab-cathedral/templates/404.html
+++ b/examples/slab-cathedral/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<main style="padding:120px 0;text-align:center;">
+  <div style="font-family:'JetBrains Mono',monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.4em;color:#756c5a;margin-bottom:24px;">— Missing Vault —</div>
+  <div style="font-family:'Roboto Slab',serif;font-weight:900;font-size:260px;line-height:0.85;letter-spacing:-0.05em;color:#a73826;">404</div>
+  <h1 style="font-family:'Roboto Slab',serif;font-weight:900;font-size:48px;letter-spacing:-0.02em;margin:30px 0 18px;">The Page Was Never Built</h1>
+  <p style="max-width:480px;margin:0 auto 32px;font-style:italic;font-size:19px;color:#2c2924;line-height:1.45;">The architect drew it. The masons cut the stones. But the vault never closed, and the chapel was abandoned to time.</p>
+  <a href="{{ base_url }}/" style="font-family:'JetBrains Mono',monospace;font-size:11px;letter-spacing:0.25em;text-transform:uppercase;border-top:1px solid #0b0a08;border-bottom:1px solid #0b0a08;padding:14px 22px;text-decoration:none;color:#0b0a08;display:inline-block;">↩ Return to the Nave</a>
+</main>
+{% include "footer.html" %}

--- a/examples/slab-cathedral/templates/doc.html
+++ b/examples/slab-cathedral/templates/doc.html
@@ -1,0 +1,81 @@
+{% include "header.html" %}
+<main class="doc-shell">
+  <aside class="aisle-left">
+    <div class="group">
+      <span class="label">— The Canons —</span>
+      {% if section.pages %}
+        {% for doc in section.pages %}
+          <a href="{{ base_url }}{{ doc.url }}" {% if doc.url == page.url %}class="active"{% endif %}>
+            <span class="num">{{ doc.extra.roman | default(value=loop.index) }}.</span>{{ doc.title }}
+          </a>
+        {% endfor %}
+      {% endif %}
+    </div>
+    <div class="group">
+      <span class="label">— Liturgy —</span>
+      <a href="{{ base_url }}/">Nave</a>
+      <a href="{{ base_url }}/about/">Colophon</a>
+      <a href="{{ base_url }}/tags/">Index</a>
+    </div>
+  </aside>
+
+  <article class="doc">
+    <div class="crumb">
+      <a href="{{ base_url }}/">NAVE</a>
+      <span class="sep">·</span>
+      <a href="{{ base_url }}/canons/">CANONS</a>
+      <span class="sep">·</span>
+      <span>{{ page.title | upper }}</span>
+    </div>
+
+    <header class="doc-head">
+      <div class="chapter-mark">Canon {{ page.extra.roman | default(value="I") }}</div>
+      <div class="chapter-num">{{ page.extra.roman | default(value="I") }}</div>
+      <h1>{{ page.title }}</h1>
+      {% if page.description %}<p class="desc">{{ page.description }}</p>{% endif %}
+      <div class="rule"></div>
+    </header>
+
+    <div class="doc-body">
+      {{ content }}
+    </div>
+
+    <div class="doc-end">
+      <span class="em">✦</span><br>
+      Here ends Canon {{ page.extra.roman | default(value="I") }}
+    </div>
+
+    <nav class="doc-nav">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}">
+        <span class="label">← Previous Canon</span>
+        <span class="title">{{ page.lower.title }}</span>
+      </a>
+      {% else %}<span></span>{% endif %}
+
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="next">
+        <span class="label">Next Canon →</span>
+        <span class="title">{{ page.higher.title }}</span>
+      </a>
+      {% else %}<span></span>{% endif %}
+    </nav>
+  </article>
+
+  <aside class="aisle-right">
+    {% if page.toc %}
+    <div>
+      <span class="label">— In This Chapel —</span>
+      <div class="toc">{{ page.toc }}</div>
+    </div>
+    {% endif %}
+    <div style="margin-top:30px;">
+      <span class="label">— Status —</span>
+      <div style="font-family:'Source Serif 4',serif;font-size:14px;letter-spacing:0;text-transform:none;color:#2c2924;line-height:1.6;">
+        Inscribed {{ page.date | date(format="%d %B %Y") }}<br>
+        {{ page.reading_time | default(value="—") }} min observance
+      </div>
+    </div>
+  </aside>
+</main>
+{% include "footer.html" %}

--- a/examples/slab-cathedral/templates/footer.html
+++ b/examples/slab-cathedral/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="colophon">
+      Set in Roboto Slab and Source Serif 4 · Printed in Anno {{ current_year }}
+      <div class="mono-rule"></div>
+      {{ site.title }} · <a href="{{ base_url }}/feeds/rss.xml">Annals</a> · <a href="{{ base_url }}/about/">Colophon</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/slab-cathedral/templates/header.html
+++ b/examples/slab-cathedral/templates/header.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} — {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;700;900&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="shell">
+    <header class="masthead">
+      <div class="mast-row">
+        <div class="left">VOLUMEN · MMXXVI</div>
+        <a class="brand" href="{{ base_url }}/">{{ site.title | upper }}</a>
+        <div class="right">FOLIO {{ current_year }}</div>
+      </div>
+    </header>
+    <nav class="topnav">
+      <a href="{{ base_url }}/" {% if page.url == "/" %}class="active"{% endif %}>The Nave</a>
+      <a href="{{ base_url }}/canons/" {% if page.section == "canons" %}class="active"{% endif %}>The Canons</a>
+      <a href="{{ base_url }}/canons/observance/">Observance</a>
+      <a href="{{ base_url }}/canons/glossary/">Glossary</a>
+      <a href="{{ base_url }}/about/">Colophon</a>
+    </nav>

--- a/examples/slab-cathedral/templates/page.html
+++ b/examples/slab-cathedral/templates/page.html
@@ -1,0 +1,68 @@
+{% include "header.html" %}
+<main>
+  <section class="nave">
+    <div class="pre">A Cathedral of Documentation · Anno MMXXVI</div>
+    <h1>Slab<br><span class="ampersand">&amp;</span><br>Cathedral</h1>
+    <p class="lede">A documentation system built like a cathedral — monumental in its proportions, single-column in its nave, deliberate in its silence. Every chapter is a chapel; every numeral is carved in stone.</p>
+    <div class="rule"></div>
+  </section>
+
+  <section class="chapter-list">
+    <div>
+      <h2>— The Six Canons —</h2>
+      <a class="chapter" href="{{ base_url }}/canons/foundations/">
+        <div class="num">I</div>
+        <div>
+          <h3>Foundations</h3>
+          <p>The first canon. What the cathedral is, what it is not, and how it differs from the office buildings nearby.</p>
+        </div>
+        <div class="meta">Read · 7 min</div>
+      </a>
+      <a class="chapter" href="{{ base_url }}/canons/proportions/">
+        <div class="num">II</div>
+        <div>
+          <h3>Proportions</h3>
+          <p>On the discipline of single-column reading. Margins, line lengths, and why width is a virtue of restraint.</p>
+        </div>
+        <div class="meta">Read · 6 min</div>
+      </a>
+      <a class="chapter" href="{{ base_url }}/canons/typography/">
+        <div class="num">III</div>
+        <div>
+          <h3>Typography</h3>
+          <p>The slab serif and its lineage. Why this voice. What it costs in pixels. What it returns in attention.</p>
+        </div>
+        <div class="meta">Read · 8 min</div>
+      </a>
+      <a class="chapter" href="{{ base_url }}/canons/observance/">
+        <div class="num">IV</div>
+        <div>
+          <h3>Observance</h3>
+          <p>The rituals of writing in this house. How a chapter is opened, how a section is closed, how silence is held.</p>
+        </div>
+        <div class="meta">Read · 5 min</div>
+      </a>
+      <a class="chapter" href="{{ base_url }}/canons/restoration/">
+        <div class="num">V</div>
+        <div>
+          <h3>Restoration</h3>
+          <p>How the cathedral is repaired. Deprecation as a craft. Erasure as a last resort.</p>
+        </div>
+        <div class="meta">Read · 6 min</div>
+      </a>
+      <a class="chapter" href="{{ base_url }}/canons/glossary/">
+        <div class="num">VI</div>
+        <div>
+          <h3>Glossary</h3>
+          <p>The vocabulary of the order. Forty-three terms, set in alphabetical order.</p>
+        </div>
+        <div class="meta">Read · 4 min</div>
+      </a>
+    </div>
+  </section>
+
+  <div class="doc-body" style="max-width:720px;margin:0 auto 60px;padding:0 40px;">
+    {{ content }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/slab-cathedral/templates/section.html
+++ b/examples/slab-cathedral/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+<main>
+  <section class="section-head">
+    <div class="pre">— The {{ section.pages | length }} Canons —</div>
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="lede">{{ section.description }}</p>{% endif %}
+  </section>
+
+  <section class="chapter-list">
+    <div>
+      {% for doc in section.pages %}
+      <a class="chapter" href="{{ base_url }}{{ doc.url }}">
+        <div class="num">{{ doc.extra.roman | default(value=loop.index) }}</div>
+        <div>
+          <h3>{{ doc.title }}</h3>
+          {% if doc.description %}<p>{{ doc.description }}</p>{% endif %}
+        </div>
+        <div class="meta">{{ doc.reading_time | default(value="—") }} min</div>
+      </a>
+      {% endfor %}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/slab-cathedral/templates/shortcodes/alert.html
+++ b/examples/slab-cathedral/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/slab-cathedral/templates/taxonomy.html
+++ b/examples/slab-cathedral/templates/taxonomy.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<main style="padding:60px 0 80px;text-align:center;">
+  <div style="font-family:'JetBrains Mono',monospace;font-size:11px;letter-spacing:0.4em;text-transform:uppercase;color:#756c5a;margin-bottom:20px;">— The Index —</div>
+  <h1 style="font-family:'Roboto Slab',serif;font-weight:900;font-size:88px;letter-spacing:-0.03em;margin-bottom:40px;">Tags</h1>
+  <ul style="list-style:none;padding:0;display:flex;flex-wrap:wrap;gap:14px;justify-content:center;max-width:720px;margin:0 auto;">
+    {% for term in taxonomy_terms %}
+    <li><a href="{{ base_url }}{{ term.url }}" style="text-decoration:none;font-family:'Roboto Slab',serif;font-weight:700;color:#0b0a08;font-size:18px;border-top:1px solid #0b0a08;border-bottom:1px solid #0b0a08;padding:6px 14px;">{{ term.name }} <span style="color:#a73826;font-family:'JetBrains Mono',monospace;font-size:13px;">{{ term.pages | length }}</span></a></li>
+    {% endfor %}
+  </ul>
+</main>
+{% include "footer.html" %}

--- a/examples/slab-cathedral/templates/taxonomy_term.html
+++ b/examples/slab-cathedral/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<main>
+  <section class="section-head">
+    <div class="pre">— Filed Under —</div>
+    <h1>#{{ taxonomy_term }}</h1>
+  </section>
+  <section class="chapter-list">
+    <div>
+      {% for doc in taxonomy_pages %}
+      <a class="chapter" href="{{ base_url }}{{ doc.url }}">
+        <div class="num">{{ loop.index }}</div>
+        <div>
+          <h3>{{ doc.title }}</h3>
+          {% if doc.description %}<p>{{ doc.description }}</p>{% endif %}
+        </div>
+        <div class="meta">{{ doc.date | date(format="%b %Y") }}</div>
+      </a>
+      {% endfor %}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/transit-codex/AGENTS.md
+++ b/examples/transit-codex/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/transit-codex/archetypes/default.md
+++ b/examples/transit-codex/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/transit-codex/config.toml
+++ b/examples/transit-codex/config.toml
@@ -1,0 +1,190 @@
+title = "Transit Codex"
+description = "Documentation laid out as a transit map — every chapter a station, every section a colored line."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+heading_ids = true
+footnotes = true
+task_lists = true
+admonitions = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/transit-codex/content/about.md
+++ b/examples/transit-codex/content/about.md
@@ -1,0 +1,10 @@
++++
+title = "The Yard"
+description = "Where the cars are washed and the operators sleep."
++++
+
+The yard is where the documentation team meets — the back office for everyone running the lines you see on the map. Not every road in the system shows up on the public map, and that is the point of the yard.
+
+This codex is maintained as if it were rolling stock. Pages are deprecated, not deleted. Routes are renamed only when the underlying system changes. Stations are added in sequence, never inserted between two existing stops.
+
+If you find a broken signal or a chapter that needs grease, file a maintenance ticket. The yard runs 24h.

--- a/examples/transit-codex/content/index.md
+++ b/examples/transit-codex/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Transit Codex"
+description = "Documentation laid out as a transit map."
++++
+
+A documentation system patterned on the way a city moves. Each guide is a colored line; each chapter is a station on that line. Cross-references between guides appear as transfers. Boarding is free.
+
+Start at [Foundations](/routes/foundations/) for the system tour, or jump straight to [Operations](/routes/operations/) if you've ridden before.

--- a/examples/transit-codex/content/routes/_index.md
+++ b/examples/transit-codex/content/routes/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Lines in Service"
+description = "Every line currently boarding passengers."
+sort_by = "weight"
+template = "section"
++++
+
+Twelve stations across four lines. Red runs the trunk, Blue the express, Green the locals, Orange the weekend service. Switch freely.

--- a/examples/transit-codex/content/routes/foundations.md
+++ b/examples/transit-codex/content/routes/foundations.md
@@ -1,0 +1,53 @@
++++
+title = "Foundations"
+description = "The red line. Concepts, vocabulary, and the layout of the whole system."
+date = "2026-02-01"
+weight = 1
+template = "doc"
+[extra]
+line = "R"
+line_name = "Red Line"
+color = "#e63946"
+station = "01"
+transfers = [
+  { line = "B", color = "#1d4ed8" },
+  { line = "G", color = "#138a36" }
+]
++++
+
+The red line carries the foundation traffic — the vocabulary, the mental model, the layout of the whole system. Every other line connects here at least once. Board at the southern terminus and ride north through four stops.
+
+## Station R01 · Vocabulary
+
+Every documentation system has a private dialect. This one is no exception. The four words you need before riding any further:
+
+- **Line** — a thematic guide. Red runs foundations, Blue runs operations, Green runs signals, Orange runs maintenance.
+- **Station** — a single chapter, the smallest unit of documentation that stands on its own.
+- **Transfer** — a cross-reference that lets you change lines without going back to the map.
+- **Headway** — the time between revisions to a guide.
+
+Memorize the first three. The fourth will become obvious when you maintain the system.
+
+## Station R02 · The mental model
+
+Documentation lives on rails. A guide is a sequence of stations, and the rails between them are explicit. You always know what comes before and what comes after a chapter, because every page is a stop on a line. You never lose your place — the map is in your hand.
+
+> If you cannot tell which line you are riding, the system is broken.
+
+## Station R03 · Transfers
+
+Some concepts belong on multiple lines. *Authentication* is a topic on Operations (Blue) but also a station on Signals (Green) because it produces telemetry. We do not duplicate the content — we mark the station as a **transfer**, and the reader takes one of the two lines depending on what they came for.
+
+```
+[Authentication]
+  Blue ─── Operations · Station B02
+  Green ── Signals · Station G02
+```
+
+Transfers cost nothing and reduce duplication. Use them aggressively.
+
+## Station R04 · Maintenance discipline
+
+A documentation system without maintenance discipline ages into a museum. This one runs like a transit authority: pages are deprecated, not deleted; new stations are appended in sequence, not inserted between two stops; lines are renamed only when the underlying system shifts.
+
+Continue to the [Operations line](/routes/operations/) to learn what runs day-to-day.

--- a/examples/transit-codex/content/routes/maintenance.md
+++ b/examples/transit-codex/content/routes/maintenance.md
@@ -1,0 +1,43 @@
++++
+title = "Maintenance"
+description = "The orange line. Recovery, rollback, and long-tail repair."
+date = "2026-02-22"
+weight = 4
+template = "doc"
+[extra]
+line = "O"
+line_name = "Orange Line"
+color = "#ed7d2b"
+station = "01"
+transfers = [
+  { line = "B", color = "#1d4ed8" }
+]
++++
+
+The orange line runs weekends only — when traffic is low and the operators have time to fix the things they could not touch on a Tuesday. Two stops, both important, both unglamorous.
+
+## Station O01 · Rollback
+
+Every action on this system is reversible. Not undoable — *reversible*. The distinction matters. An undo erases the action. A reverse leaves the action in place and adds a corrective entry that cancels its effect.
+
+Rollback in this system is always a *reverse*, never an *undo*. The audit trail keeps both entries — the original and the corrective — so the next operator can see what happened and why.
+
+```
+$ codex reverse  [action-id]  --reason "wrong job id"
+```
+
+A reverse without a reason is rejected at the panel. The reason becomes part of the audit chain.
+
+## Station O02 · Long-tail repair
+
+Most maintenance is small. A typo in a doc, an outdated example, an alert threshold that drifts a week after a release. These are the long tail — individually trivial, collectively the difference between a system that ages well and one that fossilizes.
+
+The long-tail repair workflow is simple: file the ticket from wherever you noticed the issue (the orange line accepts tickets from every other line), pick it up in the next maintenance window, fix it in under thirty minutes, ship it.
+
+| Tier | Window | Goal time |
+|------|--------|-----------|
+| Tier 1 | Same week | < 30 min |
+| Tier 2 | Same month | < 2 hours |
+| Tier 3 | Same quarter | Tracked in a roadmap |
+
+Anything that does not fit Tier 1 or 2 is a [Foundations](/routes/foundations/) problem in disguise, not a maintenance problem. Transfer to the red line and re-think the underlying model.

--- a/examples/transit-codex/content/routes/operations.md
+++ b/examples/transit-codex/content/routes/operations.md
@@ -1,0 +1,53 @@
++++
+title = "Operations"
+description = "The blue line. Day-to-day commands, runs, and diagnostics."
+date = "2026-02-08"
+weight = 2
+template = "doc"
+[extra]
+line = "B"
+line_name = "Blue Line"
+color = "#1d4ed8"
+station = "01"
+transfers = [
+  { line = "R", color = "#e63946" },
+  { line = "G", color = "#138a36" },
+  { line = "O", color = "#ed7d2b" }
+]
++++
+
+The blue line runs express. It carries operators who already know the system and need to do something with it, today. Three stops, all the basics, no detours.
+
+## Station B01 · The control panel
+
+Every operations session starts in the same place — the control panel. From there you can start a job, observe a running one, and stop a misbehaving one. The three primary verbs are *run*, *watch*, and *halt*. Memorize them as a unit; they are how the rest of this line refers back to the basics.
+
+```
+$ codex run    [job-id]
+$ codex watch  [job-id]
+$ codex halt   [job-id]
+```
+
+The control panel is a transfer point with [Foundations](/routes/foundations/) — the vocabulary you need is already on that platform.
+
+## Station B02 · Authentication
+
+This station is a transfer to the green line. Authentication is an operations concern (who can run what?) and a signals concern (who is running what right now?). Read this page if you came in on Blue; cross to Green if you came in for the audit trail.
+
+| Mode | Use for |
+|------|---------|
+| Token | Programmatic agents, CI runs |
+| Session | Interactive operators |
+| Mutual TLS | Service-to-service inside the cluster |
+
+The default is a session token bound to the operator's identity. Tokens for agents are minted on demand and expire on idle.
+
+## Station B03 · Diagnostics
+
+When something goes wrong, ride directly to this station. The diagnostic flow is always:
+
+1. Pull the last 200 lines of the operator log.
+2. Read the most recent state transition.
+3. Replay the failing job in dry-run mode.
+
+A failing job that survives dry-run replay is a bug in the system, not in your operation. Transfer to the [Orange line](/routes/maintenance/) and file a ticket from there.

--- a/examples/transit-codex/content/routes/signals.md
+++ b/examples/transit-codex/content/routes/signals.md
@@ -1,0 +1,43 @@
++++
+title = "Signals"
+description = "The green line. Telemetry, alerts, and audit."
+date = "2026-02-15"
+weight = 3
+template = "doc"
+[extra]
+line = "G"
+line_name = "Green Line"
+color = "#138a36"
+station = "01"
+transfers = [
+  { line = "B", color = "#1d4ed8" }
+]
++++
+
+The green line is a local. Every stop matters, and there is no express. Signals are what the system tells you about itself — and the only reliable way to know what is happening inside.
+
+## Station G01 · Telemetry feeds
+
+Three feeds run on this line. The *operator feed* shows what humans did. The *job feed* shows what jobs did. The *system feed* shows what the system did on its own. Read all three together; any one in isolation tells half a story.
+
+```
+operator:  who · what · when · where
+job:       id  · state · runtime
+system:    component · severity · message
+```
+
+A change in the system feed without a corresponding entry in the operator or job feed is an anomaly. Anomalies always merit a ticket.
+
+## Station G02 · Audit trail (transfer)
+
+Authentication is the transfer point with [Operations](/routes/operations/). The audit trail records every authenticated action — token issued, session opened, command executed, session closed. Each event is hashed against the previous, forming a chain you can verify after the fact.
+
+> If the chain breaks, treat every event after the break as untrusted.
+
+The audit trail is append-only. Edits are never permitted, only annotations.
+
+## Station G03 · Alerts
+
+Alerts are the loud cousins of telemetry. A signal becomes an alert when its severity crosses a threshold. The thresholds are not magic numbers — they are documented per signal in the source repo. Never silence an alert without filing an annotation explaining why.
+
+Continue to the [Orange line](/routes/maintenance/) for the maintenance side of the system.

--- a/examples/transit-codex/static/css/style.css
+++ b/examples/transit-codex/static/css/style.css
@@ -1,0 +1,629 @@
+:root {
+  --paper: #f6f3eb;
+  --paper-soft: #efebde;
+  --ink: #111418;
+  --ink-soft: #3a3f48;
+  --rule: #d8d2c2;
+  --track: #1f242c;
+  --L-red: #e63946;
+  --L-blue: #1d4ed8;
+  --L-green: #138a36;
+  --L-orange: #ed7d2b;
+  --L-purple: #7b3aa7;
+  --L-yellow: #f5b700;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: underline; text-decoration-thickness: 1.5px; text-underline-offset: 3px; text-decoration-color: var(--ink-soft); }
+a:hover { text-decoration-color: currentColor; }
+
+.shell { max-width: 1280px; margin: 0 auto; padding: 0 48px; }
+
+/* ---- masthead ---- */
+.masthead {
+  padding: 24px 0;
+  border-bottom: 4px solid var(--ink);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 32px;
+  align-items: center;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  text-decoration: none;
+  color: var(--ink);
+}
+.brand .badge {
+  width: 46px; height: 46px;
+  border-radius: 50%;
+  background: var(--ink);
+  color: var(--paper);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.04em;
+  border: 4px solid var(--paper);
+  box-shadow: 0 0 0 2px var(--ink);
+}
+.brand .name {
+  font-family: 'Inter', sans-serif;
+  font-weight: 800;
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+.topnav {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.topnav a {
+  text-decoration: none;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 8px 14px;
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  border-radius: 100px;
+}
+.topnav a:hover, .topnav a.active { background: var(--ink); color: var(--paper); }
+.legend {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.legend-dot { width: 14px; height: 14px; border-radius: 50%; border: 2px solid var(--ink); }
+
+/* ---- hero / route map ---- */
+.routemap {
+  padding: 48px 0 56px;
+  border-bottom: 2px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 64px;
+  align-items: center;
+}
+.routemap h1 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 900;
+  font-size: 92px;
+  line-height: 0.9;
+  letter-spacing: -0.045em;
+  text-transform: uppercase;
+}
+.routemap h1 .line-red { color: var(--L-red); }
+.routemap h1 .line-blue { color: var(--L-blue); }
+.routemap h1 .line-green { color: var(--L-green); }
+.routemap .lede {
+  margin-top: 22px;
+  font-size: 20px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  max-width: 520px;
+}
+
+.routemap .map-art {
+  background: var(--paper-soft);
+  border: 2px solid var(--ink);
+  padding: 30px;
+  position: relative;
+  border-radius: 8px;
+}
+.routemap .map-art h4 {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 18px;
+}
+
+.route-line {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 6px 0;
+  position: relative;
+}
+.route-line .line-badge {
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 13px;
+  color: #fff;
+  border: 2px solid var(--ink);
+  flex-shrink: 0;
+}
+.route-line .line-name {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 15px;
+}
+.route-line .line-stops {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+/* ---- doc layout ---- */
+.doc-shell {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 56px;
+  padding: 40px 0 80px;
+}
+
+/* sidebar = route diagram */
+.diagram {
+  position: sticky;
+  top: 24px;
+  align-self: start;
+  max-height: calc(100vh - 60px);
+  overflow-y: auto;
+  padding-right: 14px;
+}
+.diagram h4 {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 18px;
+}
+.line-block {
+  position: relative;
+  margin-bottom: 30px;
+  padding-left: 40px;
+}
+.line-block::before {
+  content: "";
+  position: absolute;
+  left: 14px;
+  top: 18px;
+  bottom: 18px;
+  width: 6px;
+  background: var(--line);
+  border-radius: 3px;
+}
+.line-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+  margin-left: -40px;
+  padding-left: 0;
+}
+.line-header .line-badge {
+  width: 30px; height: 30px;
+  border-radius: 50%;
+  background: var(--line);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 14px;
+  border: 3px solid var(--paper);
+  box-shadow: 0 0 0 2px var(--ink);
+  flex-shrink: 0;
+}
+.line-header .line-name {
+  font-family: 'Inter', sans-serif;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 14px;
+  color: var(--ink);
+}
+.station {
+  position: relative;
+  display: block;
+  padding: 8px 0 8px 24px;
+  text-decoration: none;
+  color: var(--ink);
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+.station::before {
+  content: "";
+  position: absolute;
+  left: -32px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 3px solid var(--line);
+  z-index: 1;
+}
+.station:hover { color: var(--line); }
+.station.active {
+  font-weight: 800;
+  color: var(--line);
+}
+.station.active::before {
+  background: var(--line);
+  width: 18px;
+  height: 18px;
+  border-color: var(--ink);
+  left: -34px;
+}
+.station .station-code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: var(--ink-soft);
+  margin-right: 8px;
+}
+
+/* article */
+article.doc { min-width: 0; }
+article.doc .crumb {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-soft);
+  margin-bottom: 24px;
+}
+article.doc .crumb a { color: var(--ink); }
+article.doc .crumb .sep { color: var(--rule); }
+
+.doc-header {
+  border-left: 8px solid var(--line);
+  padding: 6px 0 6px 20px;
+  margin-bottom: 36px;
+}
+.doc-header .station-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.doc-header .line-badge-lg {
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  background: var(--line);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 18px;
+  border: 3px solid var(--paper);
+  box-shadow: 0 0 0 3px var(--ink);
+  flex-shrink: 0;
+}
+.doc-header .station-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-soft);
+}
+.doc-header h1 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 900;
+  font-size: 60px;
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+.doc-header .desc {
+  font-size: 19px;
+  color: var(--ink-soft);
+  max-width: 640px;
+  line-height: 1.45;
+}
+
+.transfer {
+  background: var(--paper-soft);
+  border: 2px solid var(--ink);
+  border-radius: 8px;
+  padding: 14px 18px;
+  margin: 22px 0 36px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: center;
+}
+.transfer .badge-row { display: flex; gap: 6px; }
+.transfer .mini-badge {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  color: #fff;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--ink);
+}
+.transfer .label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--ink-soft);
+}
+.transfer .label b { color: var(--ink); }
+
+/* doc body */
+.doc-body { font-size: 16.5px; line-height: 1.7; max-width: 720px; }
+.doc-body h2 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 800;
+  font-size: 30px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  margin: 56px 0 14px;
+  padding-left: 18px;
+  border-left: 6px solid var(--line);
+  line-height: 1.1;
+}
+.doc-body h3 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin: 32px 0 8px;
+  color: var(--ink);
+}
+.doc-body p { margin: 12px 0; }
+.doc-body strong { background: var(--line); color: #fff; padding: 0 5px; font-weight: 700; }
+.doc-body em { color: var(--line); font-style: normal; font-weight: 600; }
+.doc-body ul, .doc-body ol { margin: 14px 0 14px 26px; }
+.doc-body li { margin: 6px 0; }
+.doc-body ul li::marker { color: var(--line); content: "● "; }
+.doc-body ol li::marker { color: var(--ink-soft); font-family: 'JetBrains Mono', monospace; font-weight: 700; }
+
+.doc-body code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--paper-soft);
+  border: 1px solid var(--rule);
+  padding: 2px 6px;
+  font-size: 14px;
+  border-radius: 4px;
+}
+.doc-body pre {
+  background: var(--ink);
+  color: #f3f0e6;
+  padding: 22px 24px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  line-height: 1.55;
+  overflow-x: auto;
+  margin: 22px 0;
+  border-radius: 8px;
+  border-left: 8px solid var(--line);
+}
+.doc-body pre code { background: none; border: none; padding: 0; }
+
+.doc-body blockquote {
+  background: var(--paper-soft);
+  border-left: 6px solid var(--line);
+  padding: 16px 22px;
+  margin: 24px 0;
+  border-radius: 0 8px 8px 0;
+  font-size: 17px;
+  color: var(--ink-soft);
+}
+.doc-body blockquote p { margin: 6px 0; }
+.doc-body blockquote strong { background: none; color: var(--ink); padding: 0; }
+
+.doc-body table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 24px 0;
+  border: 2px solid var(--ink);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.doc-body th {
+  background: var(--ink);
+  color: var(--paper);
+  text-align: left;
+  padding: 10px 14px;
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.doc-body td { padding: 10px 14px; border-top: 1px solid var(--rule); font-size: 15px; }
+.doc-body tr:nth-child(even) td { background: var(--paper-soft); }
+
+.doc-body hr {
+  border: 0;
+  border-top: 2px dashed var(--rule);
+  margin: 36px 0;
+}
+
+/* nav */
+.doc-nav {
+  margin-top: 64px;
+  padding-top: 30px;
+  border-top: 2px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+.doc-nav a {
+  text-decoration: none;
+  border: 2px solid var(--ink);
+  padding: 18px 20px;
+  background: var(--paper);
+  color: var(--ink);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  transition: background 0.15s ease;
+}
+.doc-nav a:hover { background: var(--paper-soft); }
+.doc-nav .arrow {
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: var(--ink);
+  color: var(--paper);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.doc-nav .label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  display: block;
+  margin-bottom: 2px;
+}
+.doc-nav .title { font-weight: 800; font-size: 16px; text-transform: uppercase; letter-spacing: -0.01em; line-height: 1.2; }
+.doc-nav .next { flex-direction: row-reverse; text-align: right; }
+
+/* footer */
+.colophon {
+  margin-top: 64px;
+  padding: 30px 0 50px;
+  border-top: 4px solid var(--ink);
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 36px;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+.colophon h5 {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+  color: var(--ink);
+}
+.colophon a { color: var(--ink); }
+
+/* stations index page */
+.routes-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+  padding: 40px 0;
+}
+.route-card {
+  background: var(--paper-soft);
+  border: 2px solid var(--ink);
+  border-left: 12px solid var(--line);
+  border-radius: 10px;
+  padding: 22px 26px;
+  text-decoration: none;
+  color: var(--ink);
+  display: block;
+  transition: transform 0.15s ease;
+}
+.route-card:hover { transform: translateX(4px); }
+.route-card .head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.route-card .head .line-badge {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: var(--line);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 16px;
+  border: 3px solid var(--paper);
+  box-shadow: 0 0 0 2px var(--ink);
+  flex-shrink: 0;
+}
+.route-card .head .code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.route-card h3 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 800;
+  font-size: 22px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+}
+.route-card p { font-size: 14px; line-height: 1.5; color: var(--ink-soft); margin-bottom: 12px; }
+.route-card .stops {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink);
+  padding-top: 12px;
+  border-top: 1px dashed var(--rule);
+}
+
+@media (max-width: 980px) {
+  .shell { padding: 0 20px; }
+  .masthead { grid-template-columns: 1fr; gap: 14px; }
+  .topnav { justify-content: flex-start; }
+  .routemap { grid-template-columns: 1fr; gap: 30px; }
+  .routemap h1 { font-size: 60px; }
+  .doc-shell { grid-template-columns: 1fr; }
+  .diagram { position: static; max-height: none; }
+  .doc-header h1 { font-size: 40px; }
+  .colophon { grid-template-columns: 1fr; }
+  .routes-grid { grid-template-columns: 1fr; }
+  .doc-nav { grid-template-columns: 1fr; }
+}

--- a/examples/transit-codex/static/favicon.svg
+++ b/examples/transit-codex/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/transit-codex/templates/404.html
+++ b/examples/transit-codex/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<main style="padding:100px 0;text-align:center;">
+  <div style="width:140px;height:140px;border-radius:50%;background:#e63946;color:#fff;font-family:'Inter',sans-serif;font-weight:900;font-size:54px;display:flex;align-items:center;justify-content:center;border:6px solid #f6f3eb;box-shadow:0 0 0 6px #111418;margin:0 auto 24px;">404</div>
+  <h1 style="font-family:'Inter',sans-serif;font-weight:900;font-size:48px;text-transform:uppercase;letter-spacing:-0.03em;">Service Disrupted</h1>
+  <p style="font-family:'JetBrains Mono',monospace;font-size:12px;letter-spacing:0.2em;text-transform:uppercase;color:#3a3f48;margin:14px 0 22px;">SIGNAL FAILURE · STATION NOT IN SERVICE</p>
+  <a href="{{ base_url }}/" style="font-family:'JetBrains Mono',monospace;font-size:12px;letter-spacing:0.15em;text-transform:uppercase;border:2px solid #111418;padding:12px 22px;text-decoration:none;color:#111418;background:#f6f3eb;display:inline-block;border-radius:100px;">↩ Return to Map</a>
+</main>
+{% include "footer.html" %}

--- a/examples/transit-codex/templates/doc.html
+++ b/examples/transit-codex/templates/doc.html
@@ -1,0 +1,129 @@
+{% include "header.html" %}
+{% set L = page.extra.color | default(value="#111418") %}
+{% set LC = page.extra.line | default(value="X") %}
+{% set LN = page.extra.line_name | default(value="Route") %}
+<main class="doc-shell" style="--line:{{ L }};">
+  <aside class="diagram">
+    <h4>System Map · All Lines</h4>
+
+    {% set red_pages = [] %}
+    {% set blue_pages = [] %}
+    {% set green_pages = [] %}
+    {% set orange_pages = [] %}
+
+    <div class="line-block" style="--line:#e63946;">
+      <div class="line-header">
+        <div class="line-badge">R</div>
+        <div class="line-name" style="color:#e63946;">Red · Foundations</div>
+      </div>
+      {% for doc in section.pages %}
+        {% if doc.extra.line == "R" %}
+          <a class="station" href="{{ base_url }}{{ doc.url }}" style="--line:#e63946;{% if doc.url == page.url %}--line:#e63946;{% endif %}" {% if doc.url == page.url %}data-active{% endif %}>
+            <span class="station-code">R{{ "%02d" | format(loop.index) }}</span>{{ doc.title }}
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="line-block" style="--line:#1d4ed8;">
+      <div class="line-header">
+        <div class="line-badge">B</div>
+        <div class="line-name" style="color:#1d4ed8;">Blue · Operations</div>
+      </div>
+      {% for doc in section.pages %}
+        {% if doc.extra.line == "B" %}
+          <a class="station" href="{{ base_url }}{{ doc.url }}" style="--line:#1d4ed8;" {% if doc.url == page.url %}data-active{% endif %}>
+            <span class="station-code">B{{ "%02d" | format(loop.index) }}</span>{{ doc.title }}
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="line-block" style="--line:#138a36;">
+      <div class="line-header">
+        <div class="line-badge">G</div>
+        <div class="line-name" style="color:#138a36;">Green · Signals</div>
+      </div>
+      {% for doc in section.pages %}
+        {% if doc.extra.line == "G" %}
+          <a class="station" href="{{ base_url }}{{ doc.url }}" style="--line:#138a36;" {% if doc.url == page.url %}data-active{% endif %}>
+            <span class="station-code">G{{ "%02d" | format(loop.index) }}</span>{{ doc.title }}
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="line-block" style="--line:#ed7d2b;">
+      <div class="line-header">
+        <div class="line-badge">O</div>
+        <div class="line-name" style="color:#ed7d2b;">Orange · Maintenance</div>
+      </div>
+      {% for doc in section.pages %}
+        {% if doc.extra.line == "O" %}
+          <a class="station" href="{{ base_url }}{{ doc.url }}" style="--line:#ed7d2b;" {% if doc.url == page.url %}data-active{% endif %}>
+            <span class="station-code">O{{ "%02d" | format(loop.index) }}</span>{{ doc.title }}
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </aside>
+
+  <article class="doc">
+    <div class="crumb">
+      <a href="{{ base_url }}/">MAP</a>
+      <span class="sep">›</span>
+      <a href="{{ base_url }}/routes/">LINES</a>
+      <span class="sep">›</span>
+      <span>{{ page.title | upper }}</span>
+    </div>
+
+    <header class="doc-header">
+      <div class="station-bar">
+        <div class="line-badge-lg">{{ LC }}</div>
+        <div>
+          <div class="station-meta">{{ LN | upper }} · STATION {{ page.extra.station | default(value="01") }}</div>
+        </div>
+      </div>
+      <h1>{{ page.title }}</h1>
+      {% if page.description %}<p class="desc">{{ page.description }}</p>{% endif %}
+    </header>
+
+    {% if page.extra.transfers %}
+    <div class="transfer">
+      <div class="badge-row">
+        {% for t in page.extra.transfers %}
+          <span class="mini-badge" style="background:{{ t.color }};">{{ t.line }}</span>
+        {% endfor %}
+      </div>
+      <div class="label">TRANSFER POINT · CONNECT TO <b>{{ page.extra.transfers | length }}</b> OTHER LINE{% if page.extra.transfers | length != 1 %}S{% endif %}</div>
+    </div>
+    {% endif %}
+
+    <div class="doc-body">
+      {{ content }}
+    </div>
+
+    <nav class="doc-nav">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}">
+        <div class="arrow">←</div>
+        <div>
+          <span class="label">Previous Station</span>
+          <span class="title">{{ page.lower.title }}</span>
+        </div>
+      </a>
+      {% else %}<span></span>{% endif %}
+
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="next">
+        <div class="arrow">→</div>
+        <div>
+          <span class="label">Next Station</span>
+          <span class="title">{{ page.higher.title }}</span>
+        </div>
+      </a>
+      {% else %}<span></span>{% endif %}
+    </nav>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/transit-codex/templates/footer.html
+++ b/examples/transit-codex/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="colophon">
+      <div>
+        <h5>{{ site.title }}</h5>
+        <p>{{ site.description }} A documentation set patterned on transit maps — color-coded routes, station-by-station chapters, transfer points at every cross-reference.</p>
+      </div>
+      <div>
+        <h5>Lines in Service</h5>
+        <p>RED · Foundations<br>BLUE · Operations<br>GREEN · Signals<br>ORANGE · Maintenance</p>
+      </div>
+      <div>
+        <h5>Stations</h5>
+        <p>Open 24h<br><a href="{{ base_url }}/routes/">Browse routes</a><br><a href="{{ base_url }}/about/">Visit the yard</a></p>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/transit-codex/templates/header.html
+++ b/examples/transit-codex/templates/header.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} — {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="shell">
+    <header class="masthead">
+      <a class="brand" href="{{ base_url }}/">
+        <div class="badge">TC</div>
+        <div class="name">{{ site.title }}</div>
+      </a>
+      <nav class="topnav">
+        <a href="{{ base_url }}/" {% if page.url == "/" %}class="active"{% endif %}>Map</a>
+        <a href="{{ base_url }}/routes/" {% if page.section == "routes" %}class="active"{% endif %}>Lines</a>
+        <a href="{{ base_url }}/routes/operations/">Operations</a>
+        <a href="{{ base_url }}/routes/signals/">Signals</a>
+        <a href="{{ base_url }}/about/">Yard</a>
+      </nav>
+      <div class="legend">
+        <span class="legend-dot" style="background:#e63946;"></span>
+        <span class="legend-dot" style="background:#1d4ed8;"></span>
+        <span class="legend-dot" style="background:#138a36;"></span>
+        <span class="legend-dot" style="background:#ed7d2b;"></span>
+        <span>SYSTEM 04</span>
+      </div>
+    </header>

--- a/examples/transit-codex/templates/page.html
+++ b/examples/transit-codex/templates/page.html
@@ -1,0 +1,95 @@
+{% include "header.html" %}
+<main>
+  <section class="routemap">
+    <div>
+      <h1>Ride the<br><span class="line-red">RED</span> /
+        <span class="line-blue">BLUE</span> /
+        <span class="line-green">GREEN</span></h1>
+      <p class="lede">Documentation that runs on rails. Every concept is a station, every guide is a line, and every cross-reference is a transfer. Boards on the right show the current schedule.</p>
+    </div>
+    <div class="map-art">
+      <h4>System Map · v3.1</h4>
+      <div class="route-line">
+        <div class="line-badge" style="background:#e63946;">R</div>
+        <div>
+          <div class="line-name" style="color:#e63946;">Red — Foundations</div>
+          <div class="line-stops">4 STATIONS · 18 MIN END-TO-END</div>
+        </div>
+        <div></div>
+      </div>
+      <div class="route-line">
+        <div class="line-badge" style="background:#1d4ed8;">B</div>
+        <div>
+          <div class="line-name" style="color:#1d4ed8;">Blue — Operations</div>
+          <div class="line-stops">3 STATIONS · 14 MIN</div>
+        </div>
+      </div>
+      <div class="route-line">
+        <div class="line-badge" style="background:#138a36;">G</div>
+        <div>
+          <div class="line-name" style="color:#138a36;">Green — Signals</div>
+          <div class="line-stops">3 STATIONS · 12 MIN</div>
+        </div>
+      </div>
+      <div class="route-line">
+        <div class="line-badge" style="background:#ed7d2b;">O</div>
+        <div>
+          <div class="line-name" style="color:#ed7d2b;">Orange — Maintenance</div>
+          <div class="line-stops">2 STATIONS · 9 MIN</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="routes-grid">
+    <a class="route-card" style="--line:#e63946;" href="{{ base_url }}/routes/foundations/">
+      <div class="head">
+        <div class="line-badge">R</div>
+        <div>
+          <div class="code">RED LINE · R01</div>
+          <h3>Foundations</h3>
+        </div>
+      </div>
+      <p>The core ride. Concepts, vocabulary, and the layout of the whole system in a single pass.</p>
+      <div class="stops">4 STOPS · BOARDS AT ALL HOURS</div>
+    </a>
+    <a class="route-card" style="--line:#1d4ed8;" href="{{ base_url }}/routes/operations/">
+      <div class="head">
+        <div class="line-badge">B</div>
+        <div>
+          <div class="code">BLUE LINE · B01</div>
+          <h3>Operations</h3>
+        </div>
+      </div>
+      <p>Day-to-day commands. Run, observe, diagnose. Skip-stop service to the patterns that matter.</p>
+      <div class="stops">3 STOPS · EXPRESS OFF-PEAK</div>
+    </a>
+    <a class="route-card" style="--line:#138a36;" href="{{ base_url }}/routes/signals/">
+      <div class="head">
+        <div class="line-badge">G</div>
+        <div>
+          <div class="code">GREEN LINE · G01</div>
+          <h3>Signals</h3>
+        </div>
+      </div>
+      <p>Telemetry, alerts, and the small lights that tell you the train is moving. Quiet local service.</p>
+      <div class="stops">3 STOPS · LOCAL ONLY</div>
+    </a>
+    <a class="route-card" style="--line:#ed7d2b;" href="{{ base_url }}/routes/maintenance/">
+      <div class="head">
+        <div class="line-badge">O</div>
+        <div>
+          <div class="code">ORANGE LINE · O01</div>
+          <h3>Maintenance</h3>
+        </div>
+      </div>
+      <p>The yard. Recovery, rollback, and the long-tail repairs nobody enjoys but everybody needs.</p>
+      <div class="stops">2 STOPS · WEEKEND SERVICE</div>
+    </a>
+  </section>
+
+  <div class="doc-body" style="max-width:760px;padding-bottom:40px;">
+    {{ content }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/transit-codex/templates/section.html
+++ b/examples/transit-codex/templates/section.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+<main>
+  <section class="routemap" style="padding:48px 0 36px;border-bottom:0;">
+    <div>
+      <div style="font-family:'JetBrains Mono',monospace;font-size:12px;letter-spacing:0.2em;text-transform:uppercase;color:#3a3f48;margin-bottom:14px;">All Lines · System Map</div>
+      <h1 style="font-size:72px;">{{ section.title }}</h1>
+      {% if section.description %}<p class="lede">{{ section.description }}</p>{% endif %}
+    </div>
+  </section>
+
+  <section class="routes-grid" style="padding:20px 0 60px;">
+    {% for doc in section.pages %}
+      {% set L = doc.extra.color | default(value="#111418") %}
+      {% set LC = doc.extra.line | default(value="X") %}
+    <a class="route-card" style="--line:{{ L }};" href="{{ base_url }}{{ doc.url }}">
+      <div class="head">
+        <div class="line-badge">{{ LC }}</div>
+        <div>
+          <div class="code">STATION · {{ "%02d" | format(loop.index) }}</div>
+          <h3>{{ doc.title }}</h3>
+        </div>
+      </div>
+      {% if doc.description %}<p>{{ doc.description }}</p>{% endif %}
+      <div class="stops">{{ doc.extra.line_name | default(value="ROUTE") }} · {{ doc.reading_time }} MIN READ</div>
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/transit-codex/templates/shortcodes/alert.html
+++ b/examples/transit-codex/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/transit-codex/templates/taxonomy.html
+++ b/examples/transit-codex/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main style="padding:48px 0 80px;">
+  <h1 style="font-family:'Inter',sans-serif;font-weight:900;font-size:60px;text-transform:uppercase;letter-spacing:-0.03em;margin-bottom:20px;">Tag Map</h1>
+  <ul style="list-style:none;padding:0;display:flex;flex-wrap:wrap;gap:12px;">
+    {% for term in taxonomy_terms %}
+    <li><a href="{{ base_url }}{{ term.url }}" style="text-decoration:none;color:#111418;font-family:'JetBrains Mono',monospace;font-size:12px;text-transform:uppercase;letter-spacing:0.1em;padding:10px 16px;border:2px solid #111418;border-radius:100px;display:inline-block;background:#efebde;">#{{ term.name }} · <b>{{ term.pages | length }}</b></a></li>
+    {% endfor %}
+  </ul>
+</main>
+{% include "footer.html" %}

--- a/examples/transit-codex/templates/taxonomy_term.html
+++ b/examples/transit-codex/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<main style="padding:40px 0 80px;">
+  <div style="font-family:'JetBrains Mono',monospace;font-size:12px;letter-spacing:0.2em;text-transform:uppercase;color:#3a3f48;">Filtered Route</div>
+  <h1 style="font-family:'Inter',sans-serif;font-weight:900;font-size:60px;text-transform:uppercase;letter-spacing:-0.03em;margin:8px 0 22px;">#{{ taxonomy_term }}</h1>
+  <section class="routes-grid">
+    {% for doc in taxonomy_pages %}
+    <a class="route-card" style="--line:{{ doc.extra.color | default(value='#111418') }};" href="{{ base_url }}{{ doc.url }}">
+      <div class="head">
+        <div class="line-badge">{{ doc.extra.line | default(value="X") }}</div>
+        <div>
+          <div class="code">{{ doc.extra.line_name | default(value="ROUTE") | upper }}</div>
+          <h3>{{ doc.title }}</h3>
+        </div>
+      </div>
+      {% if doc.description %}<p>{{ doc.description }}</p>{% endif %}
+    </a>
+    {% endfor %}
+  </section>
+</main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -8847,5 +8847,30 @@
     "glassmorphism",
     "elegant",
     "cyberpunk"
+  ],
+  "risograph-codex": [
+    "light",
+    "docs",
+    "editorial"
+  ],
+  "transit-codex": [
+    "light",
+    "docs",
+    "sidebar"
+  ],
+  "slab-cathedral": [
+    "light",
+    "docs",
+    "editorial"
+  ],
+  "dictation-log": [
+    "dark",
+    "docs",
+    "sidebar"
+  ],
+  "dieter-docs": [
+    "light",
+    "docs",
+    "minimal"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds **risograph-codex** (two-color riso print, halftone dots, misregistration headings)
- Adds **transit-codex** (subway-map sidebar with colored route lines and station nodes)
- Adds **slab-cathedral** (monumental slab serif, single-column nave, 220px Roman-numeral chapter marks)
- Adds **dictation-log** (dark audio-transcript layout, timestamp gutters, solid waveform bars)
- Adds **dieter-docs** (Rams-style ultra-functional manual, single orange accent, six numbered principles)
- Adds tag entries in `tags.json` for all five

Each commits to a distinct visual language so the docs theme feels less generic at scale. No gradients, no emoji — solid colors, borders, and typography only.

## Test plan
- [x] `hwaro build --base-url ...` succeeds on each site (9 / 7 / 9 / 9 / 9 pages)
- [x] `hwaro doctor` returns 0 errors and 0 warnings on each site
- [x] `grep gradient` returns no matches in any CSS or template
- [x] `tags.json` validates and contains entries for all five sites