### PR TITLE
Add five bold landing example sites

### DIFF
--- a/examples/antiform/AGENTS.md
+++ b/examples/antiform/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/antiform/archetypes/default.md
+++ b/examples/antiform/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/antiform/config.toml
+++ b/examples/antiform/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "ANTIFORM"
+description = "A studio operating at the seam of typography and refusal."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/antiform/content/about.md
+++ b/examples/antiform/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "Dossier"
+description = "On Antiform — the position, the practice, the people."
++++
+
+## §01 — The Position
+
+Antiform is an editorial design studio. We work in print, in type, in the residue of opinion. The studio exists because most defaults are not arguments — they are habits dressed as taste. We trade those habits for positions.
+
+## §02 — The Practice
+
+We accept four commissions a quarter. Each is filed as a document. Each carries a number, a date, a name, and the trace of the person who drew it. Nothing is signed by a brand. Everything is signed by a person.
+
+## §03 — The People
+
+The studio is small on purpose. Three principals, two associates, one printer on retainer. We do not grow; we get sharper. We hire when the room runs out of disagreement.
+
+## §04 — The Address
+
+> A studio is a position, not a postcode. We answer to mail and to argument, in roughly that order.
+
+You can reach us at `file@antiform.studio`. We respond within seven working days. We do not take open calls; we read every introduction we are sent.

--- a/examples/antiform/content/index.md
+++ b/examples/antiform/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "ANTIFORM — an editorial design studio at the seam of typography, refusal and quiet revolution."
+template = "index"
++++

