### PR TITLE
fix(zen-monolith): correctly resolve post URLs in section list

### DIFF
--- a/examples/zen-monolith/templates/section.html
+++ b/examples/zen-monolith/templates/section.html
@@ -6,7 +6,7 @@
   <ul class="section-list">
     {% for item in section.pages %}
       <li>
-        <h2><a href="{{ base_url }}{{ item.permalink }}">{{ item.title | e }}</a></h2>
+        <h2><a href="{{ base_url }}{{ item.url }}">{{ item.title | e }}</a></h2>
         <div class="post-meta">
           <time>{{ item.date }}</time>
         </div>


### PR DESCRIPTION
This PR resolves a 404 issue on the `zen-monolith` example site's section pages (like `/posts/`). The template `section.html` was incorrectly referencing the undefined property `item.permalink`, which evaluated to empty. By changing it to `item.url`, links to posts and pages are correctly generated.

Testing: Built the site with `hwaro build` inside `examples/zen-monolith/` and confirmed that URLs in the generated `public/posts/index.html` were populated correctly.

---
*PR created automatically by Jules for task [8461626895189214424](https://jules.google.com/task/8461626895189214424) started by @hahwul*