### PR TITLE
Add five bold portfolio example sites

### DIFF
--- a/examples/cutout-folio/AGENTS.md
+++ b/examples/cutout-folio/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/cutout-folio/archetypes/default.md
+++ b/examples/cutout-folio/archetypes/default.md
@@ -1,0 +1,6 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
++++

--- a/examples/cutout-folio/config.toml
+++ b/examples/cutout-folio/config.toml
@@ -1,0 +1,207 @@
+title = "Cutout Folio"
+description = "Sori Lemma — a paper-collage editorial portfolio. Hand-cut, taped, annotated, scanned."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 20
+sections = ["pieces"]
+
+[markdown]
+safe = false
+heading_ids = true
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/cutout-folio/content/about.md
+++ b/examples/cutout-folio/content/about.md
@@ -1,0 +1,30 @@
++++
+title = "Say hi"
+description = "Sori Lemma is open for editorial, identity and music-packaging commissions."
+[extra]
+kicker = "About"
+kind = "Studio"
+client = "—"
+materials = "—"
++++
+
+## who
+
+I'm **Sori Lemma**, a collage illustrator and art director from Seoul. I've been working independently since 2018 — first from a kitchen table in Mapo, now from a small studio in Itaewon and a part-time desk in Berlin-Wedding.
+
+## what I do
+
+- Editorial illustration (covers, features, columns)
+- Album packaging and music identity
+- Small-press art direction (zines, books, riso editions)
+- The occasional independent project under my own imprint, *cutout reader*.
+
+## what I don't do
+
+I don't work on crypto, gambling or military projects. I don't deliver source files (only print-ready PDFs and scanned masters). I don't pitch unpaid.
+
+## contact
+
+**studio at sori-lemma dot example** · I respond to emails Wednesdays and Fridays. If you write any other day, expect a slow reply.
+
+I'm always open for a print swap — send me a zine and I'll send you one back.

--- a/examples/cutout-folio/content/index.md
+++ b/examples/cutout-folio/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Cutout Folio"
+description = "Sori Lemma — paper-collage editorial illustration and art direction."
+template = "index"
++++

--- a/examples/cutout-folio/content/pieces/_index.md
+++ b/examples/cutout-folio/content/pieces/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Pieces"
+sort_by = "date"
+reverse = true
+template = "section"
++++
+
+Editorial commissions, zine work and personal pieces from the last 18 months. Older work is in the printed *cutout reader*, available on request.

--- a/examples/cutout-folio/content/pieces/late-news-poster.md
+++ b/examples/cutout-folio/content/pieces/late-news-poster.md
@@ -1,0 +1,25 @@
++++
+title = "Late News — A Poster Series"
+date = "2025-06-02"
+description = "A series of 12 wheat-pasted street posters around Hongdae, Seoul."
+[extra]
+letter = "L"
+kind = "Posters"
+client = "Self · with Hongdae Print Co-op"
+materials = "Cut newspaper, ink, paste"
+kicker = "Street poster series"
++++
+
+## the brief
+
+A self-initiated series. Twelve posters, each made from a single day's newspaper, pasted at a different intersection in Hongdae.
+
+## how it came together
+
+Every poster was cut from that morning's edition of *Hankyoreh* or *Joongang Ilbo*. The headlines are real, the lettering is rearranged. The posters were pasted before sundown and left to rot.
+
+I photographed each poster the day it went up, then revisited every site at one week, four weeks and three months.
+
+## the result
+
+A 96-page documentation book — *Late News* — is now in the second printing. Three of the posters survived the rainy season; the others survived through the photographs.

--- a/examples/cutout-folio/content/pieces/maeun-record.md
+++ b/examples/cutout-folio/content/pieces/maeun-record.md
@@ -1,0 +1,26 @@
++++
+title = "Maeun — Album Sleeve"
+date = "2025-12-08"
+description = "Sleeve, inner cards and 12-page booklet for Korean singer Maeun's third album."
+[extra]
+letter = "M"
+kind = "Music"
+client = "Maeun · Lush Records"
+materials = "Cut paper, gold thread, screenprint"
+kicker = "Album packaging"
+mark = "Maeun"
++++
+
+## the brief
+
+Maeun's third album is a record about leaving home and coming back. She asked for a sleeve "that looks like the inside of an envelope I forgot to post."
+
+## how it came together
+
+The outer sleeve is a single collage assembled from 27 small letters I wrote — and re-sealed — over six weeks. Each letter is a real letter, addressed to a real person. The fronts of the envelopes are torn off and reassembled into the sleeve. The backs of the envelopes are still in the studio.
+
+The 12-page booklet is hand-stitched with gold thread, six copies per hour.
+
+## the result
+
+The album shipped 4,000 vinyl copies in December 2025. The booklet is now sold separately as a 100-copy edition for the next pressing.

--- a/examples/cutout-folio/content/pieces/parallel-feature.md
+++ b/examples/cutout-folio/content/pieces/parallel-feature.md
@@ -1,0 +1,25 @@
++++
+title = "Parallel — A Feature on Public Libraries"
+date = "2026-02-12"
+description = "Six full-bleed illustrations for a Berlin magazine feature on public libraries."
+[extra]
+letter = "P"
+kind = "Editorial"
+client = "Parallel Magazine"
+materials = "Cut paper, ink, library catalogue cards (1972–1989)"
+kicker = "Editorial illustration"
++++
+
+## the brief
+
+*Parallel* commissioned six full-bleed illustrations for a 14-page feature on the future of public libraries. The art director's only constraint: "do not draw a book."
+
+## how it came together
+
+I built each illustration entirely from cut library catalogue cards. The cards are from a 1972–1989 set I bought at a Berlin flea market two years ago. Every word that appears in the final illustrations is a fragment from an actual catalogue entry.
+
+The largest illustration uses 412 individual fragments. The smallest uses 19.
+
+## the result
+
+Issue 47 of *Parallel* shipped in February 2026. The print version of the feature pulls the illustrations across full spreads; the online version reads them as one continuous scrolling collage.

--- a/examples/cutout-folio/content/pieces/quiet-week-zine.md
+++ b/examples/cutout-folio/content/pieces/quiet-week-zine.md
@@ -1,0 +1,25 @@
++++
+title = "Quiet Week — Self-published Zine"
+date = "2025-09-19"
+description = "A 32-page risograph zine made during a week-long writing retreat."
+[extra]
+letter = "Q"
+kind = "Zine"
+client = "Self"
+materials = "Cut paper, riso ink, hand-stitched binding"
+kicker = "Self-published"
++++
+
+## the brief
+
+I gave myself one week, four printers, and no permission to use the internet. Out came a 32-page zine called *Quiet Week*.
+
+## how it came together
+
+Every spread was cut, glued and scanned the same day it was made. No spread took longer than four hours. The cover was the last thing I cut, on day seven.
+
+The zine was printed in a single overnight run at a riso studio in Mapo. 120 numbered copies, hand-stitched with linen thread.
+
+## the result
+
+Sold out at the Seoul Art Book Fair within four hours. Second pressing of 80 sold out by mail order in a week. A small London distro now stocks it.

--- a/examples/cutout-folio/content/pieces/yeon-cover.md
+++ b/examples/cutout-folio/content/pieces/yeon-cover.md
@@ -1,0 +1,26 @@
++++
+title = "Yeon Magazine — Spring Cover"
+date = "2026-04-04"
+description = "A six-layer collage cover for Yeon Magazine's spring 2026 issue on Korean home cooking."
+[extra]
+letter = "Y"
+kind = "Editorial"
+client = "Yeon Magazine"
+materials = "Cut paper, dried persimmon skin, screen-print on rice paper"
+kicker = "Cover commission"
+mark = "Yeon"
++++
+
+## the brief
+
+Yeon's editor asked for "a cover that smells like our grandmother's pantry." Six layers, no photographs, no digital paint.
+
+## how it came together
+
+I bought 4 kilos of fresh persimmon from the Garak market, peeled them, and dried the skins on the studio windowsill for three weeks. The skins became the orange tones in the final piece. The lettering is hand-cut from a 1970s home-cooking pamphlet I bought at a flea market in Seochon.
+
+> "The cover is the only one that customers tried to lick at the newsstand." — bookshop note, week one.
+
+## what it shipped as
+
+A six-layer cover scanned at 1200 dpi and printed offset on uncoated stock. The print run was 18,000 — the largest the studio has touched.