--- a/examples/antiform/static/css/style.css
+++ b/examples/antiform/static/css/style.css
@@ -1,0 +1,371 @@
+/* ANTIFORM — brutalist swiss editorial */
+
+:root {
+  --paper: #f1ece1;
+  --paper-dim: #e5dfd1;
+  --ink: #0c0c0c;
+  --ink-soft: #2b2b2b;
+  --ink-mute: #6c6862;
+  --rule: #0c0c0c;
+  --hot: #e22d18;
+  --hot-deep: #b51e0c;
+  --hair: #cbc3b1;
+  --mono: "JetBrains Mono", "IBM Plex Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+  --sans: "Helvetica Neue", "Inter Tight", -apple-system, BlinkMacSystemFont, "Arial Black", sans-serif;
+}
+
+@font-face { font-family: "Helvetica Neue"; font-display: swap; }
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--paper); color: var(--ink); }
+
+body {
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--ink); text-decoration: none; border-bottom: 2px solid var(--hot); }
+a:hover { color: var(--hot); }
+
+::selection { background: var(--hot); color: var(--paper); }
+
+/* GRID & SHELL */
+.shell {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) 56px;
+  min-height: 100vh;
+  border-left: 1px solid var(--ink);
+  border-right: 1px solid var(--ink);
+  background: var(--paper);
+}
+
+.rail {
+  border-right: 1px solid var(--ink);
+  position: relative;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  padding: 1.5rem 0;
+}
+.rail.right { border-right: none; border-left: 1px solid var(--ink); }
+.rail span { display: block; padding: 0.4rem 0.6rem; }
+
+.deck { display: flex; flex-direction: column; min-width: 0; }
+
+/* HEADER */
+.bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  border-bottom: 1px solid var(--ink);
+  padding: 14px 22px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+.bar .mark { font-family: var(--sans); font-weight: 900; font-size: 18px; letter-spacing: -0.02em; color: var(--ink); border: none; }
+.bar .lat { text-align: center; color: var(--ink-mute); }
+.bar nav { display: flex; justify-content: flex-end; gap: 22px; }
+.bar nav a { border: none; color: var(--ink); }
+.bar nav a:hover { color: var(--hot); }
+
+/* MASTHEAD */
+.masthead {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  padding: 28px 22px 12px;
+  border-bottom: 4px solid var(--ink);
+}
+.masthead .issue { font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ink-mute); }
+.masthead .stamp {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  text-align: right;
+  color: var(--ink-mute);
+}
+.masthead .stamp b { color: var(--hot); font-weight: 700; }
+
+/* HERO */
+.slab {
+  padding: 36px 22px 30px;
+  border-bottom: 1px solid var(--ink);
+}
+.slab h1 {
+  font-family: var(--sans);
+  font-weight: 900;
+  font-size: clamp(56px, 12vw, 184px);
+  line-height: 0.86;
+  letter-spacing: -0.045em;
+  margin: 0;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.slab h1 .strike { display: inline-block; position: relative; }
+.slab h1 .strike::after {
+  content: "";
+  position: absolute;
+  left: -4px; right: -4px; top: 47%;
+  height: 14px;
+  background: var(--hot);
+  transform: skewY(-3deg);
+  z-index: -1;
+}
+.slab h1 .accent { color: var(--hot); }
+.slab .lede {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+  margin-top: 28px;
+  padding-top: 22px;
+  border-top: 1px solid var(--ink);
+}
+.slab .lede .blurb { font-size: 19px; max-width: 56ch; }
+.slab .lede .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  row-gap: 6px;
+  align-content: end;
+}
+.slab .lede .meta b { color: var(--ink); font-weight: 700; }
+
+.cta-row { display: flex; gap: 0; margin-top: 28px; flex-wrap: wrap; }
+.btn {
+  border: 1px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  padding: 16px 26px;
+  font-family: var(--sans);
+  font-weight: 800;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-radius: 0;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.btn + .btn { border-left: none; }
+.btn:hover { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+.btn.primary { background: var(--hot); color: var(--paper); border-color: var(--hot); }
+.btn.primary:hover { background: var(--ink); border-color: var(--ink); }
+
+/* MANIFESTO */
+.manifesto {
+  padding: 56px 22px;
+  border-bottom: 1px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 48px;
+}
+.manifesto h2 {
+  font-family: var(--sans);
+  font-size: 24px;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  margin: 0;
+}
+.manifesto .label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--hot);
+  margin-bottom: 12px;
+}
+.manifesto .body { font-size: 21px; line-height: 1.4; max-width: 70ch; }
+.manifesto .body p + p { margin-top: 1.2em; }
+.manifesto .body p:first-letter {
+  font-weight: 900;
+  font-size: 1.4em;
+}
+
+/* PILLARS */
+.pillars {
+  padding: 56px 22px;
+  border-bottom: 1px solid var(--ink);
+}
+.pillars .hd {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 32px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--ink);
+}
+.pillars .hd h2 {
+  margin: 0;
+  font-size: 56px;
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+}
+.pillars .hd .ix { font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em; color: var(--ink-mute); text-transform: uppercase; }
+
+.pillar-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--ink);
+}
+.pillar {
+  border-right: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding: 28px 22px 32px;
+  position: relative;
+  background: var(--paper);
+  transition: background 0.18s ease, color 0.18s ease;
+}
+.pillar:nth-child(4n) { border-right: none; }
+.pillar:hover { background: var(--ink); color: var(--paper); }
+.pillar:hover .pno, .pillar:hover .ptag { color: var(--hot); }
+.pillar:hover h3, .pillar:hover p { color: var(--paper); }
+.pno {
+  font-family: var(--mono);
+  font-size: 56px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  color: var(--hot);
+  line-height: 1;
+}
+.ptag { font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ink-mute); margin-top: 6px; }
+.pillar h3 {
+  font-family: var(--sans);
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  margin: 22px 0 8px;
+  color: var(--ink);
+}
+.pillar p { color: var(--ink-soft); font-size: 14.5px; margin: 0; }
+
+/* COUNTER */
+.counter {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--ink);
+}
+.counter > div { padding: 28px 22px; border-right: 1px solid var(--ink); }
+.counter > div:last-child { border-right: none; }
+.counter .n {
+  font-family: var(--sans);
+  font-weight: 900;
+  font-size: 64px;
+  letter-spacing: -0.04em;
+  line-height: 1;
+}
+.counter .n sup { font-size: 24px; vertical-align: super; color: var(--hot); }
+.counter .l { font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ink-mute); margin-top: 8px; }
+
+/* INDEX LIST */
+.index-list { padding: 56px 22px; border-bottom: 1px solid var(--ink); }
+.index-list h2 { margin: 0 0 24px; font-size: 28px; text-transform: uppercase; font-weight: 900; letter-spacing: -0.01em; }
+.index-row {
+  display: grid;
+  grid-template-columns: 60px 1fr auto auto;
+  align-items: center;
+  border-top: 1px solid var(--ink);
+  padding: 22px 0;
+  font-size: 17px;
+  gap: 24px;
+}
+.index-row:last-child { border-bottom: 1px solid var(--ink); }
+.index-row .ix { font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; color: var(--ink-mute); }
+.index-row .ti { font-weight: 800; text-transform: uppercase; letter-spacing: -0.01em; }
+.index-row .ti a { border: none; }
+.index-row .ti a:hover { color: var(--hot); }
+.index-row .ty { font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em; color: var(--ink-mute); text-transform: uppercase; }
+.index-row .dt { font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; color: var(--ink-mute); }
+
+/* PROSE */
+.prose {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 48px 22px 56px;
+  font-size: 18px;
+  line-height: 1.65;
+}
+.prose h1 { font-size: 48px; font-weight: 900; letter-spacing: -0.03em; text-transform: uppercase; margin: 0 0 24px; }
+.prose h2 { font-size: 26px; font-weight: 900; text-transform: uppercase; margin: 1.6em 0 0.5em; }
+.prose h3 { font-size: 18px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.04em; margin: 1.4em 0 0.4em; }
+.prose p { margin: 0 0 1.2em; }
+.prose blockquote { border-left: 4px solid var(--hot); margin: 1.5em 0; padding: 0.4em 1em; font-style: italic; color: var(--ink-soft); }
+.prose code { font-family: var(--mono); background: var(--paper-dim); padding: 2px 6px; font-size: 0.9em; }
+.prose pre { background: var(--ink); color: var(--paper); padding: 18px 22px; overflow-x: auto; }
+.prose pre code { background: none; color: inherit; padding: 0; }
+.prose hr { border: none; border-top: 1px solid var(--ink); margin: 2em 0; }
+
+/* FOOTER */
+.colophon {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 32px;
+  padding: 44px 22px 28px;
+  border-top: 4px solid var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.colophon h4 { margin: 0 0 12px; font-size: 11px; letter-spacing: 0.22em; color: var(--ink-mute); font-weight: 700; }
+.colophon a { display: block; color: var(--ink); border: none; padding: 4px 0; }
+.colophon a:hover { color: var(--hot); }
+.colophon .big {
+  font-family: var(--sans);
+  font-weight: 900;
+  font-size: 56px;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  line-height: 0.9;
+}
+.colophon .big small { font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em; color: var(--ink-mute); display: block; margin-top: 8px; font-weight: 400; }
+.colophon .copy { grid-column: 1 / -1; padding-top: 18px; border-top: 1px solid var(--ink); font-size: 10px; color: var(--ink-mute); display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { padding: 32px 22px; border-top: 1px solid var(--ink); border-bottom: 1px solid var(--ink); }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0; justify-content: center; flex-wrap: wrap; }
+nav.pagination .pagination-list li { border: 1px solid var(--ink); }
+nav.pagination .pagination-list li + li { border-left: none; }
+nav.pagination a, .pagination-current span, .pagination-disabled span { display: inline-block; padding: 10px 16px; font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; border: none; }
+nav.pagination a { color: var(--ink); }
+nav.pagination a:hover { background: var(--ink); color: var(--paper); }
+.pagination-current span { background: var(--hot); color: var(--paper); }
+.pagination-disabled span { color: var(--ink-mute); }
+
+/* RESPONSIVE */
+@media (max-width: 920px) {
+  .shell { grid-template-columns: 0 1fr 0; border: none; }
+  .rail { display: none; }
+  .slab h1 { font-size: clamp(48px, 14vw, 96px); }
+  .manifesto { grid-template-columns: 1fr; gap: 24px; }
+  .pillar-grid { grid-template-columns: 1fr 1fr; }
+  .pillar:nth-child(4n) { border-right: 1px solid var(--ink); }
+  .pillar:nth-child(2n) { border-right: none; }
+  .counter { grid-template-columns: 1fr 1fr; }
+  .counter > div:nth-child(2n) { border-right: none; }
+  .colophon { grid-template-columns: 1fr; }
+  .index-row { grid-template-columns: 40px 1fr; gap: 12px; }
+  .index-row .ty, .index-row .dt { display: none; }
+}
+@media (max-width: 540px) {
+  .bar { grid-template-columns: 1fr 1fr; }
+  .bar .lat { display: none; }
+  .slab .lede { grid-template-columns: 1fr; gap: 16px; }
+  .pillars .hd h2 { font-size: 32px; }
+}

--- a/examples/antiform/static/favicon.svg
+++ b/examples/antiform/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/antiform/templates/404.html
+++ b/examples/antiform/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &mdash; FILE NOT FOUND</h1>
+  <p>The document you requested is not in the archive. It may have been refused, redacted, or never filed.</p>
+  <p><a href="{{ base_url }}/">Return to Index &rarr;</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/antiform/templates/footer.html
+++ b/examples/antiform/templates/footer.html
@@ -1,0 +1,30 @@
+      <footer class="colophon">
+        <div>
+          <h4>The Studio</h4>
+          <a href="{{ base_url }}/about/">Dossier</a>
+          <a href="{{ base_url }}/">Index of Work</a>
+          <a href="{{ base_url }}/tags/">Tagged Files</a>
+        </div>
+        <div>
+          <h4>Channels</h4>
+          <a href="#">Telegraph — Newsletter</a>
+          <a href="#">Open Studio — Fridays</a>
+          <a href="#">Press &amp; Stockists</a>
+        </div>
+        <div>
+          <div class="big">ANTI<br>FORM<small>End of Document. Continue Reading.</small></div>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} ANTIFORM STUDIO — Set in Helvetica Neue &amp; JetBrains Mono.</span>
+          <span>Built with Hwaro — Doc 04 / 04</span>
+        </div>
+      </footer>
+    </div>
+    <aside class="rail right" aria-hidden="true">
+      <span>END / TRANSMIT / FILE.04</span>
+    </aside>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/antiform/templates/header.html
+++ b/examples/antiform/templates/header.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} / {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@500;700;900&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <aside class="rail left" aria-hidden="true">
+      <span>FILED N.{{ current_year }} / VOL.IV</span>
+    </aside>
+    <div class="deck">
+      <header class="bar">
+        <a href="{{ base_url }}/" class="mark">{{ site.title }}</a>
+        <div class="lat">N 37.5665&deg; / E 126.9780&deg;</div>
+        <nav>
+          <a href="{{ base_url }}/">Index</a>
+          <a href="{{ base_url }}/about/">Dossier</a>
+          <a href="{{ base_url }}/tags/">Files</a>
+        </nav>
+      </header>

--- a/examples/antiform/templates/index.html
+++ b/examples/antiform/templates/index.html
@@ -1,0 +1,115 @@
+{% include "header.html" %}
+
+<section class="masthead">
+  <div class="issue">FILE 04 — A STUDIO MANIFEST FOR THE UNFINISHED CENTURY</div>
+  <div class="stamp">DOC.NO <b>AF-{{ current_year }}/04</b> &middot; {{ current_date | default("PRESENT") }}</div>
+</section>
+
+<section class="slab">
+  <h1>BREAK<br><span class="strike">THE FORM</span><br>BUILD <span class="accent">ANOTHER.</span></h1>
+  <div class="lede">
+    <p class="blurb">ANTIFORM is an editorial design studio operating at the seam of typography, refusal and quiet revolution. We publish work that argues, then prints it on the heaviest paper we can find.</p>
+    <div class="meta">
+      <span>STUDIO</span><b>Seoul &middot; Berlin</b>
+      <span>YEAR</span><b>MMXXV</b>
+      <span>CONTACT</span><b>file@antiform.studio</b>
+    </div>
+  </div>
+  <div class="cta-row">
+    <a class="btn primary" href="{{ base_url }}/about/">Open the Dossier &rarr;</a>
+    <a class="btn" href="#manifesto">Read the Manifesto</a>
+  </div>
+</section>
+
+<section class="manifesto" id="manifesto">
+  <div>
+    <div class="label">&sect; 01 &mdash; MANIFESTO</div>
+    <h2>WE OPPOSE THE DEFAULT. WE BUILD THE ANSWER.</h2>
+  </div>
+  <div class="body">
+    <p>The design we inherit is exhausted. Soft corners, soft promises, soft work. Antiform was assembled to push back &mdash; to render the brief obsolete the moment it arrives. We argue with the page until it concedes.</p>
+    <p>Every project leaves with a position. Every position leaves with a reason. We do not decorate. We file documents into the record and trust the work to survive its first opinion.</p>
+  </div>
+</section>
+
+<section class="pillars">
+  <div class="hd">
+    <h2>FOUR DEPARTMENTS</h2>
+    <div class="ix">&sect; 02 / OPERATIONS</div>
+  </div>
+  <div class="pillar-grid">
+    <article class="pillar">
+      <div class="pno">01</div>
+      <div class="ptag">EDITORIAL</div>
+      <h3>Print &amp; Periodical</h3>
+      <p>Quarterlies, monographs, archives. We set type until the language obeys; we ship until the binding cracks.</p>
+    </article>
+    <article class="pillar">
+      <div class="pno">02</div>
+      <div class="ptag">IDENTITY</div>
+      <h3>Brand Systems</h3>
+      <p>Logotypes that argue and grids that hold. We do not ship style guides &mdash; we ship operating manuals.</p>
+    </article>
+    <article class="pillar">
+      <div class="pno">03</div>
+      <div class="ptag">DIGITAL</div>
+      <h3>Interface &amp; Build</h3>
+      <p>Sites that read like documents and load like memos. Static where possible. Loud only where necessary.</p>
+    </article>
+    <article class="pillar">
+      <div class="pno">04</div>
+      <div class="ptag">CONSULTING</div>
+      <h3>Editorial Direction</h3>
+      <p>We sit in the room until the position is sharp. Then we leave behind a manuscript &mdash; not a moodboard.</p>
+    </article>
+  </div>
+</section>
+
+<section class="counter" aria-label="Studio statistics">
+  <div>
+    <div class="n">112<sup>+</sup></div>
+    <div class="l">Documents Filed</div>
+  </div>
+  <div>
+    <div class="n">04</div>
+    <div class="l">Departments Active</div>
+  </div>
+  <div>
+    <div class="n">11<sup>yr</sup></div>
+    <div class="l">Years On The Page</div>
+  </div>
+  <div>
+    <div class="n">00</div>
+    <div class="l">Compromises Logged</div>
+  </div>
+</section>
+
+<section class="index-list">
+  <h2>SELECTED WORK &mdash; INDEX</h2>
+  <div class="index-row">
+    <div class="ix">N&deg; 112</div>
+    <div class="ti"><a href="#">Heliograph Quarterly &mdash; Volume IV</a></div>
+    <div class="ty">EDITORIAL</div>
+    <div class="dt">{{ current_year }} / 05</div>
+  </div>
+  <div class="index-row">
+    <div class="ix">N&deg; 109</div>
+    <div class="ti"><a href="#">Concrete &amp; Carbon &mdash; A Catalogue</a></div>
+    <div class="ty">IDENTITY</div>
+    <div class="dt">{{ current_year }} / 03</div>
+  </div>
+  <div class="index-row">
+    <div class="ix">N&deg; 104</div>
+    <div class="ti"><a href="#">The Refusal Room &mdash; Web Build</a></div>
+    <div class="ty">DIGITAL</div>
+    <div class="dt">{{ current_year }} / 01</div>
+  </div>
+  <div class="index-row">
+    <div class="ix">N&deg; 101</div>
+    <div class="ti"><a href="#">Foundry Postscript &mdash; Wordmark Suite</a></div>
+    <div class="ty">IDENTITY</div>
+    <div class="dt">2025 / 11</div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/antiform/templates/page.html
+++ b/examples/antiform/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/antiform/templates/section.html
+++ b/examples/antiform/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+<section class="index-list">
+  {% if page.title is present %}<h2>{{ page.title | e | upper }}</h2>{% endif %}
+  {{ content | safe }}
+  {% for post in section.pages %}
+  <div class="index-row">
+    <div class="ix">N&deg; {{ loop.index }}</div>
+    <div class="ti"><a href="{{ post.url }}">{{ post.title | e }}</a></div>
+    <div class="ty">{{ post.section | upper }}</div>
+    <div class="dt">{{ post.date | date(format="%Y / %m") }}</div>
+  </div>
+  {% endfor %}
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/antiform/templates/shortcodes/alert.html
+++ b/examples/antiform/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/antiform/templates/taxonomy.html
+++ b/examples/antiform/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>An index of files tagged in the studio archive.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/antiform/templates/taxonomy_term.html
+++ b/examples/antiform/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>Documents filed under this term.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/bunker-deck/AGENTS.md
+++ b/examples/bunker-deck/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/bunker-deck/archetypes/default.md
+++ b/examples/bunker-deck/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/bunker-deck/config.toml
+++ b/examples/bunker-deck/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Bunker Deck"
+description = "A hardened control plane for production-grade operations — built for teams who treat uptime as a defense posture."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/bunker-deck/content/about.md
+++ b/examples/bunker-deck/content/about.md
@@ -1,0 +1,27 @@
++++
+title = "Dossier"
+description = "The brief on Bunker Deck — what we believe production looks like, and how we run it."
++++
+
+## What this platform is
+
+Bunker Deck is a hardened control plane for teams who run production at scale. Where most tools optimize for the happy path, the deck is built for the worst hour of the year — the 3 a.m. incident that gets escalated three times and ends in a postmortem.
+
+## Posture, not features
+
+We do not ship a feature list; we ship a posture.
+
+- **Sealed deploys.** Nothing reaches production without a signed artifact and a second human signature.
+- **Short-lived access.** No persistent root, no permanent kubeconfig. Operator sessions expire in minutes, not days.
+- **Recorded rooms.** Incident command happens in a sealed war room. The recording is the postmortem's first draft.
+- **Cold archive.** Every signal is replicated to two regions and one offline vault.
+
+## Who runs it
+
+> The team is small, the brief is loud. We have been on call long enough to be honest about what hurts.
+
+We are platform engineers, security operators, and one industrial designer who insists the console look like a panel you would trust at 03:00.
+
+## How to engage
+
+The line is `ops@bunker.deck`. We answer signed requests first, unsigned requests second, and never the demo bots. Office hours every Thursday at 17:00 KST in the war room.

--- a/examples/bunker-deck/content/index.md
+++ b/examples/bunker-deck/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Bunker Deck — a hardened control plane for production operations. Signed deploys, sealed sessions, recorded war rooms."
+template = "index"
++++

--- a/examples/bunker-deck/static/css/style.css
+++ b/examples/bunker-deck/static/css/style.css
@@ -1,0 +1,471 @@
+/* Bunker Deck — hardened industrial control plane */
+
+:root {
+  --plate: #1c1d1a;
+  --plate-2: #25272a;
+  --plate-3: #2d2f33;
+  --steel: #45484c;
+  --hair: #3a3d40;
+  --concrete: #c8c4ba;
+  --concrete-2: #d8d3c4;
+  --paper: #ece8da;
+  --ink: #0a0a0a;
+  --ink-soft: #1a1a1a;
+  --ink-mute: #8a8576;
+  --hazard: #f4cb22;
+  --hazard-2: #d9b418;
+  --rust: #b04528;
+  --ok: #6fa55f;
+  --warn: #cf8a1b;
+  --err: #c43c2a;
+  --display: "Oswald", "Bebas Neue", "Anton", "Arial Narrow", sans-serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: "JetBrains Mono", "IBM Plex Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+
+  /* warning stripe — solid color tiling via SVG, NOT a gradient */
+  --warn-stripes: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32'><polygon points='0,0 16,0 0,16' fill='%23f4cb22'/><polygon points='32,0 32,16 16,32 0,32 0,16' fill='%23f4cb22'/><rect width='32' height='32' fill='%230a0a0a' opacity='0'/></svg>");
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--plate); color: var(--concrete); }
+
+body {
+  font-family: var(--sans);
+  font-size: 15.5px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='6' height='6'><circle cx='3' cy='3' r='0.7' fill='%23252628'/></svg>");
+  background-attachment: fixed;
+}
+
+a { color: var(--hazard); text-decoration: none; border-bottom: 1px dashed var(--hazard); }
+a:hover { color: var(--paper); border-bottom-color: var(--paper); }
+
+::selection { background: var(--hazard); color: var(--ink); }
+
+.frame {
+  max-width: 1240px;
+  margin: 24px auto;
+  background: var(--plate-2);
+  border: 2px solid var(--ink);
+  position: relative;
+  box-shadow: 0 0 0 4px var(--plate), 0 30px 60px -30px #000;
+}
+
+/* rivets */
+.frame::before, .frame::after,
+.frame > .rivets-bottom::before, .frame > .rivets-bottom::after {
+  content: "";
+  position: absolute;
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  background: var(--steel);
+  box-shadow: inset 0 0 0 1px var(--ink), inset 1px 1px 0 #6a6f76;
+}
+.frame::before { top: 10px; left: 10px; }
+.frame::after { top: 10px; right: 10px; }
+.frame > .rivets-bottom { position: absolute; left: 0; right: 0; bottom: 0; height: 0; pointer-events: none; }
+.frame > .rivets-bottom::before { bottom: 10px; left: 10px; }
+.frame > .rivets-bottom::after { bottom: 10px; right: 10px; }
+
+/* TOP BAR */
+.bar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 32px;
+  background: var(--plate);
+  border-bottom: 2px solid var(--ink);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.bar .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--hazard);
+  color: var(--ink);
+  padding: 6px 12px;
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  border: 1px solid var(--ink);
+}
+.bar .badge .blip { width: 8px; height: 8px; background: var(--ink); display: inline-block; transform: rotate(45deg); }
+.bar .mid { text-align: center; color: var(--concrete); }
+.bar .mid b { color: var(--hazard); }
+.bar nav { display: flex; gap: 22px; justify-content: flex-end; }
+.bar nav a { color: var(--concrete); border: none; }
+.bar nav a:hover { color: var(--hazard); }
+
+/* HAZARD STRIPE */
+.hazard {
+  height: 16px;
+  background-color: var(--hazard);
+  background-image: var(--warn-stripes);
+  background-size: 32px 32px;
+  border-bottom: 2px solid var(--ink);
+}
+
+/* HERO */
+.hero {
+  position: relative;
+  padding: 56px 40px 48px;
+  border-bottom: 2px solid var(--ink);
+  background: var(--plate-2);
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  right: 36px; top: 36px;
+  width: 100px; height: 100px;
+  border: 2px solid var(--hazard);
+  outline: 2px solid var(--ink);
+  outline-offset: 6px;
+  background: var(--plate-2);
+  display: flex;
+}
+.hero .seal {
+  position: absolute;
+  right: 36px; top: 36px;
+  width: 100px; height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  color: var(--hazard);
+  line-height: 1.05;
+  z-index: 2;
+}
+.hero .seal b { color: var(--paper); font-size: 20px; display: block; }
+
+.hero .stamp {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 22px;
+}
+.hero .stamp .pill {
+  display: inline-block;
+  background: var(--rust);
+  color: var(--paper);
+  padding: 4px 10px;
+  margin-right: 12px;
+  border: 1px solid var(--ink);
+  letter-spacing: 0.24em;
+}
+
+.hero h1 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(60px, 11vw, 168px);
+  line-height: 0.86;
+  letter-spacing: 0.005em;
+  margin: 0;
+  text-transform: uppercase;
+  color: var(--paper);
+}
+.hero h1 .alt { color: var(--hazard); }
+.hero h1 .stencil {
+  display: inline-block;
+  -webkit-text-stroke: 2px var(--paper);
+  color: transparent;
+}
+.hero h1 .sub {
+  display: block;
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 13px;
+  letter-spacing: 0.32em;
+  color: var(--ink-mute);
+  margin-top: 14px;
+  text-transform: uppercase;
+}
+
+.hero .grid-info {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 48px;
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 2px solid var(--ink);
+}
+.hero .lede { font-size: 19px; color: var(--concrete-2); margin: 0; max-width: 56ch; }
+.hero .lede b { color: var(--paper); }
+
+.hero .specs {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  row-gap: 8px;
+  column-gap: 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  align-self: end;
+}
+.hero .specs b { color: var(--hazard); font-weight: 600; }
+
+.hero .cta { margin-top: 36px; display: flex; gap: 0; flex-wrap: wrap; }
+.btn {
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  padding: 14px 24px;
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  transition: background 0.15s ease, color 0.15s ease;
+  position: relative;
+}
+.btn + .btn { margin-left: -2px; }
+.btn:hover { background: var(--hazard); color: var(--ink); border-color: var(--ink); }
+.btn.solid { background: var(--hazard); }
+.btn.solid:hover { background: var(--paper); }
+.btn.ghost { background: transparent; color: var(--paper); border-color: var(--paper); }
+.btn.ghost:hover { background: var(--paper); color: var(--ink); }
+.btn .ar { font-family: var(--mono); }
+
+/* PANEL */
+.panels { padding: 40px 40px 56px; border-bottom: 2px solid var(--ink); background: var(--plate-2); }
+.panels .hd {
+  display: flex; justify-content: space-between; align-items: baseline;
+  border-bottom: 2px solid var(--ink); padding-bottom: 18px; margin-bottom: 24px;
+}
+.panels .hd h2 { font-family: var(--display); font-weight: 600; font-size: 36px; letter-spacing: 0.06em; text-transform: uppercase; margin: 0; color: var(--paper); }
+.panels .hd h2 .num { color: var(--hazard); margin-right: 14px; }
+.panels .hd .meta { font-family: var(--mono); font-size: 11px; letter-spacing: 0.28em; color: var(--ink-mute); text-transform: uppercase; }
+.panels .hd .meta b { color: var(--hazard); }
+
+.modules { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.module {
+  background: var(--plate-3);
+  border: 2px solid var(--ink);
+  padding: 26px 22px;
+  position: relative;
+  transition: transform 0.18s ease, background 0.18s ease;
+}
+.module::before {
+  content: "";
+  position: absolute;
+  top: -2px; left: -2px;
+  width: 50px; height: 8px;
+  background: var(--hazard);
+  background-image: var(--warn-stripes);
+  background-size: 16px 16px;
+  border-right: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+}
+.module:hover { transform: translateY(-3px); background: #36383b; }
+.module .mnum { font-family: var(--mono); font-size: 11px; letter-spacing: 0.32em; color: var(--ink-mute); text-transform: uppercase; }
+.module .mnum b { color: var(--hazard); }
+.module h3 { font-family: var(--display); font-weight: 600; font-size: 22px; letter-spacing: 0.04em; text-transform: uppercase; margin: 16px 0 8px; color: var(--paper); }
+.module p { margin: 0; color: var(--concrete); font-size: 14px; }
+.module .stat {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--hair);
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.module .stat b { color: var(--ok); }
+.module.warn .stat b { color: var(--warn); }
+.module.err .stat b { color: var(--err); }
+
+/* DIRECTIVES — warning table */
+.directives {
+  padding: 48px 40px;
+  background: var(--paper);
+  color: var(--ink);
+  border-bottom: 2px solid var(--ink);
+  position: relative;
+}
+.directives::before {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 0;
+  height: 12px;
+  background-color: var(--hazard);
+  background-image: var(--warn-stripes);
+  background-size: 24px 24px;
+  border-bottom: 2px solid var(--ink);
+}
+.directives .hd { display: flex; justify-content: space-between; align-items: baseline; margin: 12px 0 22px; }
+.directives .hd h2 { font-family: var(--display); font-weight: 600; font-size: 36px; letter-spacing: 0.06em; text-transform: uppercase; margin: 0; }
+.directives .hd .legend { font-family: var(--mono); font-size: 11px; letter-spacing: 0.24em; text-transform: uppercase; color: var(--ink-mute); }
+
+.directive-table { width: 100%; border-collapse: collapse; border: 2px solid var(--ink); background: var(--concrete-2); font-family: var(--mono); }
+.directive-table th, .directive-table td { padding: 14px 18px; border-bottom: 1px solid var(--ink); text-align: left; font-size: 13px; }
+.directive-table th { background: var(--ink); color: var(--paper); font-size: 11px; letter-spacing: 0.24em; text-transform: uppercase; }
+.directive-table td b { color: var(--rust); }
+.directive-table .ok { color: var(--ok); font-weight: 600; }
+.directive-table .wn { color: var(--warn); font-weight: 600; }
+.directive-table .er { color: var(--err); font-weight: 600; }
+.directive-table tr:last-child td { border-bottom: none; }
+
+/* TELEMETRY */
+.telemetry {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 2px solid var(--ink);
+  background: var(--ink);
+}
+.telemetry > div { padding: 28px 22px; border-right: 2px solid var(--steel); }
+.telemetry > div:last-child { border-right: none; }
+.telemetry .n { font-family: var(--display); font-weight: 600; font-size: 58px; line-height: 1; letter-spacing: 0.02em; color: var(--hazard); }
+.telemetry .n sup { font-size: 18px; color: var(--paper); vertical-align: super; }
+.telemetry .l { font-family: var(--mono); font-size: 11px; letter-spacing: 0.24em; text-transform: uppercase; color: var(--ink-mute); margin-top: 10px; }
+.telemetry .l b { color: var(--paper); }
+
+/* LOG ENTRIES */
+.entries-block { padding: 48px 40px; background: var(--plate-2); border-bottom: 2px solid var(--ink); }
+.entries-block .hd { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 22px; border-bottom: 2px solid var(--ink); padding-bottom: 18px; }
+.entries-block .hd h2 { font-family: var(--display); font-weight: 600; font-size: 36px; letter-spacing: 0.06em; text-transform: uppercase; margin: 0; color: var(--paper); }
+.entries-block .hd .meta { font-family: var(--mono); font-size: 11px; letter-spacing: 0.24em; color: var(--ink-mute); text-transform: uppercase; }
+
+.entry {
+  display: grid;
+  grid-template-columns: 90px 60px 1fr auto;
+  gap: 22px;
+  align-items: center;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--hair);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.entry:last-child { border-bottom: none; }
+.entry .ts { color: var(--ink-mute); font-size: 11px; letter-spacing: 0.18em; }
+.entry .lv { font-weight: 600; letter-spacing: 0.18em; font-size: 11px; }
+.entry .lv.ok { color: var(--ok); }
+.entry .lv.wn { color: var(--warn); }
+.entry .lv.er { color: var(--err); }
+.entry .lv.in { color: var(--hazard); }
+.entry .ms { font-family: var(--sans); font-size: 15px; color: var(--paper); }
+.entry .ms a { color: var(--hazard); border: none; }
+.entry .ms small { color: var(--ink-mute); }
+.entry .ar { color: var(--ink-mute); font-family: var(--mono); }
+
+/* PROSE */
+.prose {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 48px 32px 64px;
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--concrete);
+}
+.prose h1 { font-family: var(--display); font-weight: 600; font-size: 52px; line-height: 1; margin: 0 0 24px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--paper); }
+.prose h2 { font-family: var(--display); font-weight: 600; font-size: 28px; text-transform: uppercase; letter-spacing: 0.05em; margin-top: 1.8em; color: var(--paper); }
+.prose h3 { font-family: var(--mono); font-size: 12px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--hazard); margin-top: 1.6em; }
+.prose p { margin: 0 0 1.1em; }
+.prose blockquote { border-left: 4px solid var(--hazard); padding: 6px 22px; margin: 1.4em 0; color: var(--paper); font-style: normal; background: var(--plate-3); }
+.prose code { background: var(--plate); padding: 2px 6px; font-family: var(--mono); font-size: 0.9em; color: var(--hazard); border: 1px solid var(--hair); }
+.prose pre { background: var(--ink); border: 2px solid var(--steel); padding: 18px 22px; overflow-x: auto; font-family: var(--mono); }
+.prose pre code { background: none; border: none; color: var(--concrete); padding: 0; }
+.prose hr { border: none; border-top: 1px dashed var(--hair); margin: 2em 0; }
+
+/* FOOTER */
+.colophon {
+  background: var(--ink);
+  color: var(--concrete);
+  padding: 56px 40px 24px;
+  border-top: 2px solid var(--steel);
+}
+.colophon .stripe {
+  height: 14px;
+  background-color: var(--hazard);
+  background-image: var(--warn-stripes);
+  background-size: 28px 28px;
+  border-bottom: 2px solid var(--ink);
+  margin: -56px -40px 36px;
+}
+.colophon .big {
+  font-family: var(--display); font-weight: 600;
+  font-size: clamp(56px, 12vw, 168px);
+  letter-spacing: 0.02em;
+  line-height: 0.86;
+  text-transform: uppercase;
+  color: var(--paper);
+  margin: 0 0 36px;
+}
+.colophon .big .stencil { -webkit-text-stroke: 2px var(--hazard); color: transparent; }
+.colophon .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 28px;
+  padding-top: 32px;
+  border-top: 2px solid var(--steel);
+}
+.colophon h4 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--hazard); margin: 0 0 14px; }
+.colophon a { display: block; padding: 4px 0; color: var(--concrete); border: none; }
+.colophon a:hover { color: var(--hazard); }
+.colophon .copy { grid-column: 1 / -1; padding-top: 24px; border-top: 1px dashed var(--steel); font-family: var(--mono); font-size: 11px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ink-mute); display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { padding: 28px 40px; border-bottom: 2px solid var(--ink); background: var(--plate-2); }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0; flex-wrap: wrap; justify-content: center; }
+nav.pagination .pagination-list li { border: 2px solid var(--ink); border-right: none; }
+nav.pagination .pagination-list li:last-child { border-right: 2px solid var(--ink); }
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  display: inline-block;
+  padding: 10px 18px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  background: var(--plate-3);
+  color: var(--concrete);
+  border: none;
+}
+nav.pagination a:hover { background: var(--hazard); color: var(--ink); }
+.pagination-current span { background: var(--hazard); color: var(--ink); }
+.pagination-disabled span { color: var(--ink-mute); }
+
+/* RESPONSIVE */
+@media (max-width: 980px) {
+  .modules { grid-template-columns: 1fr 1fr; }
+  .telemetry { grid-template-columns: 1fr 1fr; }
+  .telemetry > div:nth-child(2n) { border-right: none; }
+  .colophon .grid { grid-template-columns: 1fr 1fr; }
+  .hero .grid-info { grid-template-columns: 1fr; gap: 24px; }
+}
+@media (max-width: 640px) {
+  .frame { margin: 12px; }
+  .bar { grid-template-columns: 1fr 1fr; }
+  .bar .mid { display: none; }
+  .hero { padding: 36px 22px 36px; }
+  .hero::after, .hero .seal { display: none; }
+  .modules { grid-template-columns: 1fr; }
+  .telemetry { grid-template-columns: 1fr; }
+  .telemetry > div { border-right: none; }
+  .panels, .directives, .entries-block, .colophon { padding-left: 22px; padding-right: 22px; }
+  .colophon .stripe { margin: -56px -22px 36px; }
+  .entry { grid-template-columns: 70px 50px 1fr; }
+  .entry .ar { display: none; }
+  .colophon .grid { grid-template-columns: 1fr; }
+  .colophon .copy { flex-direction: column; gap: 8px; }
+}

