### PR TITLE
Add five bold editorial-aesthetic blog examples

### DIFF
--- a/examples/anti-pattern/config.toml
+++ b/examples/anti-pattern/config.toml
@@ -1,0 +1,193 @@
+title = "Anti Pattern"
+description = "An anti-design blog. Mismatched fonts on purpose, broken grid on purpose, sentences that overlap with the furniture. We are sorry, and we are not."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 20
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/anti-pattern/content/about.md
+++ b/examples/anti-pattern/content/about.md
@@ -1,0 +1,14 @@
++++
+title = "About this mess"
+description = "What we are doing here, what we are not, and why we will not apologize past this paragraph."
++++
+
+## We Are Anti-Design, Not Bad Design.
+
+These are different things, and the difference matters. **Bad design** is the result of not knowing the rules. **Anti-design** is the result of knowing the rules, internalizing them so thoroughly that they have become reflexes, and then deliberately and joyfully breaking them — not at random, but with purpose, in the places where the rules have hardened into a kind of unconscious tyranny.
+
+This blog has chosen, for the year 2026, to break the rule of **grid alignment**. Everything you see is laid out on a grid that wanders. Columns shift. Paragraphs lean. The header is not where you expected. The footer disagrees with the header. The body copy is set in a face that argues with the headlines. A small reader of design history will recognize the lineage: Dada, the Bauhaus's irrational hour, David Carson's *Ray Gun*, Stefan Sagmeister's hand-drawn typography, Ed Fella's gloriously broken posters.
+
+We are not the first to do this. We are doing it anyway, because the design language of the contemporary web has converged on a kind of polite uniformity that we find slightly suffocating. Every blog looks like every other blog. Every blog wants to be readable on phones. Every blog has decided that the user is in a hurry. **We do not want to be in a hurry.** We want to be looked at. We want, occasionally, to be slightly confused.
+
+If this is not the kind of blog you want to read, that is entirely fair. There are many excellent blogs that are not this kind of blog. Go read those, with our blessing. If, on the other hand, you want to read a piece of writing that has, in its layout, made an argument about what reading should sometimes feel like — stay. Read carefully. The grid will not help you. The grid is not on your side this time.

--- a/examples/anti-pattern/content/index.md
+++ b/examples/anti-pattern/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Anti Pattern"
+description = "A blog that has, on principle, abandoned its grid."
++++
+
+Contents below.

--- a/examples/anti-pattern/content/posts/_index.md
+++ b/examples/anti-pattern/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Everything, In No Particular Order"
+description = "All posts. Ordered by date, but not by importance."
+sort_by = "date"
+paginate = 10
+template = "section"
+generate_feeds = true
++++
+
+All posts. They are sorted by date because that is the only sort the software was willing to give us without further argument.

--- a/examples/anti-pattern/content/posts/in-praise-of-the-broken-grid.md
+++ b/examples/anti-pattern/content/posts/in-praise-of-the-broken-grid.md
@@ -1,0 +1,41 @@
++++
+title = "In Praise Of The Broken Grid"
+date = "2026-05-21"
+description = "Why the layout of this post is wrong on purpose, and why being wrong on purpose is sometimes the only honest thing left to do."
+tags = ["design", "anti-design", "manifesto"]
+categories = ["essay"]
+[extra]
+authors = ["A. Fellini"]
++++
+
+I have, in my career as a designer, set perhaps eleven thousand pages on a grid. The grid has been my friend. The grid has saved my work from chaos at moments when I was too tired to resist chaos. **The grid has earned my respect.** This post is not against the grid. This post is against the idea that the grid is the *only* available answer to the problem of laying out a page.
+
+<!-- more -->
+
+## A Confession
+
+For about fifteen years, I designed magazines. The magazines were good. The work was solid. The grid was a twelve-column with a 5-unit baseline, and every spread I produced began with a piece of tracing paper laid over the grid and a series of pencil sketches that obeyed the grid even when I was not yet sure what the spread was going to be about. The grid was, for me, a kind of secular monastery — I entered it every morning, I worked inside its walls, and I left it at the end of the day with a feeling of accomplishment that had as much to do with the structure as with the work.
+
+And then, around the eleventh year, I noticed something. **Every spread I produced was beginning to look like every other spread I produced.** The differences were small. The differences were *legible only to me*. To a reader of the magazine, the spreads had become interchangeable, and the interchangeability was, I came to think, the cost of my fluency with the grid.
+
+## What Happened Next
+
+I stopped using the grid for the next issue. I told nobody. I designed every spread without a guide. I positioned things by eye, by feel, by the principle that the page should *register a decision* in every visible element rather than recede into infrastructure. The issue was the most controversial in the magazine's history. Half the staff hated it. Half the readers wrote in to say it was the best issue we had ever produced. **The half that hated it included the editor in chief.**
+
+The next issue, I went back to the grid. I had made my point. The point, I want to emphasize, was not that the grid was wrong. The point was that the grid was a *choice*, and that I had stopped, somewhere along the way, perceiving it as one.
+
+## On Anti-Design As A Practice
+
+What I am calling "anti-design" — and what this blog is, frankly, an instance of — is not a rejection of design. It is a particular kind of design that has, as its central commitment, **the visibility of the design decision**. A well-executed traditional layout is, in the best sense, *invisible*. The reader does not notice the design; the reader notices the content. An anti-design layout is the opposite: the layout is so visibly present that the reader cannot help but notice it, cannot help but ask why this paragraph is where it is, cannot help but be aware that someone made every position on the page.
+
+This is not, in all contexts, what you want. There are kinds of writing that benefit from invisible design. Long-form journalism, novels, technical documentation — these are forms in which the design should disappear, and the work to disappear is some of the most skilled work that designers do. I am not arguing against that work. I am arguing that there is a *parallel tradition* in which the design does not disappear, and the design's presence is part of the meaning, and this parallel tradition is currently in retreat on the web.
+
+> A grid is a contract. The reader assumes that aligned elements are related. The reader assumes that the heading three pixels above the paragraph is the heading *of* that paragraph. A page that breaks the grid breaks the contract — and the broken contract is, when handled with care, a piece of writing of its own.
+
+## The Cost
+
+Anti-design is **expensive**. It costs the designer more time. It costs the reader more attention. It costs the project more controversy. It does not, in most commercial settings, produce better results. I am not recommending it as a default. I am recommending it as a *posture* — a stance the designer takes, perhaps once a year, on a project where the writing can bear the weight of the layout.
+
+The writing has to be good enough. This is the iron rule. **A broken grid cannot rescue weak prose.** It can amplify the prose that is already strong. It can give the reader a reason to slow down and reread. It can produce, in the best case, the kind of page that becomes the page someone shows their friend years later, saying "look at this."
+
+I am hoping this is one of those pages. I am aware that it is, statistically, not going to be. The hope is the part of the practice that matters. The grid will be there tomorrow. Today, the grid is on holiday.

--- a/examples/anti-pattern/content/posts/notes-from-an-ugly-poster.md
+++ b/examples/anti-pattern/content/posts/notes-from-an-ugly-poster.md
@@ -1,0 +1,40 @@
++++
+title = "Notes From An Ugly Poster"
+date = "2026-04-02"
+description = "I made an ugly poster on purpose, and three people asked me to design their wedding invitation."
+tags = ["practice", "anti-design", "fragment"]
+categories = ["fragment"]
+[extra]
+authors = ["L. Brikson"]
++++
+
+I made a poster, last fall, for a poetry reading in a basement in a city where I no longer live. The poster was, by every conventional metric, **ugly**. The type was set in five faces. The grid was, in the kindest interpretation, "absent." The colors were chosen by leaving a tab of *coupon ads* open in another window and stealing the worst of them. The poster was, in short, an act of small typographic violence.
+
+<!-- more -->
+
+I made fifty copies. I put them up on poles in the neighborhood where the reading was happening. I expected nothing. I expected, at most, that the people who already knew about the reading would chuckle at the poster and that the poster would die a peaceful death in the second wave of layoffs at the local advertising department.
+
+Instead, **three people asked me to design their wedding invitations.**
+
+## What I Think Happened
+
+I think what happened was that the poster was the only thing on the pole that was *trying anything*. The other posters were tasteful. The other posters had been designed by professionals using sensible faces on sensible grids in sensible colors. The other posters were *invisible*, because they had all colluded on the visual language of "small-business-flyer," and the eye had stopped registering them as discrete objects.
+
+My poster was none of those things. My poster was a *piece of garbage*. The piece of garbage was, however, *garbage with a personality*, and the personality registered in a way that the well-mannered posters did not.
+
+This is, I want to suggest, a thing worth knowing about the contemporary visual environment. We are so saturated with competent design that competent design has become a kind of camouflage. **The page that wants to be looked at, in 2026, has to be willing to be slightly disliked.**
+
+## The Wedding Invitations
+
+I did not, in the end, take any of the three commissions. I told all three couples that they did not, in fact, want their wedding invitations to look like the poetry-reading poster. I told them that what they had liked about the poster was its *unsuitability* for the context — and that a wedding invitation is, by the very nature of the event it announces, a context in which unsuitability would not be charming but worrying.
+
+Two of them accepted this. One of them insisted, and I designed her an invitation that was as ugly as the poster, and I have not heard from her since the wedding. I am taking this as **a sign that the marriage is going well**, on the principle that I would otherwise have heard.
+
+## A Short List Of What I Took Away
+
+1. The page that takes a risk will sometimes be loved by the wrong people for the wrong reasons. *Accept this.* Do not write to the wrong people. Write to the people the page was for.
+2. The page that takes a risk will be remembered, even by the people who hate it. *This is the prize.*
+3. The page that takes a risk should not be the only page you make in a given year. *The risk is the exception, not the practice.*
+4. The page that takes a risk should not be a wedding invitation. Trust me on this. **Trust me on this.**
+
+The poster is still up, in a few places. I do not visit the city anymore. I am told, by friends, that two of the posters have survived a year, faded, with bits of tape over the corners. I find this a reasonable level of immortality for an ugly poster. I would not have asked for more.

--- a/examples/anti-pattern/content/posts/six-fonts-on-a-page.md
+++ b/examples/anti-pattern/content/posts/six-fonts-on-a-page.md
@@ -1,0 +1,51 @@
++++
+title = "Six Fonts On A Page, And Why It Worked"
+date = "2026-05-09"
+description = "Against the dogma that a single page should be set in no more than two faces. A defense of typographic noise."
+tags = ["typography", "anti-design"]
+categories = ["essay"]
+[extra]
+authors = ["L. Brikson"]
++++
+
+There is a piece of conventional wisdom in design that I would like to dismantle here. The wisdom goes: **a single page should be set in no more than two faces** — one for display, one for body — and any deviation from this rule is the sign of an amateur.
+
+<!-- more -->
+
+I have come, over time, to consider this wisdom a piece of well-meaning conformism. The rule is not wrong. The rule is *correct for most purposes*, and most pages benefit from following it. The rule is also a kind of **safety net**, and like all safety nets, it has the side effect of preventing certain kinds of fall.
+
+## Where The Rule Came From
+
+The "two faces" rule is, in its current form, a product of the early-twentieth-century modernist project — Jan Tschichold, the Bauhaus, the New Typography. The argument, in that period, was a *political* one as much as an aesthetic one: the Victorian printer, with his fifty-odd faces in fifty-odd sizes on every broadside, was producing work that was visually chaotic and, in the modernist's view, *intellectually dishonest*. The fifty faces were trying to compensate for a weakness in the message. Two faces, set on a clean grid, with hierarchy expressed through size and weight rather than face variety, were proposed as the more *honest* alternative.
+
+This was, in 1928, a radical proposition. It is no longer 1928. The proposition has become an orthodoxy. The orthodoxy is, in many cases, still correct; it remains true that a page with too many faces can become a piece of visual noise. But it is also true that a *deliberately constructed* page with six faces, each doing a particular job, can produce a kind of polyphony that the two-face page cannot.
+
+## What The Six Faces Can Do
+
+Imagine a single article — a long-form essay, say, of perhaps four thousand words — laid out as follows.
+
+**Face one** is the body text. It is a quiet, well-tuned serif, set on a generous leading. This is the workhorse.
+
+**Face two** is the display headlines. It is a dramatic, opinionated face — a wedge serif, a slab, an inktrap-laden contemporary — that announces "an essay is beginning."
+
+**Face three** is for the **pull quotes**. It is *different from the headlines* and *different from the body*. It might be a humanist sans, or a script, or something almost handwritten. Its job is to register that the pull quote is a kind of *voice within a voice* — the same author, but recontextualized.
+
+**Face four** is for marginal notes, captions, and small annotations. A mono-spaced or a heavily-tracked sans, set small. This is the "scholar's voice" — the apparatus around the main text.
+
+**Face five** is for the section dividers — small ornamental ligatures, decorative initials, or display capitals that punctuate the rhythm of the piece. This is **the typographic equivalent of clearing your throat** between paragraphs.
+
+**Face six** is for the pull-out callouts, the cards, the editorial inserts — the elements that are *of* the piece but not *in* its line. A condensed sans, perhaps, or a heavy slab.
+
+Six faces. Each doing a particular job. None of them in conflict, because each has been assigned to a *level of the document's hierarchy* that no other face is occupying. The page is not noisy; the page is **layered**.
+
+## On The Risk
+
+I will not pretend this is easy. The risk of typographic incoherence is real, and the failures are spectacular and embarrassing. I have done it badly. I have done it badly *recently*. The technique requires that the designer hold all six voices in their head simultaneously and adjust each one in relation to the others — and this is hard, and it produces work that is harder to revise than a two-face page, and most designers should not do it most of the time.
+
+But "most designers should not do it most of the time" is a different claim from "no designer should ever do it." The second claim, which the two-face orthodoxy has *almost* become, is a piece of professional cowardice. The first claim is reasonable. The second is not.
+
+## A Note On This Page
+
+This post is set in **three faces**: a serif for the body, a sans for the metadata, and a slightly silly display face for the headlines. I did not push it to six because I am writing this on a Friday afternoon and the discipline required for six is the discipline of a fresh morning. **Three is what I had in me today.** The post is therefore a small example of the very orthodoxy I have been arguing against. I am, in this sense, the author and the counterexample to my own thesis, which is one of the privileges of writing on a blog and one of the embarrassments of it.
+
+The point stands. The faces are tools. The "no more than two" rule is a piece of conservatism that was once radical. The radicalism has worn off. The rule is now a habit. Habits, when they harden, are the natural enemies of design, and design is worth defending.

--- a/examples/anti-pattern/content/posts/the-bauhaus-was-loud.md
+++ b/examples/anti-pattern/content/posts/the-bauhaus-was-loud.md
@@ -1,0 +1,41 @@
++++
+title = "The Bauhaus Was Loud, And We Have Forgotten This"
+date = "2026-04-24"
+description = "A reminder that the most influential design school of the twentieth century was experimental, contradictory, and committed to noise."
+tags = ["history", "design", "bauhaus"]
+categories = ["essay"]
+[extra]
+authors = ["A. Fellini"]
++++
+
+The Bauhaus we have inherited — the Bauhaus of corporate identity manuals, of furniture catalogs, of the **muted color palette** and the *single sans-serif* and the photographic neutrality — is a domesticated Bauhaus. It is the Bauhaus as filtered through forty years of postwar Swiss design, and then again through thirty years of American corporate communication, and then again through fifteen years of Silicon Valley product design. By the time the Bauhaus reaches us, it is unrecognizable to itself.
+
+<!-- more -->
+
+The actual Bauhaus, the school that operated in Weimar and Dessau and finally Berlin from 1919 to 1933, was **loud**. It was loud typographically, loud chromatically, loud philosophically. The school's faculty argued in public, in print, on the school's walls, and in the school's parties — and the parties were famous for being themed, costumed, and louder than any party that any contemporary design school has thrown in living memory.
+
+## The Actual Color Palette
+
+If you look at the actual student work from the Bauhaus's printing workshop — and if you have not, the *Bauhaus Archive* in Berlin has digitized most of it — you will find that the so-called *"Bauhaus palette"* of primary red, primary blue, primary yellow, with black and white, is *one* palette in use at the school, and not the dominant one. There are works in lavender. There are works in peach. There are works in seventeen kinds of gray. There are works in **green**, which the canonical narrative has insisted the Bauhaus did not use, and which the actual archives contain in considerable quantity.
+
+The reduction of the Bauhaus to red-blue-yellow-black-white is a *postwar simplification*, made by people who needed a portable summary for their design textbooks. The reduction is convenient. The reduction is also a piece of misinformation. The Bauhaus was a place of *chromatic experimentation*, and the canonical palette is the end product of an experiment, not the experiment itself.
+
+## On The Sans-Serif
+
+Similarly, the idea that "the Bauhaus stood for the sans-serif" is *technically* true and *practically* misleading. The school did promote sans-serif typography — Herbert Bayer's Universal alphabet is the most famous example — but the school also produced extensive work in script, in display faces of every kind, in **lettering that was hand-drawn for the single occasion of a single poster**.
+
+If you walk into a museum of Bauhaus posters, you will be struck by how much *handwork* there is. Letters are drawn. Curves are inconsistent. Letterspacing is variable. Words are sometimes set on a baseline that is not horizontal. The "discipline" we associate with the school is real, but it is the discipline of *each project pursuing its own coherence* rather than the discipline of every project obeying a house style.
+
+## What We Have Lost
+
+What we have lost, in our domesticated reception of the Bauhaus, is the *experimental ethic*. The school was a school. The students were students. The students were encouraged to take risks, to produce failures, to make work that was confrontational, that was unfinished, that was *wrong* in interesting ways. The school's most celebrated graduates produced careers in which they continued to take risks — but the curriculum that has been distilled from their work, and that has been taught in design programs for the last sixty years, has *removed the risk* and kept only the finished objects.
+
+This is, I want to argue, what *every canonical art movement* loses in transmission. The Impressionists were considered radical and ugly in their time. The Cubists were considered fraudulent. The Beat Generation was considered juvenile. The transmission flattens. The transmission removes the *living controversy* and replaces it with a museum.
+
+> The most loyal student of the Bauhaus would not study the Bauhaus's finished work. The most loyal student would adopt the Bauhaus's *method*, which was: make work that argues with the work you have just made, and that you will argue with again tomorrow.
+
+## A Modest Recommendation
+
+If you have a design textbook on your shelf that summarizes the Bauhaus in two paragraphs and three swatches, **donate it**. Replace it with a single primary source — a facsimile of a Bauhaus poster, a copy of *Bauhaus Magazin*, the published correspondence of any of the school's faculty. You will encounter a movement that was much weirder, much louder, much more uncertain of itself than the textbooks have told you. You will encounter a movement that has been *made comfortable* for you, and that, in its original form, was not comfortable at all.
+
+The Bauhaus was loud. The Bauhaus was, in places, ugly. The Bauhaus was, on Friday nights, in costume. The Bauhaus deserves a louder commemoration than the muted one we have given it.