--- a/examples/cutout-folio/static/css/style.css
+++ b/examples/cutout-folio/static/css/style.css
@@ -1,0 +1,625 @@
+/* Cutout Folio — paper collage / editorial scrapbook portfolio
+   Look: scanned paper scraps, tape, scribbled notes, mechanical type stamped on top.
+   No gradients. Solid paper tones, deep ink, one acid green annotation.
+*/
+
+:root {
+  --paper-1: #F0EBDB;      /* base sheet */
+  --paper-2: #DCD3BA;      /* tan paper scrap */
+  --paper-3: #CABB9A;      /* darker tan */
+  --paper-4: #F7F2E5;      /* cream cut */
+  --tape: #E8E0BD;         /* masking tape */
+  --tape-edge: #B9AC73;
+  --ink: #161312;
+  --pencil: #54493A;
+  --acid: #6BCE19;         /* hand annotation */
+  --redmark: #C2342B;      /* edit pen */
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { background: var(--paper-1); scroll-behavior: smooth; }
+
+body {
+  font-family: "Caveat", "Marker Felt", "Segoe Script", cursive;
+  background: var(--paper-1);
+  color: var(--ink);
+  font-size: 17px;
+  line-height: 1.5;
+  position: relative;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+/* Paper texture — soft fibre noise */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='320' height='320'><filter id='f'><feTurbulence baseFrequency='0.7' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.30  0 0 0 0 0.25  0 0 0 0 0.15  0 0 0 0.18 0'/></filter><rect width='100%25' height='100%25' filter='url(%23f)'/></svg>");
+  opacity: 0.5;
+  mix-blend-mode: multiply;
+}
+
+main, header, footer, section { position: relative; z-index: 1; }
+
+/* Layout */
+.spread {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 40px 36px 96px;
+  position: relative;
+}
+
+/* Edge tape strips */
+.spread::before {
+  content: "";
+  position: absolute;
+  top: 18px; left: 18%;
+  width: 200px; height: 22px;
+  background: var(--tape);
+  border-left: 1px dashed var(--tape-edge);
+  border-right: 1px dashed var(--tape-edge);
+  transform: rotate(-3deg);
+  opacity: 0.85;
+  z-index: 0;
+}
+
+.spread::after {
+  content: "";
+  position: absolute;
+  top: 26px; right: 12%;
+  width: 160px; height: 22px;
+  background: var(--tape);
+  border-left: 1px dashed var(--tape-edge);
+  border-right: 1px dashed var(--tape-edge);
+  transform: rotate(4deg);
+  opacity: 0.85;
+  z-index: 0;
+}
+
+/* Header — handwritten masthead */
+header.masthead {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  margin-bottom: 56px;
+  padding-bottom: 18px;
+  border-bottom: 2px dashed var(--pencil);
+  position: relative;
+}
+
+header.masthead .name {
+  text-decoration: none;
+  color: var(--ink);
+  font-family: "Caveat", "Marker Felt", cursive;
+  font-weight: 700;
+  font-size: clamp(40px, 6vw, 80px);
+  line-height: 0.95;
+  letter-spacing: -0.01em;
+  display: block;
+}
+header.masthead .name span {
+  background: var(--acid);
+  padding: 0 8px;
+  display: inline-block;
+  transform: rotate(-1.5deg);
+}
+
+header.masthead nav {
+  display: flex;
+  gap: 8px;
+  align-items: end;
+  flex-wrap: wrap;
+}
+
+header.masthead nav a {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  text-decoration: none;
+  color: var(--ink);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: var(--paper-4);
+  border: 1.5px solid var(--ink);
+  padding: 6px 10px;
+  transform: rotate(-1deg);
+  box-shadow: 3px 3px 0 var(--ink);
+  font-weight: 700;
+}
+header.masthead nav a:nth-child(2) { transform: rotate(1deg); }
+header.masthead nav a:nth-child(3) { transform: rotate(-2deg); }
+header.masthead nav a:hover {
+  background: var(--acid);
+  transform: rotate(0) translate(-1px, -1px);
+}
+
+/* HERO — collage */
+.collage {
+  position: relative;
+  padding: 24px 0 80px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 36px;
+  align-items: start;
+}
+
+.scrap {
+  background: var(--paper-4);
+  border: 1px solid rgba(0,0,0,0.12);
+  padding: 24px 28px;
+  position: relative;
+  box-shadow: 5px 6px 0 rgba(0,0,0,0.06);
+  transform: rotate(-1.2deg);
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+}
+
+.scrap.dark { background: var(--paper-3); }
+.scrap.tan { background: var(--paper-2); }
+
+.scrap::before {
+  content: "";
+  position: absolute;
+  top: -14px;
+  left: 22%;
+  width: 88px;
+  height: 26px;
+  background: var(--tape);
+  transform: rotate(-3deg);
+  border-left: 1px dashed var(--tape-edge);
+  border-right: 1px dashed var(--tape-edge);
+  opacity: 0.92;
+}
+
+.hero-h {
+  font-family: "Caveat", "Marker Felt", cursive;
+  font-weight: 700;
+  font-size: clamp(64px, 11vw, 168px);
+  line-height: 0.84;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  text-transform: none;
+  position: relative;
+}
+
+.hero-h .mark {
+  background: var(--acid);
+  padding: 0 8px;
+  display: inline-block;
+  transform: rotate(-2deg);
+}
+.hero-h .scratch {
+  position: relative;
+}
+.hero-h .scratch::after {
+  content: "";
+  position: absolute;
+  left: -2%;
+  right: -2%;
+  top: 56%;
+  height: 6px;
+  background: var(--redmark);
+  transform: rotate(-3deg);
+  opacity: 0.85;
+}
+
+.hero-h .stamp {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--ink);
+  background: var(--paper-4);
+  border: 2px solid var(--ink);
+  padding: 4px 10px;
+  display: inline-block;
+  transform: rotate(-3deg);
+  margin-left: 6px;
+  vertical-align: middle;
+  font-weight: 800;
+}
+
+.collage .right {
+  display: grid;
+  gap: 20px;
+}
+
+.collage .right .scrap:nth-child(1) { transform: rotate(1.6deg); }
+.collage .right .scrap:nth-child(2) { transform: rotate(-2.4deg); }
+
+.scrap h3 {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--pencil);
+  margin-bottom: 10px;
+  font-weight: 800;
+}
+
+.scrap p {
+  font-family: "Caveat", "Marker Felt", cursive;
+  font-size: 24px;
+  line-height: 1.18;
+  color: var(--ink);
+}
+
+.scrap p.typed {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink);
+}
+
+.scrap.annot {
+  position: relative;
+}
+.scrap.annot::after {
+  content: "↗ urgent.";
+  position: absolute;
+  bottom: -22px;
+  right: -8px;
+  font-family: "Caveat", "Marker Felt", cursive;
+  font-size: 26px;
+  color: var(--redmark);
+  transform: rotate(-6deg);
+}
+
+/* Section heading — circled */
+.headline {
+  margin: 64px 0 32px;
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  position: relative;
+}
+
+.headline h2 {
+  font-family: "Caveat", cursive;
+  font-size: clamp(40px, 6vw, 78px);
+  line-height: 0.9;
+  letter-spacing: -0.01em;
+}
+
+.headline h2 .ring {
+  display: inline-block;
+  position: relative;
+  padding: 0 8px;
+}
+.headline h2 .ring::before {
+  content: "";
+  position: absolute;
+  inset: -8% -6%;
+  border: 3px solid var(--redmark);
+  border-radius: 50% / 60%;
+  transform: rotate(-2deg);
+  pointer-events: none;
+}
+
+.headline .note {
+  font-family: "Inter", Arial, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--pencil);
+  background: var(--tape);
+  padding: 4px 10px;
+  transform: rotate(-1deg);
+  border-left: 1px dashed var(--tape-edge);
+  border-right: 1px dashed var(--tape-edge);
+  font-weight: 700;
+  align-self: center;
+}
+
+/* Pieces grid — pinned cutouts */
+.pieces {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 28px;
+  margin-top: 12px;
+}
+
+.piece {
+  grid-column: span 4;
+  text-decoration: none;
+  color: var(--ink);
+  position: relative;
+  display: block;
+  background: var(--paper-4);
+  padding: 18px 18px 14px;
+  border: 1px solid rgba(0,0,0,0.12);
+  box-shadow: 5px 6px 0 rgba(0,0,0,0.08);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  transform: rotate(-1deg);
+}
+.piece:nth-child(3n+1) { transform: rotate(1.5deg); grid-column: span 5; }
+.piece:nth-child(3n+2) { transform: rotate(-2deg); grid-column: span 4; background: var(--paper-2); }
+.piece:nth-child(3n+3) { transform: rotate(0.5deg); grid-column: span 3; background: var(--paper-3); }
+
+.piece:hover {
+  transform: rotate(0) translate(-1px, -2px);
+  box-shadow: 7px 8px 0 rgba(0,0,0,0.12);
+}
+
+.piece::before {
+  content: "";
+  position: absolute;
+  top: -14px;
+  left: 20%;
+  width: 60px;
+  height: 22px;
+  background: var(--tape);
+  transform: rotate(-4deg);
+  border-left: 1px dashed var(--tape-edge);
+  border-right: 1px dashed var(--tape-edge);
+  opacity: 0.92;
+}
+
+.piece .photo {
+  height: 180px;
+  margin-bottom: 14px;
+  position: relative;
+  border: 1px solid rgba(0,0,0,0.18);
+  background: var(--paper-1);
+  overflow: hidden;
+}
+
+.piece:nth-child(3n+1) .photo { height: 240px; background: var(--paper-3); }
+.piece:nth-child(3n+2) .photo { height: 180px; background: var(--paper-4); }
+.piece:nth-child(3n+3) .photo { height: 140px; background: var(--ink); color: var(--paper-1); }
+
+.piece .photo::after {
+  content: attr(data-letter);
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-family: "Caveat", cursive;
+  font-weight: 700;
+  font-size: 120px;
+  color: rgba(22,19,18,0.45);
+}
+.piece:nth-child(3n+3) .photo::after { color: var(--acid); }
+
+.piece .photo::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(45deg, rgba(0,0,0,0.08) 0, rgba(0,0,0,0.08) 1px, transparent 1px, transparent 9px);
+  pointer-events: none;
+}
+
+.piece h3 {
+  font-family: "Caveat", cursive;
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+}
+
+.piece .meta-line {
+  display: flex;
+  justify-content: space-between;
+  font-family: "Inter", Arial, sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--pencil);
+  font-weight: 700;
+}
+.piece .meta-line .year { color: var(--redmark); }
+
+/* Piece page */
+.piece-page header {
+  margin: 24px 0 36px;
+  padding: 28px;
+  background: var(--paper-4);
+  border: 1px solid rgba(0,0,0,0.18);
+  box-shadow: 6px 8px 0 rgba(0,0,0,0.08);
+  transform: rotate(-0.6deg);
+  position: relative;
+}
+.piece-page header::before {
+  content: "";
+  position: absolute;
+  top: -16px;
+  left: 30%;
+  width: 120px;
+  height: 28px;
+  background: var(--tape);
+  transform: rotate(-3deg);
+  border-left: 1px dashed var(--tape-edge);
+  border-right: 1px dashed var(--tape-edge);
+}
+.piece-page header .kicker {
+  font-family: "Inter", Arial, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--redmark);
+  margin-bottom: 12px;
+  font-weight: 800;
+}
+.piece-page header h1 {
+  font-family: "Caveat", cursive;
+  font-weight: 700;
+  font-size: clamp(48px, 8vw, 110px);
+  line-height: 0.92;
+  letter-spacing: -0.02em;
+}
+.piece-page header h1 .mark {
+  background: var(--acid);
+  padding: 0 8px;
+  display: inline-block;
+  transform: rotate(-1deg);
+}
+.piece-page header .lede {
+  margin-top: 16px;
+  max-width: 56ch;
+  font-family: "Inter", Arial, sans-serif;
+  font-size: 16px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.piece-page .body-grid {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 40px;
+  position: relative;
+}
+
+.piece-page .sticky-card {
+  background: var(--paper-2);
+  border: 1px solid rgba(0,0,0,0.18);
+  padding: 18px;
+  font-family: "Inter", Arial, sans-serif;
+  align-self: start;
+  position: sticky;
+  top: 24px;
+  transform: rotate(-1.4deg);
+  box-shadow: 4px 5px 0 rgba(0,0,0,0.08);
+}
+.piece-page .sticky-card::before {
+  content: "";
+  position: absolute;
+  top: -14px;
+  left: 30%;
+  width: 80px;
+  height: 22px;
+  background: var(--tape);
+  transform: rotate(-3deg);
+  border-left: 1px dashed var(--tape-edge);
+  border-right: 1px dashed var(--tape-edge);
+  opacity: 0.95;
+}
+.piece-page .sticky-card dt {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--pencil);
+  font-weight: 800;
+  margin-top: 10px;
+}
+.piece-page .sticky-card dt:first-child { margin-top: 0; }
+.piece-page .sticky-card dd {
+  font-family: "Caveat", cursive;
+  font-size: 22px;
+  line-height: 1.1;
+  margin-top: 2px;
+  color: var(--ink);
+}
+
+.piece-page .prose {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.62;
+}
+.piece-page .prose p { margin-bottom: 1.05em; }
+.piece-page .prose h2 {
+  font-family: "Caveat", cursive;
+  font-weight: 700;
+  font-size: 36px;
+  line-height: 1;
+  margin: 1.6em 0 0.4em;
+}
+.piece-page .prose h2::before {
+  content: "✎ ";
+  color: var(--redmark);
+}
+.piece-page .prose blockquote {
+  margin: 1.2em 0;
+  padding: 16px 22px;
+  background: var(--paper-4);
+  border: 1px solid rgba(0,0,0,0.18);
+  font-family: "Caveat", cursive;
+  font-size: 24px;
+  line-height: 1.25;
+  transform: rotate(-0.6deg);
+  box-shadow: 4px 5px 0 rgba(0,0,0,0.08);
+  position: relative;
+}
+.piece-page .prose blockquote::before {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  margin-left: -38px;
+  width: 76px;
+  height: 22px;
+  background: var(--tape);
+  transform: rotate(-2deg);
+  border-left: 1px dashed var(--tape-edge);
+  border-right: 1px dashed var(--tape-edge);
+}
+.piece-page .prose code,
+.piece-page .prose pre {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--paper-2);
+  padding: 2px 6px;
+}
+.piece-page .prose ul li {
+  margin-left: 1.2em;
+  margin-bottom: 0.4em;
+}
+
+.back-strip {
+  margin-top: 80px;
+  text-align: center;
+}
+.back-strip a {
+  font-family: "Inter", Arial, sans-serif;
+  text-decoration: none;
+  border: 2px dashed var(--ink);
+  padding: 10px 16px;
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink);
+  background: var(--tape);
+  font-weight: 700;
+  display: inline-block;
+  transform: rotate(-1.4deg);
+}
+.back-strip a:hover {
+  background: var(--acid);
+  transform: rotate(0);
+}
+
+/* Footer */
+footer.colophon {
+  margin-top: 96px;
+  padding-top: 24px;
+  border-top: 2px dashed var(--pencil);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 16px;
+  align-items: center;
+  font-family: "Inter", Arial, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pencil);
+}
+
+footer.colophon .center {
+  font-family: "Caveat", cursive;
+  font-size: 22px;
+  color: var(--ink);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+footer.colophon .right { text-align: right; }
+
+@media (max-width: 900px) {
+  .spread { padding: 28px 18px 60px; }
+  header.masthead { grid-template-columns: 1fr; gap: 18px; }
+  .collage { grid-template-columns: 1fr; gap: 22px; }
+  .piece, .piece:nth-child(n) { grid-column: span 12; }
+  .piece-page .body-grid { grid-template-columns: 1fr; }
+  .piece-page .sticky-card { position: static; }
+}

--- a/examples/cutout-folio/static/favicon.svg
+++ b/examples/cutout-folio/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#F0EBDB"/><polygon points="4,6 14,4 18,14 8,18 6,11" fill="#6BCE19"/><polygon points="14,15 28,12 26,28 12,27 16,21" fill="#CABB9A"/><polygon points="20,5 28,8 27,12 19,9" fill="#C2342B"/></svg>

--- a/examples/cutout-folio/templates/404.html
+++ b/examples/cutout-folio/templates/404.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<section class="collage">
+  <div>
+    <h1 class="hero-h"><span class="scratch">found</span> not found.<br><span class="mark">404</span></h1>
+  </div>
+  <div class="right">
+    <div class="scrap dark">
+      <h3>Hmm</h3>
+      <p>I cut this page out and lost it somewhere between the studio and the post office.</p>
+    </div>
+    <div class="scrap tan">
+      <p class="typed">Try the <a href="{{ base_url }}/" style="color:var(--ink);">scrapbook</a> instead — most of the recent work is there.</p>
+    </div>
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/cutout-folio/templates/footer.html
+++ b/examples/cutout-folio/templates/footer.html
@@ -1,0 +1,8 @@
+<footer class="colophon">
+  <div>Cut by hand. Scanned at 600 dpi.</div>
+  <div class="center">— made in Seoul · {{ current_year }} —</div>
+  <div class="right">Sori Lemma · studio @ cutout-folio · example</div>
+</footer>
+</div>
+</body>
+</html>

--- a/examples/cutout-folio/templates/header.html
+++ b/examples/cutout-folio/templates/header.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if page.title is present %}{{ page.title }} — {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&family=Inter:wght@400;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="spread">
+<header class="masthead">
+  <a class="name" href="{{ base_url }}/">cutout<br>folio · <span>by Sori Lemma</span></a>
+  <nav>
+    <a href="{{ base_url }}/">scrapbook</a>
+    <a href="{{ base_url }}/pieces/">pieces</a>
+    <a href="{{ base_url }}/about/">say hi</a>
+  </nav>
+</header>

--- a/examples/cutout-folio/templates/index.html
+++ b/examples/cutout-folio/templates/index.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+
+<section class="collage">
+  <div>
+    <h1 class="hero-h">
+      I cut up<br>
+      <span class="mark">magazines</span><br>
+      <span class="scratch">for fun</span> for a living.
+      <span class="stamp">est. 2018</span>
+    </h1>
+  </div>
+  <div class="right">
+    <div class="scrap dark">
+      <h3>Who's writing</h3>
+      <p>Sori Lemma — editorial illustrator and art director working between Seoul and Berlin. I make collages with scissors first and software second.</p>
+    </div>
+    <div class="scrap tan annot">
+      <h3>What I'm doing this month</h3>
+      <p class="typed">Finishing a 24-page art-direction project for <strong>Yeon Magazine</strong>, and a small zine for a friend's record release. Open for September commissions.</p>
+    </div>
+  </div>
+</section>
+
+<div class="headline">
+  <h2>Recent <span class="ring">pieces.</span></h2>
+  <span class="note">{{ current_year }} — scrap by scrap</span>
+</div>
+
+<div class="pieces">
+{% for p in site.pages | sort_by(attribute="date", reverse=true) %}
+  {% if p.section == "pieces" %}
+  <a class="piece" href="{{ p.url }}">
+    <div class="photo" data-letter="{{ p.extra.letter | default('S') }}"></div>
+    <h3>{{ p.title }}</h3>
+    <div class="meta-line">
+      <span>{{ p.extra.kind | default('Illustration') }}</span>
+      <span class="year">'{{ p.date | date("%y") }}</span>
+    </div>
+  </a>
+  {% endif %}
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/cutout-folio/templates/page.html
+++ b/examples/cutout-folio/templates/page.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+
+<article class="piece-page">
+  <header>
+    <div class="kicker">{{ page.extra.kicker | default("Piece") }} · {{ page.date | date("%B %Y") }}</div>
+    <h1>{% if page.extra.mark %}<span class="mark">{{ page.extra.mark }}</span> {% endif %}{{ page.title }}</h1>
+    {% if page.description %}<p class="lede">{{ page.description }}</p>{% endif %}
+  </header>
+
+  <div class="body-grid">
+    <aside class="sticky-card">
+      <dl>
+        <dt>Client</dt><dd>{{ page.extra.client | default("Self") }}</dd>
+        <dt>Kind</dt><dd>{{ page.extra.kind | default("Illustration") }}</dd>
+        <dt>Year</dt><dd>{{ page.date | date("%Y") }}</dd>
+        {% if page.extra.materials %}<dt>Materials</dt><dd>{{ page.extra.materials }}</dd>{% endif %}
+        {% if page.extra.collaborators %}<dt>With</dt><dd>{{ page.extra.collaborators }}</dd>{% endif %}
+      </dl>
+    </aside>
+
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+  </div>
+
+  <div class="back-strip"><a href="{{ base_url }}/">← back to the scrapbook</a></div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/cutout-folio/templates/section.html
+++ b/examples/cutout-folio/templates/section.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<div class="headline">
+  <h2>All <span class="ring">{{ section.title | lower }}.</span></h2>
+  <span class="note">{{ section.pages | length }} entries</span>
+</div>
+
+{% if content %}<div style="max-width:60ch;font-family:Inter,Arial,sans-serif;font-size:15px;color:var(--ink);margin-bottom:32px;">{{ content | safe }}</div>{% endif %}
+
+<div class="pieces">
+{% for p in section.pages | sort_by(attribute="date", reverse=true) %}
+  <a class="piece" href="{{ p.url }}">
+    <div class="photo" data-letter="{{ p.extra.letter | default('S') }}"></div>
+    <h3>{{ p.title }}</h3>
+    <div class="meta-line">
+      <span>{{ p.extra.kind | default('Illustration') }}</span>
+      <span class="year">'{{ p.date | date("%y") }}</span>
+    </div>
+  </a>
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/kinetic-manifesto/AGENTS.md
+++ b/examples/kinetic-manifesto/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/kinetic-manifesto/archetypes/default.md
+++ b/examples/kinetic-manifesto/archetypes/default.md
@@ -1,0 +1,6 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
++++

--- a/examples/kinetic-manifesto/config.toml
+++ b/examples/kinetic-manifesto/config.toml
@@ -1,0 +1,207 @@
+title = "Kinetic Manifesto"
+description = "A bold typographic manifesto-portfolio by Ivo Reiner — letters that won't sit still."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 20
+sections = ["projects"]
+
+[markdown]
+safe = false
+heading_ids = true
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/kinetic-manifesto/content/about.md
+++ b/examples/kinetic-manifesto/content/about.md
@@ -1,0 +1,31 @@
++++
+title = "Contact"
+description = "How to commission Studio Reiner."
+[extra]
+kicker = "Studio"
+kind = "Contact"
+client = "—"
+role = "—"
++++
+
+## Studio Reiner
+
+Direction-led practice in Lisbon, founded 2019 by **Ivo Reiner**. Three staff and a rotating bench of seven collaborators.
+
+## Commissioning
+
+Briefs are accepted by email only. We respond within five working days; we do not pitch unpaid. Minimum engagement is six weeks.
+
+- Identity & wayfinding
+- Editorial direction
+- Title sequences & motion direction
+- Type design (custom and retail)
+
+## Address
+
+R. Augusta 14, 1st floor — 1100-048 Lisboa
+**studio at reiner dot example** · +351 21 000 0014
+
+## Talks & teaching
+
+Currently running a typography seminar at FBAUL on Wednesday afternoons. Reach out via the school for sit-in places.

--- a/examples/kinetic-manifesto/content/index.md
+++ b/examples/kinetic-manifesto/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Kinetic Manifesto"
+description = "Ivo Reiner — kinetic typography, identity systems and motion direction."
+template = "index"
++++

--- a/examples/kinetic-manifesto/content/manifesto.md
+++ b/examples/kinetic-manifesto/content/manifesto.md
@@ -1,0 +1,26 @@
++++
+title = "Manifesto"
+description = "Twelve rules for letters that won't sit still."
+[extra]
+kicker = "Position"
+kind = "Studio"
+client = "—"
+role = "—"
++++
+
+## Twelve rules
+
+1. **Type is a verb.** A wordmark that does not act has not earned its space.
+2. **Refuse the centre.** Symmetry is a sedative.
+3. **One accent is enough.** Black, off-white, alarm-red. Anything else must justify itself.
+4. **The screen is not the surface.** Design for paper, vinyl, glass, neon — never for "the layout."
+5. **No fake textures.** If it should look printed, print it.
+6. **No mascots.** A face on a brand is an apology.
+7. **Letters before photographs.** If the typography is right, the camera is optional.
+8. **The grid is a deadline, not a destination.**
+9. **Set type at the size of the room.** The smallest text in a building should still be larger than the smallest text on a phone.
+10. **Make the wordmark sweat.** Designers love smooth marks; brands need ones that breathe.
+11. **The third revision is the right one.** The first is for you, the second is for the client, the third is for the work.
+12. **End the project before the client does.**
+
+— Ivo Reiner, Lisbon

--- a/examples/kinetic-manifesto/content/projects/_index.md
+++ b/examples/kinetic-manifesto/content/projects/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Projects"
+sort_by = "date"
+reverse = true
+template = "section"
++++
+
+Direction, identity, and motion work between 2023 and 2026. Open the index for a chronological list, or jump to any year directly via the URL.

--- a/examples/kinetic-manifesto/content/projects/grandstand.md
+++ b/examples/kinetic-manifesto/content/projects/grandstand.md
@@ -1,0 +1,24 @@
++++
+title = "Grandstand"
+date = "2026-02-02"
+description = "Identity and signage for an indoor athletics arena in Rotterdam."
+[extra]
+kicker = "Identity & wayfinding / 2026"
+kind = "Identity"
+shout = "GRANDSTAND →"
+client = "Grandstand RDM"
+role = "Identity system & environmental graphics"
+collaborators = "Architecture by Bureau Sloot"
++++
+
+## Brief
+
+A 4,800-seat indoor athletics arena needed an identity that "shouted from the cheap seats." The mark had to be legible from row Z and survive being printed on everything from a 60-metre LED wall to a stick of chalk.
+
+## System
+
+A single condensed sans, drawn at three weights — *Track*, *Field* and *Stand* — became the entire toolkit. Wayfinding uses *Track* at 90% width, the LED ribbon uses *Stand* at 130%. No icons. No mascots.
+
+## Notes
+
+Photography was banned from the system at the client's request. "If you can't say it with letters, you don't get to say it on our walls."

--- a/examples/kinetic-manifesto/content/projects/late-edition.md
+++ b/examples/kinetic-manifesto/content/projects/late-edition.md
@@ -1,0 +1,23 @@
++++
+title = "Late Edition"
+date = "2025-11-15"
+description = "A type-only newspaper redesign for a 90-year-old regional daily."
+[extra]
+kicker = "Editorial direction / 2025"
+kind = "Editorial"
+shout = "LATE EDITION"
+client = "Diário da Costa"
+role = "Art direction, masthead and typography"
++++
+
+## Brief
+
+*Diário da Costa* had not updated its masthead since 1974. Print circulation had halved. They asked for "less of a redesign, more of a confession."
+
+## Move
+
+The redesign reduced the masthead to one word — **LATE** — set at 540 points across the front page. The day's date appears below it, twice the size of the news headlines. The actual newspaper title hides in the colophon.
+
+## Result
+
+Newsstand sales rose 38% in the first month. The Portuguese press association named it "irritating, but the right kind of irritating" at the 2025 EJA awards.

--- a/examples/kinetic-manifesto/content/projects/midnight-broadcast.md
+++ b/examples/kinetic-manifesto/content/projects/midnight-broadcast.md
@@ -1,0 +1,24 @@
++++
+title = "Midnight Broadcast"
+date = "2025-03-22"
+description = "On-air package for a late-night public radio show, including motion idents and printed station guides."
+[extra]
+kicker = "Identity & motion / 2025"
+kind = "Broadcast"
+shout = "MIDNIGHT BROADCAST"
+client = "Antena Noite"
+role = "Identity, on-air motion, print"
+collaborators = "Sound logo by Bruno Sá"
++++
+
+## Brief
+
+Antena Noite — a Portuguese late-night talk and music station — needed a new identity that could "talk softly at 02:00 and shout at 06:00."
+
+## System
+
+The wordmark is set in a single typeface with a custom *Fade* axis. At low-volume hours, the type recedes; at peak times it expands to fill the frame. Print station guides use only the same axis, scaled by hour of day.
+
+## Result
+
+Roll-out completed January 2026. Listenership for the 03:00 slot up 22% by month two.

--- a/examples/kinetic-manifesto/content/projects/red-room.md
+++ b/examples/kinetic-manifesto/content/projects/red-room.md
@@ -1,0 +1,23 @@
++++
+title = "Red Room"
+date = "2025-07-08"
+description = "An installation of 18 wall-sized type compositions for a converted Lisbon factory."
+[extra]
+kicker = "Installation / 2025"
+kind = "Installation"
+shout = "RED ROOM →"
+client = "MAAT Lisbon"
+role = "Concept & typographic direction"
++++
+
+## Brief
+
+A six-week installation at MAAT Lisbon. The brief: "fill 18 walls with words and one accent colour. No images."
+
+## System
+
+Eighteen wall-sized compositions, each set in a single typeface but at different optical sizes — 800 pt at the entrance, 14 pt at the exit. The accent is a custom alarm-red (#E63327) inspired by a 1972 Lisbon tram livery.
+
+## Reception
+
+The installation ran 12 June – 31 July 2025. Most-photographed wall was *Wall 14* — the line "Letters arrived first, you came late." Available now as a limited-edition print of 100.

--- a/examples/kinetic-manifesto/content/projects/sonic-bloom.md
+++ b/examples/kinetic-manifesto/content/projects/sonic-bloom.md
@@ -1,0 +1,26 @@
++++
+title = "Sonic Bloom"
+date = "2026-04-19"
+description = "An audio-reactive title sequence for a Berlin label's 10-year retrospective concert."
+[extra]
+kicker = "Motion direction / 2026"
+kind = "Motion"
+shout = "SONIC BLOOM"
+client = "Telegraph Pulse, Berlin"
+role = "Title sequence direction & type design"
+collaborators = "Sound by Aino Kallio · Code by Studio Hex"
++++
+
+## The ask
+
+Telegraph Pulse turned ten. They wanted a 4-minute opening sequence that "did to letters what a kick drum does to a chest."
+
+## The system
+
+A custom variable typeface with three axes — *bloom*, *clamp* and *bend* — was wired live to the soundboard's mid-band. Every letter on screen breathed in time with the headline track.
+
+> "The wordmark exhaled when Aino's bassline did. That's all I wanted." — set notes, dress rehearsal.
+
+## Outcome
+
+The sequence was performed live at Funkhaus on 14 April 2026 and again at Pitch & Drift, Helsinki, two weeks later. The variable font is now distributed as a stand-alone trial through the studio's site.

--- a/examples/kinetic-manifesto/static/css/style.css
+++ b/examples/kinetic-manifesto/static/css/style.css
@@ -1,0 +1,485 @@
+/* Kinetic Manifesto — bold typographic portfolio
+   Pure black on warm off-white. One accent: signal red.
+*/
+
+:root {
+  --ink: #0B0B0B;
+  --paper: #F4F1EA;
+  --paper-edge: #E7E1D3;
+  --signal: #E63327;
+  --mute: #6B675E;
+}
+
+@font-face {
+  font-family: "Inter Display";
+  src: local("Inter"), local("Helvetica Neue"), local("Arial Black");
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: "Helvetica Neue", "Inter", Arial, sans-serif;
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 17px;
+  line-height: 1.4;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Vertical tickers running on the edges */
+.edge {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  width: 28px;
+  background: var(--ink);
+  color: var(--paper);
+  display: flex;
+  align-items: center;
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  font-weight: 700;
+  overflow: hidden;
+  z-index: 10;
+}
+
+.edge.left { left: 0; }
+.edge.right { right: 0; justify-content: flex-end; }
+
+.edge span {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  white-space: nowrap;
+  animation: scroll-up 24s linear infinite;
+  padding: 12px 0;
+}
+
+.edge.right span {
+  transform: rotate(0deg);
+  animation: scroll-down 24s linear infinite;
+}
+
+@keyframes scroll-up {
+  from { transform: rotate(180deg) translateY(-100%); }
+  to   { transform: rotate(180deg) translateY(100%); }
+}
+@keyframes scroll-down {
+  from { transform: translateY(-100%); }
+  to   { transform: translateY(100%); }
+}
+
+.frame {
+  padding: 28px 56px 100px;
+  max-width: 1700px;
+  margin: 0 auto;
+  position: relative;
+}
+
+/* Top bar */
+.topbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 24px;
+  align-items: center;
+  border-bottom: 2px solid var(--ink);
+  padding-bottom: 18px;
+}
+
+.topbar .mark {
+  font-weight: 900;
+  font-size: 22px;
+  letter-spacing: -0.04em;
+  text-decoration: none;
+  color: var(--ink);
+}
+.topbar .mark::after {
+  content: "_";
+  color: var(--signal);
+  animation: blink 1s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+.topbar .meta {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mute);
+}
+
+.topbar nav {
+  display: flex;
+  gap: 18px;
+}
+.topbar nav a {
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  padding: 4px 0;
+  border-bottom: 2px solid transparent;
+}
+.topbar nav a:hover { border-color: var(--signal); }
+
+.topbar .now {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink);
+  background: var(--paper-edge);
+  padding: 4px 10px;
+}
+.topbar .now::before { content: "● "; color: var(--signal); }
+
+/* MASSIVE KINETIC TYPE */
+.shout {
+  padding: 14vh 0 8vh;
+  position: relative;
+}
+
+.shout .line {
+  font-weight: 900;
+  letter-spacing: -0.055em;
+  line-height: 0.82;
+  text-transform: uppercase;
+  display: block;
+  font-size: clamp(72px, 17.5vw, 280px);
+  color: var(--ink);
+  position: relative;
+}
+
+.shout .line .word {
+  display: inline-block;
+  transition: transform 0.5s cubic-bezier(.2,.8,.2,1), color 0.3s;
+}
+.shout .line .word:hover {
+  color: var(--signal);
+  transform: translateY(-12px) rotate(-2deg);
+}
+
+.shout .line.outline {
+  color: transparent;
+  -webkit-text-stroke: 2px var(--ink);
+  text-stroke: 2px var(--ink);
+}
+
+.shout .line.shift { transform: translateX(8vw); }
+.shout .line.shift-right { text-align: right; }
+.shout .line.italic { font-style: italic; }
+
+.shout .strike {
+  position: relative;
+  display: inline-block;
+}
+.shout .strike::after {
+  content: "";
+  position: absolute;
+  left: -2%;
+  right: -2%;
+  top: 48%;
+  height: 9px;
+  background: var(--signal);
+  transform: skewY(-3deg);
+}
+
+.shout .red { color: var(--signal); }
+
+.shout .marquee {
+  overflow: hidden;
+  white-space: nowrap;
+  font-size: clamp(72px, 17.5vw, 280px);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.055em;
+  line-height: 0.82;
+}
+.shout .marquee .strip {
+  display: inline-block;
+  animation: marquee 22s linear infinite;
+  padding-right: 0.4em;
+}
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+/* Manifesto rules */
+.rules {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+  margin: 80px 0;
+}
+
+.rules .rule {
+  padding: 28px 22px;
+  border-right: 2px solid var(--ink);
+  position: relative;
+}
+.rules .rule:last-child { border-right: none; }
+
+.rules .rule .n {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  color: var(--signal);
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.rules .rule h3 {
+  font-size: 26px;
+  line-height: 1;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.rules .rule p {
+  font-size: 14px;
+  color: var(--mute);
+  line-height: 1.45;
+}
+
+/* Index / projects */
+.section-label {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  margin: 64px 0 28px;
+}
+
+.section-label .num {
+  font-weight: 900;
+  font-size: 12px;
+  letter-spacing: 0.3em;
+  color: var(--signal);
+}
+.section-label h2 {
+  font-size: clamp(40px, 6vw, 90px);
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  line-height: 0.9;
+}
+.section-label .bar {
+  flex: 1;
+  height: 2px;
+  background: var(--ink);
+  align-self: center;
+}
+
+.projects {
+  border-top: 2px solid var(--ink);
+}
+
+.project {
+  display: grid;
+  grid-template-columns: 60px 1fr auto auto;
+  gap: 24px;
+  align-items: center;
+  padding: 28px 0;
+  border-bottom: 2px solid var(--ink);
+  text-decoration: none;
+  color: var(--ink);
+  position: relative;
+  overflow: hidden;
+}
+
+.project .num {
+  font-size: 14px;
+  letter-spacing: 0.2em;
+  color: var(--mute);
+  font-weight: 700;
+}
+
+.project h3 {
+  font-size: clamp(34px, 5.6vw, 84px);
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  line-height: 0.95;
+  transition: transform 0.35s cubic-bezier(.2,.8,.2,1);
+}
+
+.project .kind {
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+.project .year {
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.project::before {
+  content: attr(data-shout);
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  font-weight: 900;
+  font-size: clamp(48px, 7vw, 110px);
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  color: var(--signal);
+  transform: translateX(100%);
+  transition: transform 0.45s cubic-bezier(.2,.8,.2,1);
+  pointer-events: none;
+  z-index: 0;
+  white-space: nowrap;
+  padding-left: 80px;
+}
+
+.project:hover h3 { transform: translateX(-10px); color: var(--paper); }
+.project:hover .kind, .project:hover .year, .project:hover .num { color: var(--paper); }
+.project:hover { background: var(--ink); color: var(--paper); }
+.project:hover::before { transform: translateX(0); color: var(--signal); }
+.project:hover h3 { color: var(--paper); position: relative; z-index: 1; }
+
+/* Article (project page) */
+.article-head {
+  padding: 60px 0 40px;
+  border-bottom: 2px solid var(--ink);
+  margin-bottom: 40px;
+}
+.article-head .kicker {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--signal);
+  margin-bottom: 18px;
+  font-weight: 700;
+}
+.article-head h1 {
+  font-size: clamp(56px, 10vw, 168px);
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+  line-height: 0.85;
+}
+.article-head .lede {
+  margin-top: 24px;
+  max-width: 56ch;
+  font-size: 20px;
+  line-height: 1.4;
+  color: var(--ink);
+}
+
+.article-body {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 56px;
+  max-width: 1200px;
+}
+.article-body .sidebar {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mute);
+  position: sticky;
+  top: 40px;
+  align-self: start;
+  border-top: 2px solid var(--ink);
+}
+.article-body .sidebar dt {
+  margin-top: 16px;
+  color: var(--signal);
+  font-weight: 700;
+}
+.article-body .sidebar dt:first-child { margin-top: 12px; }
+.article-body .sidebar dd {
+  color: var(--ink);
+  font-size: 15px;
+  letter-spacing: 0;
+  text-transform: none;
+  margin-top: 4px;
+}
+
+.article-body .prose p {
+  font-size: 19px;
+  line-height: 1.55;
+  margin-bottom: 1.1em;
+  max-width: 60ch;
+}
+.article-body .prose h2 {
+  font-size: clamp(28px, 4vw, 56px);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+  margin: 1.4em 0 0.4em;
+  line-height: 0.95;
+}
+.article-body .prose h2::before {
+  content: "→ ";
+  color: var(--signal);
+}
+.article-body .prose blockquote {
+  border-left: 6px solid var(--signal);
+  padding: 4px 0 4px 22px;
+  margin: 1.3em 0;
+  font-size: 28px;
+  line-height: 1.2;
+  font-weight: 700;
+  font-style: italic;
+}
+.article-body .prose code,
+.article-body .prose pre {
+  font-family: ui-monospace, "SF Mono", monospace;
+  background: var(--paper-edge);
+  padding: 2px 6px;
+}
+
+.back-link {
+  margin-top: 80px;
+}
+.back-link a {
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 13px;
+  text-decoration: none;
+  color: var(--ink);
+  border: 2px solid var(--ink);
+  padding: 10px 16px;
+  display: inline-block;
+}
+.back-link a:hover { background: var(--ink); color: var(--paper); }
+
+/* Footer */
+.foot {
+  margin-top: 100px;
+  border-top: 2px solid var(--ink);
+  padding-top: 24px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 24px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--mute);
+}
+.foot .right { text-align: right; }
+.foot .center { text-align: center; color: var(--signal); }
+
+@media (max-width: 900px) {
+  .frame { padding: 22px 36px 60px; }
+  .topbar { grid-template-columns: 1fr auto; gap: 12px; }
+  .topbar .meta, .topbar .now { display: none; }
+  .rules { grid-template-columns: 1fr 1fr; }
+  .rules .rule { border-bottom: 2px solid var(--ink); }
+  .article-body { grid-template-columns: 1fr; }
+  .article-body .sidebar { position: static; }
+  .project { grid-template-columns: 40px 1fr auto; }
+  .project .kind { display: none; }
+}

--- a/examples/kinetic-manifesto/static/favicon.svg
+++ b/examples/kinetic-manifesto/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#F4F1EA"/><text x="50%" y="58%" text-anchor="middle" font-family="Helvetica" font-weight="900" font-size="22" fill="#0B0B0B" letter-spacing="-1">K</text><rect x="22" y="22" width="6" height="6" fill="#E63327"/></svg>

--- a/examples/kinetic-manifesto/templates/404.html
+++ b/examples/kinetic-manifesto/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<section class="shout">
+  <span class="line">404</span>
+  <span class="line outline shift">page</span>
+  <span class="line shift-right italic">went <span class="red">missing.</span></span>
+</section>
+<p style="margin-top:32px;"><a href="{{ base_url }}/" style="border:2px solid var(--ink);padding:10px 16px;font-weight:700;letter-spacing:.2em;text-transform:uppercase;font-size:13px;color:var(--ink);text-decoration:none;">← Back to the index</a></p>
+{% include "footer.html" %}

--- a/examples/kinetic-manifesto/templates/footer.html
+++ b/examples/kinetic-manifesto/templates/footer.html
@@ -1,0 +1,8 @@
+<footer class="foot">
+  <div>Ivo Reiner — Studio at R. Augusta 14, Lisbon</div>
+  <div class="center">© {{ current_year }} — Set in Inter & Helvetica Neue</div>
+  <div class="right">studio<wbr>@reiner.example  ·  +351 21 000 0014</div>
+</footer>
+</div>
+</body>
+</html>

--- a/examples/kinetic-manifesto/templates/header.html
+++ b/examples/kinetic-manifesto/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if page.title is present %}{{ page.title }} — {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+{{ auto_includes | safe }}
+</head>
+<body>
+
+<aside class="edge left"><span>KINETIC · MANIFESTO · {{ current_year }} · KINETIC · MANIFESTO · {{ current_year }} · KINETIC · MANIFESTO ·</span></aside>
+<aside class="edge right"><span>STUDIO REINER · LETTERS THAT MOVE · STUDIO REINER · LETTERS THAT MOVE ·</span></aside>
+
+<div class="frame">
+
+<header class="topbar">
+  <a class="mark" href="{{ base_url }}/">IVO/REINER</a>
+  <div class="meta">Vol. 04 — Selected work, manifestos and noise</div>
+  <nav>
+    <a href="{{ base_url }}/">Index</a>
+    <a href="{{ base_url }}/projects/">Projects</a>
+    <a href="{{ base_url }}/manifesto/">Manifesto</a>
+    <a href="{{ base_url }}/about/">Contact</a>
+  </nav>
+  <div class="now">Open for {{ current_year }} commissions</div>
+</header>

--- a/examples/kinetic-manifesto/templates/index.html
+++ b/examples/kinetic-manifesto/templates/index.html
@@ -1,0 +1,56 @@
+{% include "header.html" %}
+
+<section class="shout">
+  <span class="line"><span class="word">Letters</span></span>
+  <span class="line outline shift">That <span class="strike">won't</span></span>
+  <span class="line shift-right italic">sit <span class="red">still.</span></span>
+
+  <div class="marquee" aria-hidden="true">
+    <span class="strip">Typography · Direction · Identity · Motion · Sound · Print · Typography · Direction · Identity · Motion · Sound · Print · </span>
+    <span class="strip">Typography · Direction · Identity · Motion · Sound · Print · Typography · Direction · Identity · Motion · Sound · Print · </span>
+  </div>
+</section>
+
+<section class="rules">
+  <div class="rule">
+    <div class="n">01 / Rule</div>
+    <h3>Type is a verb.</h3>
+    <p>If the wordmark does not act, it does not earn the page. Every letter has a job, and every job has a velocity.</p>
+  </div>
+  <div class="rule">
+    <div class="n">02 / Rule</div>
+    <h3>Refuse the centre.</h3>
+    <p>Symmetry is a sedative. We will set type off-axis, off-baseline, and off-balance — until it tips back into the right place.</p>
+  </div>
+  <div class="rule">
+    <div class="n">03 / Rule</div>
+    <h3>One accent is enough.</h3>
+    <p>Black ink, off-white paper, one alarm-red. The third colour must justify itself or be cut.</p>
+  </div>
+  <div class="rule">
+    <div class="n">04 / Rule</div>
+    <h3>The screen is not the surface.</h3>
+    <p>We design for paper, for vinyl, for moving glass — never for "the layout." The grid is a deadline, not a destination.</p>
+  </div>
+</section>
+
+<div class="section-label">
+  <span class="num">SELECTED</span>
+  <h2>Projects</h2>
+  <span class="bar"></span>
+</div>
+
+<div class="projects">
+{% for p in site.pages | sort_by(attribute="date", reverse=true) %}
+  {% if p.section == "projects" %}
+  <a class="project" href="{{ p.url }}" data-shout="{{ p.extra.shout | default(p.title) }} →">
+    <span class="num">N° {{ loop.index }}</span>
+    <h3>{{ p.title }}</h3>
+    <span class="kind">{{ p.extra.kind | default('Direction') }}</span>
+    <span class="year">{{ p.date | date("%Y") }}</span>
+  </a>
+  {% endif %}
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/kinetic-manifesto/templates/page.html
+++ b/examples/kinetic-manifesto/templates/page.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<article>
+  <header class="article-head">
+    <div class="kicker">{{ page.extra.kicker | default("Project") }}</div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="lede">{{ page.description }}</p>{% endif %}
+  </header>
+
+  <div class="article-body">
+    <aside class="sidebar">
+      <dl>
+        <dt>Client</dt><dd>{{ page.extra.client | default("Self-initiated") }}</dd>
+        <dt>Role</dt><dd>{{ page.extra.role | default("Direction & design") }}</dd>
+        <dt>Kind</dt><dd>{{ page.extra.kind | default("Identity") }}</dd>
+        <dt>Year</dt><dd>{{ page.date | date("%Y") }}</dd>
+        {% if page.extra.collaborators %}<dt>With</dt><dd>{{ page.extra.collaborators }}</dd>{% endif %}
+      </dl>
+    </aside>
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+  </div>
+
+  <div class="back-link">
+    <a href="{{ base_url }}/">← Back to index</a>
+  </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/kinetic-manifesto/templates/section.html
+++ b/examples/kinetic-manifesto/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="section-label">
+  <span class="num">ALL</span>
+  <h2>{{ section.title }}</h2>
+  <span class="bar"></span>
+</div>
+
+{% if content %}<div style="max-width:60ch;margin-bottom:48px;font-size:18px;line-height:1.5;">{{ content | safe }}</div>{% endif %}
+
+<div class="projects">
+{% for p in section.pages | sort_by(attribute="date", reverse=true) %}
+  <a class="project" href="{{ p.url }}" data-shout="{{ p.extra.shout | default(p.title) }} →">
+    <span class="num">N° {{ loop.index }}</span>
+    <h3>{{ p.title }}</h3>
+    <span class="kind">{{ p.extra.kind | default('Direction') }}</span>
+    <span class="year">{{ p.date | date("%Y") }}</span>
+  </a>
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/photocopy-folio/AGENTS.md
+++ b/examples/photocopy-folio/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/photocopy-folio/archetypes/default.md
+++ b/examples/photocopy-folio/archetypes/default.md
@@ -1,0 +1,6 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
++++

--- a/examples/photocopy-folio/config.toml
+++ b/examples/photocopy-folio/config.toml
@@ -1,0 +1,207 @@
+title = "Photocopy Folio"
+description = "Kris Halver's lo-fi photocopy portfolio — pure black, paper white, and a lot of grain."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 20
+sections = ["case"]
+
+[markdown]
+safe = false
+heading_ids = true
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/photocopy-folio/content/about.md
+++ b/examples/photocopy-folio/content/about.md
@@ -1,0 +1,31 @@
++++
+title = "Contact"
+description = "Studio Halver — Antwerp & Brussels. Commission inquiries below."
+[extra]
+kicker = "Studio"
+kind = "Studio"
+client = "—"
+role = "—"
+file = "000/A"
++++
+
+## Studio Halver
+
+Two-person studio. Founded 2014 by Kris Halver. Operates out of a converted print shop in Antwerp, with a satellite room in Brussels.
+
+## Commissioning
+
+All inquiries by email. We do not pitch unpaid and we do not charge by the hour. Minimum engagement is six weeks; minimum invoice is €8,000.
+
+Send the email at one of the studio's working hours — Tue & Thu, 10:00–15:00 CET. You will hear back within five working days.
+
+## Address
+
+Antwerp · Lange Beeldekensstraat 88
+Brussels · rue Lambert Crickx 14
+
+**studio at halver dot example** · +32 3 000 0014
+
+## Teaching
+
+Kris teaches a 12-week design seminar at KASK Gent every spring. Sit-in places via the school.

--- a/examples/photocopy-folio/content/case/_index.md
+++ b/examples/photocopy-folio/content/case/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Case files"
+sort_by = "date"
+reverse = true
+template = "section"
++++
+
+A full file dump of selected projects from 2022 onward. The studio's older work is available on request.

--- a/examples/photocopy-folio/content/case/folkfair-identity.md
+++ b/examples/photocopy-folio/content/case/folkfair-identity.md
@@ -1,0 +1,26 @@
++++
+title = "Folkfair — Identity & Signage"
+date = "2026-05-04"
+description = "Identity, signage and printed programmes for a Flemish folk-music festival."
+[extra]
+kind = "Identity"
+file = "026/B"
+client = "Folkfair vzw"
+role = "Identity, signage, programmes"
+collaborators = "Wayfinding fabrication by Studio Klar"
+format = "Print + environmental"
++++
+
+## Subject
+
+Folkfair is a six-day folk-music festival held every July in Geraardsbergen. Their old identity — a hand-drawn fiddle — was loved but illegible at small sizes and a nightmare to reproduce.
+
+## What we did
+
+The new mark is a six-letter wordmark set in a single condensed face, printed exclusively on uncoated brown kraft. Signage uses the same face at three weights — *Stage*, *Path* and *Tent* — and is screen-printed on site every year, never reused.
+
+> "It looks like it was printed at the festival, because it was." — *Trouw*, 12 July 2025.
+
+## Filed result
+
+Three years of signage tooling. The studio retains a working set of stencils and screens; the festival owns the marks outright.

--- a/examples/photocopy-folio/content/case/library-of-noise.md
+++ b/examples/photocopy-folio/content/case/library-of-noise.md
@@ -1,0 +1,24 @@
++++
+title = "Library of Noise — Identity & Wayfinding"
+date = "2024-11-08"
+description = "Identity and signage for a small experimental-sound archive in Gent."
+[extra]
+kind = "Identity"
+file = "014/N"
+client = "Library of Noise"
+role = "Identity, wayfinding, plaques"
+collaborators = "Architecture by V/V"
+format = "Print + brass"
++++
+
+## Subject
+
+A small archive of experimental-music recordings — about 2,200 reel-to-reel tapes — opened in a former bank vault in Gent. They needed an identity that "didn't pretend to be quiet."
+
+## What we did
+
+The wordmark is hand-cut from 3 mm brass, mounted directly into the existing vault doors. The printed identity uses photocopies of the brass — at the worst-quality setting — for everything else. The two materials never appear at the same scale.
+
+## Filed result
+
+The brass mark has aged into a different colour every winter. The studio receives a "weather report" every February from the curator.

--- a/examples/photocopy-folio/content/case/null-coffee.md
+++ b/examples/photocopy-folio/content/case/null-coffee.md
@@ -1,0 +1,23 @@
++++
+title = "Null Coffee — Brand & Bags"
+date = "2025-09-30"
+description = "Identity, packaging and a small range of editorial inserts for a Brussels micro-roaster."
+[extra]
+kind = "Identity"
+file = "022/L"
+client = "Null Coffee, Brussels"
+role = "Identity & packaging"
+format = "Print + packaging"
++++
+
+## Subject
+
+Null Coffee is a four-person micro-roaster on rue Lambert Crickx. They didn't want "a brand" — they wanted "a bag that prints in one colour and shuts up."
+
+## What we did
+
+The packaging is a single ink — matte black — on natural craft kraft. The wordmark is one weight of one typeface set inside a black bar. The only variable: a numeric *batch code* printed on the lower corner, rotated 90°, which is the only thing the design actually says.
+
+## Filed result
+
+The bag now ships 800 units a week. The studio drinks the coffee for free in exchange for never updating the design.

--- a/examples/photocopy-folio/content/case/parallel-news.md
+++ b/examples/photocopy-folio/content/case/parallel-news.md
@@ -1,0 +1,23 @@
++++
+title = "Parallel — Weekly News Tabloid"
+date = "2026-02-18"
+description = "A redesign of an Antwerp weekly that doubled its print run within a year."
+[extra]
+kind = "Editorial"
+file = "025/Q"
+client = "Parallel BVBA"
+role = "Editorial direction & masthead"
+format = "Tabloid · 36 pages · weekly"
++++
+
+## Subject
+
+*Parallel* is a 27-year-old Antwerp weekly covering city politics. By 2024 it was a designed-by-committee mess — 9 typefaces on the cover, 4 logo lockups, and a circulation drop of 40%.
+
+## What we did
+
+We stripped the design system back to **one typeface** (a slab serif drawn by the studio in 2022 for an earlier project), **two weights**, and **no colour**. The masthead is the same height on every issue, regardless of the headline. The headline negotiates around the masthead, not the other way around.
+
+## Filed result
+
+Print run doubled by month nine. The editor still complains about not being allowed to use blue.

--- a/examples/photocopy-folio/content/case/static-films.md
+++ b/examples/photocopy-folio/content/case/static-films.md
@@ -1,0 +1,26 @@
++++
+title = "Static Films — Title Sequences"
+date = "2025-05-12"
+description = "A set of black-and-white title sequences for three independent feature films."
+[extra]
+kind = "Motion"
+file = "019/R"
+client = "Static Films Co-op"
+role = "Title direction & typography"
+collaborators = "Compositing by Lab Mille"
+format = "16 mm + digital"
++++
+
+## Subject
+
+Three feature films from the Static Films co-op needed title sequences that "looked like they had been left in a drawer for forty years."
+
+## What we did
+
+The sequences were shot in 16 mm black-and-white using a single typeface — a heavy slab — projected on a wall and re-filmed. No motion graphics. No keyframes. The wobble is real wobble.
+
+> "I have never seen a designer go this far out of their way to avoid Adobe." — director's commentary, *The Closed Door*.
+
+## Filed result
+
+All three films toured the European festival circuit between October 2025 and March 2026. The studio still has the projector.

--- a/examples/photocopy-folio/content/index.md
+++ b/examples/photocopy-folio/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Photocopy Folio"
+description = "Kris Halver's portfolio of editorial, brand and motion work — photocopied past the legible point."
+template = "index"
++++

--- a/examples/photocopy-folio/static/css/style.css
+++ b/examples/photocopy-folio/static/css/style.css
@@ -1,0 +1,524 @@
+/* Photocopy Folio — high-contrast B&W lo-fi xerox portfolio
+   Look: 5th-generation photocopy on cheap A4. Pure black, pure paper-white.
+   Texture comes from layered SVG noise + dot/line patterns.
+*/
+
+:root {
+  --ink: #0a0a0a;
+  --paper: #ECE9DF;
+  --paper-shade: #D6D2C5;
+  --highlight: #FFEC4A;   /* a single neon highlighter mark allowed */
+  --rule: 1.5px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: "Courier New", Courier, ui-monospace, monospace;
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 15px;
+  line-height: 1.55;
+  position: relative;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+/* Heavy SVG noise — like 5th-gen xerox grain */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 90;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence baseFrequency='1.05' numOctaves='3' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.04  0 0 0 0 0.04  0 0 0 0 0.04  0 0 0 0.85 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  opacity: 0.45;
+  mix-blend-mode: multiply;
+}
+
+/* Horizontal scan/copy lines */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 91;
+  background-image: repeating-linear-gradient(
+    180deg,
+    transparent 0,
+    transparent 2px,
+    rgba(0,0,0,0.05) 2px,
+    rgba(0,0,0,0.05) 3px
+  );
+  opacity: 0.6;
+}
+
+/* Page frame */
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 36px 40px 80px;
+  position: relative;
+  z-index: 1;
+}
+
+/* Stamp marks at corners */
+.page::before {
+  content: "RECEIVED · {{copy-of-copy}} · DO NOT FOLD";
+  position: absolute;
+  top: 22px;
+  right: 24px;
+  font-size: 9px;
+  letter-spacing: 0.25em;
+  border: 1.5px solid var(--ink);
+  padding: 4px 8px;
+  transform: rotate(2deg);
+  text-transform: uppercase;
+  background: var(--paper);
+}
+
+.page::after {
+  content: "FILE COPY № 014";
+  position: absolute;
+  bottom: 18px;
+  left: 24px;
+  font-size: 9px;
+  letter-spacing: 0.25em;
+  border: 1.5px solid var(--ink);
+  padding: 4px 8px;
+  transform: rotate(-1.5deg);
+  text-transform: uppercase;
+  background: var(--paper);
+}
+
+/* Top stripe */
+.banner {
+  border-top: 4px solid var(--ink);
+  border-bottom: 1.5px solid var(--ink);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 14px 0;
+  margin-bottom: 36px;
+}
+
+.banner .mark {
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.banner .mark::before {
+  content: "▮▯▮ ";
+  color: var(--ink);
+  letter-spacing: -0.1em;
+}
+
+.banner .barcode {
+  display: flex;
+  gap: 1.5px;
+  height: 32px;
+  margin: 0 auto;
+}
+.banner .barcode i {
+  display: block;
+  width: 2px;
+  background: var(--ink);
+}
+.banner .barcode i:nth-child(2n) { width: 3px; height: 80%; align-self: end; }
+.banner .barcode i:nth-child(3n) { width: 1px; }
+.banner .barcode i:nth-child(4n) { width: 5px; }
+
+.banner nav { display: flex; gap: 14px; }
+.banner nav a {
+  text-decoration: none;
+  color: var(--ink);
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  border: 1.5px solid var(--ink);
+  padding: 4px 8px;
+  background: var(--paper);
+}
+.banner nav a:hover {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+/* Hero block — like a stamped document */
+.dossier {
+  border: 3px solid var(--ink);
+  padding: 28px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 32px;
+  position: relative;
+  box-shadow:
+    6px 6px 0 var(--ink),
+    -2px 4px 0 var(--paper),
+    -3px 5px 0 var(--ink);
+}
+
+.dossier::before {
+  content: "CONFIDENTIAL";
+  position: absolute;
+  top: -14px;
+  left: 18px;
+  background: var(--paper);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  padding: 0 8px;
+  font-weight: 700;
+}
+
+.dossier h1 {
+  font-family: "Times New Roman", Times, serif;
+  font-weight: 900;
+  font-size: clamp(48px, 8vw, 108px);
+  letter-spacing: -0.03em;
+  line-height: 0.92;
+  text-transform: uppercase;
+}
+
+.dossier h1 .highlight {
+  background: var(--highlight);
+  padding: 0 6px;
+  display: inline-block;
+  transform: skewX(-6deg);
+}
+
+.dossier h1 .scratched {
+  text-decoration: line-through;
+  text-decoration-thickness: 5px;
+  color: rgba(10,10,10,0.55);
+}
+
+.dossier .fileinfo {
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.dossier .fileinfo dl {
+  border-top: 1.5px solid var(--ink);
+  border-bottom: 1.5px solid var(--ink);
+  padding: 12px 0;
+  margin-bottom: 16px;
+}
+.dossier .fileinfo dt {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+.dossier .fileinfo dt:first-child { margin-top: 0; }
+.dossier .fileinfo dd {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.dossier .fileinfo p { font-size: 13px; }
+
+/* Big stamp overlay */
+.stamp {
+  position: absolute;
+  right: -30px;
+  bottom: -28px;
+  font-family: "Times New Roman", Times, serif;
+  font-weight: 900;
+  font-size: 80px;
+  letter-spacing: 0.05em;
+  border: 6px double var(--ink);
+  padding: 6px 18px;
+  color: var(--ink);
+  background: var(--paper);
+  transform: rotate(-8deg);
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.stamp small {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-align: center;
+  margin-top: 4px;
+}
+
+/* Subhead */
+.subhead {
+  margin: 72px 0 24px;
+  border-top: 4px solid var(--ink);
+  border-bottom: 1.5px solid var(--ink);
+  padding: 16px 0;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 20px;
+}
+
+.subhead .tag {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 4px 8px;
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+}
+
+.subhead h2 {
+  font-family: "Times New Roman", Times, serif;
+  font-weight: 900;
+  font-size: clamp(28px, 4.4vw, 56px);
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+
+.subhead .meta {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+/* Index list — like a file directory */
+.dir {
+  border: 1.5px solid var(--ink);
+}
+
+.dir .row {
+  display: grid;
+  grid-template-columns: 56px 100px 1fr 120px 80px;
+  gap: 14px;
+  padding: 14px 16px;
+  border-bottom: 1.5px solid var(--ink);
+  text-decoration: none;
+  color: var(--ink);
+  font-size: 14px;
+  align-items: center;
+  position: relative;
+}
+.dir .row:last-child { border-bottom: none; }
+
+.dir .row.head {
+  background: var(--ink);
+  color: var(--paper);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+}
+
+.dir .row .file {
+  font-family: "Courier New", monospace;
+  font-weight: 700;
+  font-size: 13px;
+}
+.dir .row .title {
+  font-family: "Times New Roman", Times, serif;
+  font-weight: 900;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  line-height: 1.05;
+}
+.dir .row .kind {
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  background: var(--paper-shade);
+  padding: 2px 6px;
+  display: inline-block;
+}
+.dir .row .year { font-weight: 700; }
+
+.dir a.row:hover { background: var(--ink); color: var(--paper); }
+.dir a.row:hover .kind { background: var(--paper); color: var(--ink); }
+.dir a.row:hover::after {
+  content: "▶";
+  position: absolute;
+  right: 18px;
+  color: var(--highlight);
+}
+
+/* "ABOUT" two-column */
+.about-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+  margin-top: 48px;
+}
+
+.about-row .card {
+  border: 1.5px solid var(--ink);
+  padding: 20px;
+  position: relative;
+}
+
+.about-row .card h3 {
+  font-family: "Times New Roman", Times, serif;
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  margin-bottom: 12px;
+}
+
+.about-row .card p { font-size: 13px; margin-bottom: 0.9em; }
+
+.about-row .card.checklist ul {
+  list-style: none;
+  padding: 0;
+}
+.about-row .card.checklist li {
+  padding: 4px 0 4px 28px;
+  position: relative;
+  font-size: 13px;
+}
+.about-row .card.checklist li::before {
+  content: "▣";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  font-weight: 700;
+}
+.about-row .card.checklist li.off::before { content: "▢"; opacity: 0.45; }
+
+/* Case page (project article) */
+.case-page header {
+  border-top: 4px solid var(--ink);
+  border-bottom: 1.5px solid var(--ink);
+  padding: 20px 0;
+  margin: 32px 0 28px;
+  position: relative;
+}
+.case-page header .file {
+  font-family: "Courier New", monospace;
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+}
+.case-page header h1 {
+  font-family: "Times New Roman", Times, serif;
+  font-weight: 900;
+  font-size: clamp(40px, 7vw, 96px);
+  letter-spacing: -0.03em;
+  line-height: 0.95;
+  text-transform: uppercase;
+}
+.case-page header .lede {
+  margin-top: 16px;
+  font-size: 16px;
+  max-width: 56ch;
+  line-height: 1.45;
+}
+
+.case-page .grid {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 40px;
+}
+
+.case-page .info {
+  border: 1.5px solid var(--ink);
+  padding: 18px;
+  align-self: start;
+  font-size: 12px;
+  position: sticky;
+  top: 24px;
+}
+.case-page .info dt {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin-top: 12px;
+}
+.case-page .info dt:first-child { margin-top: 0; }
+.case-page .info dd {
+  font-weight: 700;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.case-page .prose {
+  font-family: "Times New Roman", Times, serif;
+  font-size: 17px;
+  line-height: 1.5;
+}
+.case-page .prose p { margin-bottom: 1em; }
+.case-page .prose h2 {
+  font-family: "Times New Roman", Times, serif;
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 24px;
+  letter-spacing: -0.01em;
+  margin: 1.4em 0 0.4em;
+  border-bottom: 1.5px solid var(--ink);
+  padding-bottom: 6px;
+}
+.case-page .prose blockquote {
+  border-left: 6px solid var(--ink);
+  padding: 4px 0 4px 18px;
+  font-size: 22px;
+  font-style: italic;
+  margin: 1.1em 0;
+  line-height: 1.3;
+  background: var(--highlight);
+  display: inline-block;
+}
+.case-page .prose code,
+.case-page .prose pre {
+  font-family: "Courier New", monospace;
+  background: var(--paper-shade);
+  padding: 2px 6px;
+}
+
+.case-page .back {
+  margin-top: 64px;
+  padding-top: 20px;
+  border-top: 1.5px solid var(--ink);
+}
+.case-page .back a {
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  border: 1.5px solid var(--ink);
+  padding: 6px 12px;
+  text-decoration: none;
+  color: var(--ink);
+}
+.case-page .back a:hover { background: var(--ink); color: var(--paper); }
+
+/* Footer */
+.foot {
+  margin-top: 96px;
+  border-top: 4px solid var(--ink);
+  padding-top: 18px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+.foot .center { text-align: center; }
+.foot .right { text-align: right; }
+
+@media (max-width: 880px) {
+  .page { padding: 24px 22px 60px; }
+  .banner { grid-template-columns: 1fr auto; }
+  .banner .barcode { display: none; }
+  .dossier { grid-template-columns: 1fr; }
+  .stamp { right: 8px; bottom: -22px; font-size: 48px; }
+  .dir .row { grid-template-columns: 80px 1fr; gap: 8px; }
+  .dir .row .file, .dir .row .kind, .dir .row .year { display: none; }
+  .dir .row.head { display: none; }
+  .case-page .grid { grid-template-columns: 1fr; }
+  .case-page .info { position: static; }
+  .about-row { grid-template-columns: 1fr; }
+}

--- a/examples/photocopy-folio/static/favicon.svg
+++ b/examples/photocopy-folio/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#ECE9DF"/><rect x="3" y="3" width="26" height="26" fill="none" stroke="#0a0a0a" stroke-width="2"/><text x="50%" y="62%" text-anchor="middle" font-family="Times New Roman" font-weight="900" font-size="18" fill="#0a0a0a">H</text></svg>

--- a/examples/photocopy-folio/templates/404.html
+++ b/examples/photocopy-folio/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<section class="dossier">
+  <h1><span class="scratched">FILE</span> 404 <span class="highlight">missing.</span></h1>
+  <div class="fileinfo">
+    <p>Either this file was misplaced, never filed, or pulled from the cabinet.</p>
+    <p style="margin-top:18px;"><a href="{{ base_url }}/" style="border:1.5px solid var(--ink);padding:6px 12px;letter-spacing:.24em;text-transform:uppercase;font-size:11px;color:var(--ink);text-decoration:none;">← Back to the file cabinet</a></p>
+  </div>
+  <div class="stamp">VOID<small>not found</small></div>
+</section>
+{% include "footer.html" %}

--- a/examples/photocopy-folio/templates/footer.html
+++ b/examples/photocopy-folio/templates/footer.html
@@ -1,0 +1,8 @@
+<footer class="foot">
+  <div>Studio Halver — Antwerp & Brussels</div>
+  <div class="center">© {{ current_year }} · Photocopied with consent</div>
+  <div class="right">Last filed {{ current_date }}</div>
+</footer>
+</div>
+</body>
+</html>

--- a/examples/photocopy-folio/templates/header.html
+++ b/examples/photocopy-folio/templates/header.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if page.title is present %}{{ page.title }} — {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="page">
+<header class="banner">
+  <a class="mark" href="{{ base_url }}/">KRIS HALVER / Studio</a>
+  <div class="barcode">
+    <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+    <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+    <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+  </div>
+  <nav>
+    <a href="{{ base_url }}/">Cover</a>
+    <a href="{{ base_url }}/case/">Cases</a>
+    <a href="{{ base_url }}/about/">Contact</a>
+  </nav>
+</header>

--- a/examples/photocopy-folio/templates/index.html
+++ b/examples/photocopy-folio/templates/index.html
@@ -1,0 +1,74 @@
+{% include "header.html" %}
+
+<section class="dossier">
+  <h1>
+    Kris<br>
+    <span class="highlight">Halver.</span><br>
+    <span class="scratched">Designer</span> Operator.
+  </h1>
+  <div class="fileinfo">
+    <dl>
+      <dt>Subject</dt><dd>Independent design practice</dd>
+      <dt>Location</dt><dd>Antwerp / Brussels</dd>
+      <dt>Active since</dt><dd>2014–present</dd>
+      <dt>Status</dt><dd>Open for {{ current_year }} commissions</dd>
+    </dl>
+    <p>The studio works on identity, editorial, and the kind of motion direction that doesn't need to be in colour. Files are delivered as PDFs and PostScript, never as PowerPoint.</p>
+    <p style="margin-top:8px;"><strong>↘ Skip to <a href="#cases" style="color:var(--ink)">selected cases</a>.</strong></p>
+  </div>
+  <div class="stamp">Filed<small>by hand</small></div>
+</section>
+
+<div class="subhead" id="cases">
+  <span class="tag">001 / Cases</span>
+  <h2>Selected file dump</h2>
+  <span class="meta">Sorted descending · {{ current_year }}</span>
+</div>
+
+<div class="dir">
+  <div class="row head">
+    <span>File</span>
+    <span>Type</span>
+    <span>Project</span>
+    <span>Client</span>
+    <span>Year</span>
+  </div>
+  {% for p in site.pages | sort_by(attribute="date", reverse=true) %}
+    {% if p.section == "case" %}
+    <a class="row" href="{{ p.url }}">
+      <span class="file">№ {{ loop.index }}</span>
+      <span><span class="kind">{{ p.extra.kind | default('Identity') }}</span></span>
+      <span class="title">{{ p.title }}</span>
+      <span>{{ p.extra.client | default('Self') }}</span>
+      <span class="year">'{{ p.date | date("%y") }}</span>
+    </a>
+    {% endif %}
+  {% endfor %}
+</div>
+
+<div class="subhead">
+  <span class="tag">002 / Operator</span>
+  <h2>Two sides of the page</h2>
+  <span class="meta">About the studio</span>
+</div>
+
+<div class="about-row">
+  <div class="card">
+    <h3>What the studio does</h3>
+    <p>Brand identities and identity systems. Editorial direction and book design. Motion idents and title sequences that don't pretend to be live action.</p>
+    <p>The studio works on a flat day-rate and refuses to bill by the hour. Most projects last 6–14 weeks.</p>
+  </div>
+  <div class="card checklist">
+    <h3>What the studio refuses</h3>
+    <ul>
+      <li>Unpaid pitches, ever.</li>
+      <li>Crypto, gambling, military.</li>
+      <li class="off">Decks longer than 16 slides.</li>
+      <li class="off">Stock photography.</li>
+      <li>Mascots, "fun" emojis, exclamation marks.</li>
+      <li>Anyone who says "make it pop."</li>
+    </ul>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/photocopy-folio/templates/page.html
+++ b/examples/photocopy-folio/templates/page.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<article class="case-page">
+  <header>
+    <div class="file">FILE № {{ page.extra.file | default("014/Z") }} · {{ page.extra.kind | default("Project") }}</div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="lede">{{ page.description }}</p>{% endif %}
+  </header>
+
+  <div class="grid">
+    <aside class="info">
+      <dl>
+        <dt>Client</dt><dd>{{ page.extra.client | default("Self-initiated") }}</dd>
+        <dt>Role</dt><dd>{{ page.extra.role | default("Direction & design") }}</dd>
+        <dt>Type</dt><dd>{{ page.extra.kind | default("Identity") }}</dd>
+        <dt>Year</dt><dd>{{ page.date | date("%Y") }}</dd>
+        {% if page.extra.collaborators %}<dt>With</dt><dd>{{ page.extra.collaborators }}</dd>{% endif %}
+        {% if page.extra.format %}<dt>Format</dt><dd>{{ page.extra.format }}</dd>{% endif %}
+      </dl>
+    </aside>
+
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+  </div>
+
+  <div class="back"><a href="{{ base_url }}/">← Back to file cabinet</a></div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/photocopy-folio/templates/section.html
+++ b/examples/photocopy-folio/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+
+<div class="subhead">
+  <span class="tag">All files</span>
+  <h2>{{ section.title }}</h2>
+  <span class="meta">{{ section.pages | length }} entries</span>
+</div>
+
+{% if content %}<div style="max-width:60ch;margin-bottom:24px;font-size:14px;">{{ content | safe }}</div>{% endif %}
+
+<div class="dir">
+  <div class="row head"><span>File</span><span>Type</span><span>Project</span><span>Client</span><span>Year</span></div>
+  {% for p in section.pages | sort_by(attribute="date", reverse=true) %}
+    <a class="row" href="{{ p.url }}">
+      <span class="file">№ {{ loop.index }}</span>
+      <span><span class="kind">{{ p.extra.kind | default('Identity') }}</span></span>
+      <span class="title">{{ p.title }}</span>
+      <span>{{ p.extra.client | default('Self') }}</span>
+      <span class="year">'{{ p.date | date("%y") }}</span>
+    </a>
+  {% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/riso-folio/AGENTS.md
+++ b/examples/riso-folio/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/riso-folio/archetypes/default.md
+++ b/examples/riso-folio/archetypes/default.md
@@ -1,0 +1,6 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
++++

--- a/examples/riso-folio/config.toml
+++ b/examples/riso-folio/config.toml
@@ -1,0 +1,202 @@
+title = "Riso Folio"
+description = "Two-ink risograph portfolio — overprinted, halftoned, smudged on purpose."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[[taxonomies]]
+name = "tags"
+
+[[taxonomies]]
+name = "discipline"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 20
+sections = ["work"]
+
+[markdown]
+safe = false
+lazy_loading = true
+heading_ids = true
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/riso-folio/content/about.md
+++ b/examples/riso-folio/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "About the Studio"
+description = "Mira Vandal runs a one-person print studio in Lisbon. She works with two inks at a time."
+[extra]
+kicker = "Colophon"
+client = "Mira Vandal, Lisbon"
+kind = "Studio"
+stock = "—"
+inks = "Two at a time"
++++
+
+## Mira Vandal
+
+Mira Vandal is a graphic designer and printmaker working between Lisbon and Porto. The studio operates two Risograph machines — an SF9450 and an MZ1090 — and one Heidelberg Windmill kept around as a paperweight.
+
+## How the work happens
+
+Every project is treated as a print constraint first and a screen artefact second. Files are designed at 1:1 with the press in mind: two inks, one drum at a time, no overprint above 70%.
+
+## Contact
+
+For commissions, lectures, or to send paper samples, write to **studio at mira-vandal dot example**. The studio does not accept unpaid spec work, ever.
+
+## Selected clients
+
+Pyrite Foundry · Soft Boundary Records · Tributary Press · Casa Mira · Ode Festival · Lisbon Architecture Triennale (2024 catalogue) · ZINEFest Bilbao

--- a/examples/riso-folio/content/index.md
+++ b/examples/riso-folio/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Riso Folio"
+description = "Two-ink risograph portfolio of Mira Vandal — overprinted, halftoned, smudged on purpose."
+template = "index"
++++

--- a/examples/riso-folio/content/work/_index.md
+++ b/examples/riso-folio/content/work/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Work"
+sort_by = "date"
+reverse = true
+template = "section"
++++
+
+A selection of recent print and identity work. Each entry was printed as a small pamphlet — 4 pages, two ink passes, hand-bound at the studio.

--- a/examples/riso-folio/content/work/aliso-typeface.md
+++ b/examples/riso-folio/content/work/aliso-typeface.md
@@ -1,0 +1,26 @@
++++
+title = "Aliso — A Variable Display Face"
+date = "2026-03-08"
+description = "A high-contrast display typeface in 7 axes, drawn for risograph reproduction."
+[extra]
+symbol = "A"
+kind = "Type design"
+kicker = "Type design / 2026"
+client = "Pyrite Foundry"
+stock = "100gsm Plike"
+inks = "Fluo Pink"
++++
+
+## Brief
+
+Pyrite Foundry asked for a high-contrast display face that survived the registration drift of a two-pass riso pull. Hairlines die first under that constraint, so the face was drawn from the limitation outward.
+
+## Approach
+
+Drawn entirely in ink on tracing paper, scanned, then vectorised at 300 dpi. Spacing was tested on a Risograph SF9450 before any digital kerning happened. The result is a face that **gets sharper as it gets softer** — the misregistration of pink over blue reads as intent rather than error.
+
+> "The drum hates this face less than it hates any of the others." — Pyrite test sheet, run 04.
+
+## Specimens
+
+Seven optical sizes, ranging from a 14-pt caption to a 320-pt poster cut. The whole specimen book is set in two ink passes — one for the body, one for the marginal notes.

--- a/examples/riso-folio/content/work/casa-mira-identity.md
+++ b/examples/riso-folio/content/work/casa-mira-identity.md
@@ -1,0 +1,24 @@
++++
+title = "Casa Mira — Identity System"
+date = "2025-11-04"
+description = "Brand identity for a Galician seafood restaurant, built around hand-cut lettering."
+[extra]
+symbol = "M"
+kind = "Identity"
+kicker = "Identity / 2025"
+client = "Casa Mira, A Coruña"
+stock = "Coated kraft"
+inks = "Federal Blue"
++++
+
+## Brief
+
+A small Galician seafood restaurant opening in A Coruña wanted an identity that "felt eaten-in by salt air." No photography in the system — only ink and paper.
+
+## Approach
+
+The wordmark is cut by hand from rubber and re-stamped for every print run, so no two business cards align identically. The menu is reprinted weekly, riso-pulled in the kitchen on the same press as the daily specials.
+
+## Result
+
+The card stock yellows on purpose. By the time you're handed the menu, it's already a souvenir.

--- a/examples/riso-folio/content/work/marginalia-cover.md
+++ b/examples/riso-folio/content/work/marginalia-cover.md
@@ -1,0 +1,24 @@
++++
+title = "Marginalia — Book Cover"
+date = "2025-05-30"
+description = "A cover for a 220-page essay collection on the future of footnotes."
+[extra]
+symbol = "¶"
+kind = "Book"
+kicker = "Book / 2025"
+client = "Tributary Press"
+stock = "300gsm uncoated"
+inks = "Fluo Pink"
++++
+
+## Brief
+
+Tributary Press wanted a cover for *Marginalia* — Lina Soto's essay collection on the future of the footnote — that was itself a footnote. Small, dense, low to the ground.
+
+## Approach
+
+The whole cover is set at 9-point. The title and the author's name are smaller than the publisher's address. The negative space is filled with a halftoned thumbprint, deliberately misregistered by one millimetre, pink-on-cream.
+
+## Result
+
+The first edition cover is now used as the section divider for the second.

--- a/examples/riso-folio/content/work/ode-poster-series.md
+++ b/examples/riso-folio/content/work/ode-poster-series.md
@@ -1,0 +1,24 @@
++++
+title = "Ode — Poster Series"
+date = "2025-09-12"
+description = "A series of seven 70×100 posters for a Lisbon poetry festival."
+[extra]
+symbol = "■"
+kind = "Posters"
+kicker = "Posters / 2025"
+client = "Ode Festival"
+stock = "100gsm Munken Lynx"
+inks = "Fluo Pink + Federal Blue"
++++
+
+## Brief
+
+Seven posters for Lisbon's Ode poetry festival. Each poster pairs a single line from a participating poet with a typographic gesture — no images, no decoration.
+
+## Approach
+
+The posters were printed at the festival itself. A two-colour Risograph was wheeled into the lobby and visitors watched the run pull through one ink pass at a time. The smell of the drum was, apparently, part of the brief.
+
+## Result
+
+All 700 copies given away by the third night. Six framed sets are in the festival's permanent archive.

--- a/examples/riso-folio/content/work/quiet-fauna-zine.md
+++ b/examples/riso-folio/content/work/quiet-fauna-zine.md
@@ -1,0 +1,24 @@
++++
+title = "Quiet Fauna — Zine 03"
+date = "2026-01-22"
+description = "An 80-page zine cataloguing urban nocturnal animals, printed in two ink passes."
+[extra]
+symbol = "○"
+kind = "Editorial"
+kicker = "Zine / 2026"
+client = "Self-initiated"
+stock = "70gsm Munken Pure"
+inks = "Federal Blue + Fluo Pink"
++++
+
+## Brief
+
+An 80-page zine cataloguing urban nocturnal animals — moths, raccoons, common pipistrelles — printed in a run of 120 numbered copies for the Lisbon Print Fair.
+
+## Approach
+
+The zine is structured as a field journal. Each spread pairs a halftoned animal portrait (pink) with handwritten field notes (blue). The two inks never touch in the layout, which keeps the registration honest even when the drum slips.
+
+## Result
+
+Sold out in 36 hours. A second run of 80 was pulled the following week, hand-stamped with the new edition number on the cover.

--- a/examples/riso-folio/content/work/static-noise-record.md
+++ b/examples/riso-folio/content/work/static-noise-record.md
@@ -1,0 +1,24 @@
++++
+title = "Static Noise — Sleeve & Inserts"
+date = "2025-03-18"
+description = "A double-LP record sleeve and 12-page insert booklet for an ambient label."
+[extra]
+symbol = "◐"
+kind = "Music"
+kicker = "Music packaging / 2025"
+client = "Soft Boundary Records"
+stock = "350gsm linen-finish"
+inks = "Federal Blue + Fluo Pink"
++++
+
+## Brief
+
+A double-LP for the ambient label Soft Boundary. The artist asked the sleeve to "look like a photograph that had been rained on, then dried, then rained on again."
+
+## Approach
+
+The sleeve has nine ink passes — the maximum the studio drum can do before the paper begins to delaminate. Each pass slightly misregisters the title type, so the wordmark hovers a few millimetres off-axis.
+
+## Result
+
+The first 200 copies sold to the label's mailing list before the official announcement. The next 300 sold at distro within a week.

--- a/examples/riso-folio/static/css/style.css
+++ b/examples/riso-folio/static/css/style.css
@@ -1,0 +1,518 @@
+/* Riso Folio — duotone overprint portfolio
+   Ink 1: Fluorescent Pink (#FF4D8D)
+   Ink 2: Federal Blue   (#2B2B7B)
+   Stock: 80gsm cream     (#F2EBDD)
+*/
+
+:root {
+  --ink-1: #FF4D8D;
+  --ink-2: #2B2B7B;
+  --ink-mix: #6E2C5F;
+  --stock: #F2EBDD;
+  --stock-shadow: #E5DBC4;
+  --ink-black: #1A1410;
+  --halftone: rgba(43, 43, 123, 0.18);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: "Times New Roman", Times, serif;
+  background: var(--stock);
+  color: var(--ink-black);
+  font-size: 18px;
+  line-height: 1.5;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Paper grain — repeating noise via SVG inline */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 100;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='280' height='280'><filter id='n'><feTurbulence baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.10  0 0 0 0 0.08  0 0 0 0 0.06  0 0 0 0.16 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  opacity: 0.55;
+  mix-blend-mode: multiply;
+}
+
+/* Halftone dots layer */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 99;
+  background-image: radial-gradient(var(--halftone) 0.9px, transparent 1px);
+  background-size: 5px 5px;
+  opacity: 0.5;
+  mix-blend-mode: multiply;
+}
+
+/* Layout */
+.sheet {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 56px 48px 96px;
+  position: relative;
+  z-index: 1;
+}
+
+/* Crop marks at corners */
+.sheet::before,
+.sheet::after {
+  content: "";
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--ink-2);
+  border-right: none;
+  border-bottom: none;
+  top: 14px;
+  left: 14px;
+}
+.sheet::after {
+  top: auto;
+  left: auto;
+  bottom: 14px;
+  right: 14px;
+  border: 1px solid var(--ink-2);
+  border-left: none;
+  border-top: none;
+}
+
+/* Masthead */
+.masthead {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: end;
+  gap: 24px;
+  padding-bottom: 18px;
+  border-bottom: 2px solid var(--ink-2);
+  margin-bottom: 48px;
+}
+
+.masthead .logo a {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 900;
+  font-size: 28px;
+  letter-spacing: -0.02em;
+  color: var(--ink-2);
+  text-decoration: none;
+  display: inline-block;
+  transform: skewX(-6deg);
+}
+
+.masthead .logo a span { color: var(--ink-1); }
+
+.masthead nav {
+  display: flex;
+  gap: 18px;
+  justify-self: end;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+}
+
+.masthead nav a {
+  color: var(--ink-2);
+  text-decoration: none;
+  padding: 3px 8px;
+  border: 1px solid var(--ink-2);
+  background: var(--stock);
+}
+
+.masthead nav a:hover {
+  background: var(--ink-1);
+  color: var(--stock);
+  border-color: var(--ink-1);
+}
+
+.masthead .issue {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  text-align: center;
+  line-height: 1.4;
+}
+
+.masthead .issue strong {
+  display: block;
+  font-size: 13px;
+  color: var(--ink-1);
+}
+
+/* Hero block */
+.hero {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 40px;
+  align-items: end;
+  margin-bottom: 80px;
+  position: relative;
+}
+
+.hero h1 {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 900;
+  font-size: clamp(56px, 11vw, 160px);
+  line-height: 0.84;
+  letter-spacing: -0.04em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.hero h1 .knockout {
+  color: var(--ink-1);
+  display: inline-block;
+  transform: translate(3px, 4px);
+  mix-blend-mode: multiply;
+}
+
+.hero h1 .overprint {
+  position: relative;
+  display: inline-block;
+}
+
+.hero h1 .overprint::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: var(--ink-1);
+  transform: translate(4px, 4px);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+.hero .lede {
+  font-size: 19px;
+  line-height: 1.45;
+  border-left: 4px solid var(--ink-1);
+  padding: 8px 0 8px 18px;
+  color: var(--ink-2);
+}
+
+.hero .lede em {
+  background: var(--ink-1);
+  color: var(--stock);
+  font-style: normal;
+  padding: 0 4px;
+}
+
+/* Big halftone disc */
+.disc {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  right: -60px;
+  top: -80px;
+  background-image: radial-gradient(var(--ink-1) 2.5px, transparent 3px);
+  background-size: 8px 8px;
+  opacity: 0.85;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+/* Section heading */
+.section-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 18px;
+  margin: 64px 0 28px;
+}
+
+.section-head .nb {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 900;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  color: var(--ink-1);
+  padding: 4px 8px;
+  border: 1.5px solid var(--ink-1);
+}
+
+.section-head h2 {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 38px;
+  letter-spacing: -0.01em;
+  color: var(--ink-2);
+}
+
+.section-head .rule {
+  height: 0;
+  border-top: 1.5px dashed var(--ink-2);
+}
+
+/* Work grid */
+.work-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 22px;
+}
+
+.work {
+  grid-column: span 6;
+  background: var(--stock);
+  border: 2px solid var(--ink-2);
+  padding: 0;
+  position: relative;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  transition: transform 0.18s ease;
+}
+
+.work:nth-child(3n+1) { grid-column: span 7; }
+.work:nth-child(3n+2) { grid-column: span 5; }
+.work:nth-child(3n+3) { grid-column: span 12; }
+
+.work:hover { transform: translate(-3px, -3px); }
+.work:hover .swatch::before { transform: translate(6px, 6px); }
+
+.work .swatch {
+  aspect-ratio: 16 / 9;
+  border-bottom: 2px solid var(--ink-2);
+  position: relative;
+  overflow: hidden;
+}
+
+.work:nth-child(3n+3) .swatch { aspect-ratio: 21 / 6; }
+
+.work .swatch::before {
+  content: "";
+  position: absolute;
+  inset: 16px;
+  background-image: radial-gradient(var(--ink-1) 1.4px, transparent 1.5px);
+  background-size: 7px 7px;
+  transition: transform 0.25s ease;
+  mix-blend-mode: multiply;
+}
+
+.work .swatch::after {
+  content: attr(data-shape);
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 900;
+  font-size: clamp(48px, 9vw, 120px);
+  color: var(--ink-2);
+  letter-spacing: -0.05em;
+  line-height: 1;
+  mix-blend-mode: multiply;
+}
+
+.work .meta {
+  display: flex;
+  justify-content: space-between;
+  padding: 14px 18px 18px;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.work .meta .title {
+  font-weight: 900;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.work .meta .kind {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-1);
+  align-self: end;
+}
+
+/* Notes block — like printer's marks */
+.notes {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  margin: 72px 0 0;
+  border: 2px solid var(--ink-2);
+  border-bottom: none;
+}
+
+.notes div {
+  border-right: 2px solid var(--ink-2);
+  border-bottom: 2px solid var(--ink-2);
+  padding: 18px 16px;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+}
+
+.notes div:last-child { border-right: none; }
+
+.notes div strong {
+  display: block;
+  font-size: 24px;
+  letter-spacing: -0.01em;
+  text-transform: none;
+  color: var(--ink-1);
+  margin-bottom: 2px;
+  letter-spacing: 0;
+}
+
+/* Page (work detail) */
+article.work-page {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 56px;
+  margin-top: 32px;
+}
+
+article.work-page header {
+  grid-column: 1 / -1;
+  border-bottom: 2px solid var(--ink-2);
+  padding-bottom: 18px;
+  margin-bottom: 24px;
+}
+
+article.work-page header h1 {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 900;
+  font-size: clamp(48px, 8vw, 96px);
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+}
+
+article.work-page header .kicker {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-1);
+  margin-bottom: 12px;
+}
+
+article.work-page .body p {
+  margin-bottom: 1.2em;
+  font-size: 18px;
+}
+
+article.work-page .body h2 {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 900;
+  font-size: 26px;
+  text-transform: uppercase;
+  color: var(--ink-1);
+  margin: 1.5em 0 0.5em;
+}
+
+article.work-page .body blockquote {
+  border-left: 4px solid var(--ink-1);
+  padding-left: 18px;
+  font-size: 24px;
+  line-height: 1.3;
+  margin: 1.2em 0;
+  color: var(--ink-2);
+}
+
+article.work-page .body code,
+article.work-page .body pre {
+  font-family: "Courier New", monospace;
+  background: var(--stock-shadow);
+  padding: 2px 6px;
+}
+
+article.work-page aside {
+  border: 2px solid var(--ink-2);
+  padding: 18px;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  align-self: start;
+  position: sticky;
+  top: 24px;
+}
+
+article.work-page aside dt {
+  color: var(--ink-1);
+  margin-top: 12px;
+}
+
+article.work-page aside dt:first-child { margin-top: 0; }
+
+article.work-page aside dd {
+  color: var(--ink-2);
+  font-size: 14px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+article.work-page .back {
+  grid-column: 1 / -1;
+  margin-top: 48px;
+}
+
+article.work-page .back a {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  text-decoration: none;
+  border: 1.5px solid var(--ink-2);
+  padding: 8px 14px;
+}
+
+article.work-page .back a:hover {
+  background: var(--ink-1);
+  border-color: var(--ink-1);
+  color: var(--stock);
+}
+
+/* Footer */
+.colophon {
+  margin-top: 96px;
+  padding-top: 24px;
+  border-top: 2px solid var(--ink-2);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+}
+
+.colophon .center {
+  text-align: center;
+  color: var(--ink-1);
+  font-weight: 900;
+}
+
+.colophon .right { text-align: right; }
+
+@media (max-width: 880px) {
+  .sheet { padding: 36px 22px 60px; }
+  .masthead { grid-template-columns: 1fr auto; }
+  .masthead .issue { display: none; }
+  .hero { grid-template-columns: 1fr; gap: 24px; }
+  .work, .work:nth-child(n) { grid-column: span 12; }
+  article.work-page { grid-template-columns: 1fr; }
+  article.work-page aside { position: static; }
+  .notes { grid-template-columns: repeat(2, 1fr); }
+}

--- a/examples/riso-folio/static/favicon.svg
+++ b/examples/riso-folio/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#F2EBDD"/><circle cx="13" cy="13" r="9" fill="#FF4D8D"/><circle cx="18" cy="18" r="9" fill="#2B2B7B" fill-opacity="0.75"/></svg>

--- a/examples/riso-folio/templates/404.html
+++ b/examples/riso-folio/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<section class="hero">
+  <h1>Mis<span class="knockout">·</span>print<br><span class="overprint" data-text="404">404</span></h1>
+  <div>
+    <p class="lede">This page jammed the press. The page roller is empty — try <em>the index</em> instead.</p>
+    <p style="margin-top:24px;"><a href="{{ base_url }}/" style="font-family:Helvetica,Arial,sans-serif;text-transform:uppercase;letter-spacing:.2em;font-size:12px;border:1.5px solid var(--ink-2);padding:8px 14px;text-decoration:none;color:var(--ink-2);">← back to the run</a></p>
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/riso-folio/templates/footer.html
+++ b/examples/riso-folio/templates/footer.html
@@ -1,0 +1,8 @@
+<footer class="colophon">
+  <div>Printed two ink-passes — Fluorescent Pink + Federal Blue</div>
+  <div class="center">© {{ current_year }} Riso Folio</div>
+  <div class="right">Set in Helvetica Neue & Times. Stock: 80 gsm cream.</div>
+</footer>
+</div>
+</body>
+</html>

--- a/examples/riso-folio/templates/header.html
+++ b/examples/riso-folio/templates/header.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if page.title is present %}{{ page.title }} — {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="sheet">
+<header class="masthead">
+  <div class="logo"><a href="{{ base_url }}/">RISO<span>·</span>FOLIO</a></div>
+  <div class="issue">Issue №14<br><strong>{{ current_year }} — Print Run 250</strong></div>
+  <nav>
+    <a href="{{ base_url }}/">Index</a>
+    <a href="{{ base_url }}/work/">Work</a>
+    <a href="{{ base_url }}/about/">About</a>
+  </nav>
+</header>

--- a/examples/riso-folio/templates/index.html
+++ b/examples/riso-folio/templates/index.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <h1>
+    Mira<br>
+    Vandal<span class="knockout">.</span><br>
+    <span class="overprint" data-text="Designer">Designer</span>
+  </h1>
+  <div>
+    <p class="lede">An independent <em>graphic designer</em> based in Lisbon. Portfolio printed at 600 dpi using two ink passes — pink first, blue second — on uncoated paper. Each project is its own short pamphlet.</p>
+    <div class="disc"></div>
+  </div>
+</section>
+
+<div class="section-head">
+  <span class="nb">№ 01</span>
+  <h2>Recent Press Runs</h2>
+  <span class="rule"></span>
+</div>
+
+<div class="work-grid">
+{% for p in site.pages | sort_by(attribute="date", reverse=true) %}
+  {% if p.section == "work" %}
+  <a class="work" href="{{ p.url }}">
+    <div class="swatch" data-shape="{{ p.extra.symbol | default('◐') }}"></div>
+    <div class="meta">
+      <span class="title">{{ p.title }}</span>
+      <span class="kind">{{ p.extra.kind | default('Print') }}</span>
+    </div>
+  </a>
+  {% endif %}
+{% endfor %}
+</div>
+
+<div class="notes">
+  <div><strong>250</strong>copies pulled</div>
+  <div><strong>2</strong>ink colours</div>
+  <div><strong>14</strong>projects in run</div>
+  <div><strong>0</strong>perfect prints</div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/riso-folio/templates/page.html
+++ b/examples/riso-folio/templates/page.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<article class="work-page">
+  <header>
+    <div class="kicker">{{ page.extra.kicker | default("Folio entry") }}</div>
+    <h1>{{ page.title }}</h1>
+  </header>
+
+  <div class="body">
+    {{ content | safe }}
+  </div>
+
+  <aside>
+    <dl>
+      <dt>Client</dt>
+      <dd>{{ page.extra.client | default("Self-initiated") }}</dd>
+      <dt>Discipline</dt>
+      <dd>{{ page.extra.kind | default("Print") }}</dd>
+      <dt>Year</dt>
+      <dd>{{ page.date | date("%Y") }}</dd>
+      <dt>Stock</dt>
+      <dd>{{ page.extra.stock | default("80gsm cream") }}</dd>
+      <dt>Inks</dt>
+      <dd>{{ page.extra.inks | default("Fluo Pink + Federal Blue") }}</dd>
+    </dl>
+  </aside>
+
+  <div class="back">
+    <a href="{{ base_url }}/">← Back to index</a>
+  </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/riso-folio/templates/section.html
+++ b/examples/riso-folio/templates/section.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<div class="section-head">
+  <span class="nb">№ All</span>
+  <h2>{{ section.title }}</h2>
+  <span class="rule"></span>
+</div>
+
+{% if content %}<div style="margin-bottom:32px;max-width:42em;">{{ content | safe }}</div>{% endif %}
+
+<div class="work-grid">
+  {% for p in section.pages %}
+  <a class="work" href="{{ p.url }}">
+    <div class="swatch" data-shape="{{ p.extra.symbol | default('◐') }}"></div>
+    <div class="meta">
+      <span class="title">{{ p.title }}</span>
+      <span class="kind">{{ p.extra.kind | default('Print') }}</span>
+    </div>
+  </a>
+  {% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/slab-folio/AGENTS.md
+++ b/examples/slab-folio/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/slab-folio/archetypes/default.md
+++ b/examples/slab-folio/archetypes/default.md
@@ -1,0 +1,6 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
++++

--- a/examples/slab-folio/config.toml
+++ b/examples/slab-folio/config.toml
@@ -1,0 +1,207 @@
+title = "Slab Folio"
+description = "Hadrien Vex — an architectural portfolio cast in concrete-grey slabs and structural type."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 20
+sections = ["works"]
+
+[markdown]
+safe = false
+heading_ids = true
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/slab-folio/content/about.md
+++ b/examples/slab-folio/content/about.md
@@ -1,0 +1,33 @@
++++
+title = "Studio Vex"
+description = "Two-person studio. Founded 2014 in Lisbon, satellite in Marseille."
+[extra]
+kicker = "Studio"
+kind = "Studio"
+location = "Lisbon · Marseille"
+file = "00"
+format = "—"
++++
+
+## Studio
+
+Studio Vex is run by **Hadrien Vex** and the studio manager Inês Cardoso. Founded 2014 in Lisbon; we opened a small Marseille satellite in 2021.
+
+We accept commissions for identity, signage, exhibition design, and editorial work. We do not pitch unpaid, do not bill by the hour, and do not work with crypto, military or extractive clients.
+
+## Working with us
+
+- Minimum engagement is **eight weeks**.
+- Minimum fee is **€12,000**.
+- We work with one client per quarter on the architectural-scale projects.
+
+## Address
+
+Lisbon · R. Capelão 22, 1100-040 Lisboa
+Marseille · 7 cours Julien, 13006
+
+**studio at vex dot example** · +351 21 000 0014
+
+## Teaching
+
+Hadrien teaches an annual graduate seminar at École Supérieure d'Art de Marseille on environmental graphic systems.

--- a/examples/slab-folio/content/index.md
+++ b/examples/slab-folio/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Slab Folio"
+description = "Hadrien Vex — selected works in architecture, exhibition and brand systems."
+template = "index"
++++

--- a/examples/slab-folio/content/works/_index.md
+++ b/examples/slab-folio/content/works/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Works"
+sort_by = "date"
+reverse = true
+template = "section"
++++
+
+Twelve selected entries from the studio's catalogue. The older portfolio is available as a printed booklet — request a copy by email.

--- a/examples/slab-folio/content/works/borda-press.md
+++ b/examples/slab-folio/content/works/borda-press.md
@@ -1,0 +1,23 @@
++++
+title = "Borda Press — Brand & Books"
+date = "2024-09-09"
+description = "Identity and book series for a Porto-based small press of architectural writing."
+[extra]
+kind = "Identity"
+file = "07"
+client = "Borda Press, Porto"
+location = "Porto"
+format = "Identity + 8-book series"
++++
+
+## Brief
+
+A new small press in Porto, focused on first-generation architectural writing — built before built. They asked for "an identity that knows it will outlast us."
+
+## Approach
+
+A monogram of two stacked slabs forms the press mark. The first eight books are bound identically, only the spine title changes. The interior grid never alters between titles. The mark is debossed, never printed.
+
+## Result
+
+The first three titles released in autumn 2024; the next five are scheduled through 2027. Press is now distributed across Iberia and France.

--- a/examples/slab-folio/content/works/cement-festival.md
+++ b/examples/slab-folio/content/works/cement-festival.md
@@ -1,0 +1,23 @@
++++
+title = "Cement — Architecture Festival"
+date = "2025-10-04"
+description = "Identity, environmental graphics and a 96-page programme for a Marseille architecture festival."
+[extra]
+kind = "Identity"
+file = "10"
+client = "Cement Festival, MUCEM"
+location = "Marseille"
+format = "Identity + signage + 96 pp programme"
++++
+
+## Brief
+
+A new architecture festival hosted at the MUCEM in Marseille needed an identity that would survive a 14-day public programme of talks, walks and screenings.
+
+## Approach
+
+The festival mark is a single set of dimensional figures — *14 / 14 / 14* — laid on the concrete platforms of the museum in vinyl. The mark scales by venue, not by hierarchy. The programme is set on a single page-grid, with all entries treated as equal weight.
+
+## Result
+
+The mark is now used by the festival on every annual return, scaled to the new dates.

--- a/examples/slab-folio/content/works/forma-tower.md
+++ b/examples/slab-folio/content/works/forma-tower.md
@@ -1,0 +1,27 @@
++++
+title = "Forma — Tower Signage"
+date = "2026-04-12"
+description = "Permanent exterior signage and wayfinding for a 22-storey residential tower."
+[extra]
+kind = "Signage"
+file = "12"
+client = "Forma Habitar"
+location = "Algés, Lisbon"
+format = "Cast bronze + sandblasted concrete"
++++
+
+## Brief
+
+Forma Habitar built a 22-storey residential tower on the river side of Algés. They asked for "signage that lasts as long as the building."
+
+## Approach
+
+The wordmark — *Forma* — is cast in 12 mm bronze and bolted directly into the structural concrete on the south face. There is no second logo, no secondary mark. Wayfinding inside the building is sandblasted into the concrete walls at each landing, not applied as a layer.
+
+> "The mark won't outlast the building. It is the building." — Studio statement, opening 14 April 2026.
+
+## Specifications
+
+- 4 m × 1.2 m exterior wordmark, bronze, eight-bolt fixing
+- 24 sandblasted floor markers, 60 × 40 cm
+- 3 mm typographic grid cast into entry threshold

--- a/examples/slab-folio/content/works/macba-survey.md
+++ b/examples/slab-folio/content/works/macba-survey.md
@@ -1,0 +1,23 @@
++++
+title = "Survey — Catalogue Volume 03"
+date = "2026-01-20"
+description = "A 412-page exhibition catalogue printed in two volumes for MACBA Barcelona."
+[extra]
+kind = "Editorial"
+file = "11"
+client = "MACBA, Barcelona"
+location = "Barcelona"
+format = "Two-volume catalogue, 412 pp"
++++
+
+## Brief
+
+MACBA's *Survey* exhibition ran from October 2025 through February 2026. The 412-page catalogue had to ship 10 weeks earlier than the show opened — a window only a stripped-back system could meet.
+
+## Approach
+
+A single typeface (IBM Plex Serif) at three sizes across both volumes. No images larger than 60% of the page width. The two-volume set is bound with a single visible spine — no slipcase.
+
+## Result
+
+Catalogue sold out by the show's closing weekend. The studio retains nine numbered copies in the archive.

--- a/examples/slab-folio/content/works/orbis-exhibition.md
+++ b/examples/slab-folio/content/works/orbis-exhibition.md
@@ -1,0 +1,23 @@
++++
+title = "Orbis — Permanent Exhibition"
+date = "2025-02-15"
+description = "Exhibition design and graphics for a permanent installation at the Tower of Belém archive."
+[extra]
+kind = "Exhibition"
+file = "08"
+client = "Património Cultural"
+location = "Belém, Lisbon"
+format = "Permanent installation, four rooms"
++++
+
+## Brief
+
+A new permanent exhibition inside the archive wing of the Tower of Belém. The works on display range from 1502 to 1944 — the design had to address all of them without making one feel more recent than another.
+
+## Approach
+
+A single material — natural lime plaster — was used for every label, mounted by cast bronze pins. The typography is set at one optical size across all four rooms and changes only by weight, never by colour. There is no English signage; translation cards are stacked at the entrance to each room and visitors take them with them.
+
+## Result
+
+The exhibition opened 15 February 2025. The lime plaster ages — slightly — over the course of every season; the studio approves the patina annually.

--- a/examples/slab-folio/content/works/quarry-typeface.md
+++ b/examples/slab-folio/content/works/quarry-typeface.md
@@ -1,0 +1,23 @@
++++
+title = "Quarry — A Type Family"
+date = "2025-06-22"
+description = "A 6-weight slab serif drawn for environmental and large-scale use."
+[extra]
+kind = "Typeface"
+file = "09"
+client = "Self-released"
+location = "Studio"
+format = "Type family, 6 weights"
++++
+
+## Brief
+
+The studio's environmental work needed a face that could survive being printed at 4 metres, sandblasted into stone, and used at 9 points on a printed map of the same building.
+
+## Approach
+
+*Quarry* is a 6-weight slab serif drawn over 14 months. The face is engineered backwards from the manufacturer of choice (Cnc-Ibérica) so that every shape can be milled in 8 mm aluminium without modification.
+
+## Result
+
+The face has shipped on five studio projects since release. Retail licences open from September 2025.

--- a/examples/slab-folio/static/css/style.css
+++ b/examples/slab-folio/static/css/style.css
@@ -1,0 +1,521 @@
+/* Slab Folio — brutalist concrete portfolio
+   Cast concrete grey, deep ink, one accent ochre.
+*/
+
+:root {
+  --slab-0: #1A1A1A;
+  --slab-1: #2C2C2A;
+  --slab-2: #4A4945;
+  --slab-3: #74726C;
+  --slab-4: #B3AFA4;
+  --slab-5: #DCD8CC;
+  --slab-6: #EFECE2;
+  --ochre: #C68B2C;
+  --rebar: #E63327;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; background: var(--slab-1); }
+
+body {
+  font-family: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  background: var(--slab-1);
+  color: var(--slab-5);
+  font-size: 14px;
+  line-height: 1.55;
+  position: relative;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+/* Concrete texture — soft mottling */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><filter id='c'><feTurbulence baseFrequency='0.012 0.008' numOctaves='2' seed='3' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.07  0 0 0 0 0.07  0 0 0 0 0.06  0 0 0 0.55 0'/></filter><rect width='100%25' height='100%25' filter='url(%23c)'/></svg>");
+  opacity: 0.6;
+  mix-blend-mode: overlay;
+}
+
+/* Fine grain */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='g'><feTurbulence baseFrequency='1.6' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.16 0'/></filter><rect width='100%25' height='100%25' filter='url(%23g)'/></svg>");
+  opacity: 0.5;
+}
+
+main, header, footer { position: relative; z-index: 2; }
+
+/* The architectural grid */
+.slab {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 28px 32px 96px;
+}
+
+/* Header */
+.bar {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 24px;
+  padding: 14px 18px;
+  background: var(--slab-0);
+  border: 1px solid var(--slab-2);
+  border-bottom: 4px solid var(--ochre);
+  margin-bottom: 36px;
+}
+
+.bar .mark {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--slab-6);
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 13px;
+}
+
+.bar .mark .block {
+  width: 18px;
+  height: 18px;
+  background: var(--ochre);
+  display: inline-block;
+}
+
+.bar .coords {
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  color: var(--slab-3);
+  text-transform: uppercase;
+}
+
+.bar nav { display: flex; gap: 16px; }
+.bar nav a {
+  color: var(--slab-5);
+  text-decoration: none;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  padding: 4px 0;
+  border-bottom: 2px solid transparent;
+}
+.bar nav a:hover { color: var(--ochre); border-color: var(--ochre); }
+
+.bar .tag {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  color: var(--slab-0);
+  background: var(--ochre);
+  padding: 4px 10px;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+/* Massive header slab */
+.cast {
+  background: var(--slab-2);
+  border: 1px solid var(--slab-3);
+  padding: 56px 40px 48px;
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 40px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+/* Formwork lines on hero */
+.cast::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 119px,
+    rgba(0,0,0,0.24) 120px,
+    transparent 121px
+  ),
+  repeating-linear-gradient(
+    0deg,
+    transparent 0,
+    transparent 79px,
+    rgba(0,0,0,0.24) 80px,
+    transparent 81px
+  );
+  opacity: 0.55;
+}
+
+.cast::after {
+  content: "";
+  position: absolute;
+  width: 4px;
+  background: var(--rebar);
+  top: 24px;
+  bottom: 24px;
+  right: 32px;
+}
+
+.cast h1 {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 800;
+  font-size: clamp(56px, 9.5vw, 160px);
+  line-height: 0.88;
+  letter-spacing: -0.04em;
+  color: var(--slab-6);
+  text-transform: uppercase;
+}
+
+.cast h1 .light {
+  color: var(--slab-3);
+  font-weight: 300;
+  font-style: italic;
+}
+
+.cast h1 .ochre { color: var(--ochre); }
+
+.cast .meta {
+  align-self: end;
+  position: relative;
+  z-index: 1;
+  border-left: 4px solid var(--ochre);
+  padding-left: 16px;
+}
+.cast .meta p { font-size: 14px; line-height: 1.55; color: var(--slab-5); }
+.cast .meta .role {
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  color: var(--ochre);
+  text-transform: uppercase;
+  margin-bottom: 10px;
+  font-weight: 700;
+}
+
+/* Strip of dimension data under hero */
+.dims {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  background: var(--slab-0);
+  border: 1px solid var(--slab-3);
+  margin-bottom: 56px;
+}
+.dims div {
+  padding: 14px 18px;
+  border-right: 1px solid var(--slab-2);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  color: var(--slab-4);
+  text-transform: uppercase;
+}
+.dims div:last-child { border-right: none; }
+.dims div strong {
+  display: block;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 24px;
+  letter-spacing: -0.01em;
+  color: var(--slab-6);
+  margin-top: 4px;
+  text-transform: none;
+}
+
+/* Section header */
+.head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 18px;
+  align-items: baseline;
+  margin: 64px 0 22px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--slab-3);
+}
+.head .ix {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 14px;
+  color: var(--ochre);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+.head h2 {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 800;
+  font-size: clamp(28px, 4.4vw, 56px);
+  letter-spacing: -0.02em;
+  color: var(--slab-6);
+  text-transform: uppercase;
+}
+.head .count {
+  color: var(--slab-3);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+/* Work grid — concrete blocks */
+.blocks {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 8px;
+}
+
+.block {
+  text-decoration: none;
+  color: var(--slab-6);
+  display: block;
+  background: var(--slab-2);
+  border: 1px solid var(--slab-3);
+  padding: 22px;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.2s ease, background 0.2s ease;
+  min-height: 220px;
+  grid-column: span 6;
+}
+
+.block:nth-child(6n+1) { grid-column: span 7; min-height: 320px; }
+.block:nth-child(6n+2) { grid-column: span 5; min-height: 320px; }
+.block:nth-child(6n+3) { grid-column: span 4; }
+.block:nth-child(6n+4) { grid-column: span 4; }
+.block:nth-child(6n+5) { grid-column: span 4; }
+.block:nth-child(6n+6) { grid-column: span 12; min-height: 180px; }
+
+.block::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(rgba(255,255,255,0.04) 1px, transparent 2px),
+    radial-gradient(rgba(0,0,0,0.18) 1px, transparent 2px);
+  background-size: 5px 5px, 7px 7px;
+  background-position: 0 0, 3px 3px;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.block:hover {
+  background: var(--slab-0);
+  transform: translateY(-2px);
+}
+.block:hover .label .title { color: var(--ochre); }
+
+.block .stamp {
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  color: var(--slab-4);
+  text-transform: uppercase;
+  border: 1px solid var(--slab-4);
+  padding: 2px 6px;
+  display: inline-block;
+}
+
+.block .label {
+  position: absolute;
+  bottom: 22px;
+  left: 22px;
+  right: 22px;
+}
+
+.block .label .title {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 800;
+  font-size: clamp(20px, 2.4vw, 32px);
+  letter-spacing: -0.02em;
+  line-height: 1;
+  text-transform: uppercase;
+  transition: color 0.18s ease;
+}
+
+.block .label .row {
+  margin-top: 10px;
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--slab-4);
+}
+
+.block .label .row .y { color: var(--ochre); }
+
+/* Large block patterns — different on each modulo */
+.block:nth-child(6n+1)::before {
+  background-image: linear-gradient(90deg, transparent 49%, rgba(0,0,0,0.4) 50%, transparent 51%);
+  background-size: 60px 60px;
+  background-position: 0 0;
+  opacity: 0.25;
+}
+.block:nth-child(6n+2)::before {
+  background-image: repeating-linear-gradient(45deg, rgba(0,0,0,0.18) 0, rgba(0,0,0,0.18) 2px, transparent 2px, transparent 14px);
+  opacity: 0.5;
+}
+.block:nth-child(6n+6)::before {
+  background-image: repeating-linear-gradient(0deg, transparent 0, transparent 18px, rgba(0,0,0,0.18) 18px, rgba(0,0,0,0.18) 19px);
+  opacity: 0.6;
+}
+
+/* Tear-out (project page) */
+.pour {
+  background: var(--slab-2);
+  border: 1px solid var(--slab-3);
+  padding: 56px 40px 48px;
+  margin-bottom: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.pour .ix {
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ochre);
+  margin-bottom: 12px;
+  font-weight: 700;
+}
+
+.pour h1 {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 800;
+  font-size: clamp(48px, 8vw, 120px);
+  letter-spacing: -0.04em;
+  line-height: 0.92;
+  text-transform: uppercase;
+  color: var(--slab-6);
+}
+
+.pour p.lede {
+  margin-top: 18px;
+  max-width: 56ch;
+  font-size: 16px;
+  color: var(--slab-5);
+}
+
+.pour::after {
+  content: "";
+  position: absolute;
+  width: 4px;
+  background: var(--rebar);
+  right: 36px;
+  top: 28px;
+  bottom: 28px;
+}
+
+.specs {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  background: var(--slab-0);
+  border: 1px solid var(--slab-3);
+  margin-bottom: 36px;
+  margin-top: -1px;
+}
+.specs div {
+  padding: 12px 16px;
+  border-right: 1px solid var(--slab-2);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--slab-4);
+}
+.specs div:last-child { border-right: none; }
+.specs strong {
+  display: block;
+  color: var(--slab-6);
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  margin-top: 4px;
+  text-transform: none;
+}
+
+.body {
+  max-width: 64ch;
+  margin: 0 auto;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  color: var(--slab-5);
+  font-size: 17px;
+  line-height: 1.6;
+}
+.body p { margin-bottom: 1.1em; }
+.body h2 {
+  font-weight: 800;
+  text-transform: uppercase;
+  font-size: 24px;
+  letter-spacing: -0.01em;
+  color: var(--slab-6);
+  margin: 1.6em 0 0.5em;
+  border-bottom: 1px solid var(--slab-3);
+  padding-bottom: 6px;
+}
+.body h2::before { content: "—— "; color: var(--ochre); }
+.body blockquote {
+  border-left: 4px solid var(--ochre);
+  padding: 6px 0 6px 18px;
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.35;
+  margin: 1.2em 0;
+  color: var(--slab-6);
+}
+.body code, .body pre {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  background: var(--slab-1);
+  border: 1px solid var(--slab-3);
+  padding: 2px 6px;
+  font-size: 0.92em;
+  color: var(--ochre);
+}
+
+.back {
+  margin-top: 80px;
+  text-align: center;
+}
+.back a {
+  text-decoration: none;
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--slab-5);
+  border: 1px solid var(--slab-3);
+  padding: 10px 16px;
+}
+.back a:hover { color: var(--ochre); border-color: var(--ochre); }
+
+/* Footer */
+.foundation {
+  margin-top: 100px;
+  background: var(--slab-0);
+  border: 1px solid var(--slab-2);
+  border-top: 4px solid var(--ochre);
+  padding: 24px 32px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 20px;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--slab-3);
+}
+.foundation .right { text-align: right; }
+.foundation .center { text-align: center; color: var(--ochre); }
+.foundation strong { color: var(--slab-6); display: block; font-size: 14px; letter-spacing: 0; text-transform: none; margin-bottom: 4px; }
+
+@media (max-width: 900px) {
+  .slab { padding: 22px 18px 60px; }
+  .bar { grid-template-columns: 1fr auto; }
+  .bar .coords, .bar .tag { display: none; }
+  .cast { grid-template-columns: 1fr; padding: 36px 22px; }
+  .cast::after { display: none; }
+  .dims { grid-template-columns: repeat(2, 1fr); }
+  .dims div { border-bottom: 1px solid var(--slab-2); }
+  .block, .block:nth-child(n) { grid-column: span 12; min-height: 180px; }
+  .specs { grid-template-columns: repeat(2, 1fr); }
+  .specs div { border-bottom: 1px solid var(--slab-2); }
+}

--- a/examples/slab-folio/static/favicon.svg
+++ b/examples/slab-folio/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#1A1A1A"/><rect x="4" y="4" width="10" height="24" fill="#C68B2C"/><rect x="16" y="4" width="12" height="11" fill="#74726C"/><rect x="16" y="17" width="12" height="11" fill="#4A4945"/></svg>

--- a/examples/slab-folio/templates/404.html
+++ b/examples/slab-folio/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<section class="cast">
+  <h1><span class="light">N°</span> 404<span class="ochre">.</span></h1>
+  <div class="meta">
+    <div class="role">Catalogue entry missing</div>
+    <p>This entry has not been cast. The plans may still be on a drafting table somewhere; the slab itself isn't poured.</p>
+    <p style="margin-top:16px;"><a href="{{ base_url }}/" style="color:var(--ochre);border:1px solid var(--ochre);padding:8px 14px;text-decoration:none;font-size:11px;letter-spacing:.24em;text-transform:uppercase;">← Return to catalogue</a></p>
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/slab-folio/templates/footer.html
+++ b/examples/slab-folio/templates/footer.html
@@ -1,0 +1,8 @@
+<footer class="foundation">
+  <div><strong>Studio Vex</strong>R. Capelão 22, 1100-040 Lisbon</div>
+  <div class="center">© {{ current_year }} — Cast in place</div>
+  <div class="right"><strong>Filed catalogue {{ current_year }}</strong>Volume 04 / 12 entries</div>
+</footer>
+</div>
+</body>
+</html>

--- a/examples/slab-folio/templates/header.html
+++ b/examples/slab-folio/templates/header.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if page.title is present %}{{ page.title }} — {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+<link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
+{{ auto_includes | safe }}
+</head>
+<body>
+<div class="slab">
+<header class="bar">
+  <a class="mark" href="{{ base_url }}/"><span class="block"></span>HADRIEN&nbsp;VEX</a>
+  <span class="coords">N 38° 42′ · W 9° 08′ · LISBON</span>
+  <nav>
+    <a href="{{ base_url }}/">Cover</a>
+    <a href="{{ base_url }}/works/">Works</a>
+    <a href="{{ base_url }}/about/">Studio</a>
+  </nav>
+  <span class="tag">{{ current_year }} Catalogue</span>
+</header>

--- a/examples/slab-folio/templates/index.html
+++ b/examples/slab-folio/templates/index.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+
+<section class="cast">
+  <h1>
+    Hadrien<br>
+    <span class="light">Vex,</span><br>
+    Designer<span class="ochre">.</span>
+  </h1>
+  <div class="meta">
+    <div class="role">Practice / 2014 — Present</div>
+    <p>Independent design practice working between Lisbon and Marseille. The studio works at the scale of buildings — identity, signage, exhibition — and brings the same logic to printed matter and screen.</p>
+    <p style="margin-top:10px;color:var(--ochre)">↘ Available for {{ current_year }} commissions.</p>
+  </div>
+</section>
+
+<div class="dims">
+  <div>Founded<strong>2014</strong></div>
+  <div>Permanent<strong>Three staff</strong></div>
+  <div>Catalogue<strong>87 projects</strong></div>
+  <div>Awards<strong>D&AD ×2</strong></div>
+  <div>Travel<strong>Lisbon ↔ Marseille</strong></div>
+</div>
+
+<div class="head">
+  <span class="ix">N° 01 · Selected</span>
+  <h2>Works in concrete & ink</h2>
+  <span class="count">{{ current_year }} Catalogue</span>
+</div>
+
+<div class="blocks">
+{% for p in site.pages | sort_by(attribute="date", reverse=true) %}
+  {% if p.section == "works" %}
+  <a class="block" href="{{ p.url }}">
+    <span class="stamp">N° {{ loop.index }} · {{ p.extra.kind | default('Project') }}</span>
+    <div class="label">
+      <div class="title">{{ p.title }}</div>
+      <div class="row"><span>{{ p.extra.location | default('—') }}</span><span class="y">{{ p.date | date("%Y") }}</span></div>
+    </div>
+  </a>
+  {% endif %}
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/slab-folio/templates/page.html
+++ b/examples/slab-folio/templates/page.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<article>
+  <section class="pour">
+    <div class="ix">N° {{ page.extra.file | default("04") }} · {{ page.extra.kind | default("Project") }}</div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="lede">{{ page.description }}</p>{% endif %}
+  </section>
+
+  <div class="specs">
+    <div>Client<strong>{{ page.extra.client | default("Self-initiated") }}</strong></div>
+    <div>Location<strong>{{ page.extra.location | default("—") }}</strong></div>
+    <div>Type<strong>{{ page.extra.kind | default("Identity") }}</strong></div>
+    <div>Year<strong>{{ page.date | date("%Y") }}</strong></div>
+    <div>Format<strong>{{ page.extra.format | default("Mixed") }}</strong></div>
+  </div>
+
+  <div class="body">
+    {{ content | safe }}
+  </div>
+
+  <div class="back"><a href="{{ base_url }}/">← Back to catalogue</a></div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/slab-folio/templates/section.html
+++ b/examples/slab-folio/templates/section.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<div class="head">
+  <span class="ix">All entries</span>
+  <h2>{{ section.title }}</h2>
+  <span class="count">{{ section.pages | length }} works</span>
+</div>
+
+{% if content %}<div class="body" style="margin-bottom:32px;">{{ content | safe }}</div>{% endif %}
+
+<div class="blocks">
+{% for p in section.pages | sort_by(attribute="date", reverse=true) %}
+  <a class="block" href="{{ p.url }}">
+    <span class="stamp">N° {{ loop.index }} · {{ p.extra.kind | default('Project') }}</span>
+    <div class="label">
+      <div class="title">{{ p.title }}</div>
+      <div class="row"><span>{{ p.extra.location | default('—') }}</span><span class="y">{{ p.date | date("%Y") }}</span></div>
+    </div>
+  </a>
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -8937,5 +8937,35 @@
     "light",
     "docs",
     "minimal"
+  ],
+  "riso-folio": [
+    "light",
+    "portfolio",
+    "editorial",
+    "print"
+  ],
+  "kinetic-manifesto": [
+    "light",
+    "portfolio",
+    "editorial",
+    "typography"
+  ],
+  "photocopy-folio": [
+    "light",
+    "portfolio",
+    "editorial",
+    "minimal"
+  ],
+  "slab-folio": [
+    "dark",
+    "portfolio",
+    "brutalist",
+    "minimal"
+  ],
+  "cutout-folio": [
+    "light",
+    "portfolio",
+    "collage",
+    "editorial"
   ]
 }


### PR DESCRIPTION
## Summary

Five new portfolio example sites with committed, fresh aesthetics — each fully self-contained under `examples/`:

- **riso-folio** — two-ink Risograph print portfolio (fluo pink + federal blue, halftone, paper grain)
- **kinetic-manifesto** — massive kinetic typography manifesto-style portfolio
- **photocopy-folio** — lo-fi xerox dossier portfolio with file-cabinet directory listing
- **slab-folio** — brutalist concrete-slab architectural portfolio (charcoal + ochre + rebar red)
- **cutout-folio** — paper-collage editorial scrapbook portfolio (Caveat + Inter, tape strips, ringed annotations)

Each site ships custom templates, CSS, favicon, 5–6 fictional case studies, and an about page. `tags.json` updated with entries for all five.

No gradients or emojis used (per existing project convention) — texture comes from solid colors, SVG noise filters, and repeating stripe/dot patterns.

## Test plan

- [x] `hwaro build` succeeds for each site (8–9 pages each)
- [x] `hwaro doctor --fix` passes on each site
- [x] `tags.json` is valid JSON
- [x] Index pages render the project listings (riso 6, kinetic 5, photocopy 5, slab 6, cutout 5)
- [ ] CI build of all examples completes and screenshots land on the index page