--- a/examples/bunker-deck/static/favicon.svg
+++ b/examples/bunker-deck/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/bunker-deck/templates/404.html
+++ b/examples/bunker-deck/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 // ROUTE DENIED</h1>
+  <p>This corridor is not on the facility plan. Either the route was decommissioned, or the request did not carry a valid sign-off.</p>
+  <p><a href="{{ base_url }}/">// return to brief</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/bunker-deck/templates/footer.html
+++ b/examples/bunker-deck/templates/footer.html
@@ -1,0 +1,40 @@
+    <footer class="colophon">
+      <div class="stripe" aria-hidden="true"></div>
+      <div class="big">BUNKER<br><span class="stencil">DECK.</span></div>
+      <div class="grid">
+        <div>
+          <h4>// Platform</h4>
+          <a href="{{ base_url }}/about/">Architecture brief</a>
+          <a href="#">Runtime &amp; agents</a>
+          <a href="#">SDK / CLI</a>
+        </div>
+        <div>
+          <h4>// Operations</h4>
+          <a href="#">Runbooks</a>
+          <a href="#">Postmortems</a>
+          <a href="#">Status board</a>
+        </div>
+        <div>
+          <h4>// Security</h4>
+          <a href="#">Compliance pack</a>
+          <a href="#">Disclosure policy</a>
+          <a href="#">Audit log</a>
+        </div>
+        <div>
+          <h4>// Comms</h4>
+          <a href="#">ops@bunker.deck</a>
+          <a href="#">PGP / signed reqs</a>
+          <a href="#">Office hours &mdash; Thu 17:00</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} BUNKER DECK &middot; FACILITY 07-N &middot; ALL OPS LOGGED</span>
+          <span>Build {{ current_year }}.04.18 &middot; sealed</span>
+        </div>
+      </div>
+    </footer>
+    <div class="rivets-bottom" aria-hidden="true"></div>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/bunker-deck/templates/header.html
+++ b/examples/bunker-deck/templates/header.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&family=Oswald:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="frame">
+    <header class="bar">
+      <a href="{{ base_url }}/" class="badge"><span class="blip"></span>BUNKER&middot;DECK</a>
+      <span class="mid">CONTROL PLANE &middot; <b>OPSEC GREEN</b> &middot; FACILITY 07-N</span>
+      <nav>
+        <a href="{{ base_url }}/">// brief</a>
+        <a href="{{ base_url }}/about/">// dossier</a>
+        <a href="{{ base_url }}/tags/">// logs</a>
+      </nav>
+    </header>
+    <div class="hazard" aria-hidden="true"></div>

--- a/examples/bunker-deck/templates/index.html
+++ b/examples/bunker-deck/templates/index.html
@@ -1,0 +1,110 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="seal">OP<b>07&middot;N</b>SEALED</div>
+  <div class="stamp"><span class="pill">RESTRICTED</span>OP. CODENAME &middot; FACILITY 07-N &middot; BRIEF VOL. IV</div>
+  <h1>HOLD<br><span class="alt">THE LINE.</span><br><span class="stencil">SHIP THE FLEET.</span>
+    <span class="sub">// a hardened control plane for production-grade operations</span>
+  </h1>
+  <div class="grid-info">
+    <p class="lede"><b>Bunker Deck</b> is the control plane for teams who treat uptime as a defense posture. We don't ship demos &mdash; we ship runbooks, signed builds, and a war room you can actually fight from at 03:00.</p>
+    <div class="specs">
+      <span>CODENAME</span><b>07-N / DELTA</b>
+      <span>POSTURE</span><b>OPSEC GREEN</b>
+      <span>UPTIME / 90D</span><b>99.998%</b>
+      <span>MTTR / P1</span><b>4 min 12 s</b>
+      <span>SIGNED BUILDS</span><b>100% / 30D</b>
+    </div>
+  </div>
+  <div class="cta">
+    <a class="btn solid" href="#install">Provision a deck<span class="ar">&gt;&gt;</span></a>
+    <a class="btn ghost" href="{{ base_url }}/about/">Read the brief<span class="ar">&gt;&gt;</span></a>
+    <a class="btn ghost" href="#log">Tail the log<span class="ar">&gt;&gt;</span></a>
+  </div>
+</section>
+
+<section class="panels">
+  <div class="hd">
+    <h2><span class="num">&sect; 02</span>MODULES &mdash; SHIPPED IN THE CORE</h2>
+    <div class="meta">CLASS / <b>STANDARD</b> &middot; ROTATION / 90D</div>
+  </div>
+  <div class="modules">
+    <article class="module">
+      <div class="mnum"><b>M-01</b> &middot; SIGNAL</div>
+      <h3>Sealed Deploy</h3>
+      <p>Every build is signed, logged and held until a second human signs off. Unsigned artifacts are quarantined &mdash; not deployed.</p>
+      <div class="stat"><span>// status</span><b>HEALTHY</b></div>
+    </article>
+    <article class="module">
+      <div class="mnum"><b>M-02</b> &middot; SENTINEL</div>
+      <h3>Runbook Auto-Pilot</h3>
+      <p>Encoded runbooks fire on detected incidents. Operators steer; the deck handles the rote. Postmortems are generated, not chased.</p>
+      <div class="stat"><span>// drills 30d</span><b>14 OK</b></div>
+    </article>
+    <article class="module warn">
+      <div class="mnum"><b>M-03</b> &middot; SCOPE</div>
+      <h3>Field Telemetry</h3>
+      <p>Edge agents stream telemetry over an end-to-end signed channel. No client-side mystery; no shipping logs to a third-party black box.</p>
+      <div class="stat"><span>// rotation</span><b>72 H</b></div>
+    </article>
+    <article class="module">
+      <div class="mnum"><b>M-04</b> &middot; SHIELD</div>
+      <h3>Zero-Trust Console</h3>
+      <p>Operator access is short-lived, hardware-attested, and audited per command. No persistent kubeconfig; no shared root.</p>
+      <div class="stat"><span>// tokens live</span><b>11 min</b></div>
+    </article>
+    <article class="module">
+      <div class="mnum"><b>M-05</b> &middot; SAFEHOUSE</div>
+      <h3>Cold Archive</h3>
+      <p>Logs replicated to two regions and one offline vault. Tamper-evident, subpoena-ready, and ready when the office burns down.</p>
+      <div class="stat"><span>// last sync</span><b>00:04 AGO</b></div>
+    </article>
+    <article class="module err">
+      <div class="mnum"><b>M-06</b> &middot; SCRAMBLE</div>
+      <h3>War Room</h3>
+      <p>One button opens a sealed, recorded room for incident command &mdash; with the right people paged, the right docs already loaded.</p>
+      <div class="stat"><span>// last fire</span><b>23 D AGO</b></div>
+    </article>
+  </div>
+</section>
+
+<section class="directives">
+  <div class="hd">
+    <h2>&sect; 03 &mdash; DIRECTIVES THE PLATFORM ENFORCES</h2>
+    <div class="legend">LEGEND: <b style="color:#6fa55f">ALLOW</b> / <b style="color:#cf8a1b">HOLD</b> / <b style="color:#c43c2a">DENY</b></div>
+  </div>
+  <table class="directive-table">
+    <thead>
+      <tr><th>DIRECTIVE</th><th>SCOPE</th><th>POSTURE</th><th>RESULT</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><b>D-01</b> Unsigned artifact reaches edge</td><td>GLOBAL</td><td>HARDENED</td><td class="er">DENY &middot; QUARANTINE</td></tr>
+      <tr><td><b>D-02</b> Deploy outside maintenance window</td><td>PROD-EU</td><td>RESTRICTED</td><td class="wn">HOLD &middot; APPROVAL</td></tr>
+      <tr><td><b>D-03</b> Signed build + two-human sign-off</td><td>GLOBAL</td><td>STANDARD</td><td class="ok">ALLOW &middot; SEAL</td></tr>
+      <tr><td><b>D-04</b> Console session past 15 minutes</td><td>GLOBAL</td><td>HARDENED</td><td class="er">DENY &middot; ROTATE TOKEN</td></tr>
+      <tr><td><b>D-05</b> Telemetry agent fails integrity check</td><td>EDGE</td><td>HARDENED</td><td class="er">DENY &middot; ISOLATE</td></tr>
+      <tr><td><b>D-06</b> Runbook executed during P1</td><td>GLOBAL</td><td>STANDARD</td><td class="ok">ALLOW &middot; RECORD</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="telemetry">
+  <div><div class="n">99.998<sup>%</sup></div><div class="l"><b>UPTIME</b> / 90 D</div></div>
+  <div><div class="n">4:12</div><div class="l"><b>MTTR</b> / P1 INCIDENTS</div></div>
+  <div><div class="n">0</div><div class="l"><b>UNSIGNED</b> DEPLOYS / 90 D</div></div>
+  <div><div class="n">07&middot;N</div><div class="l"><b>FACILITY</b> / ACTIVE WATCH</div></div>
+</section>
+
+<section class="entries-block" id="log">
+  <div class="hd">
+    <h2>&sect; 04 &mdash; LIVE OPS LOG</h2>
+    <div class="meta">STREAM // <b>EAST</b> &middot; <b>WEST</b> &middot; <b>COLD</b></div>
+  </div>
+  <div class="entry"><span class="ts">00:00:14</span><span class="lv ok">OK</span><span class="ms">Build <b>0xb4c1...</b> signed by <b>p.h@kakaocorp</b>, sealed for prod-eu</span><span class="ar">&rarr;</span></div>
+  <div class="entry"><span class="ts">00:00:32</span><span class="lv in">INFO</span><span class="ms">Operator session opened &mdash; ttl <small>14 min</small> &middot; hardware-attested</span><span class="ar">&rarr;</span></div>
+  <div class="entry"><span class="ts">00:01:07</span><span class="lv wn">HOLD</span><span class="ms">D-02 triggered &mdash; deploy outside window, awaiting <b>oncall+1</b> sign-off</span><span class="ar">&rarr;</span></div>
+  <div class="entry"><span class="ts">00:01:48</span><span class="lv ok">OK</span><span class="ms">Sign-off received &middot; deploy released to <b>edge-37</b> &middot; runbook M-02 armed</span><span class="ar">&rarr;</span></div>
+  <div class="entry"><span class="ts">00:02:31</span><span class="lv ok">OK</span><span class="ms">Cold archive sync complete &middot; <b>3 of 3</b> targets &middot; verified</span><span class="ar">&rarr;</span></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/bunker-deck/templates/page.html
+++ b/examples/bunker-deck/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/bunker-deck/templates/section.html
+++ b/examples/bunker-deck/templates/section.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<section class="entries-block">
+  <div class="hd">
+    {% if page.title is present %}<h2>&sect; LOG &mdash; {{ page.title | e | upper }}</h2>{% endif %}
+    <div class="meta">RETENTION 90D &middot; SIGNED</div>
+  </div>
+  {{ content | safe }}
+  {% for post in section.pages %}
+  <div class="entry">
+    <span class="ts">{{ post.date | date(format="%Y.%m.%d") }}</span>
+    <span class="lv in">ENTRY</span>
+    <span class="ms"><a href="{{ post.url }}">{{ post.title | e | upper }}</a></span>
+    <span class="ar">&rarr;</span>
+  </div>
+  {% endfor %}
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/bunker-deck/templates/shortcodes/alert.html
+++ b/examples/bunker-deck/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/bunker-deck/templates/taxonomy.html
+++ b/examples/bunker-deck/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Index of subjects across the facility log.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/bunker-deck/templates/taxonomy_term.html
+++ b/examples/bunker-deck/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Entries filed under this term.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/harvest-moon/AGENTS.md
+++ b/examples/harvest-moon/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/harvest-moon/archetypes/default.md
+++ b/examples/harvest-moon/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/harvest-moon/config.toml
+++ b/examples/harvest-moon/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Harvest Moon"
+description = "A slow fashion house dressing late-autumn nights — natural fibres, cool ochres, deep prose."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/harvest-moon/content/about.md
+++ b/examples/harvest-moon/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "The Atelier"
+description = "On the practice — why we cut one collection a year, by hand, and post it with a letter."
++++
+
+## A small house, kept small on purpose
+
+Harvest Moon is a slow fashion house. We make a single collection a year, released at the late harvest and retired at the first thaw. The collection is small because we sew by name; the year is short because the winter is long.
+
+## What we make
+
+Outerwear, knitwear, linen. All of it for the late hour — the slow walk home, the long supper, the kitchen at midnight. Nothing for the runway; everything for the room.
+
+## How we work
+
+> The moon turns. The harvest comes in. We make for that hour.
+
+Every garment carries the name of the person who finished it. Every order leaves with a letter. Every letter is answered. The studio book is up to date; the dye lots are numbered; the wool is from places we have walked.
+
+## Where we are
+
+The atelier is in Seoul. The dyeing room is in Kyoto. The linen comes from Kortrijk, and the wool from Galloway. We host an open studio every Friday afternoon — write first, and arrive in flat shoes.