--- a/examples/anti-pattern/static/css/style.css
+++ b/examples/anti-pattern/static/css/style.css
@@ -1,0 +1,742 @@
+:root {
+  --bg: #f3eee3;
+  --ink: #100c08;
+  --ink-soft: #3a342a;
+  --red: #ff3324;
+  --blue: #1320ff;
+  --lime: #c8ff1f;
+  --pink: #ff77c8;
+  --mustard: #f0c000;
+  --paper-2: #e8e0cb;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Fraunces", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.55;
+  overflow-x: hidden;
+}
+
+::selection { background: var(--lime); color: var(--ink); }
+
+a { color: var(--blue); text-decoration: underline; text-decoration-thickness: 1.5px; text-underline-offset: 3px; }
+a:hover { background: var(--blue); color: var(--bg); text-decoration: none; }
+
+/* ---------------- WRAPPER ---------------- */
+
+.ap {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 28px 60px;
+  position: relative;
+}
+
+/* ---------------- HEADER ---------------- */
+
+.ap-header { padding: 22px 0 40px; position: relative; }
+
+.ap-marquee {
+  background: var(--ink);
+  color: var(--lime);
+  padding: 10px 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin: -22px -28px 30px;
+  border-bottom: 4px solid var(--red);
+}
+.ap-marquee span {
+  display: inline-block;
+  animation: ap-scroll 28s linear infinite;
+  padding-left: 100%;
+}
+@keyframes ap-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
+
+.ap-title {
+  display: block;
+  text-decoration: none;
+  color: var(--ink);
+  font-family: "Bungee", "Anton", sans-serif;
+  font-size: clamp(54px, 12vw, 168px);
+  line-height: 0.82;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+  margin: 0 0 8px;
+  position: relative;
+  padding: 0;
+}
+.ap-title:hover { background: transparent; color: var(--ink); }
+.ap-title-a {
+  display: inline-block;
+  color: var(--ink);
+  transform: rotate(-2deg);
+  margin-right: -8px;
+}
+.ap-title-b {
+  display: inline-block;
+  font-family: "Fraunces", serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 0.9em;
+  color: var(--red);
+  transform: rotate(2deg) translateY(8px);
+  letter-spacing: -0.02em;
+  text-transform: lowercase;
+  margin-left: 8px;
+}
+.ap-title-period {
+  color: var(--blue);
+  font-size: 1.1em;
+  display: inline-block;
+}
+
+.ap-subtitle-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 12px 0 28px;
+  flex-wrap: wrap;
+}
+.ap-subtitle-tag {
+  background: var(--mustard);
+  color: var(--ink);
+  padding: 4px 10px;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border: 2px solid var(--ink);
+  transform: rotate(-2deg);
+}
+.ap-subtitle-text {
+  font-family: "Caveat", cursive;
+  font-size: 24px;
+  color: var(--ink-soft);
+  font-weight: 700;
+}
+
+.ap-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+  padding: 18px 0;
+  border-top: 4px solid var(--ink);
+  border-bottom: 4px solid var(--ink);
+}
+.ap-nav a {
+  text-decoration: none;
+  padding: 4px 10px;
+  font-weight: 700;
+  border: 2px solid var(--ink);
+}
+.ap-nav-1 {
+  background: var(--lime);
+  color: var(--ink);
+  font-family: "Bungee", sans-serif;
+  font-size: 14px;
+  text-transform: uppercase;
+  transform: rotate(-2deg);
+}
+.ap-nav-2 {
+  background: var(--ink);
+  color: var(--bg);
+  font-family: "Anton", sans-serif;
+  font-size: 22px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transform: rotate(1.5deg);
+}
+.ap-nav-3 {
+  background: var(--pink);
+  color: var(--ink);
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-weight: 900;
+  font-size: 18px;
+  transform: rotate(-1deg);
+}
+.ap-nav-4 {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Caveat", cursive;
+  font-size: 22px;
+  transform: rotate(2deg);
+}
+.ap-nav-5 {
+  background: var(--blue);
+  color: var(--bg);
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  transform: rotate(-1.5deg);
+}
+.ap-nav a:hover {
+  transform: rotate(0) translateY(-3px);
+  background: var(--red);
+  color: var(--bg);
+  border-color: var(--red);
+}
+.ap-nav-sep {
+  font-family: "Space Mono", monospace;
+  font-size: 18px;
+  color: var(--ink);
+  font-weight: 700;
+}
+
+/* ---------------- HOME / HERO ---------------- */
+
+.ap-home { padding-top: 30px; }
+
+.ap-hero { position: relative; padding: 30px 0 50px; min-height: 200px; }
+
+.ap-hero-sticker {
+  position: absolute;
+  font-family: "Bungee", sans-serif;
+  font-size: 16px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  border: 3px solid var(--ink);
+  background: var(--bg);
+  z-index: 3;
+}
+.ap-hero-sticker-1 {
+  top: 0;
+  right: 60px;
+  background: var(--red);
+  color: var(--bg);
+  border-color: var(--red);
+  transform: rotate(8deg);
+  font-size: 22px;
+}
+.ap-hero-sticker-2 {
+  top: 60px;
+  right: 18px;
+  background: var(--lime);
+  color: var(--ink);
+  transform: rotate(-12deg);
+  font-size: 28px;
+  padding: 12px 16px;
+}
+.ap-hero-sticker-3 {
+  top: 30px;
+  left: -10px;
+  background: var(--mustard);
+  color: var(--ink);
+  font-family: "Caveat", cursive;
+  font-size: 22px;
+  text-transform: none;
+  letter-spacing: 0;
+  transform: rotate(-6deg);
+  padding: 6px 12px;
+}
+
+.ap-hero-headline {
+  font-size: clamp(48px, 10vw, 140px);
+  line-height: 0.92;
+  letter-spacing: -0.025em;
+  margin: 0 0 24px;
+  font-weight: 400;
+  max-width: 14ch;
+}
+.ap-hero-headline .hl-1, .hl-2, .hl-3, .hl-4, .hl-5, .hl-6 {
+  display: inline-block;
+  padding: 0 8px;
+  line-height: 0.95;
+  margin: 0 4px;
+}
+.hl-1 { font-family: "Bungee", sans-serif; background: var(--ink); color: var(--bg); transform: rotate(-2deg); }
+.hl-2 { font-family: "Fraunces", serif; font-style: italic; font-weight: 900; color: var(--red); transform: rotate(1deg); }
+.hl-3 { font-family: "Anton", sans-serif; text-transform: uppercase; color: var(--blue); transform: rotate(-1deg); }
+.hl-4 { font-family: "Caveat", cursive; font-weight: 700; color: var(--ink); background: var(--lime); transform: rotate(2deg); padding: 0 14px; }
+.hl-5 { font-family: "Syne", sans-serif; font-weight: 800; color: var(--ink); transform: rotate(-0.5deg); }
+.hl-6 { font-family: "Fraunces", serif; font-weight: 300; color: var(--ink); font-style: italic; transform: rotate(1.5deg); }
+
+.ap-hero-deck {
+  font-family: "Space Mono", monospace;
+  font-size: clamp(15px, 1.6vw, 18px);
+  line-height: 1.55;
+  max-width: 64ch;
+  margin: 0;
+  position: relative;
+  z-index: 2;
+}
+.deck-frag { display: inline; }
+.deck-a { font-family: "Bungee", sans-serif; color: var(--red); font-size: 0.9em; }
+.deck-b { font-family: "Fraunces", serif; font-style: italic; font-weight: 700; color: var(--blue); }
+.deck-c { font-family: "Caveat", cursive; font-size: 1.3em; }
+.deck-d { font-family: "Anton", sans-serif; text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink); }
+
+/* ---------------- ZIGZAG CARDS ---------------- */
+
+.ap-zigzag {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 26px;
+  padding: 40px 0;
+}
+.ap-card {
+  position: relative;
+  background: var(--bg);
+  border: 3px solid var(--ink);
+  padding: 24px 22px 50px;
+  box-shadow: 10px 10px 0 var(--ink);
+  min-height: 220px;
+}
+.ap-card-1 { grid-column: 1 / span 7; background: var(--lime); transform: rotate(-1.2deg); }
+.ap-card-2 { grid-column: 8 / span 5; background: var(--bg); transform: rotate(1.4deg); box-shadow: 10px 10px 0 var(--red); }
+.ap-card-3 { grid-column: 1 / span 4; background: var(--pink); transform: rotate(0.8deg); box-shadow: 10px 10px 0 var(--ink); margin-top: -20px; }
+.ap-card-4 { grid-column: 5 / span 5; background: var(--ink); color: var(--bg); transform: rotate(-0.5deg); box-shadow: 10px 10px 0 var(--mustard); margin-top: 30px; }
+.ap-card-5 { grid-column: 10 / span 3; background: var(--mustard); transform: rotate(-2deg); box-shadow: 10px 10px 0 var(--blue); }
+.ap-card-4 a { color: var(--lime); }
+.ap-card-4 .ap-card-cat, .ap-card-4 .ap-card-num, .ap-card-4 .ap-card-meta { color: var(--bg); }
+
+.ap-card-num {
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  color: var(--ink-soft);
+  margin-bottom: 4px;
+}
+.ap-card-cat {
+  font-family: "Bungee", sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+  color: var(--red);
+}
+.ap-card-title {
+  font-family: "Fraunces", serif;
+  font-size: clamp(22px, 2.6vw, 32px);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  margin: 0 0 12px;
+  font-weight: 900;
+}
+.ap-card-1 .ap-card-title, .ap-card-3 .ap-card-title {
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.01em;
+}
+.ap-card-5 .ap-card-title {
+  font-family: "Bungee", sans-serif;
+  font-size: clamp(18px, 2vw, 22px);
+  text-transform: uppercase;
+}
+.ap-card-title a { color: var(--ink); text-decoration: none; }
+.ap-card-title a:hover { background: var(--ink); color: var(--bg); }
+.ap-card-deck {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-size: 15.5px;
+  line-height: 1.4;
+  margin: 0 0 14px;
+}
+.ap-card-3 .ap-card-deck, .ap-card-5 .ap-card-deck { font-family: "Space Mono", monospace; font-style: normal; font-size: 14px; }
+.ap-card-meta {
+  display: flex;
+  gap: 14px;
+  font-family: "Space Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.ap-card-scribble {
+  position: absolute;
+  bottom: 14px;
+  right: 20px;
+  font-family: "Caveat", cursive;
+  font-size: 22px;
+  color: var(--ink);
+  transform: rotate(-4deg);
+}
+.ap-card-4 .ap-card-scribble { color: var(--lime); }
+.ap-card-1 .ap-card-scribble, .ap-card-3 .ap-card-scribble, .ap-card-5 .ap-card-scribble { color: var(--ink); }
+
+/* ---------------- QUOTE BLOCK ---------------- */
+
+.ap-quote {
+  margin: 60px auto;
+  max-width: 760px;
+  padding: 40px 30px;
+  background: var(--ink);
+  color: var(--bg);
+  border: 4px solid var(--ink);
+  position: relative;
+  transform: rotate(-0.6deg);
+  box-shadow: 14px 14px 0 var(--red);
+}
+.ap-quote-bracket {
+  position: absolute;
+  top: -36px;
+  left: 24px;
+  font-family: "Fraunces", serif;
+  font-size: 100px;
+  font-weight: 900;
+  color: var(--lime);
+  line-height: 1;
+}
+.ap-quote-text {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: clamp(22px, 3.2vw, 34px);
+  line-height: 1.25;
+  margin: 0 0 14px;
+}
+.ap-quote-author {
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mustard);
+}
+
+/* ---------------- POST / PAGE ---------------- */
+
+.ap-post {
+  position: relative;
+  padding: 40px 0 30px;
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.ap-post-strip {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 26px;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.ap-post-cat {
+  background: var(--red);
+  color: var(--bg);
+  padding: 4px 10px;
+  border: 2px solid var(--ink);
+  transform: rotate(-2deg);
+  font-family: "Bungee", sans-serif;
+}
+.ap-post-date { color: var(--ink-soft); }
+.ap-post-time { color: var(--blue); }
+
+.ap-post-title {
+  font-family: "Fraunces", serif;
+  font-weight: 900;
+  font-size: clamp(40px, 6.2vw, 80px);
+  line-height: 0.96;
+  letter-spacing: -0.025em;
+  margin: 0 0 22px;
+}
+.ap-post-deck {
+  font-family: "Caveat", cursive;
+  font-weight: 700;
+  font-size: clamp(24px, 2.8vw, 32px);
+  line-height: 1.25;
+  color: var(--ink-soft);
+  margin: 0 0 26px;
+  max-width: 64ch;
+}
+.ap-post-byline {
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  margin-bottom: 16px;
+}
+.byline-name {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--red);
+  letter-spacing: 0;
+}
+
+.ap-post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.ap-post-tag {
+  text-decoration: none;
+  font-family: "Bungee", sans-serif;
+  font-size: 11px;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border: 2px solid var(--ink);
+}
+.ap-post-tag-1 { background: var(--lime); color: var(--ink); transform: rotate(-2deg); }
+.ap-post-tag-2 { background: var(--pink); color: var(--ink); transform: rotate(2deg); }
+.ap-post-tag-3 { background: var(--mustard); color: var(--ink); transform: rotate(-1deg); }
+.ap-post-tag-4 { background: var(--blue); color: var(--bg); transform: rotate(1.5deg); }
+.ap-post-tag:hover { background: var(--ink); color: var(--bg); transform: rotate(0); }
+
+.ap-post-rule {
+  border-top: 4px solid var(--ink);
+  border-bottom: 4px dotted var(--ink);
+  height: 8px;
+  margin: 24px 0;
+}
+
+.ap-post-body {
+  font-family: "Fraunces", serif;
+  font-size: 19px;
+  line-height: 1.72;
+  max-width: 68ch;
+}
+.ap-post-body p { margin: 0 0 1.15em; }
+.ap-post-body p:first-of-type::first-letter {
+  float: left;
+  font-family: "Bungee", sans-serif;
+  font-size: 5.4em;
+  line-height: 0.85;
+  padding: 8px 14px 0 0;
+  color: var(--red);
+}
+.ap-post-body h2 {
+  font-family: "Anton", sans-serif;
+  font-size: clamp(28px, 3.6vw, 42px);
+  line-height: 1.05;
+  letter-spacing: 0.005em;
+  text-transform: uppercase;
+  margin: 1.8em 0 0.4em;
+  color: var(--blue);
+  font-weight: 400;
+  display: inline-block;
+  position: relative;
+  padding-right: 14px;
+}
+.ap-post-body h2::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 4px;
+  width: 100%;
+  height: 8px;
+  background: var(--lime);
+  z-index: -1;
+}
+.ap-post-body h3 {
+  font-family: "Bungee", sans-serif;
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin: 1.6em 0 0.4em;
+  color: var(--red);
+}
+.ap-post-body blockquote {
+  margin: 1.8em -20px;
+  padding: 20px 26px;
+  background: var(--ink);
+  color: var(--bg);
+  border: 0;
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1.18em;
+  line-height: 1.35;
+  transform: rotate(-0.5deg);
+  position: relative;
+}
+.ap-post-body blockquote::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border: 3px solid var(--red);
+  z-index: -1;
+  transform: rotate(1deg);
+}
+.ap-post-body code {
+  font-family: "Space Mono", monospace;
+  background: var(--lime);
+  border: 1.5px solid var(--ink);
+  padding: 0.05em 0.32em;
+  font-size: 0.9em;
+}
+.ap-post-body pre {
+  font-family: "Space Mono", monospace;
+  background: var(--ink);
+  color: var(--lime);
+  padding: 18px 22px;
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-x: auto;
+  border: 3px solid var(--ink);
+  box-shadow: 8px 8px 0 var(--red);
+  margin: 1.8em 0;
+}
+.ap-post-body pre code { background: transparent; color: inherit; border: 0; padding: 0; }
+.ap-post-body ul, .ap-post-body ol { padding-left: 1.4em; }
+.ap-post-body li { margin: 0.4em 0; }
+.ap-post-body li::marker { color: var(--red); font-weight: 700; font-family: "Bungee", sans-serif; }
+.ap-post-body strong { background: var(--mustard); padding: 0 4px; font-weight: 700; }
+.ap-post-body em { color: var(--blue); font-style: italic; font-weight: 500; }
+.ap-post-body a { color: var(--blue); text-decoration-color: var(--red); text-decoration-thickness: 2px; }
+.ap-post-body a:hover { background: var(--blue); color: var(--bg); }
+
+.ap-post-foot {
+  margin-top: 30px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.ap-post-foot-mark {
+  font-family: "Bungee", sans-serif;
+  font-size: 24px;
+  letter-spacing: 0.16em;
+  color: var(--red);
+  transform: rotate(-2deg);
+  border: 3px solid var(--red);
+  padding: 4px 12px;
+}
+.ap-post-back {
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  color: var(--ink);
+  border: 2px solid var(--ink);
+  background: var(--lime);
+  padding: 6px 12px;
+  transform: rotate(1.5deg);
+  display: inline-block;
+}
+.ap-post-back:hover { background: var(--ink); color: var(--lime); }
+
+/* ---------------- TAG PILE ---------------- */
+
+.ap-tag-pile {
+  list-style: none;
+  padding: 0;
+  margin: 30px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+.ap-tag-blob a {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+  text-decoration: none;
+  padding: 10px 16px;
+  border: 3px solid var(--ink);
+  font-weight: 700;
+}
+.ap-tag-blob-1 a { background: var(--lime); color: var(--ink); font-family: "Bungee", sans-serif; font-size: 14px; text-transform: uppercase; transform: rotate(-2deg); }
+.ap-tag-blob-2 a { background: var(--pink); color: var(--ink); font-family: "Fraunces", serif; font-style: italic; font-size: 18px; transform: rotate(1deg); }
+.ap-tag-blob-3 a { background: var(--mustard); color: var(--ink); font-family: "Anton", sans-serif; font-size: 20px; text-transform: uppercase; transform: rotate(-1deg); }
+.ap-tag-blob-4 a { background: var(--ink); color: var(--bg); font-family: "Space Mono", monospace; font-size: 13px; text-transform: lowercase; transform: rotate(1.5deg); }
+.ap-tag-blob-5 a { background: var(--bg); color: var(--ink); font-family: "Caveat", cursive; font-size: 22px; transform: rotate(-1.5deg); }
+.ap-tag-blob a:hover { background: var(--red); color: var(--bg); transform: rotate(0); }
+.ap-tag-count {
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  opacity: 0.65;
+}
+
+/* ---------------- 404 ---------------- */
+
+.four-oh-four .ap-hero { padding-top: 60px; min-height: 300px; }
+.four-oh-four .ap-hero-sticker-1 { font-size: 32px; }
+.four-oh-four .ap-hero-sticker-2 { font-size: 56px; }
+.four-oh-four .ap-post-back { display: inline-block; margin-top: 28px; }
+
+/* ---------------- FOOTER ---------------- */
+
+.ap-footer { margin-top: 70px; }
+.ap-foot-strip {
+  display: flex;
+  gap: 30px;
+  justify-content: space-between;
+  font-family: "Bungee", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  background: var(--ink);
+  color: var(--lime);
+  padding: 12px 20px;
+  border: 4px solid var(--ink);
+  flex-wrap: wrap;
+  margin: 0 -28px 24px;
+}
+.ap-foot-cols {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  padding: 24px 0;
+}
+.ap-foot-col {
+  padding: 18px 20px;
+  border: 3px solid var(--ink);
+}
+.ap-foot-a { background: var(--mustard); transform: rotate(-0.8deg); }
+.ap-foot-b { background: var(--pink); transform: rotate(0.6deg); }
+.ap-foot-c { background: var(--lime); transform: rotate(-0.4deg); }
+.ap-foot-col h4 {
+  font-family: "Bungee", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin: 0 0 8px;
+  color: var(--ink);
+}
+.ap-foot-col p {
+  font-family: "Fraunces", serif;
+  font-size: 15px;
+  line-height: 1.45;
+  margin: 0;
+}
+.ap-foot-col a { color: var(--ink); text-decoration-color: var(--red); }
+
+.ap-foot-mark {
+  display: flex;
+  gap: 16px;
+  align-items: baseline;
+  padding: 20px 0;
+  flex-wrap: wrap;
+  border-top: 4px solid var(--ink);
+}
+.ap-foot-c1 { font-family: "Fraunces", serif; font-size: 20px; color: var(--red); }
+.ap-foot-y { font-family: "Bungee", sans-serif; font-size: 18px; }
+.ap-foot-s { font-family: "Anton", sans-serif; font-size: 18px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--blue); }
+.ap-foot-h { font-family: "Space Mono", monospace; font-size: 12px; letter-spacing: 0.1em; color: var(--ink-soft); }
+
+/* ---------------- RESPONSIVE ---------------- */
+
+@media (max-width: 900px) {
+  .ap-zigzag { grid-template-columns: 1fr; gap: 24px; }
+  .ap-card-1, .ap-card-2, .ap-card-3, .ap-card-4, .ap-card-5 { grid-column: 1; margin-top: 0; }
+  .ap-foot-cols { grid-template-columns: 1fr; }
+  .ap-foot-strip { gap: 14px; font-size: 11px; }
+  .ap-hero-sticker-1, .ap-hero-sticker-2, .ap-hero-sticker-3 { transform: scale(0.85) rotate(var(--r, 0)); }
+  .ap-hero-headline { font-size: clamp(36px, 12vw, 80px); }
+}
+@media (max-width: 520px) {
+  .ap { padding: 0 14px 40px; }
+  .ap-marquee, .ap-foot-strip { margin-left: -14px; margin-right: -14px; }
+  .ap-nav { gap: 8px; padding: 12px 0; }
+  .ap-nav a { font-size: 13px !important; padding: 3px 8px; }
+}

--- a/examples/anti-pattern/templates/404.html
+++ b/examples/anti-pattern/templates/404.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<section class="ap-home four-oh-four">
+  <div class="ap-hero">
+    <div class="ap-hero-sticker ap-hero-sticker-1">oops</div>
+    <div class="ap-hero-sticker ap-hero-sticker-2">404</div>
+    <h1 class="ap-hero-headline">
+      <span class="hl-1">page</span>
+      <span class="hl-3">misaligned.</span>
+    </h1>
+    <p class="ap-hero-deck">It either does not exist, or it exists somewhere we have not bothered to look. Both are honest answers.</p>
+    <a class="ap-post-back" href="{{ base_url }}/">&larr; go home</a>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/anti-pattern/templates/footer.html
+++ b/examples/anti-pattern/templates/footer.html
@@ -1,0 +1,32 @@
+    </main>
+    <footer class="ap-footer">
+      <div class="ap-foot-strip">
+        <span>NOT A GRID</span>
+        <span>NOT A SYSTEM</span>
+        <span>NOT EVEN SORRY</span>
+        <span>WE LIED ABOUT THE NOT SORRY</span>
+      </div>
+      <div class="ap-foot-cols">
+        <div class="ap-foot-col ap-foot-a">
+          <h4>Made by</h4>
+          <p>Several people who do not always agree, including, occasionally, themselves.</p>
+        </div>
+        <div class="ap-foot-col ap-foot-b">
+          <h4>Set in</h4>
+          <p>Bungee, Syne, Fraunces, Space Mono, Caveat, Anton. Yes, all six. <a href="{{ base_url }}/posts/six-fonts-on-a-page/">We wrote about it</a>.</p>
+        </div>
+        <div class="ap-foot-col ap-foot-c">
+          <h4>Subscribe</h4>
+          <p>Via <a href="{{ base_url }}/rss.xml">RSS</a>. We have not built a newsletter. We will not build a newsletter.</p>
+        </div>
+      </div>
+      <div class="ap-foot-mark">
+        <span class="ap-foot-c1">&copy;</span>
+        <span class="ap-foot-y">{{ current_year }}</span>
+        <span class="ap-foot-s">{{ site.title }}</span>
+        <span class="ap-foot-h">// built with Hwaro // do not align this</span>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/anti-pattern/templates/header.html
+++ b/examples/anti-pattern/templates/header.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+  <title>{% if page.title %}{{ page.title }} // {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bungee&family=Syne:wght@400;700;800&family=Fraunces:opsz,wght@9..144,300;9..144,500;9..144,900&family=Space+Mono:wght@400;700&family=Caveat:wght@400;700&family=Anton&display=swap" rel="stylesheet">
+  <link href="{{ base_url }}/rss.xml" type="application/rss+xml" rel="alternate" title="RSS">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="ap">
+    <header class="ap-header">
+      <div class="ap-marquee"><span>{{ site.description }} &nbsp;&nbsp;//&nbsp;&nbsp; we are sorry, and we are not. &nbsp;&nbsp;//&nbsp;&nbsp; refresh for a different opinion. &nbsp;&nbsp;//&nbsp;&nbsp; {{ site.description }} &nbsp;&nbsp;//&nbsp;&nbsp; we are sorry, and we are not.</span></div>
+
+      <a href="{{ base_url }}/" class="ap-title">
+        <span class="ap-title-a">{{ site.title | split(pat=" ") | first }}</span>
+        {% if site.title | split(pat=" ") | length > 1 %}
+        <span class="ap-title-b">{{ site.title | split(pat=" ") | slice(start=1) | join(sep=" ") }}</span>
+        {% endif %}
+        <span class="ap-title-period">.</span>
+      </a>
+
+      <div class="ap-subtitle-row">
+        <span class="ap-subtitle-tag">[ blog ]</span>
+        <span class="ap-subtitle-text">{{ site.description }}</span>
+      </div>
+
+      <nav class="ap-nav">
+        <a href="{{ base_url }}/" class="ap-nav-1">home</a>
+        <span class="ap-nav-sep">/</span>
+        <a href="{{ base_url }}/posts/" class="ap-nav-2">POSTS</a>
+        <span class="ap-nav-sep">//</span>
+        <a href="{{ base_url }}/tags/" class="ap-nav-3">tags</a>
+        <span class="ap-nav-sep">~</span>
+        <a href="{{ base_url }}/about/" class="ap-nav-4">about</a>
+        <span class="ap-nav-sep">•</span>
+        <a href="{{ base_url }}/rss.xml" class="ap-nav-5">rss</a>
+      </nav>
+    </header>
+
+    <main class="ap-main">

--- a/examples/anti-pattern/templates/index.html
+++ b/examples/anti-pattern/templates/index.html
@@ -1,0 +1,54 @@
+{% include "header.html" %}
+
+{% set all_posts = site.pages | where("section", "posts") | sort_by("date", reverse=true) %}
+
+<section class="ap-home">
+  <div class="ap-hero">
+    <div class="ap-hero-sticker ap-hero-sticker-1">NEW</div>
+    <div class="ap-hero-sticker ap-hero-sticker-2">!!!</div>
+    <div class="ap-hero-sticker ap-hero-sticker-3">est. yesterday</div>
+
+    <h1 class="ap-hero-headline">
+      <span class="hl-1">A</span>
+      <span class="hl-2">blog</span>
+      <span class="hl-3">that</span>
+      <span class="hl-4">forgot</span>
+      <span class="hl-5">to</span>
+      <span class="hl-6">align.</span>
+    </h1>
+    <p class="ap-hero-deck">
+      <span class="deck-frag deck-a">Six fonts. </span>
+      <span class="deck-frag deck-b">Three colors. </span>
+      <span class="deck-frag deck-c">No grid. </span>
+      <span class="deck-frag deck-d">Considerable conviction.</span>
+    </p>
+  </div>
+
+  <div class="ap-zigzag">
+    {% for post in all_posts %}
+    {% set variant = (loop.index0 % 5) + 1 %}
+    <article class="ap-card ap-card-{{ variant }}">
+      <div class="ap-card-num">№ {{ "%02d" | format(loop.index) }}</div>
+      <div class="ap-card-cat">{% if post.categories %}{{ post.categories | first }}{% else %}post{% endif %}</div>
+      <h2 class="ap-card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+      {% if post.description %}
+      <p class="ap-card-deck">{{ post.description }}</p>
+      {% endif %}
+      <div class="ap-card-meta">
+        <span class="ap-card-date">{{ post.date | date("%d %b") }}</span>
+        <span class="ap-card-by">{% if post.extra is defined and post.extra.authors %}{{ post.extra.authors | first }}{% else %}staff{% endif %}</span>
+        <span class="ap-card-min">{{ post.reading_time }}m</span>
+      </div>
+      <div class="ap-card-scribble">read &#8594;</div>
+    </article>
+    {% endfor %}
+  </div>
+
+  <div class="ap-quote">
+    <div class="ap-quote-bracket">&laquo;</div>
+    <p class="ap-quote-text">A grid is a contract. A broken grid is a broken contract. A broken contract, when handled with care, is a piece of writing of its own.</p>
+    <div class="ap-quote-author">— from "In Praise of the Broken Grid"</div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/anti-pattern/templates/page.html
+++ b/examples/anti-pattern/templates/page.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+
+<article class="ap-post">
+  <div class="ap-post-strip">
+    <span class="ap-post-cat">{% if page.categories %}{{ page.categories | first }}{% else %}post{% endif %}</span>
+    <span class="ap-post-date">{{ page.date | date("%A, %d %B %Y") }}</span>
+    <span class="ap-post-time">{{ page.reading_time }} min</span>
+  </div>
+
+  <h1 class="ap-post-title">{{ page.title }}</h1>
+
+  {% if page.description %}
+  <p class="ap-post-deck">{{ page.description }}</p>
+  {% endif %}
+
+  <div class="ap-post-byline">
+    by <span class="byline-name">{% if page.extra is defined and page.extra.authors %}{{ page.extra.authors | join(", ") }}{% else %}the editors{% endif %}</span>
+  </div>
+
+  {% if page.tags %}
+  <div class="ap-post-tags">
+    {% for tag in page.tags %}
+    <a class="ap-post-tag ap-post-tag-{{ (loop.index0 % 4) + 1 }}" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="ap-post-rule"></div>
+
+  <div class="ap-post-body">
+    {{ content | safe }}
+  </div>
+
+  <div class="ap-post-rule"></div>
+
+  <div class="ap-post-foot">
+    <div class="ap-post-foot-mark">END.</div>
+    <a class="ap-post-back" href="{{ base_url }}/posts/">&larr; back to everything else</a>
+  </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/anti-pattern/templates/section.html
+++ b/examples/anti-pattern/templates/section.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+
+<section class="ap-home">
+  <div class="ap-hero">
+    <h1 class="ap-hero-headline">
+      <span class="hl-1">{{ section.title | split(pat=" ") | first }}</span>
+      {% for word in section.title | split(pat=" ") | slice(start=1) %}
+      <span class="hl-{{ (loop.index0 % 5) + 2 }}">{{ word }}</span>
+      {% endfor %}
+    </h1>
+    {% if section.description %}
+    <p class="ap-hero-deck">{{ section.description }}</p>
+    {% endif %}
+  </div>
+
+  <div class="ap-zigzag">
+    {% for post in section.pages %}
+    {% set variant = (loop.index0 % 5) + 1 %}
+    <article class="ap-card ap-card-{{ variant }}">
+      <div class="ap-card-num">№ {{ "%02d" | format(loop.index) }}</div>
+      <div class="ap-card-cat">{% if post.categories %}{{ post.categories | first }}{% else %}post{% endif %}</div>
+      <h2 class="ap-card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+      {% if post.description %}
+      <p class="ap-card-deck">{{ post.description }}</p>
+      {% endif %}
+      <div class="ap-card-meta">
+        <span class="ap-card-date">{{ post.date | date("%d %b") }}</span>
+        <span class="ap-card-by">{% if post.extra is defined and post.extra.authors %}{{ post.extra.authors | first }}{% else %}staff{% endif %}</span>
+      </div>
+      <div class="ap-card-scribble">read &#8594;</div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/anti-pattern/templates/taxonomy.html
+++ b/examples/anti-pattern/templates/taxonomy.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<section class="ap-home">
+  <div class="ap-hero">
+    <h1 class="ap-hero-headline">
+      <span class="hl-1">all</span>
+      <span class="hl-3">the</span>
+      <span class="hl-5">{{ taxonomy_name }}.</span>
+    </h1>
+    <p class="ap-hero-deck">{{ taxonomy_terms | length }} subjects, sorted by how loudly we got about them.</p>
+  </div>
+
+  <ul class="ap-tag-pile">
+    {% for term in taxonomy_terms %}
+    <li class="ap-tag-blob ap-tag-blob-{{ (loop.index0 % 5) + 1 }}">
+      <a href="{{ base_url }}{{ term.url }}">
+        <span class="ap-tag-name">{{ term.name }}</span>
+        <span class="ap-tag-count">{{ term.pages | length }}</span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/anti-pattern/templates/taxonomy_term.html
+++ b/examples/anti-pattern/templates/taxonomy_term.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<section class="ap-home">
+  <div class="ap-hero">
+    <div class="ap-hero-sticker ap-hero-sticker-1">tag</div>
+    <h1 class="ap-hero-headline">
+      <span class="hl-2">{{ taxonomy_term }}</span><span class="hl-1">.</span>
+    </h1>
+    <p class="ap-hero-deck">{{ taxonomy_pages | length }} post{% if taxonomy_pages | length != 1 %}s{% endif %} we wrote with this subject in mind, and one or two we didn't, but it ended up here anyway.</p>
+  </div>
+
+  <div class="ap-zigzag">
+    {% for post in taxonomy_pages %}
+    {% set variant = (loop.index0 % 5) + 1 %}
+    <article class="ap-card ap-card-{{ variant }}">
+      <div class="ap-card-num">№ {{ "%02d" | format(loop.index) }}</div>
+      <div class="ap-card-cat">{% if post.categories %}{{ post.categories | first }}{% else %}post{% endif %}</div>
+      <h2 class="ap-card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+      {% if post.description %}
+      <p class="ap-card-deck">{{ post.description }}</p>
+      {% endif %}
+      <div class="ap-card-meta">
+        <span class="ap-card-date">{{ post.date | date("%d %b") }}</span>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/broadsheet-riot/config.toml
+++ b/examples/broadsheet-riot/config.toml
@@ -1,0 +1,193 @@
+title = "Broadsheet Riot"
+description = "A brutalist newspaper-agitprop blog. Red ink, oversized headlines, hand-set type that argues back."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 20
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/broadsheet-riot/content/about.md
+++ b/examples/broadsheet-riot/content/about.md
@@ -1,0 +1,18 @@
++++
+title = "Colophon"
+description = "About this paper."
++++
+
+## A Paper That Argues With Itself
+
+**Broadsheet Riot** is a publication printed exclusively in the colors of insistence — black, ink-red, and the unbleached pulp of newsprint. We follow three rules and break the rest:
+
+1. Every headline must be louder than the one above it.
+2. Every column must contradict the one to its left.
+3. The masthead is allowed to be wrong.
+
+Set in Bodoni Moda, Domine, and IBM Plex Mono on a five-column grid that we ignore whenever it suits us. Founded in a basement; deposited at the printers in a panic; distributed by anyone willing to carry it.
+
+> "The newspaper must be a weapon, but also a love letter, but also a confession."
+
+For corrections, hate mail, and unsolicited manifestos, write to the editors. They are reading.

--- a/examples/broadsheet-riot/content/index.md
+++ b/examples/broadsheet-riot/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Broadsheet Riot"
+description = "A newspaper that argues with itself."
++++
+
+Front page below.

--- a/examples/broadsheet-riot/content/posts/_index.md
+++ b/examples/broadsheet-riot/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "The Stack"
+description = "Every issue, archived. Front to back."
+sort_by = "date"
+paginate = 6
+template = "section"
+generate_feeds = true
++++
+
+Every issue we've ever put out, archived chronologically. The earliest at the bottom, the latest screaming from the top.

--- a/examples/broadsheet-riot/content/posts/against-the-infinite-scroll.md
+++ b/examples/broadsheet-riot/content/posts/against-the-infinite-scroll.md
@@ -1,0 +1,31 @@
++++
+title = "Against The Infinite Scroll"
+date = "2026-05-04"
+description = "Pages have edges. Edges have a purpose. The fold is not a bug."
+tags = ["web", "manifesto", "media"]
+categories = ["editorial"]
+[extra]
+authors = ["M. Halvorsen"]
++++
+
+The infinite scroll is the architectural confession of a medium that does not believe in endings. It is the digital equivalent of refusing to fold the newspaper — a refusal that pretends to be generosity but is, in fact, a kind of cowardice. *Editions* end. *Issues* end. *Books* end. The end is the whole point.
+
+<!-- more -->
+
+## The Fold Is A Feature
+
+When a paper is folded, the top half becomes a contract: **these are the things we will defend.** The bottom half is a footnote, the inside is the conversation, and the back is the corrections. Every part of the object has a role, and every role implies a hierarchy of importance that the editor was forced to choose between.
+
+Infinite scroll abolishes that hierarchy. It says: *everything is the same height, everything is equally important, equally trivial.* This is not democracy. This is mush.
+
+## Editions Tell You What Year It Is
+
+Open any newspaper from 1968 and the year is the first thing you see. It is set in red. It is set in twelve points. It cannot be missed. Open a website from 2014 and you will spend ninety seconds hunting for a footer date that may not exist.
+
+A blog post without a clear date is a piece of writing that wants plausible deniability. We do not offer plausible deniability. **Our dates are loud because our positions are loud.** If we were wrong in March, we were wrong, and the date is the proof.
+
+## A Brief Defense Of The Page Number
+
+The page number is the simplest piece of typography in the world, and the most misunderstood. It is not navigation. It is **a promise**. It says: *this object has a shape. It can be measured. It will not grow under your hand while you are not looking.*
+
+Give us the fold. Give us the edition. Give us the page. Take your river back.

--- a/examples/broadsheet-riot/content/posts/in-defense-of-the-correction.md
+++ b/examples/broadsheet-riot/content/posts/in-defense-of-the-correction.md
@@ -1,0 +1,38 @@
++++
+title = "In Defense Of The Correction"
+date = "2026-04-22"
+description = "Where it says 'the mayor', read 'the former mayor'. We regret the error. We do not regret printing it."
+tags = ["ethics", "media", "manifesto"]
+categories = ["columns"]
+[extra]
+authors = ["R. Okafor"]
++++
+
+The correction is the most underrated genre in the history of letters. It is the only piece of writing that publicly admits the writer was wrong, and it does so in eight points, in the gutter, where nobody is supposed to look. We propose moving it to the front page. We propose setting it in red. We propose **writing it with care**.
+
+<!-- more -->
+
+## What A Correction Is For
+
+A correction is not a confession. A confession is a private matter between a person and their conscience. A correction is a *public* matter, between a publication and the people it has misled — and the people it has misled have a right to a published apology, set in the same face, at a comparable size, on a comparable day of the week.
+
+```
+CORRECTION — In the issue of 14 April, we reported
+that the foundation's annual budget was $4.2 million.
+The correct figure is $42 million. We regret the error,
+and apologize to the foundation and to our readers.
+```
+
+The above is a model. Note what it does: it identifies the issue, it states the wrong fact, it states the right fact, it apologizes, and it stops. There is no excuse. There is no "due to a transcription error." A transcription error is **somebody's** error, and that somebody is the paper, and the paper is sorry.
+
+## The Erratum As Literature
+
+The best erratum we ever printed was four words long: *"Where it says 'Tuesday,' read 'Thursday.'"* That sentence has the rhythm of a poem and the moral seriousness of a vow. It is the entire job of the press, in twelve syllables.
+
+> A publication that does not correct itself is not a publication; it is a press release.
+
+## Print The Mistake. Print It Loud.
+
+We have made mistakes. We will make more. Every issue of every paper that has ever existed contains at least one statement that was wrong on the day it was printed, and the only honest response is to admit it, in print, in the same font, at the same volume, **on the front page**. Anything quieter is an apology shaped like a hiding place.
+
+We regret the error. We do not regret printing it.

--- a/examples/broadsheet-riot/content/posts/the-grid-is-not-a-cage.md
+++ b/examples/broadsheet-riot/content/posts/the-grid-is-not-a-cage.md
@@ -1,0 +1,41 @@
++++
+title = "The Grid Is Not A Cage, But It Is Not Furniture Either"
+date = "2026-04-09"
+description = "On the discipline of the column inch and the moral obligation to violate it."
+tags = ["design", "typography", "manifesto"]
+categories = ["columns"]
+[extra]
+authors = ["The Editors"]
++++
+
+The grid is the architecture of the newspaper, and like any architecture, it carries a politics. **Five columns** is the politics of the metropolitan daily — a wide-shouldered, all-purpose grid that says *we contain multitudes, but neatly.* **Three columns** is the politics of the literary monthly, the slow read, the long form. **One column** is the politics of the manifesto: there is one voice here, and you are going to listen to it without distraction.
+
+<!-- more -->
+
+We use all three on the same page, sometimes in the same article. This is not eclecticism; it is **argument by layout**.
+
+## When To Break The Grid
+
+The grid exists to be broken, but only by people who can explain why. A headline that bleeds across four columns is making a claim about scale: *this story is bigger than the others on this page.* A photograph that overlaps three columns and a margin is making a claim about presence: *this image is not a piece of evidence; it is the whole story, and the words are footnotes.*
+
+You may not break the grid because:
+
+- You ran out of words.
+- The layout software made it convenient.
+- "It looked nicer that way."
+
+You **may** break the grid because:
+
+- The story is genuinely larger than its container, and any container would have been insulting.
+- The opposition of the broken element to the rest of the page is itself the argument.
+- The reader has earned a reward for getting this far down the page, and the reward is a moment of beautiful, deliberate disorder.
+
+## The Column Rule As A Moral Object
+
+The thin vertical line that separates one column from the next — the **column rule** — is the most modest piece of typography on the page and one of the most important. It is the publication's promise that *these two pieces of writing are adjacent but distinct.* The opinion column and the news column share a page, but they do not share a position.
+
+When we remove the column rule, we are saying these two pieces speak with one voice. When we double it, we are signaling a categorical break — *this side is news, this side is something else.* When we set it in red, we are flagging an exception, an intrusion, a piece that does not belong to the section it has been placed in.
+
+These are micro-decisions, and we make hundreds of them per issue. They are why the page **feels** the way it feels even when the reader cannot articulate why.
+
+The grid is not a cage. But it is not furniture either. It is **an argument we are having with ourselves, in public, every week.**

--- a/examples/broadsheet-riot/content/posts/the-headline-is-a-weapon.md
+++ b/examples/broadsheet-riot/content/posts/the-headline-is-a-weapon.md
@@ -1,0 +1,35 @@
++++
+title = "The Headline Is A Weapon, Use It Accordingly"
+date = "2026-05-18"
+description = "On display type, propaganda, and the moral weight of a 96-point Bodoni."
+tags = ["typography", "manifesto", "design"]
+categories = ["editorial"]
+[extra]
+authors = ["The Editors"]
++++
+
+A headline is not a label. A headline is a **fist**. It opens the page the way an axe opens a door — with announcement, with violence, with the implication that what's on the other side has changed forever.
+
+<!-- more -->
+
+## The Display Face Is A Political Object
+
+Every typeface is a posture, and Bodoni is the posture of someone who has stopped negotiating. The thin strokes and high contrast are not "elegant" — they are the visual equivalent of a clenched jaw. Helvetica wants to be liked. Times wants to be trusted. Bodoni wants to be **obeyed**.
+
+When you set a headline 96 points tall and bleed it off the edge of the page, you are not "designing." You are deciding what the reader is going to think about for the next four seconds, and four seconds is a long time in the architecture of a person's day.
+
+> A modest headline is a kind of lie. It suggests that what follows is also modest, which is almost never true.
+
+## On The Use Of Red Ink
+
+Black ink is information. Red ink is **insistence**. The history of the press is the history of red being rationed — a second color was expensive, so it was reserved for what mattered: the date the war began, the name of the dead, the price of bread.
+
+We use red now because we can afford to, but we use it as if we still couldn't. One word per page. One rule per spread. The accent is the argument; the rest is just context.
+
+## Three Rules For Setting A Headline
+
+1. **Read it out loud before you set it.** If you cannot say it without lowering your voice, it is not a headline; it is a footnote with delusions of grandeur.
+2. **Set it bigger than you think.** Then go up another size. The page can take it. The reader cannot.
+3. **Break it on a noun, never on a preposition.** A headline that ends a line on "the" is a headline that has lost its nerve.
+
+The page is a battlefield. The headline is the first soldier across it. Send it loud.

--- a/examples/broadsheet-riot/content/posts/we-do-not-set-times-roman.md
+++ b/examples/broadsheet-riot/content/posts/we-do-not-set-times-roman.md
@@ -1,0 +1,37 @@
++++
+title = "We Do Not Set Times Roman, And Other Style Rules"
+date = "2026-03-27"
+description = "A partial list of our prohibitions, with reasons."
+tags = ["typography", "style", "manifesto"]
+categories = ["editorial"]
+[extra]
+authors = ["The Editors"]
++++
+
+The following is not exhaustive. It is what we have managed to write down so far. The rules are not negotiable except by collective vote of the editors, and the editors are notoriously hard to assemble.
+
+<!-- more -->
+
+## Faces We Will Not Set
+
+- **Times New Roman.** Not because it is a bad typeface — it is in fact a brilliant typeface — but because it has been used to justify too much. When a piece of writing arrives in our inbox set in Times New Roman, we read it suspecting that the author has not thought about anything else either.
+- **Helvetica.** It is not neutral. Nothing is neutral. Anything that pretends to be neutral has merely chosen a side and forgotten which one.
+- **Comic Sans.** The argument in defense of Comic Sans is that it is accessible to readers with dyslexia. The argument is correct. We are open to using it for that purpose. We are not open to using it because somebody thought it would be funny.
+
+## Rules About Numerals
+
+- **Old-style figures in running text, lining figures in tables.** This is not negotiable. The reason is that running text wants letters that descend below the baseline (3, 4, 5, 7, 9); tables want letters that align (1, 2, 3, 4, 5, 6, 7, 8, 9, 0).
+- **Never set a year in italics.** A year is a fact. Facts do not lean.
+- **Always set a price in red if the price is the news.** *Bread up to $9 a loaf.* The $9 is the headline.
+
+## Rules About Punctuation
+
+- **The em dash gets no space around it.** This is a stylistic position, not a typographic one. We believe the em dash is an interruption, and an interruption does not announce itself with two breaths of warning.
+- **No serial comma.** We will fight you on this. We have already fought several of our own writers on this.
+- **The ellipsis is three dots and no more.** Four dots is a sentence that did not know when to stop.
+
+## Rules About The Editors
+
+- Editors may overrule any of the above on a case-by-case basis, **provided they are willing to be quoted in the corrections column the following week.**
+
+This is the discipline of the page. It is not freedom. It is the **opposite** of freedom, and that is precisely why the page is free.

--- a/examples/broadsheet-riot/static/css/style.css
+++ b/examples/broadsheet-riot/static/css/style.css
@@ -1,0 +1,642 @@
+:root {
+  --ink: #14110f;
+  --ink-soft: #2a2520;
+  --ink-faint: #5a5048;
+  --pulp: #f1e9d8;
+  --pulp-dark: #e3d8be;
+  --pulp-deep: #d4c5a3;
+  --red: #c8202a;
+  --red-deep: #962027;
+}
+
+* { box-sizing: border-box; }
+
+html { background: var(--pulp); }
+body {
+  margin: 0;
+  font-family: "Domine", Georgia, serif;
+  color: var(--ink);
+  background: var(--pulp);
+  line-height: 1.55;
+  font-size: 17px;
+}
+
+::selection { background: var(--red); color: var(--pulp); }
+
+.paper {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 28px 36px 60px;
+  border-left: 1px solid rgba(20,17,15,0.08);
+  border-right: 1px solid rgba(20,17,15,0.08);
+}
+
+/* ---------------- MASTHEAD ---------------- */
+
+.masthead { margin-bottom: 18px; }
+.masthead-strip {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  border-top: 2px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding: 6px 0;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.strip-item { white-space: nowrap; }
+.strip-date { color: var(--red); font-weight: 700; }
+
+.masthead-title {
+  display: block;
+  text-align: center;
+  font-family: "Bodoni Moda", "Times New Roman", serif;
+  font-weight: 900;
+  font-size: clamp(56px, 11vw, 148px);
+  line-height: 0.86;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+  text-decoration: none;
+  margin: 28px 0 8px;
+  text-transform: uppercase;
+  font-variant: small-caps;
+}
+.masthead-title-main {
+  display: inline-block;
+  border-bottom: 0;
+  position: relative;
+}
+.masthead-title-main::after {
+  content: ".";
+  color: var(--red);
+}
+.masthead-tagline {
+  text-align: center;
+  font-style: italic;
+  font-family: "Bodoni Moda", serif;
+  font-size: 18px;
+  letter-spacing: 0.02em;
+  color: var(--ink-soft);
+  margin-bottom: 20px;
+}
+.masthead-nav {
+  display: flex;
+  justify-content: center;
+  gap: 26px;
+  border-top: 1px solid var(--ink);
+  border-bottom: 4px double var(--ink);
+  padding: 10px 0;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+.masthead-nav a {
+  color: var(--ink);
+  text-decoration: none;
+  position: relative;
+  padding: 0 2px;
+}
+.masthead-nav a:hover {
+  color: var(--pulp);
+  background: var(--ink);
+}
+.masthead-rule { display: none; }
+
+/* ---------------- FRONT PAGE ---------------- */
+
+.front-page { margin-top: 30px; }
+
+.front-lead {
+  position: relative;
+  padding-bottom: 36px;
+  border-bottom: 1px solid var(--ink);
+  margin-bottom: 36px;
+}
+.front-kicker {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--red);
+  margin-bottom: 10px;
+  border-top: 1px solid var(--red);
+  border-bottom: 1px solid var(--red);
+  padding: 4px 0;
+  display: inline-block;
+  padding-right: 22px;
+  padding-left: 4px;
+}
+.front-lead-title {
+  font-family: "Bodoni Moda", serif;
+  font-weight: 900;
+  font-size: clamp(40px, 7vw, 92px);
+  line-height: 0.92;
+  letter-spacing: -0.025em;
+  margin: 12px 0 18px;
+  text-transform: none;
+}
+.front-lead-title a {
+  color: var(--ink);
+  text-decoration: none;
+}
+.front-lead-title a:hover { color: var(--red); }
+.front-lead-deck {
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: clamp(20px, 2.2vw, 26px);
+  line-height: 1.3;
+  color: var(--ink-soft);
+  margin: 0 0 18px;
+  max-width: 80ch;
+}
+.front-lead-meta {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-faint);
+  margin-bottom: 18px;
+}
+.front-lead-meta .byline { color: var(--ink); font-weight: 700; }
+.front-lead-meta .reading-time::before { content: " / "; }
+.front-lead-body {
+  column-count: 3;
+  column-gap: 28px;
+  column-rule: 1px solid rgba(20,17,15,0.18);
+  font-size: 16px;
+  line-height: 1.6;
+}
+.front-lead-body p:first-child::first-letter {
+  float: left;
+  font-family: "Bodoni Moda", serif;
+  font-weight: 900;
+  font-size: 5.4em;
+  line-height: 0.85;
+  padding: 6px 10px 0 0;
+  color: var(--red);
+}
+.continue-reading {
+  display: inline-block;
+  margin-top: 18px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 2px solid var(--red);
+  padding-bottom: 2px;
+}
+.continue-reading:hover { color: var(--red); }
+
+.front-rule {
+  border-top: 1px solid var(--ink);
+  border-bottom: 3px solid var(--ink);
+  height: 6px;
+  margin: 36px 0;
+}
+
+.front-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 28px;
+  border-top: 4px double var(--ink);
+  border-bottom: 4px double var(--ink);
+  padding: 26px 0;
+}
+.front-card {
+  border-right: 1px solid rgba(20,17,15,0.25);
+  padding-right: 26px;
+}
+.front-card:last-child { border-right: none; padding-right: 0; }
+.front-card-1 {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+.front-card-1 .card-title { font-size: 38px; }
+.card-kicker {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--red);
+  margin-bottom: 8px;
+}
+.card-title {
+  font-family: "Bodoni Moda", serif;
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  margin: 0 0 12px;
+}
+.card-title a { color: var(--ink); text-decoration: none; }
+.card-title a:hover { color: var(--red); }
+.card-deck {
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: 14.5px;
+  line-height: 1.4;
+  color: var(--ink-soft);
+  margin: 0 0 12px;
+}
+.card-meta {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.card-meta .dot { margin: 0 4px; }
+
+.front-pull {
+  text-align: center;
+  padding: 40px 8%;
+}
+.front-pull blockquote {
+  margin: 0;
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: clamp(24px, 3vw, 38px);
+  line-height: 1.25;
+  position: relative;
+}
+.front-pull cite {
+  display: block;
+  margin-top: 18px;
+  font-family: "IBM Plex Mono", monospace;
+  font-style: normal;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--red);
+}
+
+.front-bottom { padding-top: 8px; }
+.bottom-head {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  margin: 0 0 16px;
+  padding-bottom: 6px;
+  border-bottom: 2px solid var(--ink);
+  display: inline-block;
+  padding-right: 24px;
+}
+.bottom-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  columns: 2;
+  column-gap: 36px;
+}
+.bottom-list li {
+  display: flex;
+  gap: 14px;
+  border-bottom: 1px dotted rgba(20,17,15,0.25);
+  padding: 8px 0;
+  break-inside: avoid;
+}
+.bottom-date {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--red);
+  width: 64px;
+  flex-shrink: 0;
+}
+.bottom-list a {
+  font-family: "Bodoni Moda", serif;
+  font-size: 17px;
+  color: var(--ink);
+  text-decoration: none;
+}
+.bottom-list a:hover { color: var(--red); text-decoration: underline; text-decoration-thickness: 2px; }
+
+/* ---------------- ARTICLE ---------------- */
+
+.article {
+  max-width: 920px;
+  margin: 40px auto 0;
+}
+.article-kicker {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--red);
+  border-top: 1px solid var(--red);
+  border-bottom: 1px solid var(--red);
+  padding: 4px 0;
+  display: inline-block;
+  padding-right: 22px;
+  padding-left: 4px;
+  margin-bottom: 14px;
+}
+.kicker-sep { color: var(--ink-faint); margin: 0 4px; }
+.kicker-tag {
+  color: var(--red);
+  text-decoration: none;
+}
+.kicker-tag:hover { background: var(--red); color: var(--pulp); }
+
+.article-title {
+  font-family: "Bodoni Moda", serif;
+  font-weight: 900;
+  font-size: clamp(38px, 6.5vw, 84px);
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  margin: 0 0 18px;
+}
+.article-deck {
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: clamp(18px, 2vw, 24px);
+  line-height: 1.35;
+  color: var(--ink-soft);
+  max-width: 70ch;
+  margin: 0 0 18px;
+}
+.article-byline {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 18px;
+}
+.byline-name { color: var(--ink); font-weight: 700; }
+.byline-sep { color: var(--red); margin: 0 8px; }
+
+.article-rule-thick {
+  border-top: 4px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  height: 6px;
+  margin: 18px 0 26px;
+}
+
+.article-body { font-size: 17px; line-height: 1.7; }
+.article-body p { margin: 0 0 1.1em; }
+.article-body p:first-of-type::first-letter {
+  float: left;
+  font-family: "Bodoni Moda", serif;
+  font-weight: 900;
+  font-size: 5.6em;
+  line-height: 0.85;
+  padding: 8px 12px 0 0;
+  color: var(--red);
+}
+.article-body h2 {
+  font-family: "Bodoni Moda", serif;
+  font-weight: 700;
+  font-size: clamp(28px, 3.4vw, 40px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  margin: 1.8em 0 0.4em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--ink);
+}
+.article-body h3 {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin: 1.8em 0 0.6em;
+  color: var(--red);
+}
+.article-body blockquote {
+  border-left: 4px solid var(--red);
+  margin: 1.8em 0;
+  padding: 0.4em 0 0.4em 1.2em;
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: 1.25em;
+  line-height: 1.35;
+  color: var(--ink);
+}
+.article-body code {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--pulp-dark);
+  padding: 0.1em 0.3em;
+  border: 1px solid var(--pulp-deep);
+  font-size: 0.92em;
+}
+.article-body pre {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--ink);
+  color: var(--pulp);
+  padding: 16px 18px;
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-x: auto;
+  border-left: 4px solid var(--red);
+  margin: 1.6em 0;
+}
+.article-body pre code { background: transparent; border: 0; padding: 0; color: inherit; }
+.article-body ul, .article-body ol { padding-left: 1.2em; }
+.article-body li { margin: 0.3em 0; }
+.article-body a { color: var(--red); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+.article-body a:hover { background: var(--red); color: var(--pulp); text-decoration: none; }
+.article-body strong { color: var(--ink); font-weight: 700; }
+
+.article-end {
+  text-align: center;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 14px;
+  letter-spacing: 0.4em;
+  color: var(--red);
+  margin: 24px 0;
+}
+
+/* ---------------- STACK / SECTION ---------------- */
+
+.stack { max-width: 980px; margin: 40px auto 0; }
+.stack-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.stack-item {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 28px;
+  padding: 26px 0;
+  border-bottom: 1px solid rgba(20,17,15,0.25);
+}
+.stack-item:first-child { border-top: 1px solid rgba(20,17,15,0.25); }
+.stack-num {
+  font-family: "Bodoni Moda", serif;
+  font-weight: 900;
+  font-size: 44px;
+  line-height: 1;
+  color: var(--red);
+  letter-spacing: -0.02em;
+}
+.stack-meta {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 6px;
+}
+.stack-title {
+  font-family: "Bodoni Moda", serif;
+  font-weight: 700;
+  font-size: clamp(24px, 3vw, 36px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+.stack-title a { color: var(--ink); text-decoration: none; }
+.stack-title a:hover { color: var(--red); }
+.stack-deck {
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.4;
+  color: var(--ink-soft);
+  margin: 0 0 8px;
+  max-width: 70ch;
+}
+.stack-byline {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* ---------------- TAGS ---------------- */
+
+.tag-cloud {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.tag-cloud-item a {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  border: 1px solid var(--ink);
+  padding: 8px 14px;
+  text-decoration: none;
+  color: var(--ink);
+  font-family: "Bodoni Moda", serif;
+  font-weight: 700;
+  font-size: 17px;
+  background: var(--pulp);
+}
+.tag-cloud-item a:hover { background: var(--ink); color: var(--pulp); }
+.tag-cloud-item a:hover .tag-cloud-count { color: var(--red); }
+.tag-cloud-name { letter-spacing: -0.01em; }
+.tag-cloud-count {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 400;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--ink-faint);
+}
+
+/* ---------------- 404 ---------------- */
+
+.four-oh-four { max-width: 680px; margin: 80px auto; text-align: center; }
+.error-num {
+  font-family: "Bodoni Moda", serif;
+  font-weight: 900;
+  font-size: clamp(140px, 22vw, 280px);
+  line-height: 1;
+  color: var(--red);
+  margin: 12px 0;
+  letter-spacing: -0.05em;
+}
+.error-deck {
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink-soft);
+  margin: 0 0 20px;
+}
+.error-back a {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 3px solid var(--red);
+}
+
+/* ---------------- FOOTER ---------------- */
+
+.paper-footer { margin-top: 60px; }
+.footer-rule-double {
+  border-top: 1px solid var(--ink);
+  border-bottom: 4px double var(--ink);
+  height: 6px;
+}
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 36px;
+  padding: 30px 0;
+}
+.footer-col h4 {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--red);
+  margin: 0 0 8px;
+  border-bottom: 1px solid var(--red);
+  padding-bottom: 4px;
+}
+.footer-col p {
+  font-family: "Bodoni Moda", serif;
+  font-size: 15px;
+  line-height: 1.45;
+  margin: 0;
+  color: var(--ink-soft);
+}
+.footer-col a { color: var(--red); text-decoration: underline; }
+.footer-imprint {
+  display: flex;
+  justify-content: space-between;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding: 16px 0;
+}
+
+/* ---------------- RESPONSIVE ---------------- */
+
+@media (max-width: 900px) {
+  .paper { padding: 18px 18px 40px; }
+  .masthead-strip { font-size: 9.5px; flex-wrap: wrap; }
+  .strip-item { white-space: normal; }
+  .masthead-nav { flex-wrap: wrap; gap: 14px; }
+  .front-lead-body { column-count: 1; }
+  .front-grid { grid-template-columns: 1fr 1fr; }
+  .front-card { border-right: none; padding-right: 0; padding-bottom: 18px; border-bottom: 1px solid rgba(20,17,15,0.2); }
+  .front-card-1 { grid-column: span 2; }
+  .bottom-list { columns: 1; }
+  .stack-item { grid-template-columns: 60px 1fr; gap: 16px; }
+  .footer-grid { grid-template-columns: 1fr; gap: 18px; padding: 18px 0; }
+  .footer-imprint { flex-direction: column; gap: 4px; text-align: center; }
+}
+@media (max-width: 520px) {
+  .front-grid { grid-template-columns: 1fr; }
+  .front-card-1 { grid-column: span 1; }
+  .stack-num { font-size: 32px; }
+}

--- a/examples/broadsheet-riot/templates/404.html
+++ b/examples/broadsheet-riot/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+<section class="four-oh-four">
+  <div class="article-kicker">STOP THE PRESSES</div>
+  <h1 class="error-num">404</h1>
+  <p class="error-deck">The page you were looking for has been pulled from the run. Possibly libellous. Possibly never written. Possibly both.</p>
+  <div class="article-rule-thick"></div>
+  <p class="error-back"><a href="{{ base_url }}/">Return to the front page →</a></p>
+</section>
+
+{% include "footer.html" %}

--- a/examples/broadsheet-riot/templates/footer.html
+++ b/examples/broadsheet-riot/templates/footer.html
@@ -1,0 +1,27 @@
+    </main>
+    <footer class="paper-footer">
+      <div class="footer-rule-double"></div>
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h4>The Editors</h4>
+          <p>Reachable at the basement door, weekday evenings, after the press has cooled.</p>
+        </div>
+        <div class="footer-col">
+          <h4>Corrections</h4>
+          <p>Set in red. Printed in full. Apologized for in person, when possible.</p>
+        </div>
+        <div class="footer-col">
+          <h4>Subscriptions</h4>
+          <p>Free, with the understanding that you will argue back. <a href="{{ base_url }}/rss.xml">RSS</a>.</p>
+        </div>
+      </div>
+      <div class="footer-rule-double"></div>
+      <div class="footer-imprint">
+        <span>© {{ current_year }} {{ site.title }}</span>
+        <span>Hand-set on the web by Hwaro</span>
+        <span>END — 30 —</span>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/broadsheet-riot/templates/header.html
+++ b/examples/broadsheet-riot/templates/header.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+  <title>{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:ital,opsz,wght@0,6..96,400;0,6..96,700;0,6..96,900;1,6..96,700&family=Domine:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="{{ base_url }}/rss.xml" type="application/rss+xml" rel="alternate" title="RSS Feed">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="paper">
+    <header class="masthead">
+      <div class="masthead-strip">
+        <span class="strip-item">VOL. XI</span>
+        <span class="strip-item">№ 47</span>
+        <span class="strip-item strip-date">{{ current_date }}</span>
+        <span class="strip-item">PRICE: ATTENTION</span>
+        <span class="strip-item">PRINTED IN A BASEMENT</span>
+      </div>
+      <a href="{{ base_url }}/" class="masthead-title">
+        <span class="masthead-title-main">{{ site.title }}</span>
+      </a>
+      <div class="masthead-tagline">{{ site.description }}</div>
+      <nav class="masthead-nav">
+        <a href="{{ base_url }}/">Front Page</a>
+        <a href="{{ base_url }}/posts/">The Stack</a>
+        <a href="{{ base_url }}/tags/">Subjects</a>
+        <a href="{{ base_url }}/about/">Colophon</a>
+        <a href="{{ base_url }}/rss.xml">Wire</a>
+      </nav>
+      <div class="masthead-rule"></div>
+    </header>
+    <main class="paper-main">

--- a/examples/broadsheet-riot/templates/index.html
+++ b/examples/broadsheet-riot/templates/index.html
@@ -1,0 +1,68 @@
+{% include "header.html" %}
+
+{% set all_posts = site.pages | where("section", "posts") | sort_by("date", reverse=true) %}
+{% set lead = all_posts | first %}
+
+<section class="front-page">
+  {% if lead %}
+  <article class="front-lead">
+    <div class="front-kicker">Lead Editorial · {{ lead.date | date("%A, %d %B %Y") }}</div>
+    <h1 class="front-lead-title"><a href="{{ lead.url }}">{{ lead.title }}</a></h1>
+    {% if lead.description %}
+    <p class="front-lead-deck">{{ lead.description }}</p>
+    {% endif %}
+    <div class="front-lead-meta">
+      <span class="byline">By {% if lead.extra is defined and lead.extra.authors %}{{ lead.extra.authors | join(", ") }}{% else %}The Editors{% endif %}</span>
+      <span class="reading-time">{{ lead.reading_time }} min read</span>
+    </div>
+    <div class="front-lead-body">
+      {{ lead.summary | safe }}
+    </div>
+    <a class="continue-reading" href="{{ lead.url }}">Continue on the inside pages →</a>
+  </article>
+  {% endif %}
+
+  <div class="front-rule"></div>
+
+  <div class="front-grid">
+    {% for post in all_posts | slice(start=1, end=5) %}
+    <article class="front-card front-card-{{ loop.index }}">
+      <div class="card-kicker">{% if post.tags %}{{ post.tags | first | upper }}{% else %}DISPATCH{% endif %}</div>
+      <h2 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+      {% if post.description %}
+      <p class="card-deck">{{ post.description }}</p>
+      {% endif %}
+      <div class="card-meta">
+        <time>{{ post.date | date("%d %b %Y") }}</time>
+        <span class="dot">·</span>
+        <span>{% if post.extra is defined and post.extra.authors %}{{ post.extra.authors | first }}{% else %}The Editors{% endif %}</span>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+
+  <div class="front-rule"></div>
+
+  <section class="front-pull">
+    <blockquote>
+      &ldquo;A modest headline is a kind of lie. It suggests that what follows is also modest, which is almost never true.&rdquo;
+      <cite>— From the colophon</cite>
+    </blockquote>
+  </section>
+
+  <div class="front-rule"></div>
+
+  <section class="front-bottom">
+    <h3 class="bottom-head">From the archive</h3>
+    <ul class="bottom-list">
+      {% for post in all_posts | slice(start=5) %}
+      <li>
+        <span class="bottom-date">{{ post.date | date("%d %b") }}</span>
+        <a href="{{ post.url }}">{{ post.title }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+</section>
+
+{% include "footer.html" %}

--- a/examples/broadsheet-riot/templates/page.html
+++ b/examples/broadsheet-riot/templates/page.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+
+<article class="article">
+  <div class="article-kicker">
+    {% if page.section %}{{ page.section | upper }}{% else %}DISPATCH{% endif %}
+    {% if page.tags %}<span class="kicker-sep">·</span>{% for tag in page.tags %}<a class="kicker-tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag | upper }}</a>{% if not loop.last %} <span class="kicker-sep">/</span> {% endif %}{% endfor %}{% endif %}
+  </div>
+  <h1 class="article-title">{{ page.title }}</h1>
+  {% if page.description %}
+  <p class="article-deck">{{ page.description }}</p>
+  {% endif %}
+  <div class="article-byline">
+    <span class="byline-name">By {% if page.extra is defined and page.extra.authors %}{{ page.extra.authors | join(", ") }}{% else %}The Editors{% endif %}</span>
+    <span class="byline-sep">/</span>
+    <time>{{ page.date | date("%A, %d %B %Y") }}</time>
+    <span class="byline-sep">/</span>
+    <span>{{ page.reading_time }} min</span>
+  </div>
+  <div class="article-rule-thick"></div>
+  <div class="article-body">
+    {{ content | safe }}
+  </div>
+  <div class="article-rule-thick"></div>
+  <div class="article-end">— 30 —</div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/broadsheet-riot/templates/section.html
+++ b/examples/broadsheet-riot/templates/section.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+
+<section class="stack">
+  <div class="article-kicker">SECTION</div>
+  <h1 class="article-title">{{ section.title }}</h1>
+  {% if section.description %}
+  <p class="article-deck">{{ section.description }}</p>
+  {% endif %}
+  <div class="article-rule-thick"></div>
+
+  <ul class="stack-list">
+    {% for post in section.pages %}
+    <li class="stack-item">
+      <div class="stack-num">№ {{ "%02d" | format(loop.index) }}</div>
+      <div class="stack-body">
+        <div class="stack-meta">
+          <time>{{ post.date | date("%d %B %Y") }}</time>
+          {% if post.tags %}
+          <span class="kicker-sep">·</span>
+          {% for tag in post.tags %}<a class="kicker-tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag | upper }}</a>{% if not loop.last %} <span class="kicker-sep">/</span> {% endif %}{% endfor %}
+          {% endif %}
+        </div>
+        <h2 class="stack-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.description %}
+        <p class="stack-deck">{{ post.description }}</p>
+        {% endif %}
+        <div class="stack-byline">
+          By {% if post.extra is defined and post.extra.authors %}{{ post.extra.authors | join(", ") }}{% else %}The Editors{% endif %} <span class="kicker-sep">·</span> {{ post.reading_time }} min
+        </div>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/broadsheet-riot/templates/taxonomy.html
+++ b/examples/broadsheet-riot/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+
+<section class="stack">
+  <div class="article-kicker">INDEX</div>
+  <h1 class="article-title">{{ taxonomy_name | upper }}</h1>
+  <p class="article-deck">Every subject this paper has argued about, sorted by how often we have raised our voice.</p>
+  <div class="article-rule-thick"></div>
+
+  <ul class="tag-cloud">
+    {% for term in taxonomy_terms %}
+    <li class="tag-cloud-item">
+      <a href="{{ base_url }}{{ term.url }}">
+        <span class="tag-cloud-name">{{ term.name }}</span>
+        <span class="tag-cloud-count">{{ term.pages | length }}</span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/broadsheet-riot/templates/taxonomy_term.html
+++ b/examples/broadsheet-riot/templates/taxonomy_term.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<section class="stack">
+  <div class="article-kicker">{{ taxonomy_name | upper }}</div>
+  <h1 class="article-title">{{ taxonomy_term }}</h1>
+  <p class="article-deck">{{ taxonomy_pages | length }} dispatch{% if taxonomy_pages | length != 1 %}es{% endif %} filed under this subject.</p>
+  <div class="article-rule-thick"></div>
+
+  <ul class="stack-list">
+    {% for post in taxonomy_pages %}
+    <li class="stack-item">
+      <div class="stack-num">№ {{ "%02d" | format(loop.index) }}</div>
+      <div class="stack-body">
+        <div class="stack-meta"><time>{{ post.date | date("%d %B %Y") }}</time></div>
+        <h2 class="stack-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.description %}
+        <p class="stack-deck">{{ post.description }}</p>
+        {% endif %}
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/cut-paper-zine/config.toml
+++ b/examples/cut-paper-zine/config.toml
@@ -1,0 +1,193 @@
+title = "Cut Paper Zine"
+description = "A photocopy-and-glue blog. Riso ink, torn edges, halftones loud enough to hear."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 20
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/cut-paper-zine/content/about.md
+++ b/examples/cut-paper-zine/content/about.md
@@ -1,0 +1,30 @@
++++
+title = "About / Contact"
+description = "Who made this. How to find them."
++++
+
+## A Zine, In The Old Sense
+
+**Cut Paper Zine** is assembled in a kitchen at 2 a.m. with a stack of newsprint, two Risograph drums (fluorescent pink and federal blue), a glue stick, and the kind of resentment that only makes sense if you started this in 1997.
+
+It is published "whenever," which means usually every six weeks, sometimes every six months, occasionally twice in a week if something has made one of us angry enough.
+
+### What's In Each Issue
+
+- One **rant** (long, unedited, written in one sitting).
+- Two **interviews** (mostly with people who do not have publicists).
+- One **review** of something nobody else is reviewing.
+- One **collage** that does not load on this web version.
+- A **letters page** consisting entirely of complaints.
+
+### How To Reach Us
+
+- Mail: a P.O. box we'll tell you about if you ask twice.
+- Email: works, but slowly.
+- The actual paper version: stapled, postage-paid, $3 or trade.
+
+### A Note On Authorship
+
+Nothing here is signed because nothing here is ours alone. The collages quote other collages. The fonts were borrowed from a free fonts site we cannot remember. The opinions are formed in the same way opinions have always been formed: by argument, in person, over food.
+
+If you see something that should be credited and isn't, tell us. We'll set it right in the next issue, in red ink, on the cover.

--- a/examples/cut-paper-zine/content/index.md
+++ b/examples/cut-paper-zine/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Cut Paper Zine"
+description = "Issue 14 — printed in three colors, two of them by accident."
++++
+
+Issue contents below.

--- a/examples/cut-paper-zine/content/posts/_index.md
+++ b/examples/cut-paper-zine/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "All Issues"
+description = "Back catalog. Every issue we still have copies of."
+sort_by = "date"
+paginate = 10
+template = "section"
+generate_feeds = true
++++
+
+Every issue we've stapled and put out into the world. Order is reverse chronological, the way the photocopier remembers.

--- a/examples/cut-paper-zine/content/posts/a-letter-to-the-staple.md
+++ b/examples/cut-paper-zine/content/posts/a-letter-to-the-staple.md
@@ -1,0 +1,39 @@
++++
+title = "A Letter To The Saddle Staple"
+date = "2026-03-28"
+description = "The two little pieces of wire that hold the zine together, and what they ask of us in return."
+tags = ["binding", "craft", "letter"]
+categories = ["letter"]
+[extra]
+authors = ["The Editors"]
+issue = "13"
++++
+
+Dear staple,
+
+We've been thinking about you. Specifically about the two of you — the long one through the spine of every zine we make, and the short one through the corner of our drafts. You are the smallest piece of hardware in our entire workflow, and arguably the most important. We want to apologize for how rarely we say so.
+
+<!-- more -->
+
+## You Hold Things Together. That's The Whole Job.
+
+A staple is the only piece of a zine that the reader will actually **touch**, repeatedly, with intent. They will run their thumb across the spine to keep their place. They will bend you the wrong way when they shove the zine into a bag. They will eventually, in the case of a beloved issue, work you loose and the pages will scatter onto the floor of a bus, and the reader will swear, but they will pick up the pages anyway, because by that point the zine has become **theirs**.
+
+A staple is the difference between a stack of paper and a publication. We do not say this lightly. The act of stapling is the act of declaring: *these things belong together, and the world is now allowed to read them as one.*
+
+## On Choosing Your Staple Length
+
+The short ones are for drafts. The long ones — 7 millimeters, ideally — are for the finished object. There is a particular grade of staple sold for "heavy-duty" use that we have never been able to fit into our stapler, and we suspect this is true of most independent zine-makers in the world. **Use the long ones if you can. The reader will notice, in the way you notice good bookbinding without being able to name it.**
+
+## The Crooked Staple
+
+A perfectly straight staple is a sign of factory-made work. We do not make factory-made work. **Most of our staples are slightly crooked.** This is because we staple them by hand, holding the zine open over the corner of a desk, with a long-throw stapler we bought at a thrift store in 2014. The crookedness is the only signature we leave.
+
+## What We Owe You
+
+Patience, mainly. There are issues where we have run out of staples halfway through a print run, and instead of going to buy more, we have tied the centerfolds with butcher's twine. The reader has, on at least three occasions, written to thank us specifically for the twine. We do not know what to do with this information. We are telling you, the staple, because we suspect you will not be jealous.
+
+In any case: thank you, staple. The next round of beers is on us. We have not yet figured out how to buy a piece of wire a drink. We are working on it.
+
+Yours,  
+The Editors

--- a/examples/cut-paper-zine/content/posts/interview-with-a-bookbinder.md
+++ b/examples/cut-paper-zine/content/posts/interview-with-a-bookbinder.md
@@ -1,0 +1,50 @@
++++
+title = "Interview: A Bookbinder Who Doesn't Want To Be Famous"
+date = "2026-05-02"
+description = "A conversation in a basement workshop, with the smell of hide glue and old paper, about the moral weight of a signature."
+tags = ["interview", "bookbinding", "craft"]
+categories = ["interview"]
+[extra]
+authors = ["L. Tanaka"]
+issue = "14"
++++
+
+We caught up with **N.**, who has been binding books out of a basement in the same city for thirty-one years, in a workshop that smells like hide glue, beeswax, and the kind of dust that only accumulates around paper. She is in her early sixties, asked us not to name her, and laughed at us when we asked about Instagram.
+
+<!-- more -->
+
+## "I Bind Books. I Don't Brand Them."
+
+**CPZ**: Most bookbinders we've talked to lately have very active social media. You don't.
+
+**N.**: I bind books. I don't brand them. The book either holds up, or it doesn't. The customer either comes back, or they don't. The internet is a layer of conversation I don't need, on top of a layer of conversation I'm not having.
+
+**CPZ**: Some of your colleagues would say that's commercial suicide.
+
+**N.**: Some of my colleagues are starving. Some of them aren't. I'm fine. I have a waitlist that's eighteen months long, and the people on it are not the people I would have reached through a marketing account.
+
+## The Signature Is The Promise
+
+**CPZ**: You don't sign your work, either. Most binders do.
+
+**N.**: I sign the inside, in pencil, in a place where you have to take the book apart to find it. The person who commissions a book from me knows where it is. The person who finds the book at an estate sale in forty years can find it if they care to look. Everybody else can just have a book.
+
+A signature is **a promise**, not an advertisement. I'm making the promise to the book and to the person who paid for it. The promise is that I will fix it for free if it falls apart on my watch, and that "my watch" lasts as long as I do.
+
+> The signature is the architecture. It's where the book ends and I begin.
+
+## A Defense Of Slowness
+
+**CPZ**: Eighteen months is a long wait.
+
+**N.**: It's because I work alone, and I work slow, and I refuse to take more commissions than I can finish well. I lost two clients last year because they got tired of waiting. I gained six because they got tired of fast.
+
+**CPZ**: What changed?
+
+**N.**: Nothing changed. *They* changed. The pendulum swings. Right now we're in a moment where people want a thing made by a person, in a quantity of one, that will last longer than they will. I have been making that thing in the same way for thirty years. The market found me. I did not find it.
+
+## What She Wanted Us To Print
+
+**N.**: One thing. Tell the readers that I am not accepting new clients until 2027. They will write anyway, and I will say no, but I want them to know I tried.
+
+We are printing this one, in pink, on page seven.

--- a/examples/cut-paper-zine/content/posts/review-a-place-i-cannot-name.md
+++ b/examples/cut-paper-zine/content/posts/review-a-place-i-cannot-name.md
@@ -1,0 +1,48 @@
++++
+title = "Review: A Place I Cannot Name"
+date = "2026-03-04"
+description = "A noodle shop, two flights underground, with no sign and a phone that rings twice before someone hangs up."
+tags = ["review", "food", "city"]
+categories = ["review"]
+[extra]
+authors = ["L. Tanaka"]
+issue = "12"
++++
+
+I am not going to tell you where it is. I am not going to tell you what street, or which neighborhood, or how to find it. I am not going to give it stars. If you happen to find it, you will know, and you will not tell anyone either, which is the only way a place like this remains a place like this.
+
+<!-- more -->
+
+## What I Will Tell You
+
+There is one dish. It is a noodle, in a broth, with two pieces of meat and one piece of pickle and a green herb I cannot identify. The bowl is a heavy ceramic that has been used by so many hands that the glaze has worn off the rim in two places, where the thumb sits. The bowl costs nine dollars and you eat it in seven minutes.
+
+The room holds eight people. Three of those people work there. There is a stove, a cutting board, a chest freezer, a clock that has been stopped at 4:17 for at least a year, and a single fluorescent light that flickers in a way that you stop noticing about ninety seconds after you sit down.
+
+## The Owner
+
+She does not introduce herself. She makes the noodles. She has been making the noodles for **what I am told is forty-six years**, in this room, two flights underground. I asked her what is in the broth and she said *"you don't need to know"* and I have not asked again.
+
+She is right. I do not need to know.
+
+## Why I Am Reviewing A Place I Cannot Name
+
+Because I am tired of restaurant criticism that exists only to make you go to restaurants. There are places that should be reviewed and then **not visited**. The review is a way of putting them on the record, of saying: *this exists, this is what it is doing, this is what we owe it.* The review is the thing the place will never write about itself.
+
+There is also a kind of food writing that has been swallowed by the **tourism industry**, and to read it is to read a piece of marketing dressed up as a private experience. I would rather write the opposite: a review that exists to keep a place private, by being so vague about its location that no one can possibly act on it.
+
+> Some places do not want to be discovered. They want to be visited by the people who already know.
+
+## The Pickle
+
+The pickle is the best part. It is some kind of root vegetable, fermented for a length of time I cannot guess, sliced thin, and laid across the broth in three pieces that look like brushstrokes. I asked about it. She said *"the pickle"* and walked away.
+
+The pickle was the answer.
+
+## Closing Notes
+
+The noodle shop is open, as far as I can tell, on the days the owner feels like opening it. There is no schedule. There is no menu. There is no Instagram. There is, in the corner, a small white cat who sleeps on a sack of rice and is, I suspect, the real owner.
+
+If you find it, sit down quietly. Order. Eat. Pay. Leave. Do not write about it.
+
+I am sorry I have.

--- a/examples/cut-paper-zine/content/posts/risograph-is-not-a-trend.md
+++ b/examples/cut-paper-zine/content/posts/risograph-is-not-a-trend.md
@@ -1,0 +1,34 @@
++++
+title = "Risograph Is Not A Trend, It Is A Limitation We Married"
+date = "2026-05-19"
+description = "On the discipline of two colors and the moral failure of perfect registration."
+tags = ["risograph", "print", "process"]
+categories = ["rant"]
+[extra]
+authors = ["K. Marquez"]
+issue = "14"
++++
+
+People keep asking us why we don't print in full color. **Full color is a confession.** Full color says we could not decide what mattered, so we kept everything. The Risograph forces you to decide. You get pink. You get blue. You get the place where pink and blue overlap, which is a kind of bruised purple, and if you don't love bruised purple, you should be making something else.
+
+<!-- more -->
+
+## The Math Of Two
+
+A two-color print is a different *medium* from a four-color print, and people who confuse the two will produce work that is mediocre in both. The Riso refuses to give you brown. It refuses to give you the precise shade of someone's skin. It refuses, most importantly, to give you **silence** — every Riso color is loud, even the pale ones, because they are sitting on a surface that wants to absorb them.
+
+You learn very quickly that the question is not "what color is this object?" The question is: **what is the shape of the part of this object that I want the reader to feel?** Everything else has to drop out.
+
+## On Misregistration
+
+A perfectly registered two-color print is a piece of work that has been **scared into politeness**. The little gap between the pink layer and the blue layer is the point. It is the print's confession that it is hand-made, that it passed through a machine, that the human who set it up was tired or in a hurry or feeling experimental that day.
+
+We hold our prints up to the light and we look for the misregistration the way other people look for crop marks. It tells us the print is alive.
+
+> Perfect registration is the typography equivalent of a customer service voice. Polite. Useless. Suspicious.
+
+## What The Riso Cannot Do
+
+It cannot do gradients well. It cannot do photographs well. It cannot do anything that requires more than two passes without the paper warping. **These are not bugs.** These are the things that have kept us honest. If you cannot make the page work with two flat colors of fluorescent ink, you have not yet figured out what the page is for.
+
+The Riso is the kitchen of print. Other media are the restaurant. We are not closing the restaurant. We are saying that you should learn to cook before you go.

--- a/examples/cut-paper-zine/content/posts/the-photocopier-as-collaborator.md
+++ b/examples/cut-paper-zine/content/posts/the-photocopier-as-collaborator.md
@@ -1,0 +1,34 @@
++++
+title = "The Photocopier As Collaborator"
+date = "2026-04-15"
+description = "On the dark machine that hums in the corner and refuses to lie to you."
+tags = ["process", "print", "manifesto"]
+categories = ["rant"]
+[extra]
+authors = ["K. Marquez"]
+issue = "13"
++++
+
+The photocopier is the only piece of office equipment that has ever been honest with me. It takes what you put in, and it makes a *worse version of it,* and it does so with a calm green flash and a smell of warm toner that has not changed since 1981. Everything we love about this zine — the slightly broken letterforms, the deep blacks that turn out to be 60% gray on close inspection, the dust on the platen that shows up on every page — is the photocopier's contribution.
+
+<!-- more -->
+
+## What The Copier Knows That The Printer Doesn't
+
+A modern inkjet wants to **improve** your art. It will sharpen the edges. It will smooth the blacks. It will guess at color and almost always guess wrong. The photocopier has no opinion about your art. It will reproduce a thumbprint with the same gravity as it reproduces a poem. The democracy of the photocopier is total, and that is exactly the right kind of relationship to have with a machine you are using to print political work.
+
+## The Generational Drift
+
+If you photocopy a photocopy of a photocopy, the image **degrades**, but it degrades in a particular direction: toward graphic abstraction. Lines thicken. Halftones collapse into solid blocks. Faces lose their middle tones and become contour drawings. This is the most generous gift any tool has ever given to a designer — it converts photographs into something that *looks like a print,* by doing nothing more than what it is told to do, repeatedly.
+
+We print the first version. Then we make a copy of it. Then we make a copy of that. The version we publish is somewhere around the seventh generation. We can no longer tell you what the original looked like. **That is the point.**
+
+## A Liturgy For The Office Copier
+
+Most photocopiers spend their lives copying receipts and tax returns. They deserve better. Once a month, take your nearest office copier out for an evening. Bring a stack of textured papers (newsprint, kraft, the back of a cereal box). Bring a folder of black-and-white images you have no respect for. Set the contrast to maximum and hit start.
+
+You will not produce a finished piece of work the first time. You will produce **about a hundred pages of garbage**, and somewhere in the middle of that garbage will be one image that is better than anything you could have designed deliberately. That image is the photocopier's answer to a question you did not know you were asking. Pull it out. Frame it. Apologize to the machine. Begin again.
+
+## The Toner-Smell Test
+
+If you make a zine, and the finished object does not smell faintly of toner, you have either used the wrong machine or printed in the wrong city. Both are recoverable. Neither should happen twice.

--- a/examples/cut-paper-zine/static/css/style.css
+++ b/examples/cut-paper-zine/static/css/style.css
@@ -1,0 +1,756 @@
+:root {
+  --paper: #f5efe2;
+  --paper-dark: #ece4d0;
+  --ink: #15131a;
+  --pink: #ff5a8d;
+  --pink-deep: #e7437a;
+  --blue: #1f3aff;
+  --blue-deep: #1a2cc4;
+  --yellow: #ffe338;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  font-family: "DM Sans", system-ui, sans-serif;
+  color: var(--ink);
+  line-height: 1.55;
+  font-size: 17px;
+}
+
+::selection { background: var(--pink); color: var(--paper); }
+
+a { color: var(--blue); text-decoration: underline; text-decoration-thickness: 1.5px; text-underline-offset: 3px; }
+a:hover { background: var(--blue); color: var(--paper); text-decoration: none; }
+
+/* ---------------- PAPER BACKGROUND ---------------- */
+
+.paper-bg, .halftone-overlay { display: none; }
+
+/* ---------------- LAYOUT ---------------- */
+
+.zine {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 32px 60px;
+  position: relative;
+  z-index: 1;
+}
+
+/* ---------------- HEADER ---------------- */
+
+.zine-header {
+  position: relative;
+  padding: 26px 0 42px;
+  margin-bottom: 26px;
+}
+
+.stamp {
+  position: absolute;
+  font-family: "Special Elite", "Courier New", monospace;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  border: 2.5px solid currentColor;
+  line-height: 1.15;
+  text-align: center;
+}
+.stamp::after {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border: 1px dashed currentColor;
+  opacity: 0.5;
+  pointer-events: none;
+}
+.stamp-pink {
+  color: var(--pink-deep);
+  background: var(--paper);
+  top: 8px;
+  left: 0;
+  transform: rotate(-7deg);
+}
+.stamp-blue {
+  color: var(--blue-deep);
+  background: var(--paper);
+  top: 16px;
+  right: 12px;
+  transform: rotate(5deg);
+}
+
+.zine-title {
+  display: block;
+  text-align: center;
+  font-family: "Archivo Black", system-ui, sans-serif;
+  font-weight: 900;
+  text-transform: uppercase;
+  text-decoration: none;
+  margin: 60px 0 14px;
+  line-height: 0.82;
+  letter-spacing: -0.025em;
+}
+.zine-title:hover { background: transparent; color: inherit; }
+.zine-title-cut {
+  display: block;
+  font-size: clamp(60px, 13vw, 168px);
+  color: var(--ink);
+  position: relative;
+}
+.zine-title-cut-1 {
+  color: var(--pink-deep);
+  transform: translateX(-2%) rotate(-1.2deg);
+  text-shadow: 4px 4px 0 var(--ink);
+}
+.zine-title-cut-2 {
+  color: var(--blue-deep);
+  transform: translateX(3%) rotate(0.8deg);
+  text-shadow: -4px 4px 0 var(--ink);
+}
+.zine-subtitle {
+  text-align: center;
+  font-family: "Special Elite", monospace;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+  margin: 24px auto 24px;
+  max-width: 60ch;
+  color: var(--ink);
+}
+
+.zine-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 28px;
+}
+.zine-nav-pill {
+  background: var(--ink);
+  color: var(--paper);
+  font-family: "Archivo Black", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 8px 18px;
+  text-decoration: none;
+  border: 3px solid var(--ink);
+  position: relative;
+  transition: transform 0.06s ease;
+}
+.zine-nav-pill:nth-child(2) { background: var(--pink); color: var(--ink); border-color: var(--ink); transform: rotate(-1.5deg); }
+.zine-nav-pill:nth-child(3) { background: var(--blue); color: var(--paper); transform: rotate(1deg); }
+.zine-nav-pill:nth-child(4) { background: var(--paper); color: var(--ink); transform: rotate(-0.5deg); }
+.zine-nav-pill:nth-child(5) { background: var(--yellow); color: var(--ink); transform: rotate(1.5deg); }
+.zine-nav-pill:hover {
+  transform: rotate(0) translateY(-2px);
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.torn-edge {
+  height: 12px;
+  margin-top: 26px;
+  background: var(--ink);
+  position: relative;
+}
+.torn-edge::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 6px;
+  background-color: var(--paper);
+  clip-path: polygon(0 100%, 3% 0, 6% 100%, 9% 20%, 12% 100%, 15% 30%, 18% 100%, 21% 10%, 24% 100%, 27% 25%, 30% 100%, 33% 0, 36% 100%, 39% 30%, 42% 100%, 45% 10%, 48% 100%, 51% 25%, 54% 100%, 57% 0, 60% 100%, 63% 30%, 66% 100%, 69% 15%, 72% 100%, 75% 25%, 78% 100%, 81% 0, 84% 100%, 87% 20%, 90% 100%, 93% 30%, 96% 100%, 100% 10%, 100% 100%);
+}
+.torn-edge-flip {
+  height: 12px;
+  margin: 26px 0;
+  background: var(--ink);
+  position: relative;
+}
+.torn-edge-flip::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -1px;
+  height: 6px;
+  background-color: var(--paper);
+  clip-path: polygon(0 0, 3% 100%, 6% 0, 9% 80%, 12% 0, 15% 70%, 18% 0, 21% 90%, 24% 0, 27% 75%, 30% 0, 33% 100%, 36% 0, 39% 70%, 42% 0, 45% 90%, 48% 0, 51% 75%, 54% 0, 57% 100%, 60% 0, 63% 70%, 66% 0, 69% 85%, 72% 0, 75% 75%, 78% 0, 81% 100%, 84% 0, 87% 80%, 90% 0, 93% 70%, 96% 0, 100% 90%, 100% 0);
+}
+
+/* ---------------- COVER ---------------- */
+
+.cover { padding-top: 12px; }
+.cover-stamp {
+  font-family: "Special Elite", monospace;
+  font-size: 13px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--pink-deep);
+  border-top: 3px solid var(--pink-deep);
+  border-bottom: 3px solid var(--pink-deep);
+  padding: 5px 0;
+  display: inline-block;
+  padding-right: 24px;
+  padding-left: 4px;
+  margin-bottom: 18px;
+}
+
+.cover-headline {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(36px, 7vw, 96px);
+  line-height: 0.9;
+  letter-spacing: -0.025em;
+  text-transform: uppercase;
+  margin: 0 0 26px;
+  max-width: 18ch;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 24px;
+}
+.hl {
+  display: inline-block;
+  padding: 0 14px;
+  line-height: 1;
+}
+.hl-pink { color: var(--paper); background: var(--pink-deep); transform: rotate(-2deg); }
+.hl-blue { color: var(--paper); background: var(--blue-deep); transform: rotate(1deg); }
+.hl-black { color: var(--paper); background: var(--ink); transform: rotate(-0.8deg); }
+
+.cover-deck {
+  font-family: "Special Elite", monospace;
+  font-size: 17px;
+  line-height: 1.5;
+  max-width: 60ch;
+  margin: 0 0 40px;
+}
+
+/* ---------------- CARDS GRID ---------------- */
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 20px;
+  margin-bottom: 60px;
+}
+.card {
+  position: relative;
+  padding: 24px 22px 20px;
+  background: var(--paper);
+  border: 3px solid var(--ink);
+  box-shadow: 8px 8px 0 var(--ink);
+}
+.card-1 { grid-column: span 7; transform: rotate(-1deg); }
+.card-2 { grid-column: span 5; background: var(--pink); color: var(--ink); transform: rotate(1.2deg); box-shadow: 8px 8px 0 var(--blue-deep); }
+.card-3 { grid-column: span 5; transform: rotate(-0.6deg); }
+.card-4 { grid-column: span 7; background: var(--blue); color: var(--paper); transform: rotate(0.7deg); box-shadow: -8px 8px 0 var(--pink-deep); }
+.card-2 .card-title a, .card-4 .card-title a { color: inherit; }
+.card-2 .card-cat, .card-2 .card-meta { color: var(--ink); }
+.card-4 .card-cat, .card-4 .card-meta { color: var(--paper); }
+.card-4 a { color: var(--paper); }
+.card-2 a:hover { background: var(--ink); color: var(--paper); }
+.card-4 a:hover { background: var(--paper); color: var(--blue-deep); }
+
+.card-tape {
+  position: absolute;
+  top: -14px;
+  left: 24px;
+  width: 90px;
+  height: 26px;
+  background: var(--yellow);
+  border: 2px solid var(--ink);
+  transform: rotate(-3deg);
+  z-index: 2;
+}
+.card-2 .card-tape { background: var(--paper); left: auto; right: 24px; transform: rotate(4deg); }
+.card-3 .card-tape { background: var(--pink); transform: rotate(-2deg); left: 36px; }
+.card-4 .card-tape { background: var(--yellow); right: 30px; left: auto; transform: rotate(2deg); }
+
+.card-cat {
+  font-family: "Special Elite", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  margin-top: 6px;
+  margin-bottom: 8px;
+}
+.card-title {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(22px, 2.6vw, 32px);
+  line-height: 1.04;
+  letter-spacing: -0.01em;
+  margin: 0 0 12px;
+  text-transform: uppercase;
+}
+.card-title a { color: var(--ink); text-decoration: none; }
+.card-title a:hover { background: var(--ink); color: var(--paper); }
+.card-deck {
+  font-family: "Special Elite", monospace;
+  font-size: 14px;
+  line-height: 1.45;
+  margin: 0 0 14px;
+}
+.card-meta {
+  display: flex;
+  justify-content: space-between;
+  font-family: "Special Elite", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.card-corner-1, .card-corner-2, .card-corner-3 {
+  position: absolute;
+  right: -3px;
+  bottom: -3px;
+  width: 38px;
+  height: 38px;
+  border-right: 3px solid var(--ink);
+  border-bottom: 3px solid var(--ink);
+}
+.card-corner-2 { border-color: var(--pink-deep); }
+.card-corner-3 { border-color: var(--blue-deep); }
+
+/* ---------------- PULL QUOTE ---------------- */
+
+.pull-quote {
+  position: relative;
+  margin: 80px auto 40px;
+  max-width: 760px;
+  padding: 40px 20px;
+  border-top: 5px dashed var(--ink);
+  border-bottom: 5px dashed var(--ink);
+  text-align: center;
+}
+.pull-mark {
+  position: absolute;
+  top: -28px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60px;
+  height: 60px;
+  background: var(--pink-deep);
+  color: var(--paper);
+  font-size: 78px;
+  line-height: 0.9;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Archivo Black", sans-serif;
+}
+.pull-quote p {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(22px, 3vw, 32px);
+  line-height: 1.2;
+  margin: 8px 0 12px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+}
+.pull-quote cite {
+  font-family: "Special Elite", monospace;
+  font-style: normal;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--blue-deep);
+}
+
+/* ---------------- PIECE / PAGE ---------------- */
+
+.piece { max-width: 740px; margin: 28px auto 0; }
+.piece-head { margin-bottom: 30px; }
+.piece-cat {
+  display: inline-block;
+  font-family: "Special Elite", monospace;
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  padding: 5px 14px;
+  background: var(--ink);
+  color: var(--paper);
+  margin-bottom: 18px;
+  transform: rotate(-1.4deg);
+}
+.piece-title {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(34px, 5.6vw, 64px);
+  line-height: 0.95;
+  letter-spacing: -0.025em;
+  text-transform: uppercase;
+  margin: 0 0 16px;
+}
+.piece-deck {
+  font-family: "Special Elite", monospace;
+  font-size: 18px;
+  line-height: 1.4;
+  margin: 0 0 18px;
+}
+.piece-byline {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  font-family: "Special Elite", monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+.byline-tape {
+  background: var(--yellow);
+  padding: 4px 10px;
+  border: 2px solid var(--ink);
+  transform: rotate(-1deg);
+}
+.byline-date { color: var(--blue-deep); }
+.piece-tags { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 6px; }
+.piece-tag {
+  font-family: "Archivo Black", sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  text-decoration: none;
+  background: var(--paper);
+  color: var(--ink);
+  border: 2px solid var(--ink);
+}
+.piece-tag:hover { background: var(--ink); color: var(--paper); }
+
+.piece-body { font-family: "DM Sans", sans-serif; font-size: 18px; line-height: 1.7; }
+.piece-body p { margin: 0 0 1.1em; }
+.piece-body p:first-of-type::first-letter {
+  float: left;
+  font-family: "Archivo Black", sans-serif;
+  font-weight: 900;
+  font-size: 5.4em;
+  line-height: 0.85;
+  padding: 10px 14px 0 0;
+  color: var(--pink-deep);
+  text-shadow: 3px 3px 0 var(--ink);
+}
+.piece-body h2 {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(24px, 3.2vw, 36px);
+  text-transform: uppercase;
+  letter-spacing: -0.015em;
+  margin: 1.8em 0 0.6em;
+  line-height: 1.05;
+  display: inline-block;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 4px 14px;
+  transform: rotate(-0.7deg);
+}
+.piece-body h3 {
+  font-family: "Special Elite", monospace;
+  font-size: 14px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--blue-deep);
+  margin: 1.6em 0 0.4em;
+  border-bottom: 3px dotted var(--blue-deep);
+  padding-bottom: 4px;
+  display: inline-block;
+}
+.piece-body blockquote {
+  margin: 1.6em 0;
+  padding: 16px 22px;
+  background: var(--pink);
+  border: 3px solid var(--ink);
+  font-family: "Archivo Black", sans-serif;
+  font-size: 1.05em;
+  line-height: 1.25;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  transform: rotate(-0.8deg);
+  box-shadow: 6px 6px 0 var(--ink);
+}
+.piece-body code {
+  font-family: "Special Elite", monospace;
+  background: var(--paper-dark);
+  border: 1.5px solid var(--ink);
+  padding: 0.05em 0.32em;
+  font-size: 0.9em;
+}
+.piece-body pre {
+  font-family: "Special Elite", monospace;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 18px 22px;
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-x: auto;
+  border: 3px solid var(--ink);
+  box-shadow: 6px 6px 0 var(--pink-deep);
+  margin: 1.6em 0;
+}
+.piece-body pre code { background: transparent; border: 0; padding: 0; color: inherit; }
+.piece-body ul, .piece-body ol { padding-left: 1.4em; }
+.piece-body li { margin: 0.35em 0; }
+.piece-body li::marker { color: var(--pink-deep); font-weight: 700; }
+.piece-body strong { background: var(--yellow); padding: 0 4px; }
+.piece-body em { color: var(--blue-deep); }
+
+.piece-foot {
+  margin-top: 50px;
+  padding-top: 26px;
+  border-top: 4px dashed var(--ink);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.piece-foot-stamp {
+  font-family: "Special Elite", monospace;
+  font-size: 14px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--pink-deep);
+  padding: 6px 14px;
+  border: 3px solid var(--pink-deep);
+  transform: rotate(-2deg);
+}
+.piece-foot-back {
+  font-family: "Archivo Black", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--ink);
+  border-bottom: 4px solid var(--blue);
+  padding-bottom: 2px;
+}
+
+/* ---------------- ARCHIVE / SECTION ---------------- */
+
+.archive { max-width: 980px; margin: 28px auto 0; }
+.archive-stamp {
+  font-family: "Special Elite", monospace;
+  font-size: 13px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--blue-deep);
+  border-top: 3px solid var(--blue-deep);
+  border-bottom: 3px solid var(--blue-deep);
+  padding: 5px 0;
+  display: inline-block;
+  padding-right: 24px;
+  padding-left: 4px;
+  margin-bottom: 16px;
+}
+.archive-title {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(40px, 6vw, 72px);
+  text-transform: uppercase;
+  letter-spacing: -0.025em;
+  line-height: 0.95;
+  margin: 0 0 14px;
+}
+.archive-deck {
+  font-family: "Special Elite", monospace;
+  font-size: 17px;
+  line-height: 1.45;
+  max-width: 60ch;
+  margin: 0 0 36px;
+}
+
+.archive-list { display: flex; flex-direction: column; gap: 22px; }
+.archive-row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 24px;
+  padding: 20px 22px;
+  border: 3px solid var(--ink);
+  background: var(--paper);
+  align-items: start;
+}
+.archive-row-1 { box-shadow: 6px 6px 0 var(--pink-deep); }
+.archive-row-2 { box-shadow: 6px 6px 0 var(--blue-deep); transform: rotate(-0.4deg); }
+.archive-row-3 { box-shadow: 6px 6px 0 var(--ink); }
+.archive-num {
+  font-family: "Archivo Black", sans-serif;
+  font-size: 52px;
+  line-height: 0.9;
+  color: var(--pink-deep);
+  letter-spacing: -0.03em;
+  text-shadow: 3px 3px 0 var(--ink);
+}
+.archive-meta {
+  font-family: "Special Elite", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  color: var(--ink);
+}
+.archive-issue { color: var(--blue-deep); }
+.archive-cat { color: var(--pink-deep); }
+.archive-dot { margin: 0 6px; }
+.archive-title-row {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(20px, 2.4vw, 28px);
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  text-transform: uppercase;
+  margin: 0 0 8px;
+}
+.archive-title-row a { color: var(--ink); text-decoration: none; }
+.archive-title-row a:hover { background: var(--ink); color: var(--paper); }
+.archive-deck-row {
+  font-family: "Special Elite", monospace;
+  font-size: 14.5px;
+  line-height: 1.4;
+  margin: 0;
+}
+
+/* ---------------- TAG CLOUD ---------------- */
+
+.tags-cloud {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+.tags-cloud-item a {
+  display: inline-flex;
+  gap: 10px;
+  align-items: baseline;
+  text-decoration: none;
+  padding: 10px 16px;
+  border: 3px solid var(--ink);
+  font-family: "Archivo Black", sans-serif;
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  background: var(--paper);
+  box-shadow: 5px 5px 0 var(--ink);
+}
+.tags-cloud-item-1 a { background: var(--pink); box-shadow: 5px 5px 0 var(--blue-deep); }
+.tags-cloud-item-2 a { background: var(--blue); color: var(--paper); box-shadow: 5px 5px 0 var(--pink-deep); }
+.tags-cloud-item-3 a { background: var(--yellow); box-shadow: 5px 5px 0 var(--ink); }
+.tags-cloud-item a:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 7px 7px 0 var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+}
+.tag-count {
+  font-family: "Special Elite", monospace;
+  font-weight: 400;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  opacity: 0.7;
+}
+
+/* ---------------- 404 ---------------- */
+
+.four-oh-four { max-width: 680px; margin: 80px auto; text-align: center; }
+.error-num {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(160px, 26vw, 320px);
+  line-height: 0.9;
+  letter-spacing: -0.05em;
+  color: var(--pink-deep);
+  text-shadow: 10px 10px 0 var(--ink), -6px -6px 0 var(--blue);
+  margin: 12px 0;
+}
+.error-deck {
+  font-family: "Special Elite", monospace;
+  font-size: 18px;
+  line-height: 1.4;
+  margin: 0 0 26px;
+}
+.error-back {
+  font-family: "Archivo Black", sans-serif;
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--paper);
+  background: var(--ink);
+  padding: 10px 18px;
+  text-decoration: none;
+  border: 3px solid var(--ink);
+  box-shadow: 6px 6px 0 var(--pink-deep);
+  display: inline-block;
+}
+.error-back:hover { background: var(--pink-deep); color: var(--paper); }
+
+/* ---------------- FOOTER ---------------- */
+
+.zine-footer { margin-top: 60px; }
+.footer-cuts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  padding: 30px 0;
+}
+.footer-cut {
+  padding: 22px;
+  border: 3px solid var(--ink);
+}
+.footer-cut-pink { background: var(--pink); box-shadow: 6px 6px 0 var(--ink); transform: rotate(-1deg); }
+.footer-cut-blue { background: var(--blue); color: var(--paper); box-shadow: 6px 6px 0 var(--ink); transform: rotate(0.6deg); }
+.footer-cut-white { background: var(--paper); box-shadow: 6px 6px 0 var(--ink); transform: rotate(-0.5deg); }
+.footer-cut-label {
+  font-family: "Archivo Black", sans-serif;
+  font-size: 14px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.footer-cut-text {
+  font-family: "Special Elite", monospace;
+  font-size: 14px;
+  line-height: 1.45;
+}
+.footer-cut-blue a { color: var(--paper); text-decoration-color: var(--yellow); }
+.footer-cut-blue a:hover { background: var(--paper); color: var(--blue-deep); }
+
+.footer-imprint {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 4px;
+  font-family: "Special Elite", monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.footer-imprint-stamp {
+  border: 2.5px solid var(--ink);
+  padding: 4px 10px;
+  transform: rotate(-1.5deg);
+}
+.footer-imprint-tag { color: var(--blue-deep); }
+
+/* ---------------- RESPONSIVE ---------------- */
+
+@media (max-width: 900px) {
+  .zine { padding: 18px 18px 40px; }
+  .stamp-pink { top: 0; transform: rotate(-4deg) scale(0.85); transform-origin: top left; }
+  .stamp-blue { top: 0; transform: rotate(3deg) scale(0.85); transform-origin: top right; }
+  .zine-title { margin-top: 80px; }
+  .cards { grid-template-columns: 1fr; }
+  .card-1, .card-2, .card-3, .card-4 { grid-column: span 1; }
+  .footer-cuts { grid-template-columns: 1fr; }
+  .archive-row { grid-template-columns: 80px 1fr; gap: 14px; padding: 16px; }
+  .archive-num { font-size: 36px; }
+}
+@media (max-width: 520px) {
+  .cover-headline { gap: 0 12px; }
+  .hl { padding: 0 8px; }
+}

--- a/examples/cut-paper-zine/templates/404.html
+++ b/examples/cut-paper-zine/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<section class="four-oh-four">
+  <div class="archive-stamp">PAGE TORN OUT</div>
+  <h1 class="error-num">404</h1>
+  <p class="error-deck">This page was on the centerfold, and somebody took it home. Possibly us. We'll print another one if you can describe it.</p>
+  <a class="error-back" href="{{ base_url }}/">← back to the cover</a>
+</section>
+
+{% include "footer.html" %}

--- a/examples/cut-paper-zine/templates/footer.html
+++ b/examples/cut-paper-zine/templates/footer.html
@@ -1,0 +1,25 @@
+    </main>
+    <footer class="zine-footer">
+      <div class="torn-edge torn-edge-flip"></div>
+      <div class="footer-cuts">
+        <div class="footer-cut footer-cut-pink">
+          <div class="footer-cut-label">Trade list</div>
+          <div class="footer-cut-text">We will trade an issue for: your own zine, a postcard, a recipe, a really good pickle.</div>
+        </div>
+        <div class="footer-cut footer-cut-blue">
+          <div class="footer-cut-label">Subscribe</div>
+          <div class="footer-cut-text">Mail: ask. Web: <a href="{{ base_url }}/rss.xml">RSS</a>. Person: find us at the printer's, Sundays.</div>
+        </div>
+        <div class="footer-cut footer-cut-white">
+          <div class="footer-cut-label">Colophon</div>
+          <div class="footer-cut-text">Built with Hwaro. Set in Archivo Black, Special Elite, DM Sans. Photocopied for the web.</div>
+        </div>
+      </div>
+      <div class="footer-imprint">
+        <span class="footer-imprint-stamp">© {{ current_year }}</span>
+        <span class="footer-imprint-tag">{{ site.title }} — STAPLED BY HAND</span>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/cut-paper-zine/templates/header.html
+++ b/examples/cut-paper-zine/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+  <title>{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Rubik+Mono+One&family=Special+Elite&family=DM+Sans:wght@400;500;700;800&family=Caveat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="{{ base_url }}/rss.xml" type="application/rss+xml" rel="alternate" title="RSS Feed">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="paper-bg">
+    <div class="halftone-overlay"></div>
+  </div>
+  <div class="zine">
+    <header class="zine-header">
+      <div class="stamp stamp-pink">ISSUE 14</div>
+      <div class="stamp stamp-blue">PRINTED IN 2 COLORS<br>BOTH BY ACCIDENT</div>
+      <a href="{{ base_url }}/" class="zine-title">
+        <span class="zine-title-cut zine-title-cut-1">{{ site.title | split(pat=" ") | first }}</span>
+        {% if site.title | split(pat=" ") | length > 1 %}
+        <span class="zine-title-cut zine-title-cut-2">{{ site.title | split(pat=" ") | slice(start=1) | join(sep=" ") }}</span>
+        {% endif %}
+      </a>
+      <div class="zine-subtitle">{{ site.description }}</div>
+      <nav class="zine-nav">
+        <a href="{{ base_url }}/" class="zine-nav-pill"><span>Cover</span></a>
+        <a href="{{ base_url }}/posts/" class="zine-nav-pill"><span>Issues</span></a>
+        <a href="{{ base_url }}/tags/" class="zine-nav-pill"><span>Index</span></a>
+        <a href="{{ base_url }}/about/" class="zine-nav-pill"><span>About</span></a>
+        <a href="{{ base_url }}/rss.xml" class="zine-nav-pill"><span>RSS</span></a>
+      </nav>
+      <div class="torn-edge"></div>
+    </header>
+    <main class="zine-main">

--- a/examples/cut-paper-zine/templates/index.html
+++ b/examples/cut-paper-zine/templates/index.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+
+{% set all_posts = site.pages | where("section", "posts") | sort_by("date", reverse=true) %}
+
+<section class="cover">
+  <div class="cover-stamp">CONTENTS</div>
+  <h1 class="cover-headline">
+    <span class="hl hl-pink">cut</span>
+    <span class="hl hl-blue">it</span>
+    <span class="hl hl-black">out</span>
+    <span class="hl hl-pink">read</span>
+    <span class="hl hl-black">it</span>
+    <span class="hl hl-blue">aloud</span>
+  </h1>
+  <p class="cover-deck">Issue 14, photocopied at 2 a.m., assembled with a glue stick that has seen things, distributed by hand to anyone willing to carry it.</p>
+
+  <div class="cards">
+    {% for post in all_posts %}
+    <article class="card card-{{ (loop.index0 % 4) + 1 }}">
+      <div class="card-tape"></div>
+      <div class="card-cat">{% if post.categories %}{{ post.categories | first | upper }}{% else %}PIECE{% endif %}</div>
+      <h2 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+      {% if post.description %}
+      <p class="card-deck">{{ post.description }}</p>
+      {% endif %}
+      <div class="card-meta">
+        <span class="card-issue">{% if post.extra is defined and post.extra.issue %}ISSUE {{ post.extra.issue }}{% else %}ISSUE 14{% endif %}</span>
+        <span class="card-date">{{ post.date | date("%d %b %y") | upper }}</span>
+      </div>
+      <div class="card-corner-{{ (loop.index0 % 3) + 1 }}"></div>
+    </article>
+    {% endfor %}
+  </div>
+
+  <div class="pull-quote">
+    <span class="pull-mark">&#8220;</span>
+    <p>Perfect registration is the typography equivalent of a customer service voice. Polite. Useless. Suspicious.</p>
+    <cite>From the rant on page three</cite>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/cut-paper-zine/templates/page.html
+++ b/examples/cut-paper-zine/templates/page.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<article class="piece">
+  <div class="piece-head">
+    <div class="piece-cat">{% if page.categories %}{{ page.categories | first | upper }}{% else %}PIECE{% endif %} · {% if page.extra is defined and page.extra.issue %}ISSUE {{ page.extra.issue }}{% else %}ISSUE 14{% endif %}</div>
+    <h1 class="piece-title">{{ page.title }}</h1>
+    {% if page.description %}
+    <p class="piece-deck">{{ page.description }}</p>
+    {% endif %}
+    <div class="piece-byline">
+      <span class="byline-tape">By {% if page.extra is defined and page.extra.authors %}{{ page.extra.authors | join(", ") }}{% else %}The Editors{% endif %}</span>
+      <time class="byline-date">{{ page.date | date("%d %B %Y") }}</time>
+    </div>
+    {% if page.tags %}
+    <div class="piece-tags">
+      {% for tag in page.tags %}
+      <a class="piece-tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+
+  <div class="piece-body">
+    {{ content | safe }}
+  </div>
+
+  <div class="piece-foot">
+    <div class="piece-foot-stamp">END OF PIECE</div>
+    <a class="piece-foot-back" href="{{ base_url }}/posts/">← back to all issues</a>
+  </div>
+</article>
+
+{% include "footer.html" %}

--- a/examples/cut-paper-zine/templates/section.html
+++ b/examples/cut-paper-zine/templates/section.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+
+<section class="archive">
+  <div class="archive-stamp">BACK ISSUES</div>
+  <h1 class="archive-title">{{ section.title }}</h1>
+  {% if section.description %}
+  <p class="archive-deck">{{ section.description }}</p>
+  {% endif %}
+
+  <div class="archive-list">
+    {% for post in section.pages %}
+    <article class="archive-row archive-row-{{ (loop.index0 % 3) + 1 }}">
+      <div class="archive-num">№{{ "%02d" | format(section.pages | length - loop.index0) }}</div>
+      <div class="archive-body">
+        <div class="archive-meta">
+          <span class="archive-issue">{% if post.extra is defined and post.extra.issue %}Issue {{ post.extra.issue }}{% else %}Issue —{% endif %}</span>
+          <span class="archive-dot">·</span>
+          <time>{{ post.date | date("%d %b %Y") }}</time>
+          {% if post.categories %}
+          <span class="archive-dot">·</span>
+          <span class="archive-cat">{{ post.categories | first }}</span>
+          {% endif %}
+        </div>
+        <h2 class="archive-title-row"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.description %}
+        <p class="archive-deck-row">{{ post.description }}</p>
+        {% endif %}
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/cut-paper-zine/templates/taxonomy.html
+++ b/examples/cut-paper-zine/templates/taxonomy.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<section class="archive">
+  <div class="archive-stamp">SUBJECT INDEX</div>
+  <h1 class="archive-title">{{ taxonomy_name | upper }}</h1>
+  <p class="archive-deck">Cross-reference: every subject this zine has covered, with a count of how often.</p>
+
+  <ul class="tags-cloud">
+    {% for term in taxonomy_terms %}
+    <li class="tags-cloud-item tags-cloud-item-{{ (loop.index0 % 3) + 1 }}">
+      <a href="{{ base_url }}{{ term.url }}">
+        <span class="tag-text">{{ term.name }}</span>
+        <span class="tag-count">×{{ term.pages | length }}</span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/cut-paper-zine/templates/taxonomy_term.html
+++ b/examples/cut-paper-zine/templates/taxonomy_term.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+
+<section class="archive">
+  <div class="archive-stamp">{{ taxonomy_name | upper }}</div>
+  <h1 class="archive-title">{{ taxonomy_term }}</h1>
+  <p class="archive-deck">{{ taxonomy_pages | length }} piece{% if taxonomy_pages | length != 1 %}s{% endif %} filed under this subject.</p>
+
+  <div class="archive-list">
+    {% for post in taxonomy_pages %}
+    <article class="archive-row archive-row-{{ (loop.index0 % 3) + 1 }}">
+      <div class="archive-num">№{{ "%02d" | format(loop.index) }}</div>
+      <div class="archive-body">
+        <div class="archive-meta">
+          {% if post.extra is defined and post.extra.issue %}<span class="archive-issue">Issue {{ post.extra.issue }}</span><span class="archive-dot">·</span>{% endif %}
+          <time>{{ post.date | date("%d %b %Y") }}</time>
+        </div>
+        <h2 class="archive-title-row"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.description %}
+        <p class="archive-deck-row">{{ post.description }}</p>
+        {% endif %}
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/monogram-quarterly/config.toml
+++ b/examples/monogram-quarterly/config.toml
@@ -1,0 +1,194 @@
+title = "Monogram Quarterly"
+description = "A long-form quarterly in the museum-catalog tradition. Wide margins, slow sentences, and the absolute minimum of ornament."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+filename = "atom.xml"
+limit = 20
+sections = ["essays"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/monogram-quarterly/content/about.md
+++ b/examples/monogram-quarterly/content/about.md
@@ -1,0 +1,28 @@
++++
+title = "Editorial Note"
+description = "About the Quarterly, its editors, and its house style."
++++
+
+## A Word From The Editors
+
+**Monogram Quarterly** is a journal of long-form prose, criticism, and quiet observation, published four times a year since the spring of 2014. We take the museum catalog as our formal model: wide margins, generous leading, ample white space, and the conviction that a reader who has chosen to read should be rewarded with conditions that make reading possible.
+
+### House Style
+
+- Essays should be between **three thousand and twelve thousand words**.
+- Footnotes are welcomed in moderation. Endnotes are preferred.
+- We do not commission interviews.
+- We do not publish reviews of works less than ten years old.
+- We do publish reconsiderations of works more than fifty years old.
+
+### Typography
+
+The journal is set in *Cormorant Garamond* for running text, *Marcellus* for display, and *JetBrains Mono* for figures, dates, and footnote locators. The titling face is held to two weights and is not permitted to lean. Capital letters are spaced with the patience of someone who has nowhere else to be.
+
+### Submissions
+
+We accept unsolicited manuscripts during March and September. We respond to all submissions within four months. We do not accept pitches; we accept finished work.
+
+### The Editors
+
+The journal is edited by a small and slow-moving committee whose names appear in full in the print colophon, and not here. We are reachable by post.

--- a/examples/monogram-quarterly/content/essays/_index.md
+++ b/examples/monogram-quarterly/content/essays/_index.md
@@ -1,0 +1,10 @@
++++
+title = "The Archive"
+description = "Every essay we have published, ordered by date of appearance in the journal."
+sort_by = "date"
+paginate = 12
+template = "section"
+generate_feeds = true
++++
+
+Every essay, ordered by issue. The earliest at the foot of the page, the most recent at the head.

--- a/examples/monogram-quarterly/content/essays/a-room-with-no-pictures.md
+++ b/examples/monogram-quarterly/content/essays/a-room-with-no-pictures.md
@@ -1,0 +1,48 @@
++++
+title = "A Room With No Pictures"
+date = "2026-02-08"
+description = "Notes on the unfurnished study, the contemplative life, and the discipline of working without a view."
+tags = ["writing", "rooms", "criticism"]
+categories = ["essay"]
+[extra]
+authors = ["S. Berenger"]
+volume = "XII"
+number = "1"
+issue_name = "Winter 2026"
++++
+
+The room I work in has no pictures on its walls. This is not because I do not own any pictures. I own a great many. They are in a box in a closet on the floor below. I have, over the course of seventeen years, taken them down one by one, until the walls of my study were finally what they had always been threatening to be — simply themselves, a pale gray, with a single window facing north.
+
+<!-- more -->
+
+I have been asked, sometimes with concern, why I have done this. The honest answer is that I could not write with the pictures up. Each one was an argument I had already won, or lost, or settled, or filed away for later — and an argument is a kind of company. Company is what you bring into a room when you do not want to be alone with the thing you are trying to do.
+
+## On The Furnished Room
+
+Most studies are furnished. Some are furnished with books, some with photographs, some with souvenirs of trips taken, some with the framed evidence of degrees and certificates that explain to a visitor (and, more importantly, to the room's occupant) what kind of work is supposed to happen here. The furnished study is, in its way, **an aspirational object**. It says: *I am the sort of person who, in this room, accomplishes the sort of work that this room implies.*
+
+There is nothing wrong with such a room. There are great writers who have worked in them — Edith Wharton's library at The Mount, Borges's room at the National Library, Montaigne's tower with its hundred-and-some painted maxims. The furnished room can be a great room. It can also be **a slow-acting trap**, because it is a room that is already certain of itself. It is a room that has made up its mind about what kind of writing happens in it, and the writing that subsequently happens there is sometimes the kind that the room expects.
+
+## On The Unfurnished Room
+
+The unfurnished room — the room I have arrived at — is a different proposition. It does not have an opinion about what should happen in it. It is suspicious of opinions in general. It is **a room that has put aside its own personality**, in order to be available to the personality of whatever the writer is, on this particular morning, trying to think about.
+
+I do not recommend it to everyone. There are people for whom the unfurnished room would be intolerable, a kind of sensory deprivation that would empty their thinking rather than focus it. I know this because, for the first ten of my seventeen years in this house, I was one of those people. The walls were crowded. The desk was crowded. There was a lamp in the shape of a flamingo, given to me as a joke by a friend, that I could not in good conscience throw away. The room was a museum of relationships, and I worked happily in it.
+
+The shift came slowly. It was not a decision. It was a series of small reductions, each one taken in response to a particular essay that I could not finish in the room as it was then constituted. The flamingo went first. Then the postcard wall. Then, eventually, the small framed photographs of my parents in the late 1970s, which I miss enormously and which now live, with the rest of the pictures, in the closet on the floor below. I visit them perhaps once a month. They have, if anything, become more vivid in my mind for being out of my sight.
+
+> The unfurnished room is not the absence of company. It is the *postponement* of company, in favor of a stricter and more demanding companion — the thing you came into the room to write.
+
+## What The Wall Does
+
+A blank wall, sustained over years, becomes a piece of furniture in its own right. It is not nothing; it is a kind of attention. The wall I face when I work is a particular pale gray, painted three years ago, with a slight unevenness in the upper left corner where the previous color is bleeding through. I have, in the course of writing this essay, looked at that wall perhaps four hundred times. It has not yet exhausted itself.
+
+The wall does what no piece of art on the wall could do, which is to **decline to participate**. It does not assert. It does not remind. It does not even, in the strictest sense, reflect light back at me, because the gray was chosen specifically to absorb a fraction of the morning sun. The wall is the largest object in my study, and it is silent, and that silence is the condition under which I am able to hear what I am thinking.
+
+I imagine that this is what monks have always known. The cells of certain orders are deliberately bare for a reason that is more sophisticated than mere asceticism. The bare cell is **a working space**, in the sense that the workshop is a working space. The work is the thinking. The walls are the tools.
+
+## A Brief Defense Of The View
+
+I have a window. The window faces north and overlooks a row of plane trees that are, in winter, a kind of moving lattice against the sky. I look at them with great pleasure. The window is the one feature of the room that I would not give up, because the window is not a piece of furniture; it is a piece of weather. It changes. Pictures do not change. The window changes hourly, and that hourly change is the kind of company I can bear, because it is the kind of company that does not have anything to say.
+
+If you have a window, I recommend keeping it. If you do not, I recommend not pretending that a picture is a window. A picture is a picture. A window is a window. The unfurnished room knows the difference.

--- a/examples/monogram-quarterly/content/essays/notes-on-the-footnote.md
+++ b/examples/monogram-quarterly/content/essays/notes-on-the-footnote.md
@@ -1,0 +1,68 @@
++++
+title = "Notes On The Footnote"
+date = "2025-09-14"
+description = "A brief history of the form, an argument for its return, and seven specimen footnotes for the reader's consideration."
+tags = ["typography", "writing", "criticism"]
+categories = ["essay"]
+[extra]
+authors = ["M. Halvorsen"]
+volume = "XI"
+number = "3"
+issue_name = "Summer 2025"
++++
+
+The footnote is the most architecturally interesting unit of prose in the English language. It is a sentence that has been asked to wait at the bottom of the page until called for. It is, simultaneously, a digression, a piece of evidence, an aside, a confession, a wink, an apology, and on occasion a small joke. No other punctuation does so much.
+
+<!-- more -->
+
+## A Compressed History
+
+The earliest sustained footnotes appear in the marginalia of medieval manuscripts, in the form of glosses written in the white space around the main text. These were, in effect, a slower-motion version of the conversation that footnotes still conduct — the gloss commented on the text, the text was not changed in response, and a reader could choose to read both, either, or neither.
+
+The footnote as we now recognize it is a print-era invention. The technology of typesetting made possible the placement of a smaller body of text at the foot of the page, separated by a thin rule, and connected to the main text by a small numeric superscript. The technology, in turn, **shaped the genre**: the modern footnote has the rhythm and the brevity of something that was sized to fit under a body of running prose, and no longer than that.
+
+The eighteenth century produced the **scholarly footnote** in something close to its present form: a citation, sometimes accompanied by a comment, anchored to a specific claim in the body. The nineteenth century produced the **literary footnote** — the digressive aside, the parenthetical mini-essay, the Nabokovian baroque. Both forms remain in use. They are not the same form, and a writer who confuses them produces a footnote that is doing two things badly.
+
+## The Footnote As Structural Device
+
+A well-constructed footnote does one of three things.
+
+The first is to **provide evidence** for a claim that the main text needs to make but does not wish to argue about. *The Battle of Lepanto was fought in 1571.\[1\]* The footnote is the citation; the main text proceeds without slowing down. This is the simplest and most common use, and the easiest to do well.
+
+The second is to **register a qualification** that the writer believes to be true but does not wish to interrupt the main argument with. *The Battle of Lepanto, which was decisive,\[2\] secured the Mediterranean for the Holy League.* The footnote acknowledges that "decisive" is a contested adjective; the main text declines to relitigate it. This is harder, because it requires the writer to know what they are willing to defend in the body and what they are willing to defer to the foot of the page.
+
+The third is to **digress**. *The Battle of Lepanto featured the participation of Miguel de Cervantes, who lost the use of his left hand.\[3\]* The footnote is not, in any strict sense, necessary; it is included because the writer believes the reader will be glad to know it. This is the literary footnote, and it is the most dangerous, because it is the one that most easily decays into self-indulgence.
+
+> The footnote is a contract between the writer and the reader. The writer agrees not to interrupt the main text; the reader agrees that, if the footnote is interesting enough, the small descent to the bottom of the page will have been worth it.
+
+## Against The Endnote
+
+There is, in many contemporary editions, a fashion for placing notes at the back of the book rather than at the foot of the page. This is sometimes done in the name of "clean design," sometimes in the name of cost (less paper used), and sometimes in the name of accessibility (less visual interruption for the casual reader).
+
+I am opposed to all three justifications, and to the endnote as such.
+
+The endnote breaks the contract. The writer is now asking the reader to **leave the page**, to flip to the back of the book, to find a specific number in a long list, to read the note, and to find their way back. This is a much greater imposition than the small downward glance to the foot of the page, and most readers, sensibly, do not pay it. The notes therefore become unread, and the writing in them — which is often some of the most careful in the book — is effectively dead.
+
+The footnote, at the foot of the page, **lives where the reader is**. It costs the reader an eye-flick, not a navigation. The cost is so small that the reader, if the note is well-made, will pay it almost automatically. This is the only structural condition under which the footnote, as a genre, can survive.
+
+## Seven Specimen Footnotes For The Reader's Consideration
+
+Below are seven footnotes the journal has set in recent issues. They are reproduced here without their host text, as a way of asking the reader to consider what kind of writing the form can sustain.
+
+**1.** *The translator, regrettably, has rendered "saudade" as "longing," which is the only correct choice in English and the wrong choice in this sentence.*
+
+**2.** *I have been unable to confirm this date, and the source from which I take it has been unable to confirm it either; what we have, in effect, is a tradition of agreeing to a date that nobody is in a position to verify.*
+
+**3.** *The painter's daughter, in her unpublished diary, gives a different account, in which the studio was on the third floor.*
+
+**4.** *See, however, Pelletier (1962), p. 217, for the contrary position.*
+
+**5.** *This was the first occasion on which the word "modernist" was applied to the work, and it was applied as an insult.*
+
+**6.** *I am told that the original is now in private hands.*
+
+**7.** *The author wishes to thank the librarians of the small reading room on the third floor.*
+
+Each of these is a piece of writing. Each could have been written into the main text and would have damaged it. Each was set at the foot of the page, where it has been waiting, in the small archive of the journal, for the reader who chose to look.
+
+The footnote is a piece of trust. The journal is trusting the reader to look down. The reader has, in reading this far, justified the trust. We are grateful.

--- a/examples/monogram-quarterly/content/essays/on-the-margin.md
+++ b/examples/monogram-quarterly/content/essays/on-the-margin.md
@@ -1,0 +1,42 @@
++++
+title = "On The Margin"
+date = "2026-04-12"
+description = "Notes on white space, the conditions of reading, and the moral weight of an empty page."
+tags = ["typography", "reading", "design"]
+categories = ["essay"]
+[extra]
+authors = ["E. Sallinen"]
+volume = "XII"
+number = "2"
+issue_name = "Spring 2026"
++++
+
+A wide margin is not, as is sometimes said, a luxury. A wide margin is **a condition of attention** — the formal acknowledgment that the words it surrounds are difficult and the reader has been invited to slow down. The page that crowds its text to the trim line is a page that does not believe its own argument requires patience.
+
+<!-- more -->
+
+## The Margin As Architecture
+
+Consider the book as a building. The trim is the property line. The text block is the dwelling. The margin is the **garden**, and the garden, in any architecture worth the name, is not the empty space between the building and the property line; it is the space in which the building is allowed to be seen. Remove the garden and you have not only crowded the house — you have removed the means by which the house declares itself a house.
+
+This is, by analogy, what a margin does. It declares the text. It is the medium by which the text becomes legible as text, rather than as ink. It is also, less obviously, the medium by which the reader becomes a reader — that is, a person sitting with a book in their hands, rather than a person being struck by a sequence of glyphs.
+
+A margin that is too narrow is a margin that has been embarrassed of itself. There is, in the contemporary trade-paperback tradition, an idea that the margin "wastes paper," and that the responsible book is the one that conserves paper by setting the type as close to the edge as possible. We propose that this is not an act of conservation but an act of **cowardice**. The text is afraid that its presence will not be sufficient justification for the empty space around it. The empty space, given the chance, would have done the text a tremendous favor.
+
+## A Brief History Of The Generous Margin
+
+The medieval manuscript was the first object to argue, formally, that what was *not* on the page was as important as what was. The monks who set the *Book of Kells* could have packed every page with text. They did not. They left the margins for the inhabitants of the book to play in — for the dragons, the saints, the rabbits hunting hares with crossbows, the marginalia that scholars have spent six centuries trying to explain.
+
+The Renaissance press inherited this conviction and refined it. The Aldine octavos of the early sixteenth century have margins that, by modern standards, look almost wasteful — and the books are, to this day, **a pleasure to read**, in a way that no machine-set paperback has ever managed. The reason is not that Aldus Manutius had access to better paper. The reason is that he understood that the page is a stage, and the stage is the place where the words are allowed to perform.
+
+> The page is not a vehicle for the text. The page is the *condition* of the text. To compress the page is to compress the conditions, and the conditions are the whole point.
+
+## The Reader's Margin
+
+There is, additionally, the **reader's margin** — the space in which the reader is invited to write back. The reader who marks up a book is not defacing it; the reader is completing it. Every great library in the world has, in its rare books room, copies of canonical works that are valuable precisely because some forgotten reader filled the margins with arguments, agreements, and the occasional drawing of a dog.
+
+The book that has no room for the reader's marginalia is a book that does not believe in the reader. It is a book that has decided, in advance, that the reader is a recipient rather than a participant. We do not write that kind of book here. The margins are deliberately wide. There is room for a pen, and we hope you bring one.
+
+## A Note On This Page
+
+This essay has been set in a 12-point face on a 16-point leading, with a measure of approximately 62 characters per line, and an outer margin of nearly one-third of the printed page. We have not done this to be precious. We have done it because we believe these are the conditions under which the essay's argument is most fully available to you. If you find the margins distracting, please mark up this paragraph with a note explaining why. We will print the best of your annotations in the colophon of the following issue.

--- a/examples/monogram-quarterly/content/essays/the-catalog-essay.md
+++ b/examples/monogram-quarterly/content/essays/the-catalog-essay.md
@@ -1,0 +1,48 @@
++++
+title = "The Catalog Essay, Reconsidered"
+date = "2026-03-20"
+description = "A defense of the most undervalued literary genre of the twentieth century."
+tags = ["criticism", "museums", "writing"]
+categories = ["essay"]
+[extra]
+authors = ["M. Halvorsen"]
+volume = "XII"
+number = "2"
+issue_name = "Spring 2026"
++++
+
+The catalog essay is the great unread genre of the twentieth century, and probably of the twenty-first. It is sold in the gift shop, taken home in a tote bag, and placed on a shelf where it lives, alongside thirty other catalogs, in a state of permanent and dignified neglect. This is a shame, because the catalog essay is often the most serious sustained piece of writing about a body of work that the writer will ever be allowed to produce.
+
+<!-- more -->
+
+## The Form's Constraints
+
+A catalog essay is written under a particular and unforgiving set of constraints. It must be **long enough to justify the catalog's existence as a book** (typically four to ten thousand words), but **short enough to be read in the time it takes to walk through the exhibition** (forty-five minutes, on the optimistic estimate). It must address the artist with seriousness but without sycophancy. It must offer the reader, who is not necessarily an art historian, enough context to make sense of the work — but it must not condescend, because the reader is also, in some cases, a colleague.
+
+The form is therefore caught between three audiences: the general public, the academic specialist, and the artist themselves. It is also caught between three temporal frames: the moment of the exhibition's opening, the longer life of the catalog as a book, and the still longer life of the work as a historical object. **No other contemporary writing genre operates under such a layered set of pressures**, and yet the catalog essay is almost never discussed as a genre at all.
+
+## What The Best Catalog Essays Do
+
+The best catalog essays I have ever read share three features.
+
+First, they take seriously the **specificity of the show**. They do not treat the exhibition as a generic occasion for a previously written argument; they treat the works, in their particular sequence and arrangement, as the primary text. A catalog essay that could have been written without seeing the show is a catalog essay that has not done its job.
+
+Second, they are **historically situated** without being captive to history. The best of them know exactly when their subject was made, by whom, in what tradition, in response to what — and then they let that knowledge work in the background, surfacing only when the reader needs it. The reader is not made to swim through the apparatus.
+
+Third, and most importantly, they are **written**. They are not academic prose dressed up in a museum's clothing. They have a voice, a rhythm, a willingness to be wrong out loud about something the writer cares about. The catalog essay is, at its best, the closest thing the contemporary essayist has to the pamphlet — a piece of writing produced in a specific occasion, in a specific season, for a specific community, and capable of surviving all three.
+
+## Why The Form Is Underrated
+
+The reason the catalog essay is undervalued is, I think, that it is **paid for in advance**. The catalog is commissioned by the museum, the artist's gallery, or the curator's office; the writer receives a fee, and the essay is published in a context that is not, formally, the literary press. This combination — commissioned, paid, and published outside the canonical venues — has marked the catalog essay, in the eyes of the literary establishment, as a kind of corporate writing, even when it is not.
+
+But the same conditions apply to the medieval treatise (commissioned, paid, published in a religious context) and to the eighteenth-century pamphlet (commissioned, paid, published in a political context), and we have learned to read those forms with seriousness despite their origins. The catalog essay deserves the same treatment. We are not, as a culture, at the point where we are ready to give it.
+
+I am proposing that we should be. I am proposing that the next time you walk through a museum gift shop, you should stop, pick up the catalog of the show you have just seen, open it to the title essay, and read the first page in the gift shop, standing up. If the first page is good — and surprisingly often, it is — then **buy the book**. The writer was probably paid less than you might expect, and they may, in twenty years, be very glad you read them.
+
+## A Personal Coda
+
+I have written six catalog essays in my career. I have been paid, on average, the equivalent of two months of careful work for each of them. Three of them I am proud of. Two of them I would now disavow. One — the longest and the most difficult — I consider the best thing I have ever written, and it lives, as far as I can tell, in seventy or eighty copies of a catalog that was printed in 2017 for an exhibition in a city I will not name.
+
+I do not write this to lobby for myself. I write it to say that the genre exists, that it is full of fine writing by people who have done their best work in it, and that the rest of us — readers, critics, the literary trade — have been slow to notice. The conditions of the form are demanding. The rewards are quiet. The work survives, when it survives, by being passed from one careful reader to another, on the shelves of people who go to museums.
+
+This, I think, is a tradition worth defending.

--- a/examples/monogram-quarterly/content/essays/the-second-reading.md
+++ b/examples/monogram-quarterly/content/essays/the-second-reading.md
@@ -1,0 +1,48 @@
++++
+title = "On The Second Reading"
+date = "2025-12-02"
+description = "What we lose by reading a book only once, and what we recover by going back."
+tags = ["reading", "criticism", "essay"]
+categories = ["essay"]
+[extra]
+authors = ["E. Sallinen"]
+volume = "XI"
+number = "4"
+issue_name = "Autumn 2025"
++++
+
+I have, on my shelf, perhaps four hundred books I have read once. I have, on a separate and smaller shelf, perhaps thirty I have read twice. The difference between these two shelves is, I have come to think, the difference between a library and an education.
+
+<!-- more -->
+
+## The First Reading As A Survey
+
+A first reading is, of necessity, a survey. The reader, encountering a book for the first time, does not yet know what is important and what is decoration. Every paragraph might be the key; therefore no paragraph is registered as such. The reader is, in effect, building the map of the book while walking through it, and the building of the map is so absorbing that the territory often goes unattended.
+
+This is not a failure of the reader. It is **a structural property of first encounters**. The same thing happens on a first visit to a city, or a first listening to a piece of music, or a first conversation with a person who turns out to matter. The first encounter is a kind of orientation, and orientation is, by definition, not yet understanding.
+
+## The Second Reading As An Argument
+
+The second reading is a different mode of attention. The reader, knowing now what the book is, can begin to ask why. **Why this scene in this place. Why this digression after this revelation. Why this sentence in this rhythm.** The book begins to disclose its construction, and the construction is, in any book worth a second reading, the half of the book that the first reading missed.
+
+The second reading also produces something the first reading cannot: **disagreement**. On a first reading, the reader is too busy keeping up to argue back. On a second reading, the reader knows the territory well enough to notice the moments when the book is, in their judgment, wrong, or shallow, or self-deceived. These moments of disagreement are not failures of the reading; they are the readings themselves. A second reading without disagreement is a second reading that has not yet begun.
+
+## The Third Reading As An Inheritance
+
+The third reading is something else again. By the third pass, the book is no longer a thing one is reading; it is **a thing one is living with**. The argument about the book has been internalized, and what remains is the slower, more difficult work of figuring out what the book has done to the reader — what habits of attention it has installed, what reflexes of skepticism, what new ways of noticing the world.
+
+This is what I mean by *inheritance*. A book read three times is a book the reader has inherited from themselves. It is a piece of equipment they did not have ten years ago and cannot remember not having.
+
+> A library is a record of what you have read. An education is a record of what you have re-read.
+
+## The Difficulty Of Re-Reading
+
+It is, of course, easier to read a new book than to re-read an old one. The new book offers novelty, the small jolt of unfamiliarity, the possibility that the next sentence will change one's life. The old book offers no such promise. It offers, instead, the harder reward of **deepening** — the slower, quieter pleasure of recognizing something that one missed the first time.
+
+This is part of the reason that re-reading is, in our culture, in some retreat. The economy of contemporary publishing is structured around the new book; the algorithm of recommendation is structured around what you have not yet read; the social conversation about books is, increasingly, a conversation about what is new this season. There are exceptions — book clubs, university curricula, the small and dedicated communities that re-read certain authors annually — but they are exceptions.
+
+I do not have a solution to this. I have only a practice. I read, on average, one new book a week. I re-read, on average, one old book a month. I have done this for about twelve years. **The shelf of books I have read twice is the shelf that has changed me.** The shelf of books I have read once contains many books I have enjoyed, but few books I would say have shaped me, and this is not because the books on the larger shelf are inferior. It is because I have not yet given them the second hearing they need in order to do their work.
+
+## A Practical Note
+
+If you have not re-read a book in a year, I would gently suggest the following experiment: pick the book on your shelf that you remember liking most strongly, but whose plot or argument you can no longer recall in detail. That book is the one most likely to reward you. The book you remember vividly has, in some sense, already given you what it has to give. The book you remember only as having mattered to you, but whose specific content has receded, is the book that still contains its second reading. Open it again. The book has been waiting.

--- a/examples/monogram-quarterly/content/index.md
+++ b/examples/monogram-quarterly/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Monogram Quarterly"
+description = "Volume XII, Number 2 — Spring 2026."
++++
+
+Spring issue contents below.

--- a/examples/monogram-quarterly/static/css/style.css
+++ b/examples/monogram-quarterly/static/css/style.css
@@ -1,0 +1,754 @@
+:root {
+  --paper: #f4eee0;
+  --paper-warm: #ece2c8;
+  --ink: #18130b;
+  --ink-soft: #3b3225;
+  --ink-faint: #7a6c54;
+  --ink-mute: #a59980;
+  --rule: #b5a482;
+  --gold: #8a6a1c;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Cormorant Garamond", "EB Garamond", Georgia, serif;
+  font-size: 19px;
+  line-height: 1.6;
+  font-weight: 400;
+}
+
+::selection { background: var(--gold); color: var(--paper); }
+
+a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--rule);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+  transition: color 0.18s ease, text-decoration-color 0.18s ease;
+}
+a:hover { color: var(--gold); text-decoration-color: var(--gold); }
+
+/* ---------------- JOURNAL LAYOUT ---------------- */
+
+.journal {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 64px 80px 80px;
+  position: relative;
+}
+
+/* ---------------- MASTHEAD ---------------- */
+
+.journal-header { text-align: center; padding-bottom: 28px; }
+.masthead-rule {
+  border: 0;
+  border-top: 1px solid var(--ink);
+  margin: 0;
+}
+.masthead-rule-top {
+  border-top: 0.5px solid var(--rule);
+  border-bottom: 2px solid var(--ink);
+  height: 4px;
+  margin-bottom: 18px;
+}
+.masthead-rule-bottom {
+  border-top: 2px solid var(--ink);
+  border-bottom: 0.5px solid var(--rule);
+  height: 4px;
+  margin-top: 22px;
+}
+
+.masthead-meta {
+  display: flex;
+  justify-content: center;
+  gap: 28px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 28px;
+}
+.meta-num { color: var(--gold); font-weight: 500; }
+
+.masthead-title {
+  display: block;
+  font-family: "Marcellus", "Cormorant Garamond", serif;
+  font-weight: 400;
+  font-size: clamp(46px, 7vw, 88px);
+  line-height: 0.95;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  color: var(--ink);
+  margin: 0 0 18px;
+}
+.masthead-title:hover { color: var(--ink); }
+.masthead-word { display: inline-block; }
+.masthead-word-second { font-style: italic; font-family: "Cormorant Garamond", serif; font-weight: 300; }
+.masthead-ornament {
+  display: inline-block;
+  margin: 0 14px;
+  color: var(--gold);
+  font-family: "Marcellus", serif;
+  font-weight: 400;
+}
+
+.masthead-tagline {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 19px;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  margin: 0 auto 26px;
+  line-height: 1.4;
+}
+
+.masthead-nav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 14px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+.masthead-nav a {
+  color: var(--ink-soft);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+.masthead-nav a:hover {
+  color: var(--gold);
+  border-bottom-color: var(--gold);
+}
+.nav-sep { color: var(--rule); }
+
+/* ---------------- CONTENTS / FRONT PAGE ---------------- */
+
+.contents { padding-top: 56px; }
+
+.contents-head {
+  text-align: center;
+  max-width: 56ch;
+  margin: 0 auto 60px;
+}
+.contents-label {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 22px;
+}
+.contents-title {
+  font-family: "Marcellus", serif;
+  font-size: clamp(40px, 5.5vw, 64px);
+  line-height: 1.05;
+  letter-spacing: 0.03em;
+  margin: 0 0 18px;
+  font-weight: 400;
+}
+.contents-deck {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 21px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  margin: 0;
+}
+
+/* featured */
+
+.featured {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 56px;
+  align-items: start;
+  padding: 56px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 60px;
+}
+.featured-folio { text-align: right; padding-top: 8px; position: sticky; top: 30px; }
+.folio-roman {
+  font-family: "Marcellus", serif;
+  font-size: 56px;
+  line-height: 1;
+  color: var(--gold);
+  letter-spacing: 0.04em;
+}
+.folio-label {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-top: 14px;
+  line-height: 1.5;
+}
+.featured-cat {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 18px;
+}
+.featured-title {
+  font-family: "Marcellus", serif;
+  font-size: clamp(36px, 5vw, 56px);
+  line-height: 1.05;
+  letter-spacing: 0.01em;
+  margin: 0 0 18px;
+  font-weight: 400;
+}
+.featured-title a { color: var(--ink); text-decoration: none; }
+.featured-title a:hover { color: var(--gold); }
+.featured-deck {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  margin: 0 0 22px;
+  max-width: 56ch;
+}
+.featured-meta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 24px;
+}
+.byline { color: var(--ink); }
+.meta-dot { margin: 0 10px; color: var(--rule); }
+.featured-link {
+  display: inline-block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--gold);
+  padding-bottom: 4px;
+}
+.featured-link:hover { color: var(--gold); }
+
+/* table of contents */
+
+.toc-rule {
+  height: 1px;
+  background: var(--rule);
+  margin: 36px 0 26px;
+}
+
+.toc {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: toc;
+}
+.toc-row {
+  display: grid;
+  grid-template-columns: 80px 1fr 60px 80px;
+  gap: 28px;
+  align-items: baseline;
+  padding: 26px 0;
+  border-bottom: 1px solid var(--paper-warm);
+}
+.toc-row:last-child { border-bottom: 0; }
+.toc-folio {
+  font-family: "Marcellus", serif;
+  font-size: 30px;
+  color: var(--gold);
+  letter-spacing: 0.04em;
+  text-align: right;
+}
+.toc-cat {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 8px;
+}
+.toc-title {
+  font-family: "Marcellus", serif;
+  font-size: clamp(22px, 2.6vw, 30px);
+  line-height: 1.15;
+  letter-spacing: 0.01em;
+  margin: 0 0 8px;
+  font-weight: 400;
+}
+.toc-title a { color: var(--ink); text-decoration: none; }
+.toc-title a:hover { color: var(--gold); }
+.toc-deck {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  margin: 0 0 10px;
+  max-width: 60ch;
+}
+.toc-meta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.toc-byline { color: var(--ink); }
+.toc-dots {
+  border-bottom: 1px dotted var(--rule);
+  align-self: end;
+  margin-bottom: 8px;
+}
+.toc-page {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-align: right;
+  color: var(--ink-soft);
+  font-variant-numeric: oldstyle-nums;
+}
+
+/* epigraph */
+
+.epigraph {
+  margin: 80px auto 0;
+  max-width: 56ch;
+  text-align: center;
+}
+.epigraph-mark {
+  font-family: "Marcellus", serif;
+  font-size: 36px;
+  color: var(--gold);
+  margin-bottom: 8px;
+}
+.epigraph p {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: clamp(22px, 2.5vw, 28px);
+  line-height: 1.35;
+  margin: 0 0 14px;
+}
+.epigraph cite {
+  font-family: "JetBrains Mono", monospace;
+  font-style: normal;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+
+/* ---------------- ESSAY / PAGE ---------------- */
+
+.essay { padding-top: 56px; }
+.essay-folio {
+  text-align: center;
+  margin-bottom: 48px;
+}
+.essay-folio .folio-label { margin-top: 10px; }
+
+.essay-head {
+  text-align: center;
+  max-width: 60ch;
+  margin: 0 auto 32px;
+}
+.essay-cat {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 22px;
+}
+.essay-title {
+  font-family: "Marcellus", serif;
+  font-size: clamp(40px, 6vw, 72px);
+  line-height: 1.02;
+  letter-spacing: 0.01em;
+  margin: 0 0 22px;
+  font-weight: 400;
+}
+.essay-deck {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: clamp(22px, 2.4vw, 28px);
+  line-height: 1.4;
+  color: var(--ink-soft);
+  margin: 0 0 26px;
+}
+.essay-byline {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 17px;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  margin-bottom: 12px;
+}
+.byline-by { color: var(--ink-faint); font-style: italic; }
+.byline-name { font-variant: small-caps; letter-spacing: 0.08em; font-weight: 500; }
+.essay-meta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.essay-rule {
+  height: 4px;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: transparent;
+  max-width: 80px;
+  margin: 32px auto;
+  position: relative;
+}
+.essay-rule::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 8px;
+  height: 8px;
+  background: var(--gold);
+  border-radius: 50%;
+}
+
+.essay-body {
+  max-width: 62ch;
+  margin: 0 auto;
+  font-size: 19px;
+  line-height: 1.72;
+  font-variant-numeric: oldstyle-nums;
+}
+.essay-body p { margin: 0 0 1.2em; text-align: justify; hyphens: auto; }
+.essay-body p:first-of-type::first-letter {
+  float: left;
+  font-family: "Marcellus", serif;
+  font-size: 5.2em;
+  line-height: 0.85;
+  padding: 8px 14px 0 0;
+  color: var(--gold);
+  font-weight: 400;
+}
+.essay-body h2 {
+  font-family: "Marcellus", serif;
+  font-size: clamp(24px, 3.2vw, 32px);
+  line-height: 1.1;
+  letter-spacing: 0.02em;
+  margin: 2.4em 0 0.4em;
+  font-weight: 400;
+  text-align: center;
+}
+.essay-body h2::before, .essay-body h2::after {
+  content: "·";
+  color: var(--gold);
+  margin: 0 14px;
+  vertical-align: middle;
+  position: relative;
+  top: -4px;
+  opacity: 0.6;
+}
+.essay-body h3 {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 2em 0 0.6em;
+  text-align: center;
+}
+.essay-body blockquote {
+  margin: 1.8em 0;
+  padding: 12px 0;
+  border-top: 0.5px solid var(--rule);
+  border-bottom: 0.5px solid var(--rule);
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 1.18em;
+  line-height: 1.4;
+  text-align: center;
+  color: var(--ink-soft);
+}
+.essay-body blockquote p { margin: 0; text-align: center; }
+.essay-body em { font-style: italic; color: var(--ink); }
+.essay-body strong { font-weight: 500; color: var(--ink); font-variant: small-caps; letter-spacing: 0.04em; }
+.essay-body code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.86em;
+  background: var(--paper-warm);
+  padding: 0.05em 0.32em;
+  border: 0.5px solid var(--rule);
+}
+.essay-body pre {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-warm);
+  border: 0.5px solid var(--rule);
+  border-left: 3px solid var(--gold);
+  padding: 18px 22px;
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-x: auto;
+  margin: 1.6em 0;
+}
+.essay-body pre code { background: transparent; border: 0; padding: 0; }
+.essay-body ul, .essay-body ol { padding-left: 1.6em; }
+.essay-body li { margin: 0.4em 0; }
+.essay-body li::marker { color: var(--gold); }
+.essay-body a { color: var(--ink); text-decoration-color: var(--gold); }
+.essay-body a:hover { color: var(--gold); }
+
+.essay-foot {
+  max-width: 62ch;
+  margin: 0 auto;
+  text-align: center;
+  padding-top: 30px;
+}
+.essay-tags {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 16px;
+  color: var(--ink-soft);
+  margin-bottom: 22px;
+}
+.tags-label { color: var(--ink-faint); }
+.essay-tag {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+}
+.essay-tag:hover { color: var(--gold); border-bottom-color: var(--gold); }
+.essay-ornament {
+  font-family: "Marcellus", serif;
+  font-size: 18px;
+  letter-spacing: 0.4em;
+  color: var(--gold);
+  margin-bottom: 22px;
+}
+.essay-back {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 4px;
+}
+.essay-back:hover { color: var(--gold); border-bottom-color: var(--gold); }
+
+/* ---------------- ARCHIVE / SECTION ---------------- */
+
+.archive { padding-top: 56px; }
+.archive-folio { text-align: center; margin-bottom: 32px; }
+.archive-title {
+  font-family: "Marcellus", serif;
+  font-size: clamp(40px, 5vw, 60px);
+  line-height: 1.05;
+  letter-spacing: 0.02em;
+  margin: 0 0 16px;
+  font-weight: 400;
+  text-align: center;
+}
+.archive-deck {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 20px;
+  line-height: 1.4;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  margin: 0 auto 36px;
+  text-align: center;
+}
+.archive-rule {
+  height: 4px;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  max-width: 80px;
+  margin: 0 auto 50px;
+}
+
+.archive-list { list-style: none; padding: 0; margin: 0; }
+.archive-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 36px;
+  align-items: baseline;
+  padding: 30px 0;
+  border-bottom: 1px solid var(--paper-warm);
+}
+.archive-num {
+  font-family: "Marcellus", serif;
+  font-size: 38px;
+  color: var(--gold);
+  text-align: right;
+  letter-spacing: 0.04em;
+}
+.archive-meta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 10px;
+}
+.archive-issue { color: var(--gold); }
+.archive-title-row {
+  font-family: "Marcellus", serif;
+  font-size: clamp(24px, 3vw, 32px);
+  line-height: 1.1;
+  letter-spacing: 0.01em;
+  margin: 0 0 10px;
+  font-weight: 400;
+}
+.archive-title-row a { color: var(--ink); text-decoration: none; }
+.archive-title-row a:hover { color: var(--gold); }
+.archive-deck-row {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 18px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  margin: 0 0 10px;
+  max-width: 60ch;
+}
+.archive-byline {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* ---------------- TAG LIST ---------------- */
+
+.tag-list { list-style: none; padding: 0; margin: 0; max-width: 56ch; margin: 0 auto; }
+.tag-row { border-bottom: 1px solid var(--paper-warm); }
+.tag-row a {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  padding: 16px 4px;
+  text-decoration: none;
+  color: var(--ink);
+}
+.tag-row a:hover { color: var(--gold); }
+.tag-name {
+  font-family: "Marcellus", serif;
+  font-size: 22px;
+  letter-spacing: 0.02em;
+}
+.tag-dots {
+  flex: 1;
+  border-bottom: 1px dotted var(--rule);
+  transform: translateY(-4px);
+}
+.tag-count {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* ---------------- 404 ---------------- */
+
+.four-oh-four {
+  max-width: 56ch;
+  margin: 80px auto;
+  text-align: center;
+}
+.four-oh-four .folio-roman { font-size: 100px; margin-bottom: 30px; }
+.error-title {
+  font-family: "Marcellus", serif;
+  font-size: clamp(34px, 4.6vw, 56px);
+  line-height: 1.05;
+  letter-spacing: 0.02em;
+  font-weight: 400;
+  margin: 0 0 18px;
+}
+.error-deck {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 21px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  margin: 0 0 24px;
+}
+
+/* ---------------- FOOTER ---------------- */
+
+.journal-footer { margin-top: 80px; }
+.footer-rule {
+  border-top: 1px solid var(--ink);
+  border-bottom: 0.5px solid var(--rule);
+  height: 4px;
+}
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 48px;
+  padding: 40px 0;
+}
+.footer-col p {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  margin: 0;
+}
+.footer-label {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 10px;
+}
+.footer-col a { color: var(--ink); text-decoration-color: var(--gold); }
+.footer-imprint {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 0;
+  border-top: 0.5px solid var(--rule);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  gap: 12px;
+}
+.footer-ornament { color: var(--gold); letter-spacing: 0.6em; }
+
+/* ---------------- RESPONSIVE ---------------- */
+
+@media (max-width: 880px) {
+  .journal { padding: 32px 24px 60px; }
+  .masthead-meta { gap: 14px; flex-wrap: wrap; font-size: 10px; }
+  .featured { grid-template-columns: 1fr; gap: 18px; }
+  .featured-folio { text-align: left; position: static; }
+  .toc-row { grid-template-columns: 50px 1fr; gap: 18px; }
+  .toc-dots, .toc-page { display: none; }
+  .toc-folio { font-size: 24px; }
+  .archive-row { grid-template-columns: 50px 1fr; gap: 18px; padding: 22px 0; }
+  .archive-num { font-size: 26px; }
+  .footer-grid { grid-template-columns: 1fr; gap: 28px; }
+  .footer-imprint { flex-direction: column; gap: 8px; text-align: center; }
+  .masthead-nav { flex-wrap: wrap; gap: 8px; row-gap: 8px; }
+}

--- a/examples/monogram-quarterly/templates/404.html
+++ b/examples/monogram-quarterly/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+<section class="four-oh-four">
+  <div class="folio-roman">CDIV</div>
+  <h1 class="error-title">An empty plinth.</h1>
+  <p class="error-deck">The piece you came to see is not on display in this room. It may be on loan, in storage, or never accessioned. The catalog can be consulted below.</p>
+  <div class="essay-ornament">&mdash; &middot; &mdash;</div>
+  <a class="essay-back" href="{{ base_url }}/">Return to the contents</a>
+</section>
+
+{% include "footer.html" %}

--- a/examples/monogram-quarterly/templates/footer.html
+++ b/examples/monogram-quarterly/templates/footer.html
@@ -1,0 +1,26 @@
+    </main>
+    <footer class="journal-footer">
+      <div class="footer-rule"></div>
+      <div class="footer-grid">
+        <div class="footer-col">
+          <div class="footer-label">Editorial</div>
+          <p>Reachable by post. Submissions read in March and September. <a href="{{ base_url }}/about/">Editorial note</a>.</p>
+        </div>
+        <div class="footer-col">
+          <div class="footer-label">Subscriptions</div>
+          <p>Four issues yearly, hand-bound. Subscribe to the <a href="{{ base_url }}/atom.xml">Atom feed</a> for the web edition.</p>
+        </div>
+        <div class="footer-col">
+          <div class="footer-label">Colophon</div>
+          <p>Set in Cormorant Garamond, Marcellus, and JetBrains Mono. Built with Hwaro on a slow press.</p>
+        </div>
+      </div>
+      <div class="footer-imprint">
+        <span>&copy; {{ current_year }} {{ site.title }}</span>
+        <span class="footer-ornament">&mdash; &middot; &mdash;</span>
+        <span>Printed for the web</span>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/monogram-quarterly/templates/header.html
+++ b/examples/monogram-quarterly/templates/header.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+  <title>{% if page.title %}{{ page.title }} &mdash; {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,700;1,400;1,500&family=Marcellus&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="{{ base_url }}/atom.xml" type="application/atom+xml" rel="alternate" title="Atom Feed">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="journal">
+    <header class="journal-header">
+      <div class="masthead-rule masthead-rule-top"></div>
+      <div class="masthead-meta">
+        <span class="meta-item">Volume <span class="meta-num">XII</span></span>
+        <span class="meta-item">Number <span class="meta-num">II</span></span>
+        <span class="meta-item">Spring &middot; MMXXVI</span>
+      </div>
+      <a href="{{ base_url }}/" class="masthead-title">
+        <span class="masthead-word">{{ site.title | split(pat=" ") | first }}</span>
+        {% if site.title | split(pat=" ") | length > 1 %}
+        <span class="masthead-ornament">&mdash;</span>
+        <span class="masthead-word masthead-word-second">{{ site.title | split(pat=" ") | slice(start=1) | join(sep=" ") }}</span>
+        {% endif %}
+      </a>
+      <div class="masthead-tagline">{{ site.description }}</div>
+      <nav class="masthead-nav">
+        <a href="{{ base_url }}/">Contents</a>
+        <span class="nav-sep">&middot;</span>
+        <a href="{{ base_url }}/essays/">The Archive</a>
+        <span class="nav-sep">&middot;</span>
+        <a href="{{ base_url }}/tags/">Subjects</a>
+        <span class="nav-sep">&middot;</span>
+        <a href="{{ base_url }}/about/">Editorial</a>
+        <span class="nav-sep">&middot;</span>
+        <a href="{{ base_url }}/atom.xml">Atom</a>
+      </nav>
+      <div class="masthead-rule masthead-rule-bottom"></div>
+    </header>
+    <main class="journal-main">

--- a/examples/monogram-quarterly/templates/index.html
+++ b/examples/monogram-quarterly/templates/index.html
@@ -1,0 +1,71 @@
+{% include "header.html" %}
+
+{% set all_essays = site.pages | where("section", "essays") | sort_by("date", reverse=true) %}
+{% set featured = all_essays | first %}
+{% set rest = all_essays | slice(start=1) %}
+
+<section class="contents">
+  <div class="contents-head">
+    <div class="contents-label">In this issue</div>
+    <h1 class="contents-title">Spring &middot; MMXXVI</h1>
+    <p class="contents-deck">Two original essays, three reconsiderations, and one extended note. The complete table of contents follows.</p>
+  </div>
+
+  {% if featured %}
+  <article class="featured">
+    <div class="featured-folio">
+      <div class="folio-roman">I</div>
+      <div class="folio-label">The opening essay</div>
+    </div>
+    <div class="featured-body">
+      <div class="featured-cat">{% if featured.categories %}{{ featured.categories | first | capitalize }}{% else %}Essay{% endif %}</div>
+      <h2 class="featured-title"><a href="{{ featured.url }}">{{ featured.title }}</a></h2>
+      {% if featured.description %}
+      <p class="featured-deck">{{ featured.description }}</p>
+      {% endif %}
+      <div class="featured-meta">
+        <span class="byline">{% if featured.extra is defined and featured.extra.authors %}{{ featured.extra.authors | join(", ") }}{% else %}The Editors{% endif %}</span>
+        <span class="meta-dot">&middot;</span>
+        <time>{{ featured.date | date("%B %Y") }}</time>
+        <span class="meta-dot">&middot;</span>
+        <span>{{ featured.reading_time }} minutes</span>
+      </div>
+      <a class="featured-link" href="{{ featured.url }}">Read the essay</a>
+    </div>
+  </article>
+  {% endif %}
+
+  <div class="toc-rule"></div>
+
+  <ol class="toc">
+    {% for essay in rest %}
+    <li class="toc-row">
+      <div class="toc-folio">{{ "%02d" | format(loop.index + 1) }}</div>
+      <div class="toc-body">
+        <div class="toc-cat">{% if essay.categories %}{{ essay.categories | first | capitalize }}{% else %}Essay{% endif %} &middot; {% if essay.extra is defined and essay.extra.issue_name %}{{ essay.extra.issue_name }}{% else %}{{ essay.date | date("%B %Y") }}{% endif %}</div>
+        <h3 class="toc-title"><a href="{{ essay.url }}">{{ essay.title }}</a></h3>
+        {% if essay.description %}
+        <p class="toc-deck">{{ essay.description }}</p>
+        {% endif %}
+        <div class="toc-meta">
+          <span class="toc-byline">{% if essay.extra is defined and essay.extra.authors %}{{ essay.extra.authors | join(", ") }}{% else %}The Editors{% endif %}</span>
+          <span class="meta-dot">&middot;</span>
+          <span>{{ essay.reading_time }} min</span>
+        </div>
+      </div>
+      <div class="toc-dots"></div>
+      <div class="toc-page">p. {{ "%02d" | format(loop.index * 8 + 2) }}</div>
+    </li>
+    {% endfor %}
+  </ol>
+
+  <div class="toc-rule"></div>
+
+  <div class="epigraph">
+    <div class="epigraph-mark">&para;</div>
+    <p>A library is a record of what you have read. An education is a record of what you have re-read.</p>
+    <cite>&mdash; From Volume XI, Number 4</cite>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/monogram-quarterly/templates/page.html
+++ b/examples/monogram-quarterly/templates/page.html
@@ -1,0 +1,53 @@
+{% include "header.html" %}
+
+<article class="essay">
+  <div class="essay-folio">
+    <div class="folio-roman">{% if page.extra is defined and page.extra.volume %}{{ page.extra.volume }}{% else %}XII{% endif %}</div>
+    <div class="folio-label">
+      {% if page.extra is defined and page.extra.issue_name %}{{ page.extra.issue_name }}{% else %}Spring &middot; MMXXVI{% endif %}
+      {% if page.extra is defined and page.extra.number %}<br>Number {{ page.extra.number }}{% endif %}
+    </div>
+  </div>
+
+  <header class="essay-head">
+    <div class="essay-cat">{% if page.categories %}{{ page.categories | first | capitalize }}{% else %}Essay{% endif %}</div>
+    <h1 class="essay-title">{{ page.title }}</h1>
+    {% if page.description %}
+    <p class="essay-deck">{{ page.description }}</p>
+    {% endif %}
+    <div class="essay-byline">
+      <span class="byline-by">By</span>
+      <span class="byline-name">{% if page.extra is defined and page.extra.authors %}{{ page.extra.authors | join(", ") }}{% else %}The Editors{% endif %}</span>
+    </div>
+    <div class="essay-meta">
+      <time>{{ page.date | date("%d %B %Y") }}</time>
+      <span class="meta-dot">&middot;</span>
+      <span>{{ page.word_count }} words</span>
+      <span class="meta-dot">&middot;</span>
+      <span>{{ page.reading_time }} minutes</span>
+    </div>
+  </header>
+
+  <div class="essay-rule"></div>
+
+  <div class="essay-body">
+    {{ content | safe }}
+  </div>
+
+  <div class="essay-rule"></div>
+
+  <footer class="essay-foot">
+    {% if page.tags %}
+    <div class="essay-tags">
+      <span class="tags-label">Subjects&nbsp;&middot;</span>
+      {% for tag in page.tags %}
+      <a class="essay-tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag | capitalize }}</a>{% if not loop.last %}, {% endif %}
+      {% endfor %}
+    </div>
+    {% endif %}
+    <div class="essay-ornament">&mdash; &middot; &mdash;</div>
+    <a class="essay-back" href="{{ base_url }}/essays/">Return to the archive</a>
+  </footer>
+</article>
+
+{% include "footer.html" %}

--- a/examples/monogram-quarterly/templates/section.html
+++ b/examples/monogram-quarterly/templates/section.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+
+<section class="archive">
+  <div class="archive-folio">
+    <div class="folio-roman">&para;</div>
+    <div class="folio-label">The complete archive</div>
+  </div>
+  <h1 class="archive-title">{{ section.title }}</h1>
+  {% if section.description %}
+  <p class="archive-deck">{{ section.description }}</p>
+  {% endif %}
+
+  <div class="archive-rule"></div>
+
+  <ol class="archive-list">
+    {% for essay in section.pages %}
+    <li class="archive-row">
+      <div class="archive-num">{{ "%02d" | format(section.pages | length - loop.index0) }}</div>
+      <div class="archive-body">
+        <div class="archive-meta">
+          {% if essay.extra is defined and essay.extra.issue_name %}<span class="archive-issue">{{ essay.extra.issue_name }}</span><span class="meta-dot">&middot;</span>{% endif %}
+          <time>{{ essay.date | date("%d %B %Y") }}</time>
+        </div>
+        <h2 class="archive-title-row"><a href="{{ essay.url }}">{{ essay.title }}</a></h2>
+        {% if essay.description %}
+        <p class="archive-deck-row">{{ essay.description }}</p>
+        {% endif %}
+        <div class="archive-byline">
+          {% if essay.extra is defined and essay.extra.authors %}{{ essay.extra.authors | join(", ") }}{% else %}The Editors{% endif %}<span class="meta-dot">&middot;</span>{{ essay.reading_time }} min
+        </div>
+      </div>
+    </li>
+    {% endfor %}
+  </ol>
+</section>
+
+{% include "footer.html" %}

--- a/examples/monogram-quarterly/templates/taxonomy.html
+++ b/examples/monogram-quarterly/templates/taxonomy.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<section class="archive">
+  <div class="archive-folio">
+    <div class="folio-roman">&sect;</div>
+    <div class="folio-label">Subject index</div>
+  </div>
+  <h1 class="archive-title">{{ taxonomy_name | capitalize }}</h1>
+  <p class="archive-deck">Every subject discussed in the journal, cross-referenced and sorted by frequency.</p>
+  <div class="archive-rule"></div>
+
+  <ul class="tag-list">
+    {% for term in taxonomy_terms %}
+    <li class="tag-row">
+      <a href="{{ base_url }}{{ term.url }}">
+        <span class="tag-name">{{ term.name | capitalize }}</span>
+        <span class="tag-dots"></span>
+        <span class="tag-count">{{ term.pages | length }} {% if term.pages | length == 1 %}essay{% else %}essays{% endif %}</span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/monogram-quarterly/templates/taxonomy_term.html
+++ b/examples/monogram-quarterly/templates/taxonomy_term.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+
+<section class="archive">
+  <div class="archive-folio">
+    <div class="folio-roman">&sect;</div>
+    <div class="folio-label">{{ taxonomy_name | capitalize }}</div>
+  </div>
+  <h1 class="archive-title">{{ taxonomy_term | capitalize }}</h1>
+  <p class="archive-deck">{{ taxonomy_pages | length }} essay{% if taxonomy_pages | length != 1 %}s{% endif %} filed under this subject.</p>
+  <div class="archive-rule"></div>
+
+  <ol class="archive-list">
+    {% for essay in taxonomy_pages %}
+    <li class="archive-row">
+      <div class="archive-num">{{ "%02d" | format(loop.index) }}</div>
+      <div class="archive-body">
+        <div class="archive-meta">
+          {% if essay.extra is defined and essay.extra.issue_name %}<span class="archive-issue">{{ essay.extra.issue_name }}</span><span class="meta-dot">&middot;</span>{% endif %}
+          <time>{{ essay.date | date("%d %B %Y") }}</time>
+        </div>
+        <h2 class="archive-title-row"><a href="{{ essay.url }}">{{ essay.title }}</a></h2>
+        {% if essay.description %}
+        <p class="archive-deck-row">{{ essay.description }}</p>
+        {% endif %}
+      </div>
+    </li>
+    {% endfor %}
+  </ol>
+</section>
+
+{% include "footer.html" %}

--- a/examples/samizdat/config.toml
+++ b/examples/samizdat/config.toml
@@ -1,0 +1,193 @@
+title = "Samizdat"
+description = "An underground bulletin, retyped by hand and circulated to whoever asked first. Carbon paper edition."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 30
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/samizdat/content/about.md
+++ b/examples/samizdat/content/about.md
@@ -1,0 +1,28 @@
++++
+title = "How this works"
+description = "What we are, what we are not, and how to receive an issue."
++++
+
+## You are reading a copy of a copy of a copy.
+
+**Samizdat** is a bulletin. It is retyped, by hand, on a 1971 Hermes 3000, onto onion-skin paper with two layers of carbon below. The original goes nowhere. The carbons go to four people, who retype them, who give the new originals to four people, and so on. By the time this reaches you, the typographic errors have settled in like geology.
+
+We do not have a publication schedule. We do not have a circulation. We do not have a return address. What we have is a typewriter that is older than most of our contributors and the conviction that some kinds of writing should still be put on paper before they are put anywhere else.
+
+### What you will find here
+
+Items from the bulletin, in approximate order of when they last came across the desk. Some of them are notes. Some are essays. Some are fragments retyped from older bulletins that we believe deserve another reading. **None of it is signed.** Where you see *"the author"* or *"a friend"* or *"someone we trust"*, please accept those words at face value. We have our reasons.
+
+### Why "samizdat"
+
+The word comes from Russian and means *self-published* — literally, *issued by oneself*. In the Soviet bloc it was the name for typewritten, hand-circulated literature that did not pass through state censorship. We are borrowing the word with respect and without irony. We are not in the same situation. We are in a different situation. We have learned, however, that the tools of the old tradition — the typewriter, the carbon, the slow circulation, the deliberate refusal of permanence — still produce a particular kind of attention in the reader, and we want that kind of attention.
+
+### How to receive an issue
+
+You cannot subscribe. You can ask, by word of mouth, someone who already receives the bulletin to put your address on a list. The list is not held by us. We do not know who is on it. We mail to the addresses we are given, and the addresses change.
+
+If you have received this issue and want to pass it on, do not photocopy. *Retype it.* The retyping is the point. The retyping is what makes the bulletin a bulletin instead of a leaflet, and you, in the act of retyping, become the thing the bulletin is for.
+
+### A standing apology
+
+We will get things wrong. We will misattribute. We will commit typographical errors that we will fail to correct in the second carbon and forget to address in the third. We will, on occasion, retype an item from an earlier issue and discover only afterward that the earlier version was better. We apologize, in advance, for all of it. We are doing this with the equipment we have, in the time we can find, and we are doing it slowly on purpose.

--- a/examples/samizdat/content/index.md
+++ b/examples/samizdat/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Samizdat"
+description = "Carbon copy three, perhaps. Read once. Pass it on. Don't sign it."
++++
+
+Contents below.

--- a/examples/samizdat/content/posts/_index.md
+++ b/examples/samizdat/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "All Items"
+description = "Bulletin items in retypeable order."
+sort_by = "date"
+paginate = 12
+template = "section"
+generate_feeds = true
++++
+
+Every item the bulletin has carried, in roughly the order it last passed through the carriage.

--- a/examples/samizdat/content/posts/a-conversation-on-a-bench.md
+++ b/examples/samizdat/content/posts/a-conversation-on-a-bench.md
@@ -1,0 +1,51 @@
++++
+title = "A Conversation On A Bench, Retyped From Memory"
+date = "2026-04-26"
+description = "Two people, a park, the late afternoon, a discussion of what it means to write under the assumption of being read."
+tags = ["conversation", "writing", "fragment"]
+categories = ["item"]
+[extra]
+authors = ["a friend"]
+issue = "46"
+location = "near the canal"
++++
+
+The following is reconstructed from a conversation that I had with **G.**, in late April, on a wooden bench overlooking the canal, in the slow hour between the closing of the bookstores and the opening of the bars. G. has read these notes and accepted them. The mistakes, where they exist, are mine.
+
+<!-- more -->
+
+## On The Assumption Of Being Read
+
+**G.**: The thing I've come to understand, very slowly, is that almost all of the writing I have done in my life has been done under the assumption that someone was reading it. I do not mean that I was writing for an audience. I mean that I was writing as if observed.
+
+**Me**: As if observed by whom?
+
+**G.**: That's the question, isn't it. By a teacher, when I was a child. By a colleague, when I was younger. By a particular friend, whose taste I trusted. By a category of person — *intelligent reader, common reader, hostile reader.* For thirty years I wrote with one of those people in my head, and I did not notice until quite recently that they were there.
+
+**Me**: What changed?
+
+**G.**: I tried, as an experiment, to write something with **no observer at all**. I sat down and wrote a page of prose for an hour without imagining anyone reading it. Not even me, later, reading it back. The result was — I want to say it was *terrible*, but that's not quite right. It was incoherent. It was lumpy. It moved without direction. It was a piece of writing that had been freed from the discipline of being read, and the discipline, it turned out, was most of what was holding the prose together.
+
+## The Discovery
+
+**Me**: So the imagined reader was a kind of editor.
+
+**G.**: A kind of editor. A kind of scaffold. A kind of pressure that made the sentences answer to something other than themselves. When I removed the pressure, the sentences relaxed into a shape I had not seen before, and the shape was not necessarily better. But it was different. It was **mine in a way I had not previously had access to**.
+
+**Me**: And now?
+
+**G.**: And now I do the experiment, deliberately, perhaps once a week. I write a page for no one. I do not save it. I do not reread it. I throw it away when I am done. The pages I keep — the writing I show, the writing I publish — go back to being written with the imagined reader in mind, and they are better for it. But I needed to know what the prose looked like with the reader subtracted. I needed to know what I was bringing to the prose, and what the imagined reader was bringing.
+
+## On The Bulletin
+
+**G.**: The thing I like about the bulletin — and you can put this in the next issue if you want — is that I genuinely do not know who its readers are. The carbon goes out and disappears into a network that I cannot map. Some of the people who read it are people I know. Some of them are people I will never know. The composition of the audience is **opaque to the writer**, which is the closest a published piece of writing can come to the no-observer experiment.
+
+**Me**: And does that change how you write it?
+
+**G.**: It changes the *posture*. I cannot perform for an audience I cannot see. I have to write something that I would still stand behind if it were being read by someone with whom I had no shared frame of reference. The bulletin enforces a kind of plainness on the writer. The plainness is — and I mean this seriously — the most generous thing the form does.
+
+## Coda
+
+I am typing this on the morning after, in the same room I always type in, with the light coming in at the wrong angle because it is late spring and the sun has shifted on the wall. G. has gone back to her own work. I have, in retyping the conversation, **discovered three small ways in which I had misremembered the order of the sentences**, and I have not corrected them, because the order in which I have remembered the conversation is now part of the conversation, and the reader is welcome to know that.
+
+— a friend, near the canal

--- a/examples/samizdat/content/posts/instructions-for-retypers.md
+++ b/examples/samizdat/content/posts/instructions-for-retypers.md
@@ -1,0 +1,48 @@
++++
+title = "Instructions For The Retyper"
+date = "2026-05-08"
+description = "Eleven rules for the person at the next typewriter. They are not optional, but they are not enforced either."
+tags = ["process", "instructions"]
+categories = ["bulletin"]
+[extra]
+authors = ["the editors"]
+issue = "47"
+location = "unknown"
++++
+
+If you have received this issue and intend to pass it along by retyping rather than photocopying — and we are asking, gently, that you do so — please read the following first.
+
+<!-- more -->
+
+## The Eleven Rules
+
+**1.** Choose your paper deliberately. Onion skin if you can find it. Bond if you cannot. **Avoid anything brighter than ecru.** A pure-white page looks like a press release and reads like one.
+
+**2.** Use a ribbon that has been in the machine for at least three months. A fresh ribbon is too dark; the page does not breathe. A ribbon at the **end of its life** is too faint; the page is unreadable. The middle months are the right months.
+
+**3.** Type with two sheets of carbon paper below the original. This produces three documents at once. The original is yours. The first carbon is for a friend you have already chosen. The second carbon is for a friend **you have not yet chosen** — keep it in an envelope until you are sure.
+
+**4.** Do not correct typographical errors. If you wish to mark them, strike through them with a row of *x*s and continue. The reader will know what you meant. The strikethrough is also part of the document.
+
+**5.** *Do not sign the bulletin.* Do not, in fact, identify yourself as the retyper. If you would like to indicate that you were here, you may include a single hand-written *line in the margin* on any page — your initials, a date, a small drawing of a bird. The reader is welcome to ignore it.
+
+**6.** Do not add commentary to the items themselves. If you wish to comment, type a separate page — clearly marked **"COMMENTARY"** at the top — and include it as a separate sheet. The reader is then free to keep it, discard it, or pass it along independently of the bulletin.
+
+**7.** Misspellings, in the items, are not yours to correct. The misspellings are part of the document's history. If the word *"government"* has been misspelled in five consecutive issues, it is now an artifact, and you are not entitled to remove it.
+
+**8.** If you cannot read a word in the carbon you have received, **leave a gap of three spaces** and continue. The reader will know that a word is missing. The reader is allowed to guess.
+
+**9.** Do not retype an item that you do not understand. There is no shame in skipping. The bulletin has carried items that have, in retrospect, deserved to be skipped, and we are grateful to the retypers who declined.
+
+**10.** When you give your carbons to friends, give them in person, hand to hand. Do not mail them unless you have to. Do not photograph them. Do not, on any account, *upload them anywhere.* The bulletin lives at the speed of foot traffic, and that is the speed it should continue to live at.
+
+**11.** When you are done, **set the bulletin aside for one full day before reading it yourself.** The act of retyping is not the act of reading. The retyper has, in retyping, already given the bulletin one careful read; the next read should happen later, in a different state of mind, in different light.
+
+## A Coda
+
+These rules are not enforced. They cannot be enforced. The bulletin has no authority over its retypers because the bulletin has no authority over anything at all, including, on most days, itself. **The rules are here as suggestions** from people who have been doing this for a while, to people who are about to do it for the first time.
+
+We trust you. The carbon trusts you. The next reader, who you have not yet met, trusts you. Please pass it along with the same care that you have, in retyping it, already shown.
+
+— The editors  
+*(issue 47, location unknown)*

--- a/examples/samizdat/content/posts/notes-on-going-dark.md
+++ b/examples/samizdat/content/posts/notes-on-going-dark.md
@@ -1,0 +1,50 @@
++++
+title = "Notes On Going Dark For A Month"
+date = "2026-03-15"
+description = "An experiment in disconnection, conducted by a friend, retyped from a notebook with my apologies for the legibility."
+tags = ["disconnection", "experiment", "notebook"]
+categories = ["item"]
+[extra]
+authors = ["a friend, retyped by another"]
+issue = "45"
+location = "the cabin, the city"
++++
+
+The following are notes from a friend who spent a month — March of this year — without any networked device. She has agreed to let me retype them. I have done my best to preserve the broken syntax of the notebook, on the grounds that her syntax in the field was already more interesting than my syntax at the typewriter.
+
+<!-- more -->
+
+## Week One
+
+- *Day three:* the urge to check something has not subsided. it has, in fact, gotten worse. i find myself reaching for a pocket that is not there.
+- *Day four:* a long conversation with the woman at the bakery. she has worked in this bakery for fourteen years. i had been buying bread from her for six. i did not know her name. her name is **Anna**.
+- *Day six:* writing in this notebook with a real pen. the wrist hurts. the wrist is not used to it.
+- *Day seven:* a small panic — a friend was supposed to meet me at 6 pm at a particular cafe. it is now 6:23. i cannot text. i wait. she arrives at 6:34. she has missed her bus. **the world has not ended.**
+
+## Week Two
+
+- something has shifted in the quality of my attention. i can read for longer. i can sit with a single thought for longer. i can also, distressingly, *be bored* for longer, which i had not realized was a capacity i had let atrophy.
+- *Day eleven:* i write a letter to my brother. by hand. four pages. i mail it. he will not receive it for a week. there is something about the latency that i find clarifying, although i cannot yet explain why.
+- *Day fourteen:* i meet a new person, at a bookstore. we talk for an hour. she asks for my number. i do not have a phone. she laughs and says **"like the old days."** she writes her address on a card and gives it to me.
+
+## Week Three
+
+- the world has not, materially, changed. the world has, materially, gone on. the things that i imagined i was needed for have happened without me. the meetings have happened. the deadlines have happened. the news has happened. the news, on the whole, has been bad.
+- *Day eighteen:* the bad news is easier to bear when one is not refreshing it. it is **the refreshing** that produces the particular kind of helplessness. when one reads a single article in a paper, on a single morning, and then puts the paper down, the news is news. when one reads the same article seven times in a day, the news becomes a *condition*, and the condition is more demanding than the news.
+- *Day twenty-three:* i write three pages of something that may, eventually, become an essay. i would not have written them in any other month of my life. the connection between this and the disconnection from the network is, i think, real, though i cannot prove it.
+
+## Week Four
+
+- *Day twenty-six:* a quiet sadness about the experiment ending. i had thought i would be relieved. i am not relieved.
+- *Day twenty-eight:* i make a list of the things i missed. the list is shorter than i expected. on the list: certain podcasts. one specific friend's photographs. the weather forecast. that is most of it.
+- *Day thirty:* i pick up the device. i turn it on. there are **eight thousand** notifications. i do not read them. i archive them, in bulk, without reading. nothing important is lost. i can verify this because, the next morning, the people who needed me will write to me again, and i will respond as if i have just received the message, and this is what will happen.
+
+## A Brief Reflection
+
+She has asked me to add the following, as a note for the bulletin. I am including it as she dictated it, by hand, in the back of the same notebook, on a separate page.
+
+> "I am not going to do this again. I do not need to. The point of the month was not to live this way forever. The point was to find out **what the difference feels like**, so that, on the days I return to the network, I have somewhere to compare it to. I have that now. I will go back. I will not, however, go back in quite the same way."
+
+I have retyped this for the bulletin with her permission. The original notebook is in her possession. The two carbons of this typescript are in mine, and will go, in the usual way, to people I trust.
+
+— retyped, the city

--- a/examples/samizdat/content/posts/the-ribbon-and-the-record.md
+++ b/examples/samizdat/content/posts/the-ribbon-and-the-record.md
@@ -1,0 +1,35 @@
++++
+title = "The Ribbon And The Record"
+date = "2026-04-04"
+description = "On the inked silk thread that holds the memory of everything one has typed."
+tags = ["typewriters", "memory", "fragment"]
+categories = ["item"]
+[extra]
+authors = ["a friend"]
+issue = "46"
+location = "the back room"
++++
+
+The least-noticed component of any typewriter is the ribbon. The keys get the attention. The carriage gets the metaphors. The ribbon — a thin silk band, soaked in ink, wound between two spools — does the entire work of writing, and is never spoken of by anyone except the people who change it.
+
+<!-- more -->
+
+It is also, I want to point out, **a record**.
+
+When you type a page, the impression of each character is left on the ribbon. If you have ever changed a ribbon mid-document, you have noticed this: hold the used portion up to the light, and you can read, in faint impressions running backward, the last page you typed. The ribbon remembers in a way the page does not. The page shows the document. The ribbon shows the **act** of producing it.
+
+This is not, in any practical sense, a security feature. Anyone serious about surveillance has better tools. It is, however, a small piece of **physical evidence** that the act of typing happened in a particular room, at a particular moment, by a particular set of hands — and it is the only piece of evidence of its kind in our entire writing apparatus. The screen does not retain a ribbon. The cloud does not retain a ribbon. The cloud retains, instead, the document and a million tiny pieces of metadata about the document, none of which feel, when you read them back, like the act of writing the document.
+
+The ribbon feels like the act. The ribbon **is** the act, mid-fade.
+
+I am asking, in this small item, for two things.
+
+First, that when you finish a typed document of any importance to you, you remove the ribbon from the machine and put it in an envelope, and **label the envelope with the date and the document's first sentence**. This will give you, over years, a small archive of acts. You will not look at the archive often. When you do — at, say, the end of a long decade — you will be more glad to have it than you expect.
+
+Second, that you not throw the ribbon away when it is used up. The used ribbon is a record of perhaps thirty pages of writing. Coil it. Tie it with a small piece of string. Put it in a drawer. You are keeping the evidence of your own attention, which is a thing nobody else will keep for you.
+
+This bulletin's ribbon was changed two days ago. The previous ribbon is in an envelope, on the desk, beside the typewriter. It contains, among other things, the entire text of issue 45. I have not read it back. I suspect I will, when the room is quiet and the light is right.
+
+I am telling you about it because the bulletin only matters if the small acts that produce it are visible. The ribbon is one of those acts. I hope, now that I have mentioned it, that yours will be.
+
+— a friend, the back room

--- a/examples/samizdat/content/posts/the-typewriter-as-protest.md
+++ b/examples/samizdat/content/posts/the-typewriter-as-protest.md
@@ -1,0 +1,39 @@
++++
+title = "The Typewriter As An Instrument Of Slow Protest"
+date = "2026-05-20"
+description = "Why a 1971 portable still produces, every morning, the only typography that cannot be silently revised."
+tags = ["typewriters", "protest", "process"]
+categories = ["item"]
+[extra]
+authors = ["a friend"]
+issue = "47"
+location = "the second floor"
++++
+
+A typewriter is the only writing instrument I trust completely. Everything else can be edited without leaving a trace. The typewriter cannot. Once a letter is on the page, it is on the page, and the only way to remove it is to **deny that the page exists at all** — and this, as it happens, is not a step that any reasonable person takes lightly.
+
+<!-- more -->
+
+## The First Argument: A Letter Is A Decision
+
+When you type a letter, the carriage moves one position to the right and stays there. The decision is permanent. You can strike over it with a row of *xxxxx* if you change your mind, but the **x** is still a piece of writing, and the reader will see that you reconsidered. This is, I want to argue, the most honest thing any writing tool has ever done.
+
+Word processors do not do this. They allow you to delete a word and forget that you ever typed it. They allow you to "save" without preserving an earlier draft. They allow you, in short, **to revise your own thinking without admitting that the thinking has changed.** This is a kind of personal censorship — small, casual, internal — and I have come to believe that doing it for thirty years in a row produces a particular kind of mind that I would rather not have.
+
+## The Second Argument: The Carbon
+
+When you type with two sheets of carbon, you produce three documents simultaneously. The original goes to you. The first carbon goes to a friend. The second carbon — fainter, slightly fuzzy, harder to read — goes to a stranger. *You will not know who reads the second carbon.* This is the entire point.
+
+The carbon is the **uncontrolled distribution** of a piece of writing. The bulletin does not own its readership; the readership owns itself. There is no list. There is no metrics. There is no way to "reach our audience" because we do not, in any reportable sense, have one. We have **the people who happened to have a carbon copy in their hands at any given moment**, which is a different thing entirely.
+
+## The Third Argument: The Slowness
+
+A page of double-spaced typescript, on a portable, at a careful pace, takes me about twelve minutes to produce. A page of word-processed text, at the same level of care, takes about three. The difference — the nine extra minutes per page — is not wasted time. It is **the time during which I am forced to consider whether I want this sentence to exist.**
+
+This is not a defense of nostalgia. I have used word processors for thirty years and will continue to use them for some purposes. What I am defending is the existence of a deliberately slow alternative, kept in the corner of the room, available for the kind of writing that benefits from the friction of the keys. There is some writing that should be hard to make. The typewriter makes it hard. The hardness is not the obstacle to the work; the hardness is the work.
+
+## A Note On Errors
+
+Errors are visible in typescript in a way that they are not in screen text. They are not "underlined in red" by a polite assistant; they sit on the page, in their full embarrassment, until the writer has the courage to mark them out or the willingness to let them stand. I have come, over many years, to **let many of them stand.** A typo, on a page of typescript, is a fingerprint. It is the proof that a person sat at this machine, on this morning, and was tired, or distracted, or in a hurry. The fingerprint is a kind of signature. The kind of signature this bulletin permits.
+
+We will, accordingly, not be correcting the misspelling of *"government"* on page two of issue forty-six. It happened. It will keep happening. The reader who notices is the kind of reader we want.

--- a/examples/samizdat/static/css/style.css
+++ b/examples/samizdat/static/css/style.css
@@ -1,0 +1,545 @@
+:root {
+  --onion: #ebe2cc;
+  --onion-dark: #dccfa8;
+  --onion-deep: #c7b787;
+  --ink: #2a1e0c;
+  --ink-faint: #5b4a2c;
+  --carbon: #4b3a1a;
+  --red: #9a1d1d;
+  --red-faint: #c44545;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--onion);
+  color: var(--ink);
+  font-family: "Courier Prime", "Courier New", monospace;
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+::selection { background: var(--ink); color: var(--onion); }
+
+a { color: var(--ink); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+a:hover { background: var(--ink); color: var(--onion); text-decoration: none; }
+
+/* ---------------- ONION PAPER FRAME ---------------- */
+
+.onion {
+  max-width: 880px;
+  margin: 40px auto;
+  padding: 56px 64px;
+  background: var(--onion);
+  border: 1px solid var(--onion-deep);
+  box-shadow:
+    inset 0 0 0 1px var(--onion),
+    inset 0 0 0 2px var(--onion-deep),
+    0 1px 0 var(--onion-dark),
+    0 0 0 8px var(--onion);
+  position: relative;
+}
+.onion::before, .onion::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--onion-deep);
+  opacity: 0.5;
+}
+.onion::before { left: 36px; }
+.onion::after { right: 36px; }
+
+/* ---------------- STAMPS ---------------- */
+
+.onion-stamps {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  pointer-events: none;
+}
+.onion-stamp {
+  position: absolute;
+  font-family: "Special Elite", "Courier Prime", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  border: 2.5px solid currentColor;
+  line-height: 1.2;
+  text-align: center;
+  background: var(--onion);
+}
+.stamp-red {
+  color: var(--red);
+  top: 24px;
+  right: 32px;
+  transform: rotate(8deg);
+}
+.stamp-black {
+  color: var(--ink);
+  top: 80px;
+  right: 60px;
+  transform: rotate(-4deg);
+  font-size: 10px;
+}
+
+/* ---------------- HEADER ---------------- */
+
+.onion-header { text-align: center; padding: 12px 0 28px; position: relative; z-index: 2; }
+.header-rule {
+  border-top: 1.5px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  height: 4px;
+  margin: 14px 0;
+}
+.header-ascii, .footer-ascii {
+  font-family: "Courier Prime", "Courier New", monospace;
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+  margin: 0 0 8px;
+  white-space: pre;
+  overflow-x: auto;
+  text-align: left;
+}
+
+.onion-title {
+  display: block;
+  font-family: "Special Elite", "Courier Prime", monospace;
+  font-weight: 400;
+  font-size: clamp(40px, 7vw, 78px);
+  line-height: 0.95;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--ink);
+  margin: 28px 0 10px;
+}
+.onion-title:hover { background: transparent; color: var(--ink); }
+
+.onion-tagline {
+  font-family: "Cutive Mono", "Courier Prime", monospace;
+  font-style: italic;
+  font-size: 15px;
+  color: var(--carbon);
+  max-width: 56ch;
+  margin: 0 auto 22px;
+  line-height: 1.45;
+}
+
+.onion-nav {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-family: "Courier Prime", monospace;
+  font-size: 13px;
+  text-transform: lowercase;
+  margin-top: 18px;
+}
+.onion-nav a {
+  text-decoration: none;
+  color: var(--ink);
+  padding: 2px 6px;
+}
+.onion-nav a:hover { background: var(--ink); color: var(--onion); }
+
+/* ---------------- FRONT / SECTION ---------------- */
+
+.front { padding-top: 18px; }
+
+.censor-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 26px;
+  font-family: "Courier Prime", monospace;
+  font-size: 13px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.censor-bar {
+  background: var(--ink);
+  color: var(--onion);
+  padding: 4px 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.censor-text {
+  background: var(--ink);
+  color: var(--ink);
+  padding: 0 4px;
+  user-select: none;
+}
+.censor-date {
+  color: var(--red);
+  letter-spacing: 0.08em;
+}
+
+.front-headline {
+  font-family: "Special Elite", "Courier Prime", monospace;
+  font-size: clamp(28px, 4.6vw, 44px);
+  line-height: 1.1;
+  letter-spacing: 0.02em;
+  margin: 0 0 16px;
+  text-transform: lowercase;
+  font-weight: 400;
+}
+.front-deck {
+  font-family: "Cutive Mono", monospace;
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.45;
+  max-width: 60ch;
+  color: var(--carbon);
+  margin: 0 0 30px;
+}
+
+.front-divider {
+  font-family: "Courier Prime", monospace;
+  font-size: 14px;
+  color: var(--ink-faint);
+  letter-spacing: 0.4em;
+  margin: 28px 0;
+  text-align: center;
+}
+
+/* ---------------- ITEMS LIST ---------------- */
+
+.items { list-style: none; padding: 0; margin: 0; }
+.item {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 28px;
+  padding: 22px 0;
+  border-bottom: 1px dashed var(--ink-faint);
+  position: relative;
+}
+.item:last-child { border-bottom: 0; }
+.item-num {
+  font-family: "Special Elite", monospace;
+  font-size: 14px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--red);
+  padding-top: 4px;
+}
+.item-meta {
+  font-family: "Courier Prime", monospace;
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-bottom: 8px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.item-issue { color: var(--red); }
+.item-loc { font-style: italic; }
+.item-title {
+  font-family: "Special Elite", "Courier Prime", monospace;
+  font-size: clamp(20px, 2.4vw, 26px);
+  line-height: 1.15;
+  letter-spacing: 0.01em;
+  margin: 0 0 8px;
+  font-weight: 400;
+  text-transform: none;
+}
+.item-title a { color: var(--ink); text-decoration: none; border-bottom: 1px dotted var(--ink-faint); padding-bottom: 1px; }
+.item-title a:hover { background: var(--ink); color: var(--onion); border-bottom-color: var(--ink); }
+.item-deck {
+  font-family: "Cutive Mono", monospace;
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--carbon);
+  margin: 0 0 8px;
+  max-width: 64ch;
+}
+.item-byline {
+  font-family: "Courier Prime", monospace;
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+
+/* ---------------- PULL QUOTE ---------------- */
+
+.pull-quote {
+  max-width: 60ch;
+  margin: 40px auto;
+  padding: 24px 0;
+  border-top: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+  text-align: center;
+}
+.quote-mark {
+  font-family: "Special Elite", monospace;
+  font-size: 36px;
+  color: var(--red);
+  margin: 0 0 6px;
+  font-weight: 700;
+  white-space: pre;
+}
+.pull-quote p {
+  font-family: "Special Elite", monospace;
+  font-size: clamp(18px, 2.3vw, 24px);
+  line-height: 1.35;
+  letter-spacing: 0.01em;
+  margin: 0 0 10px;
+}
+.pull-quote cite {
+  font-family: "Courier Prime", monospace;
+  font-style: normal;
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+
+/* ---------------- PAPER / PAGE ---------------- */
+
+.paper { padding-top: 22px; }
+.paper-head { margin-bottom: 18px; }
+.paper-strip {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-family: "Courier Prime", monospace;
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-bottom: 18px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--ink-faint);
+}
+.paper-cat { color: var(--ink); font-weight: 700; }
+.paper-date { color: var(--red); }
+
+.paper-title {
+  font-family: "Special Elite", monospace;
+  font-size: clamp(28px, 4.8vw, 44px);
+  line-height: 1.12;
+  letter-spacing: 0.01em;
+  margin: 0 0 16px;
+  font-weight: 400;
+  text-transform: lowercase;
+}
+.paper-deck {
+  font-family: "Cutive Mono", monospace;
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.45;
+  color: var(--carbon);
+  margin: 0 0 18px;
+  max-width: 64ch;
+}
+.paper-byline {
+  font-family: "Courier Prime", monospace;
+  font-size: 12px;
+  color: var(--ink-faint);
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.paper-rule {
+  font-family: "Courier Prime", monospace;
+  font-size: 13px;
+  letter-spacing: 0;
+  color: var(--ink);
+  margin: 18px 0;
+  white-space: pre;
+  overflow-x: hidden;
+}
+
+.paper-body {
+  font-family: "Courier Prime", monospace;
+  font-size: 16px;
+  line-height: 1.72;
+  max-width: 66ch;
+}
+.paper-body p { margin: 0 0 1.2em; }
+.paper-body p:first-of-type::first-letter {
+  font-family: "Special Elite", monospace;
+  font-size: 1.4em;
+  font-weight: 700;
+  background: var(--ink);
+  color: var(--onion);
+  padding: 0 6px;
+  margin-right: 2px;
+}
+.paper-body h2 {
+  font-family: "Special Elite", monospace;
+  font-size: clamp(20px, 2.6vw, 26px);
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  margin: 1.8em 0 0.5em;
+  text-transform: lowercase;
+  position: relative;
+  padding-left: 36px;
+}
+.paper-body h2::before {
+  content: "##";
+  position: absolute;
+  left: 0;
+  color: var(--red);
+  font-weight: 700;
+}
+.paper-body h3 {
+  font-family: "Special Elite", monospace;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 1.6em 0 0.4em;
+  color: var(--carbon);
+}
+.paper-body blockquote {
+  margin: 1.6em 0;
+  padding: 12px 18px;
+  border-left: 3px solid var(--red);
+  background: var(--onion-dark);
+  font-family: "Cutive Mono", monospace;
+  font-style: italic;
+  font-size: 0.97em;
+}
+.paper-body code {
+  font-family: "Courier Prime", monospace;
+  background: var(--ink);
+  color: var(--onion);
+  padding: 0.05em 0.32em;
+  font-size: 0.92em;
+}
+.paper-body pre {
+  font-family: "Courier Prime", monospace;
+  background: var(--ink);
+  color: var(--onion);
+  padding: 18px 22px;
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-x: auto;
+  border: 1px solid var(--ink);
+  margin: 1.6em 0;
+}
+.paper-body pre code { background: transparent; color: inherit; padding: 0; }
+.paper-body ul, .paper-body ol { padding-left: 1.4em; }
+.paper-body li { margin: 0.35em 0; }
+.paper-body li::marker { color: var(--red); font-weight: 700; }
+.paper-body strong {
+  background: var(--ink);
+  color: var(--onion);
+  padding: 0 4px;
+  font-weight: 400;
+}
+.paper-body em { color: var(--carbon); font-style: italic; }
+.paper-body a { color: var(--ink); text-decoration-color: var(--red); }
+.paper-body a:hover { background: var(--ink); color: var(--onion); }
+
+.paper-foot {
+  margin-top: 28px;
+  text-align: left;
+}
+.paper-tags {
+  font-family: "Courier Prime", monospace;
+  font-size: 13px;
+  color: var(--ink-faint);
+  margin-bottom: 18px;
+}
+.paper-tag {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--red);
+  padding-bottom: 1px;
+}
+.paper-tag:hover { background: var(--ink); color: var(--onion); }
+.paper-endmark {
+  font-family: "Special Elite", monospace;
+  font-size: 14px;
+  letter-spacing: 0.16em;
+  color: var(--red);
+  margin: 16px 0;
+}
+.paper-back {
+  font-family: "Courier Prime", monospace;
+  font-size: 13px;
+  text-decoration: none;
+  color: var(--ink);
+  border: 1px solid var(--ink);
+  padding: 4px 10px;
+  display: inline-block;
+}
+.paper-back:hover { background: var(--ink); color: var(--onion); }
+
+/* ---------------- TAG INDEX ---------------- */
+
+.tag-index {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.tag-entry {
+  border-bottom: 1px dashed var(--ink-faint);
+}
+.tag-entry a {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 12px 4px;
+  text-decoration: none;
+  color: var(--ink);
+  font-family: "Courier Prime", monospace;
+  font-size: 14px;
+}
+.tag-entry a:hover { background: var(--ink); color: var(--onion); }
+.tag-name {
+  font-family: "Special Elite", monospace;
+  font-size: 16px;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+.tag-dots {
+  flex: 1;
+  overflow: hidden;
+  color: var(--ink-faint);
+  font-family: "Courier Prime", monospace;
+  white-space: nowrap;
+  font-size: 12px;
+}
+.tag-count { color: var(--red); }
+
+/* ---------------- 404 ---------------- */
+
+.four-oh-four { padding-top: 40px; }
+.four-oh-four .censor-date { font-size: 36px; font-weight: 700; }
+
+/* ---------------- FOOTER ---------------- */
+
+.onion-footer {
+  margin-top: 56px;
+  padding-top: 18px;
+}
+.footer-meta {
+  display: flex;
+  justify-content: space-between;
+  font-family: "Courier Prime", monospace;
+  font-size: 12px;
+  color: var(--ink-faint);
+  padding: 14px 0 0;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.footer-meta a { color: var(--ink); }
+
+/* ---------------- RESPONSIVE ---------------- */
+
+@media (max-width: 760px) {
+  .onion { padding: 36px 24px; margin: 16px auto; box-shadow: inset 0 0 0 1px var(--onion-deep); }
+  .onion::before, .onion::after { display: none; }
+  .stamp-red { top: 8px; right: 8px; transform: rotate(6deg) scale(0.85); transform-origin: top right; }
+  .stamp-black { top: 56px; right: 18px; transform: rotate(-3deg) scale(0.85); transform-origin: top right; }
+  .header-ascii, .footer-ascii { font-size: 9px; }
+  .item { grid-template-columns: 70px 1fr; gap: 14px; }
+  .item-num { font-size: 11px; }
+}

--- a/examples/samizdat/templates/404.html
+++ b/examples/samizdat/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+
+<section class="front four-oh-four">
+  <div class="censor-line">
+    <span class="censor-bar">[ item missing :: <span class="censor-text">last seen, issue --</span> ]</span>
+    <span class="censor-date">404</span>
+  </div>
+  <h1 class="front-headline">this item was retyped, then lost in transit.</h1>
+  <p class="front-deck">the bulletin makes no copies of itself. you will have to ask the previous retyper. they may, or may not, remember.</p>
+  <pre class="paper-rule">--------------------------------------------------------</pre>
+  <a class="paper-back" href="{{ base_url }}/">[ back to the front ]</a>
+</section>
+
+{% include "footer.html" %}

--- a/examples/samizdat/templates/footer.html
+++ b/examples/samizdat/templates/footer.html
@@ -1,0 +1,17 @@
+    </main>
+    <footer class="onion-footer">
+      <div class="header-rule"></div>
+      <pre class="footer-ascii">
+....    ....    ....    ....    ....    ....    ....    ....
+
+end of carbon. retype before passing on.
+....    ....    ....    ....    ....    ....    ....    ....</pre>
+      <div class="footer-meta">
+        <span>(c) {{ current_year }} {{ site.title }}</span>
+        <span>typed on hwaro / not signed</span>
+        <span><a href="{{ base_url }}/rss.xml">[ rss ]</a></span>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/samizdat/templates/header.html
+++ b/examples/samizdat/templates/header.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+  <title>{% if page.title %}{{ page.title }} :: {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Special+Elite&family=Courier+Prime:ital,wght@0,400;0,700;1,400;1,700&family=Cutive+Mono&display=swap" rel="stylesheet">
+  <link href="{{ base_url }}/rss.xml" type="application/rss+xml" rel="alternate" title="RSS">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="onion">
+    <div class="onion-stamps">
+      <div class="onion-stamp stamp-red">DO NOT REPRODUCE<br>RETYPE INSTEAD</div>
+      <div class="onion-stamp stamp-black">CARBON 03 OF 03</div>
+    </div>
+    <header class="onion-header">
+      <div class="header-rule"></div>
+      <pre class="header-ascii">
++----------------------------------------------------------+
+|                                                          |
+|   S A M I Z D A T                                        |
+|   .................                                      |
+|                                                          |
+|   issue 47   /   spring   /   location: unknown          |
+|   typed on a hermes 3000, retyped by hand                |
+|                                                          |
++----------------------------------------------------------+</pre>
+      <a href="{{ base_url }}/" class="onion-title">{{ site.title }}</a>
+      <div class="onion-tagline">{{ site.description }}</div>
+      <nav class="onion-nav">
+        <a href="{{ base_url }}/">[front]</a>
+        <a href="{{ base_url }}/posts/">[items]</a>
+        <a href="{{ base_url }}/tags/">[subjects]</a>
+        <a href="{{ base_url }}/about/">[how this works]</a>
+        <a href="{{ base_url }}/rss.xml">[wire]</a>
+      </nav>
+      <div class="header-rule"></div>
+    </header>
+    <main class="onion-main">

--- a/examples/samizdat/templates/index.html
+++ b/examples/samizdat/templates/index.html
@@ -1,0 +1,47 @@
+{% include "header.html" %}
+
+{% set all_posts = site.pages | where("section", "posts") | sort_by("date", reverse=true) %}
+
+<section class="front">
+  <div class="censor-line">
+    <span class="censor-bar">[ retyped: <span class="censor-text">redacted</span> ]</span>
+    <span class="censor-date">{{ current_date }}</span>
+  </div>
+  <h1 class="front-headline">issue forty-seven<br>retyped, again, for circulation</h1>
+  <p class="front-deck">contents below. nothing is signed. all locations are approximate. errors are part of the document.</p>
+
+  <div class="front-divider">. . . . . . . . . . . . . . . . . . . .</div>
+
+  <ol class="items">
+    {% for post in all_posts %}
+    <li class="item">
+      <div class="item-num">item {{ "%03d" | format(loop.index) }}</div>
+      <div class="item-body">
+        <div class="item-meta">
+          <span class="item-issue">[ issue {% if post.extra is defined and post.extra.issue %}{{ post.extra.issue }}{% else %}--{% endif %} ]</span>
+          <span class="item-date">{{ post.date | date("%Y.%m.%d") }}</span>
+          {% if post.extra is defined and post.extra.location %}<span class="item-loc">loc: {{ post.extra.location }}</span>{% endif %}
+        </div>
+        <h2 class="item-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.description %}
+        <p class="item-deck">{{ post.description }}</p>
+        {% endif %}
+        <div class="item-byline">
+          by {% if post.extra is defined and post.extra.authors %}{{ post.extra.authors | join(", ") }}{% else %}the editors{% endif %}
+          &nbsp;|&nbsp; {{ post.reading_time }} min
+        </div>
+      </div>
+    </li>
+    {% endfor %}
+  </ol>
+
+  <div class="front-divider">. . . . . . . . . . . . . . . . . . . .</div>
+
+  <div class="pull-quote">
+    <pre class="quote-mark">"&nbsp;"</pre>
+    <p>the bulletin lives at the speed of foot traffic, and that is the speed it should continue to live at.</p>
+    <cite>-- from instructions for the retyper</cite>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/samizdat/templates/page.html
+++ b/examples/samizdat/templates/page.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+
+<article class="paper">
+  <header class="paper-head">
+    <div class="paper-strip">
+      <span class="paper-cat">[ {% if page.categories %}{{ page.categories | first }}{% else %}item{% endif %} ]</span>
+      <span class="paper-issue">issue {% if page.extra is defined and page.extra.issue %}{{ page.extra.issue }}{% else %}--{% endif %}</span>
+      <span class="paper-date">{{ page.date | date("%Y.%m.%d") }}</span>
+    </div>
+    <h1 class="paper-title">{{ page.title }}</h1>
+    {% if page.description %}
+    <p class="paper-deck">{{ page.description }}</p>
+    {% endif %}
+    <div class="paper-byline">
+      <span>by {% if page.extra is defined and page.extra.authors %}{{ page.extra.authors | join(", ") }}{% else %}the editors{% endif %}</span>
+      {% if page.extra is defined and page.extra.location %}<span>loc: {{ page.extra.location }}</span>{% endif %}
+      <span>{{ page.reading_time }} min</span>
+    </div>
+  </header>
+
+  <pre class="paper-rule">--------------------------------------------------------</pre>
+
+  <div class="paper-body">
+    {{ content | safe }}
+  </div>
+
+  <pre class="paper-rule">--------------------------------------------------------</pre>
+
+  <footer class="paper-foot">
+    {% if page.tags %}
+    <div class="paper-tags">
+      subjects: {% for tag in page.tags %}<a class="paper-tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+    </div>
+    {% endif %}
+    <div class="paper-endmark">// end of item //</div>
+    <a class="paper-back" href="{{ base_url }}/posts/">[ back to all items ]</a>
+  </footer>
+</article>
+
+{% include "footer.html" %}

--- a/examples/samizdat/templates/section.html
+++ b/examples/samizdat/templates/section.html
@@ -1,0 +1,38 @@
+{% include "header.html" %}
+
+<section class="front">
+  <div class="censor-line">
+    <span class="censor-bar">[ catalog: all items ]</span>
+    <span class="censor-date">{{ section.pages | length }} on file</span>
+  </div>
+  <h1 class="front-headline">{{ section.title }}</h1>
+  {% if section.description %}
+  <p class="front-deck">{{ section.description }}</p>
+  {% endif %}
+
+  <div class="front-divider">. . . . . . . . . . . . . . . . . . . .</div>
+
+  <ol class="items">
+    {% for post in section.pages %}
+    <li class="item">
+      <div class="item-num">item {{ "%03d" | format(section.pages | length - loop.index0) }}</div>
+      <div class="item-body">
+        <div class="item-meta">
+          <span class="item-issue">[ issue {% if post.extra is defined and post.extra.issue %}{{ post.extra.issue }}{% else %}--{% endif %} ]</span>
+          <span class="item-date">{{ post.date | date("%Y.%m.%d") }}</span>
+          {% if post.extra is defined and post.extra.location %}<span class="item-loc">loc: {{ post.extra.location }}</span>{% endif %}
+        </div>
+        <h2 class="item-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.description %}
+        <p class="item-deck">{{ post.description }}</p>
+        {% endif %}
+        <div class="item-byline">
+          by {% if post.extra is defined and post.extra.authors %}{{ post.extra.authors | join(", ") }}{% else %}the editors{% endif %}
+        </div>
+      </div>
+    </li>
+    {% endfor %}
+  </ol>
+</section>
+
+{% include "footer.html" %}

--- a/examples/samizdat/templates/taxonomy.html
+++ b/examples/samizdat/templates/taxonomy.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+
+<section class="front">
+  <div class="censor-line">
+    <span class="censor-bar">[ subject index ]</span>
+    <span class="censor-date">{{ taxonomy_terms | length }} entries</span>
+  </div>
+  <h1 class="front-headline">{{ taxonomy_name }}</h1>
+  <p class="front-deck">every subject the bulletin has touched, by hand, retyped at least once.</p>
+
+  <div class="front-divider">. . . . . . . . . . . . . . . . . . . .</div>
+
+  <ul class="tag-index">
+    {% for term in taxonomy_terms %}
+    <li class="tag-entry">
+      <a href="{{ base_url }}{{ term.url }}">
+        <span class="tag-name">{{ term.name }}</span>
+        <span class="tag-dots">..............................................</span>
+        <span class="tag-count">{{ term.pages | length }} item{% if term.pages | length != 1 %}s{% endif %}</span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/samizdat/templates/taxonomy_term.html
+++ b/examples/samizdat/templates/taxonomy_term.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+
+<section class="front">
+  <div class="censor-line">
+    <span class="censor-bar">[ subject :: {{ taxonomy_term }} ]</span>
+    <span class="censor-date">{{ taxonomy_pages | length }} item{% if taxonomy_pages | length != 1 %}s{% endif %}</span>
+  </div>
+  <h1 class="front-headline">{{ taxonomy_term }}</h1>
+  <p class="front-deck">items filed under this subject. order is by most recent retyping.</p>
+
+  <div class="front-divider">. . . . . . . . . . . . . . . . . . . .</div>
+
+  <ol class="items">
+    {% for post in taxonomy_pages %}
+    <li class="item">
+      <div class="item-num">item {{ "%03d" | format(loop.index) }}</div>
+      <div class="item-body">
+        <div class="item-meta">
+          <span class="item-issue">[ issue {% if post.extra is defined and post.extra.issue %}{{ post.extra.issue }}{% else %}--{% endif %} ]</span>
+          <span class="item-date">{{ post.date | date("%Y.%m.%d") }}</span>
+        </div>
+        <h2 class="item-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.description %}
+        <p class="item-deck">{{ post.description }}</p>
+        {% endif %}
+      </div>
+    </li>
+    {% endfor %}
+  </ol>
+</section>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9001,5 +9001,40 @@
     "portfolio",
     "collage",
     "editorial"
+  ],
+  "broadsheet-riot": [
+    "light",
+    "blog",
+    "editorial",
+    "brutalist",
+    "bodoni"
+  ],
+  "cut-paper-zine": [
+    "light",
+    "blog",
+    "editorial",
+    "risograph",
+    "collage"
+  ],
+  "monogram-quarterly": [
+    "light",
+    "blog",
+    "editorial",
+    "minimal",
+    "museum"
+  ],
+  "samizdat": [
+    "light",
+    "blog",
+    "typewriter",
+    "underground",
+    "monospace"
+  ],
+  "anti-pattern": [
+    "light",
+    "blog",
+    "editorial",
+    "anti-design",
+    "experimental"
   ]
 }


### PR DESCRIPTION
## Summary

Adds five new blog examples — each with a distinct, committed editorial aesthetic, original long-form prose, and full template/CSS implementations. No CSS gradients or emoji characters anywhere.

| Site | Aesthetic | Type stack |
|---|---|---|
| **broadsheet-riot** | Brutalist newspaper agitprop — oversize Bodoni, red ink, column rules, drop caps | Bodoni Moda · Domine · IBM Plex Mono |
| **cut-paper-zine** | Riso/photocopier zine — stamps, tape, hard-shadow cards, clip-path torn paper | Archivo Black · Special Elite · DM Sans |
| **monogram-quarterly** | Museum-grade luxury quarterly — wide margins, generous leading, gold accent | Marcellus · Cormorant Garamond · JetBrains Mono |
| **samizdat** | Underground typewriter carbon-copy — onion-paper border, censor bars, ASCII rules | Special Elite · Courier Prime · Cutive Mono |
| **anti-pattern** | Anti-design dada — six rotated fonts on one page, offset grid, marquee | Bungee · Syne · Fraunces · Space Mono · Caveat · Anton |

Each site ships with `config.toml`, 4–5 long-form posts with rich front matter, `about.md`, full template set (header/footer/index/page/section/taxonomy/taxonomy_term/404), and per-site `style.css`. `tags.json` updated with `light + blog + editorial` plus aesthetic-specific tags.

## Test plan

- [x] `hwaro build` succeeds for all 5 sites
- [x] `hwaro doctor --fix` run on each site
- [x] No CSS gradients (`linear-gradient` / `radial-gradient`) anywhere in new CSS
- [x] No emoji characters in templates or content
- [x] `tags.json` entries added for all 5 sites
- [ ] CI builds and renders screenshots on deploy preview