--- a/examples/harvest-moon/content/index.md
+++ b/examples/harvest-moon/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Harvest Moon — a slow fashion house dressing late-autumn nights in natural fibres, cool ochres, and deep prose."
+template = "index"
++++

--- a/examples/harvest-moon/static/css/style.css
+++ b/examples/harvest-moon/static/css/style.css
@@ -1,0 +1,430 @@
+/* Harvest Moon — slow-fashion editorial */
+
+:root {
+  --bone: #f3ead8;
+  --bone-2: #ebe0c8;
+  --paper: #f6efde;
+  --ink: #1a1410;
+  --ink-soft: #3b2f25;
+  --ink-mute: #7c6a55;
+  --ochre: #8a5a2b;
+  --ochre-deep: #5a3c1c;
+  --persimmon: #c4451c;
+  --hair: #d8c9a8;
+  --serif: "Fraunces", "Cormorant Garamond", Georgia, "Times New Roman", serif;
+  --display: "Fraunces", "Playfair Display", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--bone); color: var(--ink); }
+
+body {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--ochre); text-decoration: none; border-bottom: 1px solid currentColor; }
+a:hover { color: var(--persimmon); }
+
+::selection { background: var(--ochre); color: var(--bone); }
+
+.shell { max-width: 1280px; margin: 0 auto; padding: 0 32px; }
+
+/* TOP BAR */
+.top {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 28px 0 22px;
+  border-bottom: 1px solid var(--ink);
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+}
+.top .ws { color: var(--ink-mute); }
+.top .ws b { color: var(--ink); }
+.top .logo { font-family: var(--display); font-weight: 600; letter-spacing: -0.02em; text-transform: none; font-style: italic; font-size: 22px; color: var(--ink); border: none; }
+.top nav { display: flex; gap: 26px; justify-content: flex-end; }
+.top nav a { color: var(--ink); border: none; }
+.top nav a:hover { color: var(--persimmon); }
+
+/* COVER */
+.cover {
+  position: relative;
+  padding: 56px 0 36px;
+  border-bottom: 1px solid var(--ink);
+}
+.cover .meta {
+  position: absolute;
+  top: 56px;
+  right: 0;
+  text-align: right;
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  line-height: 2;
+}
+.cover .meta b { color: var(--ink); font-weight: 600; }
+
+.cover .kicker {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: var(--persimmon);
+  margin-bottom: 18px;
+}
+.cover h1 {
+  font-family: var(--display);
+  font-weight: 300;
+  font-style: italic;
+  font-size: clamp(70px, 14vw, 220px);
+  letter-spacing: -0.04em;
+  line-height: 0.88;
+  margin: 0;
+  color: var(--ink);
+}
+.cover h1 .line-2 { display: block; font-style: normal; font-weight: 700; letter-spacing: -0.045em; }
+.cover h1 .moon { display: inline-block; transform: translateY(-0.04em); }
+.cover h1 .ornament {
+  display: inline-block;
+  width: 0.95em; height: 0.95em;
+  border-radius: 50%;
+  border: 2px solid var(--ink);
+  vertical-align: -0.06em;
+  margin: 0 0.04em;
+  background: var(--bone);
+  position: relative;
+}
+.cover h1 .ornament::after {
+  content: "";
+  position: absolute;
+  inset: 6%;
+  border-radius: 50%;
+  background: var(--ink);
+  clip-path: polygon(0 0, 60% 0, 60% 100%, 0 100%);
+}
+
+.cover .lede-row {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 56px;
+  margin-top: 40px;
+  padding-top: 28px;
+  border-top: 1px solid var(--hair);
+  align-items: end;
+}
+.cover .lede-row .left {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.cover .lede-row .left b { color: var(--ink); font-weight: 600; display: block; margin-bottom: 4px; }
+.cover .lede {
+  font-size: 22px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  font-style: italic;
+  max-width: 56ch;
+  margin: 0;
+}
+.cover .lede em { color: var(--persimmon); font-style: normal; }
+
+.cover .cta {
+  margin-top: 30px;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 26px;
+  border: 1px solid var(--ink);
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ink);
+  border-radius: 999px;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+.btn:hover { background: var(--ink); color: var(--bone); border-color: var(--ink); }
+.btn.solid { background: var(--ink); color: var(--bone); }
+.btn.solid:hover { background: var(--persimmon); border-color: var(--persimmon); }
+.btn .ar { font-family: var(--serif); font-size: 14px; line-height: 1; letter-spacing: 0; }
+
+/* MARQUEE */
+.marquee {
+  border-bottom: 1px solid var(--ink);
+  padding: 18px 0;
+  overflow: hidden;
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 300;
+  font-size: 36px;
+  letter-spacing: -0.02em;
+  color: var(--ochre-deep);
+  white-space: nowrap;
+}
+.marquee .track { display: inline-flex; gap: 56px; animation: drift 38s linear infinite; }
+.marquee .track span { white-space: nowrap; }
+.marquee .track i { display: inline-block; width: 8px; height: 8px; background: var(--persimmon); border-radius: 50%; transform: translateY(-8px); margin: 0 8px; }
+@keyframes drift { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* COLLECTION GRID */
+.collection { padding: 80px 0; border-bottom: 1px solid var(--ink); }
+.collection .hd {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  align-items: end;
+  margin-bottom: 44px;
+}
+.collection .hd h2 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 300;
+  font-size: clamp(40px, 6vw, 80px);
+  margin: 0;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+}
+.collection .hd .num {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  text-align: right;
+}
+.collection .hd .num b { color: var(--persimmon); font-weight: 600; }
+
+.pieces { display: grid; grid-template-columns: repeat(3, 1fr); gap: 36px; }
+.piece {
+  position: relative;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--hair);
+}
+.piece .swatch {
+  height: 320px;
+  background: var(--ochre);
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 18px;
+}
+.piece .swatch::after {
+  content: "";
+  position: absolute;
+  left: 50%; top: 50%;
+  width: 140px; height: 140px;
+  margin: -70px 0 0 -70px;
+  border-radius: 50%;
+  background: var(--bone);
+  box-shadow: inset -22px -10px 0 var(--ink);
+  transition: transform 0.4s ease;
+}
+.piece:nth-child(2) .swatch { background: var(--ink); }
+.piece:nth-child(2) .swatch::after { background: var(--persimmon); box-shadow: inset -22px -10px 0 var(--ochre-deep); }
+.piece:nth-child(3) .swatch { background: var(--persimmon); }
+.piece:nth-child(3) .swatch::after { background: var(--bone-2); box-shadow: inset -22px -10px 0 var(--ochre-deep); }
+.piece:hover .swatch::after { transform: scale(0.92) rotate(-12deg); }
+.piece .no { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--ink-mute); }
+.piece h3 {
+  margin: 8px 0 6px;
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 28px;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.piece p { margin: 0; color: var(--ink-soft); font-size: 15px; max-width: 36ch; }
+.piece .tag {
+  position: absolute;
+  top: 14px; right: 14px;
+  background: var(--bone);
+  color: var(--ink);
+  padding: 6px 10px;
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+/* CREDO */
+.credo {
+  display: grid;
+  grid-template-columns: 1fr 1.7fr;
+  gap: 64px;
+  align-items: start;
+  padding: 80px 0;
+  border-bottom: 1px solid var(--ink);
+}
+.credo .label { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--persimmon); }
+.credo .label .ix { color: var(--ink); margin-right: 12px; }
+.credo .credo-text {
+  font-family: var(--display);
+  font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 44px);
+  line-height: 1.18;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+}
+.credo .credo-text p:first-child::first-letter {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 300;
+  font-size: 5.2em;
+  float: left;
+  line-height: 0.85;
+  margin: 0.05em 0.08em 0 0;
+  color: var(--persimmon);
+}
+.credo .credo-text p + p { margin-top: 0.7em; }
+.credo .credo-text em { color: var(--ochre); font-style: italic; }
+.credo .sig {
+  margin-top: 28px;
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink-mute);
+}
+
+/* ATELIER */
+.atelier { padding: 80px 0; border-bottom: 1px solid var(--ink); }
+.atelier .hd { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 36px; }
+.atelier .hd h2 { font-family: var(--display); font-style: italic; font-weight: 300; font-size: 56px; margin: 0; letter-spacing: -0.02em; }
+.atelier .hd .more { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; }
+
+.notes { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; border-top: 1px solid var(--ink); }
+.note { border-right: 1px solid var(--ink); border-bottom: 1px solid var(--ink); padding: 28px 22px 32px; }
+.note:nth-child(4n) { border-right: none; }
+.note .nlabel { font-family: var(--sans); font-size: 10px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--ink-mute); margin-bottom: 18px; }
+.note .nlabel b { color: var(--persimmon); }
+.note .nbig { font-family: var(--display); font-style: italic; font-weight: 300; font-size: 62px; line-height: 1; letter-spacing: -0.04em; }
+.note .nbig sup { font-size: 0.34em; vertical-align: 0.8em; color: var(--persimmon); margin-left: 4px; font-style: normal; }
+.note .ntxt { margin: 12px 0 0; font-size: 14.5px; color: var(--ink-soft); }
+
+/* JOURNAL */
+.journal { padding: 80px 0; border-bottom: 1px solid var(--ink); }
+.journal .hd {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  align-items: end;
+  margin-bottom: 36px;
+}
+.journal .hd h2 {
+  font-family: var(--display); font-style: italic; font-weight: 300;
+  font-size: clamp(40px, 6vw, 80px); margin: 0; letter-spacing: -0.03em;
+}
+.journal .hd p { margin: 0; font-size: 17px; color: var(--ink-soft); }
+
+.journal-list { border-top: 1px solid var(--ink); }
+.journal-list .row {
+  display: grid;
+  grid-template-columns: 100px 1fr 200px 60px;
+  gap: 24px;
+  align-items: center;
+  padding: 26px 0;
+  border-bottom: 1px solid var(--hair);
+}
+.journal-list .row:last-child { border-bottom: 1px solid var(--ink); }
+.journal-list .d { font-family: var(--sans); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--ink-mute); }
+.journal-list .t a { font-family: var(--display); font-style: italic; font-weight: 400; font-size: 28px; color: var(--ink); border: none; letter-spacing: -0.01em; }
+.journal-list .t a:hover { color: var(--persimmon); }
+.journal-list .t small { display: block; font-family: var(--sans); font-style: normal; font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--ink-mute); margin-top: 4px; }
+.journal-list .x { font-family: var(--sans); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--ink-soft); }
+.journal-list .ar { font-family: var(--display); font-style: italic; font-size: 28px; text-align: right; color: var(--ink); }
+
+/* PROSE */
+.prose {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 64px 0 80px;
+  font-size: 19px;
+  line-height: 1.7;
+  color: var(--ink-soft);
+}
+.prose h1 { font-family: var(--display); font-style: italic; font-weight: 300; font-size: 64px; line-height: 1; margin: 0 0 32px; color: var(--ink); letter-spacing: -0.03em; }
+.prose h2 { font-family: var(--display); font-style: italic; font-weight: 400; font-size: 32px; margin-top: 2em; color: var(--ink); letter-spacing: -0.02em; }
+.prose h3 { font-family: var(--sans); font-size: 12px; letter-spacing: 0.32em; text-transform: uppercase; margin-top: 1.8em; color: var(--persimmon); }
+.prose p { margin: 0 0 1.1em; }
+.prose blockquote { border-left: 3px solid var(--persimmon); padding-left: 22px; margin: 1.4em 0; font-style: italic; color: var(--ink); }
+.prose code { background: var(--bone-2); padding: 1px 6px; font-family: var(--mono); font-size: 0.9em; color: var(--ochre-deep); }
+.prose pre { background: var(--ink); color: var(--bone); padding: 18px 22px; overflow-x: auto; }
+.prose pre code { background: none; color: inherit; }
+
+/* FOOTER */
+.foot {
+  padding: 64px 0 36px;
+  border-top: 1px solid var(--ink);
+}
+.foot .big {
+  font-family: var(--display); font-style: italic; font-weight: 300;
+  font-size: clamp(64px, 12vw, 180px);
+  letter-spacing: -0.04em;
+  line-height: 0.9;
+  margin: 0 0 36px;
+}
+.foot .big .b { font-style: normal; font-weight: 700; }
+.foot .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 36px;
+  padding-top: 36px;
+  border-top: 1px solid var(--ink);
+}
+.foot h4 { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--persimmon); margin: 0 0 14px; }
+.foot a { display: block; color: var(--ink); border: none; padding: 4px 0; }
+.foot a:hover { color: var(--persimmon); }
+.foot .copy { grid-column: 1 / -1; padding-top: 28px; border-top: 1px solid var(--hair); font-family: var(--sans); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { margin: 40px 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  font-family: var(--sans); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase;
+  padding: 10px 18px; border: 1px solid var(--ink); border-radius: 999px; color: var(--ink); border-bottom: 1px solid var(--ink);
+}
+nav.pagination a:hover { background: var(--ink); color: var(--bone); }
+.pagination-current span { background: var(--persimmon); color: var(--bone); border-color: var(--persimmon); }
+.pagination-disabled span { color: var(--ink-mute); border-color: var(--hair); }
+
+/* RESPONSIVE */
+@media (max-width: 980px) {
+  .pieces { grid-template-columns: 1fr 1fr; }
+  .credo { grid-template-columns: 1fr; gap: 24px; }
+  .cover .lede-row { grid-template-columns: 1fr; gap: 24px; }
+  .cover .meta { position: static; text-align: left; margin-top: 14px; }
+  .notes { grid-template-columns: 1fr 1fr; }
+  .note:nth-child(4n) { border-right: 1px solid var(--ink); }
+  .note:nth-child(2n) { border-right: none; }
+  .journal-list .row { grid-template-columns: 80px 1fr; }
+  .journal-list .x, .journal-list .ar { display: none; }
+  .foot .grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 620px) {
+  .shell { padding: 0 20px; }
+  .top { grid-template-columns: 1fr 1fr; }
+  .top .ws { display: none; }
+  .pieces { grid-template-columns: 1fr; }
+  .notes { grid-template-columns: 1fr; }
+  .note { border-right: none !important; }
+  .foot .grid { grid-template-columns: 1fr; }
+  .foot .copy { flex-direction: column; gap: 10px; }
+}

--- a/examples/harvest-moon/static/favicon.svg
+++ b/examples/harvest-moon/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/harvest-moon/templates/404.html
+++ b/examples/harvest-moon/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &mdash; <em>lost in the post.</em></h1>
+  <p>This page never reached us. The letter went astray, or the address was older than the lookbook. Try the collection or the journal.</p>
+  <p><a href="{{ base_url }}/">Return to the collection &rarr;</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/harvest-moon/templates/footer.html
+++ b/examples/harvest-moon/templates/footer.html
@@ -1,0 +1,38 @@
+    <footer class="foot">
+      <div class="big">Harvest <span class="b">Moon</span>.</div>
+      <div class="grid">
+        <div>
+          <h4>The House</h4>
+          <a href="{{ base_url }}/about/">Atelier &amp; Practice</a>
+          <a href="#">Sourcing &amp; Fibres</a>
+          <a href="#">Stockists</a>
+        </div>
+        <div>
+          <h4>Read</h4>
+          <a href="{{ base_url }}/tags/">Journal</a>
+          <a href="#">Lookbook &mdash; Vol. IV</a>
+          <a href="#">Letters</a>
+        </div>
+        <div>
+          <h4>Care</h4>
+          <a href="#">Wool, Linen &amp; Silk</a>
+          <a href="#">Repair &amp; Mend</a>
+          <a href="#">Returns</a>
+        </div>
+        <div>
+          <h4>Correspondence</h4>
+          <a href="#">studio@harvestmoon.house</a>
+          <a href="#">Press &amp; Editorial</a>
+          <a href="#">Open Studio &mdash; Fridays</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} Harvest Moon House &mdash; Set in Fraunces</span>
+          <span>Issue IV. Hand-bound in Seoul.</span>
+        </div>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/harvest-moon/templates/header.html
+++ b/examples/harvest-moon/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,300;1,9..144,400;1,9..144,600&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="top">
+      <div class="ws">EST. <b>MMXIX</b> &mdash; Seoul / Kyoto / Lisbon</div>
+      <a href="{{ base_url }}/" class="logo">Harvest <em>Moon</em></a>
+      <nav>
+        <a href="{{ base_url }}/">Collection</a>
+        <a href="{{ base_url }}/about/">The Atelier</a>
+        <a href="{{ base_url }}/tags/">Journal</a>
+      </nav>
+    </header>

--- a/examples/harvest-moon/templates/index.html
+++ b/examples/harvest-moon/templates/index.html
@@ -1,0 +1,128 @@
+{% include "header.html" %}
+
+<section class="cover">
+  <div class="meta">
+    <div><b>ISSUE IV</b></div>
+    <div>{{ current_year }} / Late Autumn</div>
+    <div>Fibre &middot; <b>Linen, Wool, Camel</b></div>
+    <div>Plates &middot; <b>34</b> &middot; Press <b>003</b></div>
+  </div>
+  <div class="kicker">Lookbook &mdash; Vol. IV &mdash; for the slow hour</div>
+  <h1>Harvest<br><span class="line-2">M<span class="ornament" aria-hidden="true"></span><span class="moon">on</span>.</span></h1>
+  <div class="lede-row">
+    <div class="left">
+      <b>The House</b>
+      A small atelier dressing late-autumn nights in natural fibres &mdash; cut slowly, sewn by name, posted by hand. Available by appointment, by mail, and to those who write first.
+    </div>
+    <p class="lede">A coat the colour of <em>cooled ochre.</em> A linen shirt that softens with weather. A scarf that remembers the room it was woven in.</p>
+  </div>
+  <div class="cta">
+    <a class="btn solid" href="#collection">View the Collection<span class="ar">&rarr;</span></a>
+    <a class="btn" href="{{ base_url }}/about/">Visit the Atelier<span class="ar">&rarr;</span></a>
+  </div>
+</section>
+
+<div class="marquee" aria-hidden="true">
+  <div class="track">
+    <span>Cut slowly.<i></i>Sewn by hand.<i></i>Posted with a letter.<i></i>Cut slowly.<i></i>Sewn by hand.<i></i>Posted with a letter.<i></i></span>
+    <span>Cut slowly.<i></i>Sewn by hand.<i></i>Posted with a letter.<i></i>Cut slowly.<i></i>Sewn by hand.<i></i>Posted with a letter.<i></i></span>
+  </div>
+</div>
+
+<section class="collection" id="collection">
+  <div class="hd">
+    <h2>The Collection &mdash; <em>plates I &ndash; III</em></h2>
+    <div class="num">Plate <b>01 / 24</b> &middot; {{ current_year }}</div>
+  </div>
+  <div class="pieces">
+    <article class="piece">
+      <div class="swatch"><span class="tag">N&deg; 01</span></div>
+      <div class="no">Outerwear</div>
+      <h3>The Ochre Coat</h3>
+      <p>A long camel-and-wool coat the colour of cooled tea. Cut to walk the river in November.</p>
+    </article>
+    <article class="piece">
+      <div class="swatch"><span class="tag">N&deg; 02</span></div>
+      <div class="no">Knitwear</div>
+      <h3>The Quiet Sweater</h3>
+      <p>Hand-loomed merino, the weight of a folded letter. Worn close to the collarbone, worn often.</p>
+    </article>
+    <article class="piece">
+      <div class="swatch"><span class="tag">N&deg; 03</span></div>
+      <div class="no">Linen</div>
+      <h3>The Studio Shirt</h3>
+      <p>Belgian linen, persimmon-dyed in single small lots. Soft on the second wash; honest on the tenth.</p>
+    </article>
+  </div>
+</section>
+
+<section class="credo">
+  <div>
+    <div class="label"><span class="ix">&sect; 02</span>The Practice</div>
+  </div>
+  <div>
+    <div class="credo-text">
+      <p>We are a small house. We cut what we can <em>sew by name,</em> and we sell what we can <em>post by hand.</em> The collection is small because the year is short, and because every garment leaves with a letter from the person who finished it.</p>
+      <p>The moon turns. The harvest comes in. We make for that hour &mdash; for the slow walk home, the late supper, the long winter that follows. Everything else can wait until spring.</p>
+    </div>
+    <div class="sig">&mdash; Jin-ho &amp; Marin, Founders</div>
+  </div>
+</section>
+
+<section class="atelier">
+  <div class="hd">
+    <h2>By the numbers &mdash; <em>this year.</em></h2>
+    <a class="more" href="{{ base_url }}/about/">Read the practice &rarr;</a>
+  </div>
+  <div class="notes">
+    <div class="note">
+      <div class="nlabel"><b>01</b> &nbsp; PIECES MADE</div>
+      <div class="nbig">412<sup>&deg;</sup></div>
+      <p class="ntxt">Hand-finished, this year, by six pairs of hands &mdash; logged in the studio book.</p>
+    </div>
+    <div class="note">
+      <div class="nlabel"><b>02</b> &nbsp; FIBRES SOURCED</div>
+      <div class="nbig">9</div>
+      <p class="ntxt">Mills, all named. Wool from Galloway, linen from Kortrijk, silk from Tomioka.</p>
+    </div>
+    <div class="note">
+      <div class="nlabel"><b>03</b> &nbsp; LETTERS POSTED</div>
+      <div class="nbig">412</div>
+      <p class="ntxt">One per garment, one per friend. We answer every reply.</p>
+    </div>
+    <div class="note">
+      <div class="nlabel"><b>04</b> &nbsp; SEASONS</div>
+      <div class="nbig">1</div>
+      <p class="ntxt">A single collection a year. Released at the late harvest, retired at the first thaw.</p>
+    </div>
+  </div>
+</section>
+
+<section class="journal">
+  <div class="hd">
+    <h2>From the <em>journal.</em></h2>
+    <p>Field notes from the studio &mdash; on cloth, on slow making, and on the late hour we dress for.</p>
+  </div>
+  <div class="journal-list">
+    <div class="row">
+      <div class="d">{{ current_year }} &middot; 11</div>
+      <div class="t"><a href="#">A letter on the persimmon dye, and the friend who taught us to mind it</a><small>Notes &middot; The dyeing room</small></div>
+      <div class="x">Marin</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} &middot; 09</div>
+      <div class="t"><a href="#">On cutting the coat slowly &mdash; a record of three months in the pattern room</a><small>Process &middot; The cutting table</small></div>
+      <div class="x">Jin-ho</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} &middot; 07</div>
+      <div class="t"><a href="#">Galloway, in summer: where the wool for this winter has been waiting</a><small>Sourcing &middot; The trip north</small></div>
+      <div class="x">Studio</div>
+      <div class="ar">&rarr;</div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/harvest-moon/templates/page.html
+++ b/examples/harvest-moon/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/harvest-moon/templates/section.html
+++ b/examples/harvest-moon/templates/section.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<section class="journal">
+  <div class="hd">
+    {% if page.title is present %}<h2><em>{{ page.title | e }}</em></h2>{% endif %}
+    <p>{{ content | safe }}</p>
+  </div>
+  <div class="journal-list">
+    {% for post in section.pages %}
+    <div class="row">
+      <div class="d">{{ post.date | date(format="%Y &middot; %m") | safe }}</div>
+      <div class="t"><a href="{{ post.url }}">{{ post.title | e }}</a><small>{{ post.section | default("journal") }}</small></div>
+      <div class="x">Studio</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/harvest-moon/templates/shortcodes/alert.html
+++ b/examples/harvest-moon/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/harvest-moon/templates/taxonomy.html
+++ b/examples/harvest-moon/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>An index of subjects collected from the journal.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/harvest-moon/templates/taxonomy_term.html
+++ b/examples/harvest-moon/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>Entries from the journal on this subject.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/null-protocol/AGENTS.md
+++ b/examples/null-protocol/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/null-protocol/archetypes/default.md
+++ b/examples/null-protocol/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/null-protocol/config.toml
+++ b/examples/null-protocol/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "null.protocol"
+description = "A zero-trust deployment runtime — pinned, signed, and verified before the first packet leaves the host."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/null-protocol/content/about.md
+++ b/examples/null-protocol/content/about.md
@@ -1,0 +1,32 @@
++++
+title = "/etc/about"
+description = "What null.protocol is, who it is for, and what it refuses to ship without."
++++
+
+## What it is
+
+`null.protocol` is a zero-trust deployment runtime. It is the layer that sits between your release pipeline and your production hosts and refuses to forward anything that is not pinned, signed, and policy-approved.
+
+It does not replace your CI. It does not replace your secret manager. It replaces the unverified `kubectl apply` that everyone is pretending is safe.
+
+## Who it is for
+
+- Platform teams who own production and have been paged at 3 a.m. once too often.
+- Security engineers who want a single audit log they can hand to a regulator.
+- Founders who want to keep moving fast without inheriting an incident.
+
+## What it refuses to ship
+
+```
+[ DENY ] unsigned artifact
+[ DENY ] signer not in enrollment ledger
+[ DENY ] egress to unpinned host
+[ HOLD ] policy diff awaiting review
+[ ALLOW ] matched artifact + matched signer + matched policy
+```
+
+## How to reach us
+
+> Open a ticket, send a key, or join the room. We answer in mono.
+
+Email `op@null.protocol`. PGP key on the keyserver. Office hours every Thursday at 17:00 KST.

--- a/examples/null-protocol/content/index.md
+++ b/examples/null-protocol/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "null.protocol — a zero-trust deployment runtime that pins, signs and verifies every artifact before it reaches production."
+template = "index"
++++

--- a/examples/null-protocol/static/css/style.css
+++ b/examples/null-protocol/static/css/style.css
@@ -1,0 +1,356 @@
+/* null.protocol — terminal / leaked-document landing */
+
+:root {
+  --bg: #050707;
+  --bg-elev: #0c1010;
+  --bg-mute: #131818;
+  --ink: #d3e0d6;
+  --ink-soft: #8aa291;
+  --ink-mute: #4f6259;
+  --grid: #1a1f1d;
+  --phos: #7afdd6;
+  --phos-dim: #2a8e76;
+  --amber: #ffd166;
+  --red: #ff5b6c;
+  --mono: "JetBrains Mono", "IBM Plex Mono", "Source Code Pro", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+
+body {
+  font-family: var(--mono);
+  font-size: 14.5px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24'><circle cx='1' cy='1' r='1' fill='%231a1f1d'/></svg>");
+  background-size: 24px 24px;
+  background-attachment: fixed;
+}
+
+a { color: var(--phos); text-decoration: none; }
+a:hover { color: #fff; background: var(--phos-dim); }
+
+::selection { background: var(--phos); color: var(--bg); }
+
+/* shell */
+.term {
+  max-width: 1100px;
+  margin: 32px auto;
+  border: 1px solid var(--grid);
+  background: var(--bg-elev);
+  box-shadow: 0 0 0 1px #000, 0 32px 60px -32px rgba(0,0,0,.6);
+}
+
+.term-titlebar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--grid);
+  background: #080b0b;
+  font-size: 12px;
+  color: var(--ink-mute);
+}
+.term-titlebar .dots { display: flex; gap: 7px; }
+.term-titlebar .dots i { width: 11px; height: 11px; border-radius: 50%; border: 1px solid var(--grid); display: inline-block; }
+.term-titlebar .dots i:nth-child(1) { background: var(--red); border-color: #6b1e26; }
+.term-titlebar .dots i:nth-child(2) { background: var(--amber); border-color: #6e5a1d; }
+.term-titlebar .dots i:nth-child(3) { background: var(--phos); border-color: var(--phos-dim); }
+.term-titlebar .name { text-align: center; letter-spacing: 0.08em; }
+.term-titlebar .name b { color: var(--ink); font-weight: 600; }
+.term-titlebar .name b::before { content: "// "; color: var(--phos); }
+.term-titlebar .right { display: flex; gap: 18px; }
+.term-titlebar .right a { color: var(--ink-soft); }
+.term-titlebar .right a:hover { color: var(--phos); background: none; }
+
+.term-statusbar {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--grid);
+  background: #070a0a;
+  font-size: 11px;
+  color: var(--ink-mute);
+}
+.term-statusbar > div { padding: 8px 14px; border-right: 1px solid var(--grid); }
+.term-statusbar > div:last-child { border-right: none; }
+.term-statusbar b { color: var(--phos); font-weight: 600; }
+.term-statusbar .ok b { color: var(--phos); }
+.term-statusbar .warn b { color: var(--amber); }
+
+.body {
+  padding: 28px 28px 24px;
+}
+
+/* prompt */
+.prompt {
+  font-size: 13px;
+  color: var(--ink-mute);
+  margin-bottom: 6px;
+}
+.prompt .u { color: var(--phos); }
+.prompt .at { color: var(--ink-mute); }
+.prompt .h { color: var(--amber); }
+.prompt .p { color: var(--ink-soft); }
+.prompt .c { color: var(--ink); }
+
+.cmd {
+  font-size: 15px;
+  color: var(--ink);
+  margin-bottom: 18px;
+}
+.cmd .flag { color: var(--amber); }
+.cmd .arg { color: var(--phos); }
+.cmd .cur { display: inline-block; width: 9px; height: 17px; background: var(--phos); margin-left: 4px; vertical-align: text-bottom; animation: blink 1s steps(1) infinite; }
+@keyframes blink { 50% { opacity: 0; } }
+
+/* hero */
+.banner {
+  border: 1px solid var(--grid);
+  padding: 22px 26px;
+  margin: 6px 0 26px;
+  background: var(--bg-mute);
+  position: relative;
+}
+.banner::before {
+  content: "[ HEADER ]";
+  position: absolute; top: -9px; left: 16px;
+  font-size: 10px;
+  padding: 0 8px;
+  background: var(--bg-elev);
+  color: var(--ink-mute);
+  letter-spacing: 0.2em;
+}
+.banner pre {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.2;
+  color: var(--phos);
+  white-space: pre;
+  overflow-x: auto;
+}
+.banner h1 {
+  margin: 18px 0 6px;
+  font-family: var(--mono);
+  font-size: clamp(28px, 5vw, 44px);
+  letter-spacing: -0.01em;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.05;
+}
+.banner h1 .accent { color: var(--phos); }
+.banner h1 .strike { text-decoration: line-through; text-decoration-color: var(--red); text-decoration-thickness: 3px; color: var(--ink-mute); }
+.banner .lede { color: var(--ink-soft); max-width: 78ch; font-size: 14.5px; margin: 14px 0 18px; }
+
+.cta-row { display: flex; gap: 10px; flex-wrap: wrap; }
+.btn {
+  border: 1px solid var(--grid);
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 10px 16px;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+.btn:hover { border-color: var(--phos); color: var(--phos); }
+.btn.primary { border-color: var(--phos); color: var(--bg); background: var(--phos); }
+.btn.primary:hover { background: #9affe1; }
+.btn .pfx { color: var(--phos); margin-right: 6px; }
+.btn.primary .pfx { color: var(--bg); }
+
+/* logs / output */
+.section {
+  margin-top: 30px;
+}
+.section .label {
+  font-size: 11px;
+  color: var(--ink-mute);
+  letter-spacing: 0.2em;
+  border-bottom: 1px solid var(--grid);
+  padding-bottom: 6px;
+  margin-bottom: 12px;
+}
+.section .label b { color: var(--phos); }
+
+.log {
+  border: 1px solid var(--grid);
+  background: var(--bg-mute);
+}
+.log .row {
+  display: grid;
+  grid-template-columns: 92px 80px 1fr;
+  gap: 18px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--grid);
+  font-size: 13px;
+}
+.log .row:last-child { border-bottom: none; }
+.log .ts { color: var(--ink-mute); }
+.log .lv { font-weight: 600; }
+.log .lv.ok { color: var(--phos); }
+.log .lv.wn { color: var(--amber); }
+.log .lv.er { color: var(--red); }
+.log .lv.in { color: var(--ink-soft); }
+.log .ms { color: var(--ink); }
+.log .ms b { color: var(--phos); font-weight: 500; }
+
+/* feature grid */
+.grid3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+.cell {
+  border: 1px solid var(--grid);
+  background: var(--bg-mute);
+  padding: 18px 18px 22px;
+  position: relative;
+}
+.cell::before {
+  content: "+";
+  position: absolute; top: -7px; left: -7px;
+  width: 13px; height: 13px;
+  background: var(--bg-elev);
+  border: 1px solid var(--grid);
+  text-align: center;
+  line-height: 11px;
+  font-size: 13px;
+  color: var(--phos);
+}
+.cell::after {
+  content: "+";
+  position: absolute; bottom: -7px; right: -7px;
+  width: 13px; height: 13px;
+  background: var(--bg-elev);
+  border: 1px solid var(--grid);
+  text-align: center;
+  line-height: 11px;
+  font-size: 13px;
+  color: var(--phos);
+}
+.cell .tag { color: var(--phos); font-size: 11px; letter-spacing: 0.18em; }
+.cell h3 { margin: 12px 0 6px; color: #fff; font-size: 16px; font-weight: 600; font-family: var(--mono); letter-spacing: -0.01em; }
+.cell p { margin: 0; color: var(--ink-soft); font-size: 13px; }
+.cell .ascii {
+  margin-top: 14px;
+  white-space: pre;
+  font-size: 10px;
+  color: var(--phos-dim);
+  line-height: 1.1;
+}
+
+/* table */
+.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--grid);
+  background: var(--bg-mute);
+  font-size: 13px;
+}
+.tbl th, .tbl td { padding: 10px 14px; border-bottom: 1px solid var(--grid); text-align: left; }
+.tbl th { color: var(--ink-mute); font-weight: 500; font-size: 11px; letter-spacing: 0.16em; background: #090c0c; }
+.tbl td b { color: var(--phos); }
+.tbl tr:last-child td { border-bottom: none; }
+.tbl .ok { color: var(--phos); }
+.tbl .wn { color: var(--amber); }
+.tbl .er { color: var(--red); }
+
+/* code block */
+pre.code-block {
+  border: 1px solid var(--grid);
+  background: var(--bg-mute);
+  padding: 16px 18px;
+  font-size: 13px;
+  color: var(--ink);
+  overflow-x: auto;
+  margin: 12px 0 0;
+}
+pre.code-block .ln { color: var(--ink-mute); margin-right: 12px; }
+pre.code-block .k { color: var(--phos); }
+pre.code-block .s { color: var(--amber); }
+pre.code-block .c { color: var(--ink-mute); }
+
+/* prose */
+.prose {
+  padding: 28px 28px 36px;
+  max-width: 760px;
+  margin: 0 auto;
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--ink-soft);
+}
+.prose h1, .prose h2, .prose h3 { color: var(--ink); font-family: var(--mono); font-weight: 600; letter-spacing: -0.01em; }
+.prose h1 { font-size: 26px; color: var(--phos); }
+.prose h1::before { content: "## "; color: var(--ink-mute); }
+.prose h2 { font-size: 19px; margin-top: 1.8em; }
+.prose h2::before { content: "## "; color: var(--ink-mute); }
+.prose h3 { font-size: 15px; margin-top: 1.4em; }
+.prose h3::before { content: "### "; color: var(--ink-mute); }
+.prose p { margin: 0 0 1em; }
+.prose code { background: var(--bg-mute); border: 1px solid var(--grid); padding: 1px 6px; color: var(--phos); font-size: 0.92em; }
+.prose pre { background: var(--bg-mute); border: 1px solid var(--grid); padding: 14px 18px; }
+.prose blockquote { border-left: 2px solid var(--phos); padding-left: 14px; color: var(--ink); font-style: normal; margin: 1em 0; }
+.prose hr { border: none; border-top: 1px dashed var(--grid); margin: 2em 0; }
+.prose ul, .prose ol { padding-left: 1.4em; }
+
+/* section list */
+.entries {
+  border: 1px solid var(--grid);
+  background: var(--bg-mute);
+  margin-top: 20px;
+}
+.entries .row {
+  display: grid;
+  grid-template-columns: 100px 1fr 120px;
+  gap: 16px;
+  align-items: center;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--grid);
+}
+.entries .row:last-child { border-bottom: none; }
+.entries .row .d { color: var(--ink-mute); font-size: 12px; }
+.entries .row .t a { color: #fff; }
+.entries .row .t a:hover { color: var(--phos); background: none; }
+.entries .row .x { color: var(--phos); font-size: 12px; text-align: right; letter-spacing: 0.12em; }
+
+/* footer */
+.footer {
+  border-top: 1px solid var(--grid);
+  padding: 14px 18px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 18px;
+  font-size: 12px;
+  color: var(--ink-mute);
+  background: #070a0a;
+}
+.footer a { color: var(--ink-soft); }
+.footer a:hover { color: var(--phos); background: none; }
+.footer .copy { font-family: var(--mono); }
+.footer .copy b { color: var(--phos); }
+
+/* pagination */
+nav.pagination { margin: 24px 0 0; padding: 12px 18px; border: 1px solid var(--grid); background: var(--bg-mute); }
+nav.pagination .pagination-list { list-style: none; display: flex; gap: 8px; flex-wrap: wrap; padding: 0; margin: 0; align-items: center; justify-content: center; }
+nav.pagination a, .pagination-current span, .pagination-disabled span { display: inline-block; padding: 4px 10px; border: 1px solid var(--grid); font-size: 12px; letter-spacing: 0.06em; }
+nav.pagination a { color: var(--ink); }
+nav.pagination a:hover { color: var(--phos); border-color: var(--phos); background: none; }
+.pagination-current span { color: var(--bg); background: var(--phos); border-color: var(--phos); }
+.pagination-disabled span { color: var(--ink-mute); }
+
+@media (max-width: 820px) {
+  .term { margin: 12px; }
+  .term-statusbar { grid-template-columns: 1fr 1fr; }
+  .term-statusbar > div { border-bottom: 1px solid var(--grid); }
+  .term-statusbar > div:nth-child(2n) { border-right: none; }
+  .grid3 { grid-template-columns: 1fr; }
+  .log .row { grid-template-columns: 80px 60px 1fr; gap: 10px; padding: 8px 12px; }
+  .entries .row { grid-template-columns: 80px 1fr; }
+  .entries .row .x { display: none; }
+  .footer { grid-template-columns: 1fr; }
+  .banner pre { font-size: 9.5px; }
+}

--- a/examples/null-protocol/static/favicon.svg
+++ b/examples/null-protocol/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/null-protocol/templates/404.html
+++ b/examples/null-protocol/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 :: route not registered</h1>
+  <p><code>nullctl tail</code> shows no match for this path. The runtime denied the lookup and exited cleanly.</p>
+  <p><a href="{{ base_url }}/">$ cd ~</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/null-protocol/templates/footer.html
+++ b/examples/null-protocol/templates/footer.html
@@ -1,0 +1,14 @@
+    <footer class="footer">
+      <div class="copy"># <b>{{ site.title }}</b> &middot; sha-256:7afdd6...c8d9c5</div>
+      <div>
+        <a href="{{ base_url }}/">~/index</a>
+        &middot; <a href="{{ base_url }}/about/">~/about</a>
+        &middot; <a href="{{ base_url }}/tags/">~/tags</a>
+      </div>
+      <div style="text-align:right">&copy; {{ current_year }} NULL_PROTOCOL // exit 0</div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/null-protocol/templates/header.html
+++ b/examples/null-protocol/templates/header.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} :: {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="term">
+    <div class="term-titlebar">
+      <span class="dots"><i></i><i></i><i></i></span>
+      <span class="name">~/<b>{{ site.title }}</b> &mdash; ssh root@bastion-0</span>
+      <span class="right">
+        <a href="{{ base_url }}/">~</a>
+        <a href="{{ base_url }}/about/">/etc/about</a>
+        <a href="{{ base_url }}/tags/">/var/log</a>
+      </span>
+    </div>
+    <div class="term-statusbar">
+      <div class="ok">STATUS &middot; <b>HEALTHY</b></div>
+      <div>UPTIME &middot; <b>99.997%</b></div>
+      <div class="warn">ALERTS &middot; <b>0/24h</b></div>
+      <div>BUILD &middot; <b>{{ current_date | default(current_year) }}</b></div>
+    </div>

--- a/examples/null-protocol/templates/index.html
+++ b/examples/null-protocol/templates/index.html
@@ -1,0 +1,92 @@
+{% include "header.html" %}
+
+<div class="body">
+
+  <div class="prompt"><span class="u">root</span><span class="at">@</span><span class="h">bastion-0</span><span class="p">:~</span><span class="c">#</span></div>
+  <div class="cmd">./<span class="arg">null</span> deploy <span class="flag">--zero-trust</span> <span class="flag">--pinned</span> ./payload.tar<span class="cur"></span></div>
+
+  <section class="banner">
+    <pre>
+ _   _  _   _  _      _      ____   ____   ___ _____ ___   ____ ___  _
+| \ | || | | || |    | |    |  _ \ |  _ \ / _ \_   _/ _ \ / ___/ _ \| |
+|  \| || | | || |    | |    | |_) || |_) | | | || || | | | |  | | | | |
+| |\  || |_| || |___ | |___ |  __/ |  _ < |_| || || |_| | |__| |_| | |___
+|_| \_| \___/ |_____||_____||_|    |_| \_\\___/ |_| \___/ \____\___/|_____|</pre>
+    <h1>SHIP <span class="strike">FAST</span> <span class="accent">SAFE.</span><br>VERIFY EVERYTHING ELSE.</h1>
+    <p class="lede">null.protocol is a zero-trust deployment runtime for teams who treat production like a vault. Every artifact is pinned, every signer is enrolled, every packet is logged &mdash; before the first byte leaves the host.</p>
+    <div class="cta-row">
+      <a class="btn primary" href="#docs"><span class="pfx">$</span>install null</a>
+      <a class="btn" href="{{ base_url }}/about/"><span class="pfx">&gt;</span>read the spec</a>
+      <a class="btn" href="#log"><span class="pfx">&#x25CB;</span>tail -f log</a>
+    </div>
+  </section>
+
+  <section class="section" id="log">
+    <div class="label">[&bull;] <b>BOOT</b> &middot; LIVE TRANSCRIPT</div>
+    <div class="log">
+      <div class="row"><span class="ts">00:00.014</span><span class="lv ok">OK</span><span class="ms">handshake established with <b>bastion-0</b> via <b>noise_xk_25519</b></span></div>
+      <div class="row"><span class="ts">00:00.052</span><span class="lv in">INFO</span><span class="ms">pulled artifact <b>payload.tar</b> &middot; 11.4 MiB &middot; sha-256 verified</span></div>
+      <div class="row"><span class="ts">00:00.108</span><span class="lv ok">OK</span><span class="ms">signer <b>p.h@kakaocorp</b> matched enrolled key <b>ssh-ed25519 AAAA&hellip;jX</b></span></div>
+      <div class="row"><span class="ts">00:00.214</span><span class="lv wn">WARN</span><span class="ms">artifact references network egress &mdash; opening pinned tunnel <b>egress-37</b></span></div>
+      <div class="row"><span class="ts">00:00.318</span><span class="lv ok">OK</span><span class="ms">policy <b>null.kr/prod-eu</b> approved &mdash; 3 of 3 reviewers signed</span></div>
+      <div class="row"><span class="ts">00:00.452</span><span class="lv ok">OK</span><span class="ms">runtime sealed &middot; <b>deploy=42b9c1</b> &middot; <b>exit 0</b></span></div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="label">[&bull;] <b>MODULES</b> &middot; SHIPPED IN THE CORE</div>
+    <div class="grid3">
+      <article class="cell">
+        <div class="tag">// 01 PIN</div>
+        <h3>Reproducible artifacts</h3>
+        <p>Lockfiles by default. Every dependency, every layer, every binary blob is content-addressed and pinned to a Merkle root you can verify offline.</p>
+        <pre class="ascii">[#######] verified
+[ root  ] 7afdd6&hellip;c8d9
+[ bytes ] 11.4 MiB</pre>
+      </article>
+      <article class="cell">
+        <div class="tag">// 02 SIGN</div>
+        <h3>Enrolled signers, no exceptions</h3>
+        <p>Hardware keys, mTLS, or short-lived OIDC tokens. We do not accept anonymous deploys &mdash; not even from the founder, not even at 3 a.m.</p>
+        <pre class="ascii">[ p.h@kakaocorp ]
+  ssh-ed25519
+  enrolled 2024-11
+  rotates 90d</pre>
+      </article>
+      <article class="cell">
+        <div class="tag">// 03 LOG</div>
+        <h3>Tamper-evident audit</h3>
+        <p>Every transition is appended to a notarized log streamed to two regions and a cold archive. Subpoena-safe. Auditor-safe. Postmortem-safe.</p>
+        <pre class="ascii">[ region eu-1 ] OK
+[ region ap-2 ] OK
+[ cold        ] OK</pre>
+      </article>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="label">[&bull;] <b>POLICY</b> &middot; WHAT THE RUNTIME REJECTS</div>
+    <table class="tbl">
+      <thead><tr><th>RULE</th><th>SCOPE</th><th>RESULT</th></tr></thead>
+      <tbody>
+        <tr><td>unsigned artifact</td><td>global</td><td class="er">DENY &middot; halt</td></tr>
+        <tr><td>signer not in enrollment ledger</td><td>global</td><td class="er">DENY &middot; halt</td></tr>
+        <tr><td>policy diff requires review</td><td>prod, prod-eu</td><td class="wn">HOLD &middot; pending</td></tr>
+        <tr><td>egress to unpinned host</td><td>prod</td><td class="er">DENY &middot; quarantine</td></tr>
+        <tr><td>matched pinned artifact + signer</td><td>global</td><td class="ok">ALLOW &middot; sealed</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="section" id="docs">
+    <div class="label">[&bull;] <b>INSTALL</b> &middot; 30 SECONDS</div>
+    <pre class="code-block"><span class="c"># bootstrap the runtime — single static binary, no daemons</span>
+<span class="ln">1</span><span class="k">$</span> curl -fsSL <span class="s">https://null.protocol/install.sh</span> | sh
+<span class="ln">2</span><span class="k">$</span> null enroll <span class="s">--name "p.h@kakaocorp"</span> --device yubikey
+<span class="ln">3</span><span class="k">$</span> null deploy <span class="s">./payload.tar</span> --to prod-eu
+<span class="ln">4</span><span class="k">$</span> null tail --since 1h</pre>
+  </section>
+
+</div>
+
+{% include "footer.html" %}

--- a/examples/null-protocol/templates/page.html
+++ b/examples/null-protocol/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/null-protocol/templates/section.html
+++ b/examples/null-protocol/templates/section.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<div class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</div>
+<div class="entries">
+  {% for post in section.pages %}
+  <div class="row">
+    <div class="d">{{ post.date | date(format="%Y-%m-%d") }}</div>
+    <div class="t"><a href="{{ post.url }}">{{ post.title | e }}</a></div>
+    <div class="x">// {{ post.section | default("page") }}</div>
+  </div>
+  {% endfor %}
+</div>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/null-protocol/templates/shortcodes/alert.html
+++ b/examples/null-protocol/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/null-protocol/templates/taxonomy.html
+++ b/examples/null-protocol/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p>// terms registered in this taxonomy</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/null-protocol/templates/taxonomy_term.html
+++ b/examples/null-protocol/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p>// pages matched against this term</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/prism-cut/AGENTS.md
+++ b/examples/prism-cut/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/prism-cut/archetypes/default.md
+++ b/examples/prism-cut/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/prism-cut/config.toml
+++ b/examples/prism-cut/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "PRISM CUT"
+description = "A design & motion studio cutting brand and product launches into clear, dangerous shapes."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/prism-cut/content/about.md
+++ b/examples/prism-cut/content/about.md
@@ -1,0 +1,25 @@
++++
+title = "The Studio"
+description = "Who we are, what we ship, and the six briefs we'll accept this year."
++++
+
+## Six briefs a year
+
+PRISM CUT is a small launch studio. We take **six briefs a year** and we ship them on the date we said we would. We are three founders, four senior makers, and a copy desk that occasionally raises its voice.
+
+## What we ship
+
+- Brand identity systems for series-B and series-C technology companies.
+- Launch films and motion design for product debuts.
+- Marketing sites that load fast and look like nothing else.
+- Live events when the launch deserves a room of its own.
+
+## How we work
+
+> No moodboard ever launched a product. We bring three options on the first day, two on the second, and one cut, signed, on the third.
+
+We work in two-week cuts. After each cut you get a deliverable, a decision, and an invoice. There is no retainer; there is no holding pattern.
+
+## Brief us
+
+The line is `brief@prism.cut`. Tell us the launch date first, the budget second, and the company name last. We answer within a working day.

--- a/examples/prism-cut/content/index.md
+++ b/examples/prism-cut/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "PRISM CUT — a design and motion studio that cuts ambitious product launches into clear, dangerous shapes."
+template = "index"
++++

--- a/examples/prism-cut/static/css/style.css
+++ b/examples/prism-cut/static/css/style.css
@@ -1,0 +1,462 @@
+/* PRISM CUT — clip-path geometric, clashing electric blocks */
+
+:root {
+  --bg: #f4f1ea;
+  --bg-2: #ecdcb4;
+  --ink: #060606;
+  --ink-soft: #2a2a2a;
+  --ink-mute: #6b6b6b;
+  --blue: #1c2af0;
+  --blue-deep: #0c14a5;
+  --magenta: #ff2c6b;
+  --lemon: #ecf03a;
+  --mint: #1efaa1;
+  --paper: #ffffff;
+  --rule: #060606;
+  --sans: "Space Grotesk", "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --display: "Inter Tight", "Space Grotesk", "Helvetica Neue", sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); overflow-x: hidden; }
+
+body {
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--ink); text-decoration: none; font-weight: 600; }
+a:hover { color: var(--magenta); }
+
+::selection { background: var(--lemon); color: var(--ink); }
+
+/* TOP BAR — sharp blue stripe */
+.bar {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 14px 28px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  border-bottom: 4px solid var(--blue);
+}
+.bar a { color: var(--paper); font-weight: 500; }
+.bar a:hover { color: var(--lemon); }
+.bar .mid b { color: var(--lemon); font-weight: 700; letter-spacing: 0; font-family: var(--display); font-size: 16px; text-transform: none; }
+.bar .right { display: flex; justify-content: flex-end; gap: 22px; }
+
+/* HERO — overlapping clipped wedges */
+.cut {
+  position: relative;
+  padding: 56px 28px 80px;
+  overflow: hidden;
+  border-bottom: 4px solid var(--ink);
+}
+
+.cut .wedges {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+.cut .wedge {
+  position: absolute;
+  transform-origin: 50% 50%;
+}
+.cut .w1 {
+  top: -10%; left: -8%;
+  width: 64%; height: 90%;
+  background: var(--blue);
+  clip-path: polygon(0 0, 100% 0, 76% 100%, 0 70%);
+}
+.cut .w2 {
+  top: 18%; right: -10%;
+  width: 56%; height: 78%;
+  background: var(--magenta);
+  clip-path: polygon(28% 0, 100% 8%, 100% 100%, 0 86%);
+}
+.cut .w3 {
+  bottom: -8%; left: 22%;
+  width: 38%; height: 46%;
+  background: var(--lemon);
+  clip-path: polygon(0 24%, 100% 0, 88% 100%, 12% 92%);
+}
+.cut .w4 {
+  top: 8%; left: 32%;
+  width: 20%; height: 20%;
+  background: var(--mint);
+  clip-path: polygon(50% 0, 100% 70%, 50% 100%, 0 70%);
+}
+.cut .w5 {
+  bottom: 24%; right: 10%;
+  width: 12%; height: 14%;
+  background: var(--ink);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 70%);
+}
+
+.cut .copy {
+  position: relative;
+  z-index: 2;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.cut .kicker {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--paper);
+  background: var(--ink);
+  padding: 8px 14px;
+  display: inline-block;
+  margin-bottom: 28px;
+}
+
+.cut h1 {
+  font-family: var(--display);
+  font-weight: 800;
+  font-size: clamp(64px, 13vw, 200px);
+  line-height: 0.84;
+  letter-spacing: -0.05em;
+  margin: 0;
+  color: var(--ink);
+  font-style: italic;
+  text-transform: uppercase;
+}
+.cut h1 .l2 { display: block; color: var(--paper); font-style: normal; }
+.cut h1 .l3 { display: block; color: var(--ink); font-style: normal; -webkit-text-stroke: 2px var(--ink); color: transparent; }
+
+.cut .lede {
+  margin-top: 36px;
+  max-width: 38ch;
+  font-size: 21px;
+  color: var(--ink);
+  font-weight: 500;
+  background: var(--paper);
+  padding: 22px 24px;
+  border: 3px solid var(--ink);
+  box-shadow: 14px 14px 0 var(--lemon), 14px 14px 0 3px var(--ink);
+}
+
+.cut .cta { margin-top: 36px; display: flex; gap: 14px; flex-wrap: wrap; }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: 3px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  cursor: pointer;
+  box-shadow: 6px 6px 0 var(--ink);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease, color 0.12s ease;
+}
+.btn:hover { transform: translate(-3px, -3px); box-shadow: 9px 9px 0 var(--ink); color: var(--ink); }
+.btn:active { transform: translate(3px, 3px); box-shadow: 2px 2px 0 var(--ink); }
+.btn.lemon { background: var(--lemon); }
+.btn.magenta { background: var(--magenta); color: var(--paper); box-shadow: 6px 6px 0 var(--ink); }
+.btn.magenta:hover { color: var(--paper); }
+.btn .ar { font-family: var(--mono); font-size: 18px; line-height: 1; }
+
+/* MARQUEE STRIP */
+.strip {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 22px 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border-bottom: 4px solid var(--magenta);
+}
+.strip .track {
+  display: inline-flex;
+  gap: 56px;
+  animation: drift 28s linear infinite;
+  font-family: var(--display);
+  font-weight: 800;
+  font-size: 36px;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  font-style: italic;
+}
+.strip .track span { color: var(--paper); }
+.strip .track .alt { color: var(--lemon); }
+.strip .track .dot {
+  display: inline-block;
+  width: 14px; height: 14px;
+  background: var(--magenta);
+  margin: 0 8px;
+  transform: rotate(45deg) translateY(-2px);
+}
+@keyframes drift { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* WORK GRID */
+.work {
+  padding: 80px 28px;
+  background: var(--bg);
+  border-bottom: 4px solid var(--ink);
+}
+.work .wrap { max-width: 1200px; margin: 0 auto; }
+.work .hd {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  margin-bottom: 36px;
+  gap: 24px;
+}
+.work .hd h2 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 800;
+  font-size: clamp(48px, 7vw, 96px);
+  letter-spacing: -0.04em;
+  line-height: 0.9;
+  margin: 0;
+  text-transform: uppercase;
+}
+.work .hd h2 b { color: var(--blue); }
+.work .hd .index {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  background: var(--paper);
+  padding: 8px 14px;
+  border: 3px solid var(--ink);
+}
+
+.case-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 18px; }
+.case {
+  border: 3px solid var(--ink);
+  padding: 24px;
+  position: relative;
+  background: var(--paper);
+  min-height: 280px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+}
+.case.a1 { grid-column: span 4; background: var(--blue); color: var(--paper); }
+.case.a2 { grid-column: span 2; background: var(--lemon); }
+.case.a3 { grid-column: span 2; background: var(--paper); }
+.case.a4 { grid-column: span 2; background: var(--magenta); color: var(--paper); }
+.case.a5 { grid-column: span 2; background: var(--ink); color: var(--paper); }
+
+.case .meta { font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em; text-transform: uppercase; opacity: 0.85; }
+.case h3 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 800;
+  text-transform: uppercase;
+  font-size: clamp(28px, 3.4vw, 44px);
+  letter-spacing: -0.03em;
+  line-height: 0.92;
+  margin: 18px 0 0;
+}
+.case h3 a { color: inherit; border: none; }
+.case h3 a:hover { color: inherit; opacity: 0.7; }
+.case p { font-size: 14.5px; line-height: 1.45; margin: 14px 0 0; opacity: 0.9; }
+.case .shape {
+  position: absolute;
+  width: 120px; height: 120px;
+  right: -30px; bottom: -30px;
+  background: var(--ink);
+  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+}
+.case.a1 .shape { background: var(--lemon); }
+.case.a2 .shape { background: var(--blue); clip-path: polygon(0 0, 100% 0, 50% 100%); }
+.case.a3 .shape { background: var(--magenta); clip-path: polygon(0 0, 100% 50%, 0 100%); }
+.case.a4 .shape { background: var(--ink); clip-path: polygon(50% 0, 100% 100%, 0 100%); }
+.case.a5 .shape { background: var(--mint); }
+
+/* MANIFESTO */
+.man {
+  background: var(--magenta);
+  color: var(--paper);
+  padding: 90px 28px;
+  border-bottom: 4px solid var(--ink);
+  position: relative;
+  overflow: hidden;
+}
+.man::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--lemon);
+  clip-path: polygon(0 0, 28% 0, 8% 100%, 0 100%);
+  z-index: 0;
+}
+.man::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--ink);
+  clip-path: polygon(86% 0, 100% 0, 100% 100%, 70% 100%);
+  z-index: 0;
+}
+.man .wrap { position: relative; z-index: 1; max-width: 920px; margin: 0 auto; text-align: center; }
+.man .label { font-family: var(--mono); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; margin-bottom: 22px; }
+.man h2 {
+  font-family: var(--display);
+  font-weight: 800;
+  font-style: italic;
+  font-size: clamp(40px, 6vw, 82px);
+  letter-spacing: -0.03em;
+  line-height: 0.95;
+  margin: 0;
+  text-transform: uppercase;
+}
+.man h2 .ul { -webkit-text-stroke: 2px var(--paper); color: transparent; }
+.man h2 .hl { background: var(--paper); color: var(--magenta); padding: 0 14px; display: inline-block; }
+.man .signoff { margin-top: 36px; font-family: var(--mono); font-size: 12px; letter-spacing: 0.28em; text-transform: uppercase; }
+
+/* TICKER */
+.ticker {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  background: var(--ink);
+  color: var(--paper);
+  border-bottom: 4px solid var(--ink);
+}
+.ticker > div { padding: 36px 24px; border-right: 4px solid var(--bg); }
+.ticker > div:last-child { border-right: none; }
+.ticker .n {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 800;
+  font-size: 72px;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  color: var(--lemon);
+}
+.ticker .n sup { font-size: 24px; color: var(--magenta); vertical-align: super; font-style: normal; }
+.ticker .l { font-family: var(--mono); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--paper); margin-top: 10px; opacity: 0.7; }
+
+/* JOURNAL LIST */
+.journal { padding: 80px 28px; }
+.journal .wrap { max-width: 1200px; margin: 0 auto; }
+.journal .hd {
+  display: flex; justify-content: space-between; align-items: end; gap: 24px;
+  border-bottom: 4px solid var(--ink); padding-bottom: 18px; margin-bottom: 0;
+}
+.journal .hd h2 {
+  font-family: var(--display); font-style: italic; font-weight: 800;
+  font-size: clamp(36px, 5vw, 64px); letter-spacing: -0.03em; margin: 0; text-transform: uppercase;
+}
+.journal .row {
+  display: grid;
+  grid-template-columns: 110px 1fr auto;
+  gap: 24px;
+  align-items: center;
+  padding: 28px 0;
+  border-bottom: 2px solid var(--ink);
+  transition: background 0.14s ease, padding 0.14s ease;
+}
+.journal .row:hover { background: var(--lemon); padding-left: 18px; padding-right: 18px; }
+.journal .d { font-family: var(--mono); font-size: 11px; letter-spacing: 0.24em; color: var(--ink-mute); text-transform: uppercase; }
+.journal .t {
+  font-family: var(--display);
+  font-weight: 700;
+  font-style: italic;
+  font-size: clamp(22px, 2.6vw, 34px);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+.journal .t a { border: none; color: var(--ink); }
+.journal .ar { font-family: var(--display); font-style: italic; font-weight: 800; font-size: 36px; }
+
+/* PROSE */
+.prose {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 64px 28px 80px;
+  font-size: 18px;
+  line-height: 1.7;
+}
+.prose h1 { font-family: var(--display); font-weight: 800; font-style: italic; font-size: 56px; line-height: 0.95; margin: 0 0 28px; letter-spacing: -0.04em; text-transform: uppercase; }
+.prose h2 { font-family: var(--display); font-weight: 800; font-style: italic; font-size: 28px; text-transform: uppercase; margin-top: 1.8em; letter-spacing: -0.02em; }
+.prose h3 { font-family: var(--mono); font-size: 12px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--blue); margin-top: 1.6em; }
+.prose p { margin: 0 0 1.1em; }
+.prose blockquote { border-left: 5px solid var(--magenta); padding: 4px 0 4px 22px; margin: 1.4em 0; font-weight: 600; color: var(--ink); font-size: 22px; }
+.prose code { background: var(--lemon); padding: 2px 6px; font-family: var(--mono); font-size: 0.9em; }
+.prose pre { background: var(--ink); color: var(--paper); padding: 18px 22px; overflow-x: auto; border: 3px solid var(--ink); box-shadow: 6px 6px 0 var(--magenta); }
+.prose pre code { background: none; color: inherit; padding: 0; }
+.prose a { border-bottom: 3px solid var(--lemon); }
+
+/* FOOTER */
+.foot {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 80px 28px 30px;
+  border-top: 4px solid var(--magenta);
+}
+.foot .wrap { max-width: 1200px; margin: 0 auto; }
+.foot .big {
+  font-family: var(--display); font-weight: 800; font-style: italic;
+  font-size: clamp(72px, 16vw, 240px);
+  letter-spacing: -0.05em;
+  line-height: 0.86;
+  text-transform: uppercase;
+  color: var(--paper);
+  margin-bottom: 36px;
+}
+.foot .big .alt { -webkit-text-stroke: 3px var(--lemon); color: transparent; }
+.foot .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px;
+  padding-top: 36px;
+  border-top: 3px solid var(--paper);
+}
+.foot h4 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--lemon); margin: 0 0 14px; }
+.foot a { display: block; color: var(--paper); padding: 4px 0; }
+.foot a:hover { color: var(--lemon); }
+.foot .copy { grid-column: 1 / -1; padding-top: 28px; border-top: 1px solid #333; font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: #999; display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { margin: 32px auto; max-width: 1200px; padding: 0 28px; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  font-family: var(--display); font-weight: 700; font-style: italic;
+  padding: 10px 18px; border: 3px solid var(--ink); background: var(--paper); color: var(--ink);
+  box-shadow: 4px 4px 0 var(--ink); text-transform: uppercase; letter-spacing: 0.05em; font-size: 13px;
+}
+nav.pagination a:hover { background: var(--lemon); }
+.pagination-current span { background: var(--magenta); color: var(--paper); }
+.pagination-disabled span { background: var(--bg); color: var(--ink-mute); box-shadow: none; }
+
+/* RESPONSIVE */
+@media (max-width: 960px) {
+  .case-grid { grid-template-columns: repeat(2, 1fr); }
+  .case.a1, .case.a2, .case.a3, .case.a4, .case.a5 { grid-column: span 2; }
+  .ticker { grid-template-columns: 1fr 1fr; }
+  .ticker > div:nth-child(2n) { border-right: none; }
+  .foot .grid { grid-template-columns: 1fr 1fr; }
+  .work .hd { grid-template-columns: 1fr; }
+}
+@media (max-width: 620px) {
+  .bar { grid-template-columns: 1fr 1fr; padding: 12px 18px; }
+  .bar .mid { display: none; }
+  .cut { padding: 36px 18px 56px; }
+  .journal .row { grid-template-columns: 1fr; gap: 6px; }
+  .journal .ar { display: none; }
+  .foot .grid { grid-template-columns: 1fr; }
+  .foot .copy { flex-direction: column; gap: 8px; }
+}

--- a/examples/prism-cut/static/favicon.svg
+++ b/examples/prism-cut/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/prism-cut/templates/404.html
+++ b/examples/prism-cut/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &mdash; CUT WRONG.</h1>
+  <p>This route did not survive the latest pass. Either we removed it, or you reached for a shape that was never on the plate.</p>
+  <p><a href="{{ base_url }}/">&larr; back to the front page</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/prism-cut/templates/footer.html
+++ b/examples/prism-cut/templates/footer.html
@@ -1,0 +1,39 @@
+  <footer class="foot">
+    <div class="wrap">
+      <div class="big">PRISM<br><span class="alt">CUT.</span></div>
+      <div class="grid">
+        <div>
+          <h4>Studio</h4>
+          <a href="{{ base_url }}/about/">About the practice</a>
+          <a href="{{ base_url }}/tags/">Selected work</a>
+          <a href="#">Press &amp; awards</a>
+        </div>
+        <div>
+          <h4>Services</h4>
+          <a href="#">Brand identity</a>
+          <a href="#">Product launch</a>
+          <a href="#">Motion &amp; direction</a>
+        </div>
+        <div>
+          <h4>Brief</h4>
+          <a href="#">brief@prism.cut</a>
+          <a href="#">Open calls (Q2)</a>
+          <a href="#">Internships</a>
+        </div>
+        <div>
+          <h4>Elsewhere</h4>
+          <a href="#">Instagram</a>
+          <a href="#">Are.na channel</a>
+          <a href="#">Newsletter (~monthly)</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} PRISM CUT &mdash; Seoul / NY</span>
+          <span>Compiled with Hwaro &middot; sharper next year</span>
+        </div>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/prism-cut/templates/header.html
+++ b/examples/prism-cut/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,400;0,600;0,800;1,800&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="bar">
+    <a href="{{ base_url }}/">// home</a>
+    <span class="mid"><b>PRISM CUT</b> &mdash; design / motion / launch</span>
+    <span class="right">
+      <a href="{{ base_url }}/about/">studio</a>
+      <a href="{{ base_url }}/tags/">work</a>
+      <a href="#brief">brief us &rarr;</a>
+    </span>
+  </header>

--- a/examples/prism-cut/templates/index.html
+++ b/examples/prism-cut/templates/index.html
@@ -1,0 +1,119 @@
+{% include "header.html" %}
+
+<section class="cut">
+  <div class="wedges" aria-hidden="true">
+    <div class="wedge w1"></div>
+    <div class="wedge w2"></div>
+    <div class="wedge w3"></div>
+    <div class="wedge w4"></div>
+    <div class="wedge w5"></div>
+  </div>
+  <div class="copy">
+    <span class="kicker">// design + motion + launch &mdash; est. 2019 &middot; SE&middot;NY</span>
+    <h1>
+      We cut<br>
+      <span class="l2">brands into</span><br>
+      <span class="l3">sharp shapes.</span>
+    </h1>
+    <p class="lede">PRISM CUT is a small studio that takes ambitious product and brand launches from the napkin to the press release &mdash; in straight lines, with no compromise on shape.</p>
+    <div class="cta">
+      <a class="btn magenta" href="#brief">Start a launch <span class="ar">&rarr;</span></a>
+      <a class="btn lemon" href="#work">See the work <span class="ar">&rarr;</span></a>
+      <a class="btn" href="{{ base_url }}/about/">Meet the studio <span class="ar">&rarr;</span></a>
+    </div>
+  </div>
+</section>
+
+<div class="strip" aria-hidden="true">
+  <div class="track">
+    <span>SHARPER</span><span class="dot"></span><span class="alt">FASTER</span><span class="dot"></span><span>LOUDER</span><span class="dot"></span><span class="alt">CUT IT CLEAN</span><span class="dot"></span>
+    <span>SHARPER</span><span class="dot"></span><span class="alt">FASTER</span><span class="dot"></span><span>LOUDER</span><span class="dot"></span><span class="alt">CUT IT CLEAN</span><span class="dot"></span>
+  </div>
+</div>
+
+<section class="work" id="work">
+  <div class="wrap">
+    <div class="hd">
+      <h2>Selected work &mdash; <b>cut</b> {{ current_year }}</h2>
+      <div class="index">14 / 24 plates &middot; brand &middot; motion &middot; launch</div>
+    </div>
+    <div class="case-grid">
+      <article class="case a1">
+        <div class="shape" aria-hidden="true"></div>
+        <div class="meta">/ Launch &middot; Series B</div>
+        <h3><a href="#">Helios &mdash;<br>a clean-energy<br>brand reset.</a></h3>
+        <p>From mood-board to the first ten OOH placements in Manhattan and Daegu &mdash; ten weeks, twenty deliverables, zero apologies.</p>
+      </article>
+      <article class="case a2">
+        <div class="shape" aria-hidden="true"></div>
+        <div class="meta">/ Identity</div>
+        <h3><a href="#">Cobalt&nbsp;Press.</a></h3>
+        <p>A music label that wanted a logotype loud enough to fit on a 12-inch sleeve and quiet enough to read at 16px.</p>
+      </article>
+      <article class="case a3">
+        <div class="shape" aria-hidden="true"></div>
+        <div class="meta">/ Motion</div>
+        <h3><a href="#">Persimmon OS&nbsp;&mdash; launch&nbsp;film.</a></h3>
+        <p>A 38-second hero film for a category-creating operating system. Cut to the rhythm of the keystroke.</p>
+      </article>
+      <article class="case a4">
+        <div class="shape" aria-hidden="true"></div>
+        <div class="meta">/ Product</div>
+        <h3><a href="#">Anyhour &mdash; the calendar that refuses to flinch.</a></h3>
+        <p>Design system, marketing site, launch deck. Shipped on the day we said we would.</p>
+      </article>
+      <article class="case a5">
+        <div class="shape" aria-hidden="true"></div>
+        <div class="meta">/ Live event</div>
+        <h3><a href="#">Cut/Festival 02.</a></h3>
+        <p>Two days, six rooms, one wordmark.<br>A design conference we built and ran ourselves.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="man" id="brief">
+  <div class="wrap">
+    <div class="label">// THE PRACTICE &middot; ONE PAGE, FOUR LINES</div>
+    <h2>
+      WE TAKE <span class="hl">SIX BRIEFS</span> A YEAR.<br>
+      WE CUT THEM <span class="ul">CLEAN.</span><br>
+      WE SHIP <span class="hl">ON THE DATE</span> WE SAID.<br>
+      WE DO NOT <span class="ul">CHASE</span> AWARDS.
+    </h2>
+    <div class="signoff">&mdash; sora &middot; jin &middot; oliver &middot; founders &middot; signed off</div>
+  </div>
+</section>
+
+<section class="ticker" aria-label="Studio numbers">
+  <div><div class="n">06<sup>/yr</sup></div><div class="l">Briefs accepted</div></div>
+  <div><div class="n">14<sup>wk</sup></div><div class="l">Median launch cycle</div></div>
+  <div><div class="n">98%</div><div class="l">Shipped on stated date</div></div>
+  <div><div class="n">02</div><div class="l">Cities / Seoul + NY</div></div>
+</section>
+
+<section class="journal">
+  <div class="wrap">
+    <div class="hd">
+      <h2>From the studio.</h2>
+      <a class="btn lemon" href="{{ base_url }}/tags/">All entries <span class="ar">&rarr;</span></a>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} &middot; 04</div>
+      <div class="t"><a href="#">CUTTING A LAUNCH IN UNDER 90 DAYS &mdash; THE COBALT PRESS TIMELINE</a></div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} &middot; 02</div>
+      <div class="t"><a href="#">WHY WE STILL HANDLE THE TYPE OURSELVES</a></div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">2025 &middot; 11</div>
+      <div class="t"><a href="#">FIELD NOTES &mdash; CUT/FESTIVAL 02 IN ONE PAGE</a></div>
+      <div class="ar">&rarr;</div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/prism-cut/templates/page.html
+++ b/examples/prism-cut/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/prism-cut/templates/section.html
+++ b/examples/prism-cut/templates/section.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<section class="journal">
+  <div class="wrap">
+    <div class="hd">
+      {% if page.title is present %}<h2>{{ page.title | e | upper }}</h2>{% endif %}
+    </div>
+    {{ content | safe }}
+    {% for post in section.pages %}
+    <div class="row">
+      <div class="d">{{ post.date | date(format="%Y &middot; %m") | safe }}</div>
+      <div class="t"><a href="{{ post.url }}">{{ post.title | e | upper }}</a></div>
+      <div class="ar">&rarr;</div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/prism-cut/templates/shortcodes/alert.html
+++ b/examples/prism-cut/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/prism-cut/templates/taxonomy.html
+++ b/examples/prism-cut/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>An index of subjects across the studio archive.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/prism-cut/templates/taxonomy_term.html
+++ b/examples/prism-cut/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>Entries cut to this subject.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -233,6 +233,13 @@
     "minimal",
     "playfair"
   ],
+  "antiform": [
+    "landing",
+    "light",
+    "editorial",
+    "brutalist",
+    "swiss"
+  ],
   "antimatter": [
     "dark",
     "blog",
@@ -961,6 +968,12 @@
     "dark",
     "docs",
     "disaster-recovery"
+  ],
+  "bunker-deck": [
+    "landing",
+    "dark",
+    "industrial",
+    "stencil"
   ],
   "bureau": [
     "light",
@@ -3541,6 +3554,13 @@
     "permanent",
     "unna"
   ],
+  "harvest-moon": [
+    "landing",
+    "light",
+    "fashion",
+    "editorial",
+    "fraunces"
+  ],
   "haute-couture": [
     "elegant",
     "fashion",
@@ -5573,6 +5593,13 @@
     "spacious",
     "garamond"
   ],
+  "null-protocol": [
+    "landing",
+    "dark",
+    "terminal",
+    "cyberpunk",
+    "mono"
+  ],
   "null-result": [
     "paper",
     "light",
@@ -6320,6 +6347,13 @@
     "podcast",
     "vibrant",
     "creative"
+  ],
+  "prism-cut": [
+    "landing",
+    "light",
+    "bold",
+    "neo-brutalist",
+    "geometric"
   ],
   "prism-docs": [
     "docs",


### PR DESCRIPTION
## Summary

Five new landing example sites, each a distinct high-quality aesthetic — no generic SaaS templates, no shared CSS:

- **antiform** — Swiss brutalist editorial (light, razor red, vertical rails, document-as-landing)
- **bunker-deck** — Industrial control plane (riveted steel frame, Oswald stencil, hazard stripes, directives table)
- **harvest-moon** — Slow-fashion editorial (cream + ochre + persimmon, Fraunces italic, drift marquee, moon ornament)
- **null-protocol** — Terminal / leaked-document for a zero-trust runtime (phosphor on black, ASCII banner, log table, blinking caret)
- **prism-cut** — Neo-brutalist clip-path geometry (cobalt/magenta/lemon clashing wedges, hard-shadow buttons, italic caps)

Each site ships with:
- Full template set: `index`, `page`, `section`, `taxonomy`, `taxonomy_term`, `404`, header/footer
- Content: `index.md` + `about.md`
- Extracted CSS in `static/css/style.css`
- Tag entry in `tags.json` (inserted alphabetically)

## Test plan

- [x] `hwaro doctor --fix` passes for each site
- [x] `hwaro build` succeeds for each site
- [x] `tags.json` validates (`jq` parses; new keys present)
- [x] Verified no `linear-gradient`/`radial-gradient`/`conic-gradient` and no emoji characters across the five sites (per repo conventions)
- [ ] Spot-check screenshots after CI deploy