### PR TITLE
Add five bold admin theme example sites

### DIFF
--- a/examples/architect-blueprint/AGENTS.md
+++ b/examples/architect-blueprint/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/architect-blueprint/archetypes/default.md
+++ b/examples/architect-blueprint/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/architect-blueprint/config.toml
+++ b/examples/architect-blueprint/config.toml
@@ -1,0 +1,193 @@
+title = "Architect / Blueprint"
+description = "Drafting-room admin theme — deep navy blueprint with cyan technical lines, drafting grid, callout balloons and monospace numerics. Studio control panel."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["projects", "drawings", "specs", "site"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/architect-blueprint/content/about.md
+++ b/examples/architect-blueprint/content/about.md
@@ -1,0 +1,32 @@
++++
+title = "About the Studio"
+description = "A small studio of five — drawings, site visits, and the standing register of revisions."
+[extra]
+eyebrow = "OFFICE NOTE"
+code = "OFF-001"
+rev = "A"
+metric_label = "STAFF"
+metric = "5"
+metric_note = "4.0 FTE"
+drawn = "K. NAVARRO"
+checked = "O. KIM"
++++
+
+A small studio of five, four FTE, taking five projects at a time and never more. The drafting
+board upstairs, the model bench downstairs, and the standing register on the wall by the
+door.
+
+## What we work on
+
+Residential and small civic — a library, a school annex, two houses. We turn down the
+projects that don't fit the room or the calendar.
+
+## How we work
+
+Drawings by hand first, then in software. Every drawing is checked by a second pair of eyes
+before issue. Every revision is logged on the standing register.
+
+## Site visits
+
+One day a week on site for every active project. The studio is closed on Fridays for site
+day, by long tradition.

--- a/examples/architect-blueprint/content/drawings/_index.md
+++ b/examples/architect-blueprint/content/drawings/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Drawings"
+description = "Drawing sheets across all open projects, by issue date and revision."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/architect-blueprint/content/drawings/drg-08-c-04.md
+++ b/examples/architect-blueprint/content/drawings/drg-08-c-04.md
@@ -1,0 +1,36 @@
++++
+title = "DRG–08–C / 04 · Ground floor plan"
+date = "2026-04-30"
+description = "Ground-floor plan, House at Cove Road. Sheet 04 of 12, revision C."
+[extra]
+eyebrow = "DRAWING · PRJ-08"
+code = "DRG-08-C/04"
+rev = "C"
+metric_label = "SHEET"
+metric = "04 / 12"
+metric_note = "Issued 2026-04-30"
+drawn = "K. NAVARRO"
+checked = "O. KIM"
+tag = "ISSUED"
++++
+
+Ground-floor plan for the House at Cove Road, sheet 04 of 12, current revision C.
+
+## What's on it
+
+- Plan at 1 : 50, dimensions in mm.
+- Door swings and window openings.
+- Four callouts to the detail sheet: living entry, kitchen threshold, garden door, south
+  window.
+- Garden line for reference, plotted with the survey grid.
+
+## Revisions
+
+- **A** · 2026-04-12 · first issue.
+- **B** · 2026-04-22 · engineer's first review applied.
+- **C** · 2026-04-30 · parapet annotation noted; threshold detail revised.
+
+## Notes
+
+The south window opening is set to 1 850 × 1 200 nominal. On site this morning the
+opening measured 1 838 — within tolerance, builder confirming.

--- a/examples/architect-blueprint/content/drawings/drg-09-b-02.md
+++ b/examples/architect-blueprint/content/drawings/drg-09-b-02.md
@@ -1,0 +1,29 @@
++++
+title = "DRG–09–B / 02 · Site plan"
+date = "2026-04-22"
+description = "Site plan, Pier Library at North Quay. Sheet 02 of 18, revision B."
+[extra]
+eyebrow = "DRAWING · PRJ-09"
+code = "DRG-09-B/02"
+rev = "B"
+metric_label = "SHEET"
+metric = "02 / 18"
+metric_note = "Issued 2026-04-22"
+drawn = "O. KIM"
+checked = "K. NAVARRO"
+tag = "ISSUED"
++++
+
+Site plan for the Pier Library, sheet 02 of 18, current revision B. Issued with the tender pack.
+
+## What's on it
+
+- Pier head with the existing boat-store outline retained for reference.
+- Mean high water mark and the standing tide datum.
+- Service runs from the harbour office (cable, water, foul).
+- The reading room footprint with setbacks from the pier edge.
+
+## Engineer's review
+
+The structural engineer's first pass noted the cantilever on the east face and asked for a
+deeper section. The deeper section is on sheet 08 in this issue.

--- a/examples/architect-blueprint/content/index.md
+++ b/examples/architect-blueprint/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Drafting Board"
+template = "dashboard"
+description = "The studio drafting board — projects, drawings, site reports and tenders."
++++

--- a/examples/architect-blueprint/content/projects/_index.md
+++ b/examples/architect-blueprint/content/projects/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Projects"
+description = "The active project register, with stage, next milestone and state."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/architect-blueprint/content/projects/cove-road.md
+++ b/examples/architect-blueprint/content/projects/cove-road.md
@@ -1,0 +1,36 @@
++++
+title = "PRJ–08 · House at Cove Road"
+date = "2026-05-21"
+description = "Three-bedroom house on the south coast. Stage 4 issued. On site since Wk 18."
+[extra]
+eyebrow = "PROJECT · CONSTRUCTION"
+code = "PRJ-08"
+rev = "C"
+metric_label = "STAGE"
+metric = "4"
+metric_note = "Construction · Wk 21 of 32"
+metric2_label = "ON SITE"
+metric2_note = "Frame up, joists in."
+drawn = "K. NAVARRO"
+checked = "O. KIM"
+tag = "ON SITE"
++++
+
+A three-bedroom house on the south coast for a family of four. Concept signed in March,
+technical pack issued in April, on site since the third week of April.
+
+## Stage
+
+We are in Stage 4 — construction. The frame is up, the second-floor joists are going in this
+week, and the roof structure is scheduled for Wk 24.
+
+## Drawing pack
+
+The current drawing pack is **DRG-08-C**, 12 sheets, issued 2026-04-30 and accepted by the
+engineer with one annotation on the parapet junction.
+
+## Notes
+
+- South window opening is 12mm under nominal — within tolerance, builder confirming.
+- Garden door threshold detail is on RFI-018, due Monday.
+- Carpenter ahead of schedule, weather window holding through Wednesday.

--- a/examples/architect-blueprint/content/projects/lower-mill.md
+++ b/examples/architect-blueprint/content/projects/lower-mill.md
@@ -1,0 +1,33 @@
++++
+title = "PRJ–11 · Two Houses, Lower Mill"
+date = "2026-05-08"
+description = "A pair of attached houses on a working mill lot. In Stage 3 design dev."
+[extra]
+eyebrow = "PROJECT · DESIGN"
+code = "PRJ-11"
+rev = "A"
+metric_label = "STAGE"
+metric = "3"
+metric_note = "Design dev · sign-off May 30"
+metric2_label = "SHEETS"
+metric2_note = "9 / 14 drafted"
+drawn = "D. PRYCE"
+checked = "K. NAVARRO"
+tag = "DESIGN"
++++
+
+A pair of attached houses on a working mill lot, commissioned by the owner of the mill for
+the mill manager and the mill manager's daughter. Stage 3 design dev with sign-off
+scheduled May 30.
+
+## Brief
+
+Two houses, each of two bedrooms, sharing a wall and a courtyard. The lot is constrained
+by the mill leat on the west and the standing oak on the south. The two are non-negotiable.
+
+## Sheets drafted
+
+- Site plan, ground floor, first floor, sections × 2 — done.
+- Elevations × 4 — done.
+- Detail at the shared wall, the leat retaining wall — in draft.
+- Technical specification — in draft.

--- a/examples/architect-blueprint/content/projects/pier-library.md
+++ b/examples/architect-blueprint/content/projects/pier-library.md
@@ -1,0 +1,35 @@
++++
+title = "PRJ–09 · Pier Library, North Quay"
+date = "2026-05-15"
+description = "A small reading library at the head of the pier. In tender. Closes Jun 03."
+[extra]
+eyebrow = "PROJECT · TENDER"
+code = "PRJ-09"
+rev = "B"
+metric_label = "STAGE"
+metric = "Tender"
+metric_note = "Closes 2026-06-03"
+metric2_label = "BIDDERS"
+metric2_note = "5 shortlisted"
+drawn = "O. KIM"
+checked = "K. NAVARRO"
+tag = "TENDER"
++++
+
+A small reading library at the head of the pier, commissioned by the harbour board. Stage 4
+technical pack went out to five shortlisted builders on April 22. Tender closes Jun 03.
+
+## Brief
+
+A reading room of forty seats, two study cubicles, a tea counter and a small office. The
+building is to sit on the existing pier head, replacing the boat-store that came down in 2024.
+
+## Drawing pack
+
+The tender pack is **DRG-09-B**, 18 sheets, issued 2026-04-22. The pack reflects the
+engineer's first-pass review and the harbour board's standing advice.
+
+## Schedule
+
+If the tender lands on price we sign in early July and break ground in August. The pier
+is open to weather only from October.

--- a/examples/architect-blueprint/content/site/_index.md
+++ b/examples/architect-blueprint/content/site/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Site Reports"
+description = "Weekly site reports from the active construction projects."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/architect-blueprint/content/site/cove-2026-05-21.md
+++ b/examples/architect-blueprint/content/site/cove-2026-05-21.md
@@ -1,0 +1,34 @@
++++
+title = "Cove Road · 2026-05-21"
+date = "2026-05-21"
+description = "Friday site visit, House at Cove Road. Frame up, joists in, weather holding."
+[extra]
+eyebrow = "SITE REPORT · PRJ-08"
+code = "SR-08-21"
+rev = "A"
+metric_label = "WEEK"
+metric = "Wk 21"
+metric_note = "Of 32 planned"
+drawn = "K. NAVARRO"
+checked = "O. KIM"
+tag = "SIGNED"
++++
+
+Friday site visit. Frame is up, second-floor joists going in, weather window holding through
+Wednesday. Builder ahead of schedule by half a day.
+
+## Observations
+
+- South window opening is **12mm under nominal**. Within tolerance, builder confirming.
+- The parapet detail at the rear corner reads cleanly. Drawing pack DRG-08-C / 09 holds.
+- Carpenter is on site as planned, finished early. Roof structure to start Mon Jun 09.
+
+## Actions
+
+- Builder to confirm south window opening dimension by COB Monday.
+- RFI-018 (garden door threshold) due Monday.
+- Workshop to begin oak window frames Wk 25.
+
+## Signed
+
+K. Navarro · 2026-05-21 16:42 on site.

--- a/examples/architect-blueprint/content/specs/_index.md
+++ b/examples/architect-blueprint/content/specs/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Specifications"
+description = "Technical specifications and standing materials registers."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/architect-blueprint/content/specs/standing-details.md
+++ b/examples/architect-blueprint/content/specs/standing-details.md
@@ -1,0 +1,33 @@
++++
+title = "Standing Details · House Type 04"
+date = "2026-03-15"
+description = "The studio's house-type-04 standing details, reused across small residential projects."
+[extra]
+eyebrow = "SPEC · STANDING"
+code = "SPEC-D-04"
+rev = "B"
+metric_label = "DETAILS"
+metric = "18"
+metric_note = "Reused on PRJ-08, PRJ-11"
+drawn = "O. KIM"
+checked = "K. NAVARRO"
+tag = "STANDING"
++++
+
+Eighteen standing details for small residential projects, reused without rework on House Type
+04. Every detail is logged on the project's drawing register with the parent reference.
+
+## What's covered
+
+- Foundation to wall plate.
+- Wall plate to roof.
+- Window jambs, heads, sills (oak frame).
+- Door thresholds at internal and external.
+- Parapet at flat roof.
+- Eaves at pitched roof.
+
+## Reuse
+
+Reused without rework on PRJ-08 (Cove Road) and PRJ-11 (Lower Mill). Any deviation from
+the standing detail must be flagged on the project's drawing register and signed by the
+project lead.

--- a/examples/architect-blueprint/content/specs/timber-register.md
+++ b/examples/architect-blueprint/content/specs/timber-register.md
@@ -1,0 +1,35 @@
++++
+title = "Standing Timber Register · 2026"
+date = "2026-04-01"
+description = "The studio's standing timber register for the year — sources, species, treatments."
+[extra]
+eyebrow = "SPEC · STANDING"
+code = "SPEC-T-26"
+rev = "A"
+metric_label = "ENTRIES"
+metric = "27"
+metric_note = "Updated quarterly"
+drawn = "STUDIO"
+checked = "K. NAVARRO"
+tag = "STANDING"
++++
+
+The standing register of timber the studio uses across active projects. Updated quarterly. All
+species are from the published list and the sawmills on the standing supplier list.
+
+## Species
+
+- **Oak**, English, quarter-sawn — for window frames and exterior joinery.
+- **Larch**, Scottish, vertical grain — for external cladding.
+- **Douglas fir**, home-grown — for primary structure where unseen.
+- **Ash**, English — for handrails and reading-room joinery.
+
+## Treatments
+
+- All exterior timber is air-dried, untreated, and detailed for ventilation.
+- All interior joinery is hand-finished oil, no varnish.
+
+## Suppliers
+
+Three sawmills are on the standing list. The selection is by the project lead and is logged
+in the project's drawing register.

--- a/examples/architect-blueprint/static/css/style.css
+++ b/examples/architect-blueprint/static/css/style.css
@@ -1,0 +1,449 @@
+:root {
+  --navy: #0a1b3a;
+  --navy-2: #0e2244;
+  --navy-3: #142a55;
+  --line: #1c3a72;
+  --line-2: #2756a5;
+  --cyan: #6ee0ff;
+  --cyan-dim: #2da6c2;
+  --white: #f0f4ff;
+  --paper: #e9eef9;
+  --muted: #6f87b6;
+  --amber: #ffc94c;
+  --red: #ff6a6a;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0;
+  background: var(--navy);
+  color: var(--white);
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+a { color: inherit; text-decoration: none; }
+
+.mono { font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, monospace; }
+.condensed { font-family: "Archivo", "Inter", sans-serif; font-stretch: 75%; }
+
+/* drafting grid background */
+body::before {
+  content: "";
+  position: fixed; inset: 0; pointer-events: none;
+  background-image:
+    linear-gradient(rgba(110,224,255,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(110,224,255,0.04) 1px, transparent 1px),
+    linear-gradient(rgba(110,224,255,0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(110,224,255,0.08) 1px, transparent 1px);
+  background-size: 20px 20px, 20px 20px, 100px 100px, 100px 100px;
+  z-index: 0;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  position: relative;
+  z-index: 1;
+}
+
+/* SIDEBAR */
+.sidebar {
+  background: rgba(10,27,58,0.95);
+  border-right: 1px solid var(--line-2);
+  padding: 20px 18px;
+  position: sticky; top: 0;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.brand {
+  display: flex; align-items: center; gap: 12px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line-2);
+  margin-bottom: 18px;
+}
+.brand-icon {
+  width: 38px; height: 38px;
+  border: 1.5px solid var(--cyan);
+  position: relative;
+  flex: none;
+}
+.brand-icon::before {
+  content: ""; position: absolute;
+  top: 50%; left: 50%;
+  width: 22px; height: 22px;
+  border: 1.5px solid var(--cyan);
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+.brand-icon::after {
+  content: ""; position: absolute;
+  top: -1.5px; left: -1.5px; right: -1.5px; bottom: -1.5px;
+  border-left: 1.5px solid var(--cyan);
+  border-bottom: 1.5px solid var(--cyan);
+  width: 6px; height: 6px;
+  border-right: none; border-top: none;
+}
+.brand-text { line-height: 1.1; }
+.brand .name {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+  color: var(--cyan);
+}
+.brand .sub { font-size: 10px; letter-spacing: 0.22em; color: var(--muted); margin-top: 4px; }
+
+.nav-h {
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  color: var(--muted);
+  margin: 14px 0 6px;
+  display: flex;
+  justify-content: space-between;
+}
+.nav-h::after { content: ""; flex: 1; height: 1px; background: var(--line-2); margin-left: 8px; align-self: center; }
+
+.nav-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  margin: 2px -12px;
+  border-left: 2px solid transparent;
+  font-size: 13px;
+}
+.nav-link .id {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--muted);
+}
+.nav-link:hover { background: rgba(110,224,255,0.04); }
+.nav-link.active {
+  background: rgba(110,224,255,0.1);
+  color: var(--cyan);
+  border-left-color: var(--cyan);
+}
+.nav-link.active .id { color: var(--cyan); }
+
+.scale-bar {
+  position: absolute;
+  bottom: 18px; left: 18px; right: 18px;
+  border-top: 1px solid var(--line-2);
+  padding-top: 12px;
+  font-size: 10px;
+  color: var(--muted);
+  letter-spacing: 0.18em;
+}
+.scale-bar .ruler {
+  display: flex;
+  height: 12px;
+  margin-top: 6px;
+  border: 1px solid var(--cyan-dim);
+}
+.scale-bar .ruler span {
+  flex: 1;
+  border-right: 1px solid var(--cyan-dim);
+}
+.scale-bar .ruler span:nth-child(odd) { background: var(--cyan-dim); }
+.scale-bar .ruler span:last-child { border-right: none; }
+
+/* MAIN */
+.main { min-width: 0; }
+
+.titleblock {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto;
+  align-items: stretch;
+  border-bottom: 1px solid var(--line-2);
+  background: rgba(10,27,58,0.9);
+}
+.tb-cell {
+  padding: 12px 18px;
+  border-right: 1px solid var(--line-2);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.tb-cell:last-child { border-right: none; }
+.tb-cell .lbl { font-size: 9px; letter-spacing: 0.3em; color: var(--muted); }
+.tb-cell .val { font-family: "JetBrains Mono", monospace; color: var(--white); font-size: 13px; margin-top: 4px; letter-spacing: 0.04em; }
+.tb-cell .val.cyan { color: var(--cyan); font-weight: 700; }
+.tb-cell.crumb { font-family: "Archivo", sans-serif; }
+.tb-cell.crumb .val { font-size: 16px; font-weight: 700; letter-spacing: 0.02em; }
+.tb-cell.crumb .val .slash { color: var(--cyan); }
+
+.content { padding: 20px 28px 80px; max-width: 1320px; }
+
+/* DRAWING HEADER */
+.drawing-h {
+  border: 1px solid var(--line-2);
+  background: rgba(14,34,68,0.65);
+  padding: 0;
+  margin-bottom: 18px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+}
+.drawing-h .left {
+  padding: 26px 30px 28px;
+  border-right: 1px solid var(--line-2);
+  position: relative;
+}
+.drawing-h .eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  color: var(--cyan);
+  margin-bottom: 12px;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+.drawing-h .eyebrow .mark {
+  display: inline-block;
+  width: 18px; height: 18px;
+  border: 1.5px solid var(--cyan);
+  position: relative;
+}
+.drawing-h .eyebrow .mark::after {
+  content: ""; position: absolute;
+  inset: 4px;
+  background: var(--cyan);
+  opacity: 0.4;
+}
+.drawing-h h1 {
+  font-family: "Archivo", sans-serif;
+  font-size: 38px;
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  margin: 0 0 10px;
+  font-weight: 700;
+}
+.drawing-h h1 .strong { color: var(--cyan); }
+.drawing-h p { font-size: 13.5px; color: var(--paper); opacity: 0.85; max-width: 60ch; }
+.drawing-h .corner-mark {
+  position: absolute;
+  top: 18px; right: 22px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: var(--muted);
+  text-align: right;
+}
+.drawing-h .corner-mark b { color: var(--cyan); }
+
+.drawing-h .right {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+.drawing-h .right .cell {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--line-2);
+  border-right: 1px solid var(--line-2);
+}
+.drawing-h .right .cell:nth-child(odd) { border-right: 1px solid var(--line-2); }
+.drawing-h .right .cell:nth-child(even) { border-right: none; }
+.drawing-h .right .cell:nth-child(3), .drawing-h .right .cell:nth-child(4) { border-bottom: none; }
+.drawing-h .right .lbl { font-size: 10px; letter-spacing: 0.26em; color: var(--muted); }
+.drawing-h .right .val {
+  font-family: "Archivo", sans-serif;
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--white);
+  margin-top: 4px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.drawing-h .right .val.cyan { color: var(--cyan); }
+.drawing-h .right .val.amber { color: var(--amber); }
+.drawing-h .right .val.red { color: var(--red); }
+.drawing-h .right .note { font-size: 11px; color: var(--muted); margin-top: 6px; }
+
+/* PANELS */
+.row {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+.row.three { grid-template-columns: 1fr 1fr 1fr; }
+
+.panel {
+  border: 1px solid var(--line-2);
+  background: rgba(14,34,68,0.55);
+}
+.panel-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--line-2);
+  background: rgba(10,27,58,0.7);
+}
+.panel-h h3 {
+  font-family: "Archivo", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  font-weight: 700;
+  margin: 0;
+  text-transform: uppercase;
+  color: var(--cyan);
+}
+.panel-h .meta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.1em;
+}
+.panel-b { padding: 14px 18px; }
+
+/* TABLE */
+.t { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.t th, .t td {
+  text-align: left;
+  padding: 8px 8px;
+  border-bottom: 1px dashed var(--line-2);
+}
+.t th { font-size: 10px; letter-spacing: 0.22em; color: var(--muted); text-transform: uppercase; font-weight: 500; }
+.t tr:last-child td { border-bottom: none; }
+.t td.mono { font-family: "JetBrains Mono", monospace; color: var(--cyan); font-size: 12px; }
+.t td.num { font-family: "JetBrains Mono", monospace; font-variant-numeric: tabular-nums; text-align: right; }
+
+.pill {
+  display: inline-block;
+  border: 1px solid var(--cyan-dim);
+  color: var(--cyan);
+  padding: 1px 7px;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  font-family: "JetBrains Mono", monospace;
+  text-transform: uppercase;
+}
+.pill.amber { color: var(--amber); border-color: var(--amber); }
+.pill.red { color: var(--red); border-color: var(--red); }
+.pill.muted { color: var(--muted); border-color: var(--muted); }
+
+/* BLUEPRINT DRAWING (SVG-like via divs) */
+.bp-canvas {
+  position: relative;
+  height: 240px;
+  border: 1px solid var(--cyan-dim);
+  background: rgba(8,21,46,0.6);
+}
+.bp-canvas svg { display: block; width: 100%; height: 100%; }
+
+/* CALLOUT BALLOON */
+.callout {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px; height: 22px;
+  border: 1.5px solid var(--cyan);
+  border-radius: 50%;
+  color: var(--cyan);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+/* PROGRESS / GAUGE */
+.gauge { margin: 6px 0; }
+.gauge .row { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; font-size: 12px; }
+.gauge .lbl { width: 110px; color: var(--muted); letter-spacing: 0.06em; }
+.gauge .track { flex: 1; height: 6px; background: rgba(110,224,255,0.1); border: 1px solid var(--line-2); position: relative; }
+.gauge .fill { height: 100%; background: var(--cyan); }
+.gauge .fill.amber { background: var(--amber); }
+.gauge .fill.red { background: var(--red); }
+.gauge .val { width: 50px; text-align: right; font-family: "JetBrains Mono", monospace; }
+
+/* MILESTONE LIST */
+.steps { font-size: 12.5px; }
+.steps .step {
+  display: grid;
+  grid-template-columns: 22px 50px 1fr 90px;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--line-2);
+}
+.steps .step:last-child { border-bottom: none; }
+.steps .step .lbl { font-family: "JetBrains Mono", monospace; font-size: 10px; color: var(--muted); letter-spacing: 0.1em; }
+.steps .step .t { color: var(--white); }
+.steps .step .t .desc { color: var(--muted); font-size: 11px; margin-top: 2px; }
+
+/* SECTION LIST */
+.entries {
+  border: 1px solid var(--line-2);
+  background: rgba(14,34,68,0.45);
+}
+.entries .e {
+  display: grid;
+  grid-template-columns: 30px 70px 1fr 130px 80px;
+  gap: 16px;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px dashed var(--line-2);
+  font-size: 13px;
+}
+.entries .e:last-child { border-bottom: none; }
+.entries .e:hover { background: rgba(110,224,255,0.05); }
+.entries .balloon { display: flex; align-items: center; justify-content: center; }
+.entries .id { font-family: "JetBrains Mono", monospace; color: var(--cyan); font-size: 12px; letter-spacing: 0.06em; }
+.entries .t { color: var(--white); }
+.entries .t .desc { color: var(--muted); font-size: 11.5px; margin-top: 2px; }
+.entries .meta { font-family: "JetBrains Mono", monospace; color: var(--muted); font-size: 11px; }
+.entries .tag { text-align: right; }
+
+/* PROSE */
+.prose { font-size: 14px; line-height: 1.75; max-width: 76ch; color: var(--paper); }
+.prose h2 { font-family: "Archivo", sans-serif; color: var(--cyan); font-size: 18px; letter-spacing: 0.06em; text-transform: uppercase; border-bottom: 1px solid var(--line-2); padding-bottom: 6px; margin-top: 28px; }
+.prose h3 { font-family: "Archivo", sans-serif; color: var(--white); font-size: 14px; letter-spacing: 0.06em; text-transform: uppercase; margin-top: 22px; }
+.prose code { background: var(--navy-3); color: var(--cyan); padding: 1px 6px; border: 1px solid var(--line-2); font-size: 12px; }
+.prose pre { background: var(--navy-3); border: 1px solid var(--line-2); padding: 14px 16px; overflow-x: auto; color: var(--paper); }
+.prose blockquote { border-left: 3px solid var(--cyan); padding-left: 14px; color: var(--paper); font-style: italic; }
+.prose ul li::marker { color: var(--cyan); }
+
+/* footer ruler */
+.bottom-rule {
+  display: flex;
+  border-top: 1px solid var(--line-2);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--muted);
+  letter-spacing: 0.16em;
+  background: rgba(10,27,58,0.7);
+}
+.bottom-rule .seg {
+  padding: 8px 14px;
+  border-right: 1px solid var(--line-2);
+}
+.bottom-rule .seg:last-child { border-right: none; margin-left: auto; }
+.bottom-rule .seg b { color: var(--cyan); }
+
+/* 404 */
+.f404 { padding: 80px 40px; text-align: center; }
+.f404 h1 {
+  font-family: "Archivo", sans-serif;
+  font-size: 160px;
+  font-weight: 700;
+  color: var(--cyan);
+  margin: 0;
+  letter-spacing: -0.04em;
+}
+.f404 .lbl { font-family: "JetBrains Mono", monospace; font-size: 11px; color: var(--muted); letter-spacing: 0.3em; margin-bottom: 12px; }
+.f404 p { color: var(--paper); opacity: 0.8; }
+.f404 a { border: 1.5px solid var(--cyan); color: var(--cyan); padding: 10px 18px; letter-spacing: 0.2em; font-size: 11px; font-family: "JetBrains Mono", monospace; }
+
+@media (max-width: 1100px) {
+  .drawing-h { grid-template-columns: 1fr; }
+  .drawing-h .left { border-right: none; border-bottom: 1px solid var(--line-2); }
+  .row, .row.three { grid-template-columns: 1fr; }
+}
+@media (max-width: 800px) {
+  .app { grid-template-columns: 1fr; }
+  .sidebar { position: relative; height: auto; }
+  .titleblock { grid-template-columns: 1fr; }
+}

--- a/examples/architect-blueprint/static/favicon.svg
+++ b/examples/architect-blueprint/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/architect-blueprint/templates/404.html
+++ b/examples/architect-blueprint/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<div class="f404">
+  <div class="lbl">DRAWING NOT ON FILE</div>
+  <h1>404</h1>
+  <p>This sheet is not in the binder. The studio may not have drafted it yet.</p>
+  <p style="margin-top:24px;"><a href="{{ base_url }}/">RETURN TO DRAFTING BOARD</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/architect-blueprint/templates/dashboard.html
+++ b/examples/architect-blueprint/templates/dashboard.html
@@ -1,0 +1,196 @@
+{% include "header.html" %}
+
+<div class="drawing-h">
+  <div class="left">
+    <div class="eyebrow"><span class="mark"></span> DRAFTING BOARD · 2026 / Q2</div>
+    <h1>The studio, this morning.</h1>
+    <p>Five projects on the boards, two in tender, one on site. Drawing pack DRG-08-C went out to the engineer Wednesday and came back Friday with one annotation. Sheet 04 of 12 in front of you.</p>
+    <div class="corner-mark">STUDIO <b>DRG-04</b><br>OPEN <b>14</b> · REV <b>C</b></div>
+  </div>
+  <div class="right">
+    <div class="cell"><div class="lbl">OPEN DRAWINGS</div><div class="val cyan">42</div><div class="note">across 5 projects</div></div>
+    <div class="cell"><div class="lbl">ON SITE</div><div class="val amber">1</div><div class="note">House at Cove Road</div></div>
+    <div class="cell"><div class="lbl">IN TENDER</div><div class="val">2</div><div class="note">Pier Library &amp; Field Studio</div></div>
+    <div class="cell"><div class="lbl">RFI · OPEN</div><div class="val red">3</div><div class="note">due before Wed</div></div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="panel">
+    <div class="panel-h"><h3>PROJECT REGISTER</h3><span class="meta">14 OPEN · 5 ACTIVE</span></div>
+    <div class="panel-b">
+      <table class="t">
+        <thead><tr><th>PRJ</th><th>NAME</th><th>STAGE</th><th>NEXT MILE</th><th>STATE</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">PRJ-08</td><td>House at Cove Road</td><td>Construction</td><td>Roof — Wk 24</td><td><span class="pill amber">ON SITE</span></td></tr>
+          <tr><td class="mono">PRJ-09</td><td>Pier Library, North Quay</td><td>Tender</td><td>Tender close — Jun 03</td><td><span class="pill">TENDER</span></td></tr>
+          <tr><td class="mono">PRJ-10</td><td>Field Studio, Bramble Hill</td><td>Tender</td><td>Tender close — Jun 17</td><td><span class="pill">TENDER</span></td></tr>
+          <tr><td class="mono">PRJ-11</td><td>Two Houses, Lower Mill</td><td>Design Dev</td><td>Stage 3 sign-off — May 30</td><td><span class="pill">DESIGN</span></td></tr>
+          <tr><td class="mono">PRJ-12</td><td>School Annex, Westfield</td><td>Concept</td><td>Concept review — Jun 05</td><td><span class="pill muted">CONCEPT</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-h"><h3>STUDIO LOAD</h3><span class="meta">5 STAFF · 4.0 FTE</span></div>
+    <div class="panel-b">
+      <div class="gauge">
+        <div class="row"><span class="lbl">K. NAVARRO</span><div class="track"><div class="fill" style="width:88%"></div></div><span class="val">88%</span></div>
+        <div class="row"><span class="lbl">O. KIM</span><div class="track"><div class="fill amber" style="width:96%"></div></div><span class="val">96%</span></div>
+        <div class="row"><span class="lbl">D. PRYCE</span><div class="track"><div class="fill" style="width:74%"></div></div><span class="val">74%</span></div>
+        <div class="row"><span class="lbl">M. HAN (P/T)</span><div class="track"><div class="fill" style="width:42%"></div></div><span class="val">42%</span></div>
+        <div class="row"><span class="lbl">S. ELLER (P/T)</span><div class="track"><div class="fill" style="width:38%"></div></div><span class="val">38%</span></div>
+      </div>
+      <div style="margin-top:14px;font-size:11.5px;color:var(--muted);border-top:1px dashed var(--line-2);padding-top:10px;">
+        Studio is at 84% of capacity through Q2. O. Kim is at the cap; a new project in Q3 needs a fifth seat.
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="panel">
+    <div class="panel-h"><h3>DRAWING PACK · PRJ–08 · HOUSE AT COVE ROAD</h3><span class="meta">SHEET 04 / 12 · REV C</span></div>
+    <div class="panel-b">
+      <div class="bp-canvas">
+        <svg viewBox="0 0 800 240" preserveAspectRatio="xMidYMid meet">
+          <defs>
+            <pattern id="g" width="20" height="20" patternUnits="userSpaceOnUse">
+              <path d="M 20 0 L 0 0 0 20" fill="none" stroke="rgba(110,224,255,0.1)" stroke-width="0.5"/>
+            </pattern>
+            <pattern id="g2" width="100" height="100" patternUnits="userSpaceOnUse">
+              <path d="M 100 0 L 0 0 0 100" fill="none" stroke="rgba(110,224,255,0.18)" stroke-width="0.6"/>
+            </pattern>
+          </defs>
+          <rect width="800" height="240" fill="url(#g)"/>
+          <rect width="800" height="240" fill="url(#g2)"/>
+
+          <!-- house outline -->
+          <rect x="120" y="60" width="320" height="140" fill="none" stroke="#6ee0ff" stroke-width="2"/>
+          <!-- interior walls -->
+          <line x1="280" y1="60" x2="280" y2="200" stroke="#6ee0ff" stroke-width="1.5"/>
+          <line x1="120" y1="130" x2="280" y2="130" stroke="#6ee0ff" stroke-width="1.5"/>
+          <line x1="280" y1="150" x2="440" y2="150" stroke="#6ee0ff" stroke-width="1.5"/>
+          <!-- door swings -->
+          <path d="M 200 130 A 30 30 0 0 1 230 100" fill="none" stroke="#6ee0ff" stroke-width="1" stroke-dasharray="3 3"/>
+          <path d="M 320 150 A 28 28 0 0 1 348 122" fill="none" stroke="#6ee0ff" stroke-width="1" stroke-dasharray="3 3"/>
+          <!-- windows -->
+          <line x1="160" y1="60" x2="220" y2="60" stroke="#0a1b3a" stroke-width="3"/>
+          <line x1="160" y1="60" x2="220" y2="60" stroke="#6ee0ff" stroke-width="1"/>
+          <line x1="180" y1="58" x2="200" y2="58" stroke="#6ee0ff" stroke-width="1"/>
+          <line x1="350" y1="200" x2="420" y2="200" stroke="#0a1b3a" stroke-width="3"/>
+          <line x1="350" y1="200" x2="420" y2="200" stroke="#6ee0ff" stroke-width="1"/>
+          <!-- garden / site -->
+          <line x1="440" y1="60" x2="560" y2="60" stroke="#6ee0ff" stroke-width="1" stroke-dasharray="6 4"/>
+          <line x1="440" y1="200" x2="560" y2="200" stroke="#6ee0ff" stroke-width="1" stroke-dasharray="6 4"/>
+          <line x1="560" y1="60" x2="560" y2="200" stroke="#6ee0ff" stroke-width="1" stroke-dasharray="6 4"/>
+          <text x="480" y="135" fill="#6ee0ff" font-family="JetBrains Mono" font-size="10" letter-spacing="2">GARDEN</text>
+          <!-- north arrow -->
+          <g transform="translate(700,60)">
+            <circle cx="0" cy="0" r="22" fill="none" stroke="#6ee0ff" stroke-width="1"/>
+            <polygon points="0,-20 -6,8 0,3 6,8" fill="#6ee0ff"/>
+            <text x="0" y="-26" text-anchor="middle" fill="#6ee0ff" font-family="JetBrains Mono" font-size="10">N</text>
+          </g>
+          <!-- callouts -->
+          <g font-family="JetBrains Mono" font-size="11" fill="#6ee0ff">
+            <circle cx="200" cy="95" r="11" fill="#0a1b3a" stroke="#6ee0ff" stroke-width="1.5"/>
+            <text x="200" y="99" text-anchor="middle">1</text>
+            <line x1="200" y1="106" x2="200" y2="130" stroke="#6ee0ff" stroke-width="1"/>
+
+            <circle cx="360" cy="115" r="11" fill="#0a1b3a" stroke="#6ee0ff" stroke-width="1.5"/>
+            <text x="360" y="119" text-anchor="middle">2</text>
+            <line x1="360" y1="126" x2="360" y2="150" stroke="#6ee0ff" stroke-width="1"/>
+
+            <circle cx="500" cy="135" r="11" fill="#0a1b3a" stroke="#6ee0ff" stroke-width="1.5"/>
+            <text x="500" y="139" text-anchor="middle">3</text>
+
+            <circle cx="385" cy="200" r="11" fill="#0a1b3a" stroke="#6ee0ff" stroke-width="1.5"/>
+            <text x="385" y="204" text-anchor="middle">4</text>
+            <line x1="385" y1="189" x2="385" y2="200" stroke="#6ee0ff" stroke-width="1"/>
+          </g>
+          <!-- dimensions -->
+          <g stroke="#6ee0ff" stroke-width="0.8" fill="#6ee0ff" font-family="JetBrains Mono" font-size="10">
+            <line x1="120" y1="40" x2="440" y2="40"/>
+            <line x1="120" y1="36" x2="120" y2="44"/>
+            <line x1="440" y1="36" x2="440" y2="44"/>
+            <text x="280" y="32" text-anchor="middle">12 800</text>
+
+            <line x1="100" y1="60" x2="100" y2="200"/>
+            <line x1="96" y1="60" x2="104" y2="60"/>
+            <line x1="96" y1="200" x2="104" y2="200"/>
+            <text x="86" y="135" text-anchor="middle" transform="rotate(-90,86,135)">5 600</text>
+          </g>
+        </svg>
+      </div>
+
+      <div style="margin-top:14px;display:grid;grid-template-columns:1fr 1fr;gap:8px 22px;font-size:12px;color:var(--paper);">
+        <div><span class="callout">1</span> &nbsp; Living room entry · 900mm sliding</div>
+        <div><span class="callout">2</span> &nbsp; Kitchen / dining flush threshold</div>
+        <div><span class="callout">3</span> &nbsp; Garden door · level access</div>
+        <div><span class="callout">4</span> &nbsp; South window · oak frame</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-h"><h3>MILESTONES · PRJ–08</h3><span class="meta">WK 21 OF 32</span></div>
+    <div class="panel-b">
+      <div class="steps">
+        <div class="step"><span class="callout">1</span><span class="lbl">WK 04</span><span class="t"><div>Stage 2 concept signed</div><div class="desc">Client signed concept March 11.</div></span><span class="pill">DONE</span></div>
+        <div class="step"><span class="callout">2</span><span class="lbl">WK 10</span><span class="t"><div>Stage 3 design dev</div><div class="desc">Engineer's first review.</div></span><span class="pill">DONE</span></div>
+        <div class="step"><span class="callout">3</span><span class="lbl">WK 16</span><span class="t"><div>Stage 4 technical</div><div class="desc">Drawing pack DRG-08-C issued.</div></span><span class="pill">DONE</span></div>
+        <div class="step"><span class="callout">4</span><span class="lbl">WK 24</span><span class="t"><div>Roof structure on</div><div class="desc">Carpenter on site Jun 09.</div></span><span class="pill amber">NEXT</span></div>
+        <div class="step"><span class="callout">5</span><span class="lbl">WK 28</span><span class="t"><div>Window install</div><div class="desc">Oak frames in workshop.</div></span><span class="pill muted">QUEUED</span></div>
+        <div class="step"><span class="callout">6</span><span class="lbl">WK 32</span><span class="t"><div>Handover</div><div class="desc">Final inspection &amp; handover.</div></span><span class="pill muted">QUEUED</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row three">
+  <div class="panel">
+    <div class="panel-h"><h3>RFI · OPEN</h3><span class="meta">03 OPEN</span></div>
+    <div class="panel-b">
+      <table class="t">
+        <thead><tr><th>RFI</th><th>SUBJECT</th><th>DUE</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">RFI-018</td><td>Door threshold detail · garden door</td><td><span class="pill red">MON</span></td></tr>
+          <tr><td class="mono">RFI-019</td><td>Window head — oak vs aluminium clad</td><td><span class="pill amber">TUE</span></td></tr>
+          <tr><td class="mono">RFI-020</td><td>Roof junction at parapet</td><td><span class="pill">WED</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-h"><h3>SITE REPORT · LATEST</h3><span class="meta">2026-05-21</span></div>
+    <div class="panel-b">
+      <div style="font-size:13px;line-height:1.7;color:var(--paper);">
+        <p style="margin-top:0;"><b>House at Cove Road</b> — frame is up, second-floor joists going in. Carpenter on site as planned, finished early. Weather window holding through Wednesday.</p>
+        <p>One observation: the south window opening is 12mm under nominal. Within tolerance, but we have asked the builder to confirm before the frames go to the workshop.</p>
+        <div style="border-top:1px dashed var(--line-2);padding-top:10px;font-size:11px;color:var(--muted);">SIGNED · K.N · 2026-05-21 16:42</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-h"><h3>TENDER · LIVE</h3><span class="meta">2 OPEN</span></div>
+    <div class="panel-b">
+      <div style="display:grid;gap:14px;">
+        <div style="border:1px solid var(--line-2);padding:14px;">
+          <div style="font-family:JetBrains Mono;color:var(--cyan);font-size:11px;letter-spacing:0.1em;">PRJ-09 · PIER LIBRARY</div>
+          <div style="font-family:Archivo;font-weight:700;font-size:18px;margin:6px 0 6px;">North Quay</div>
+          <div style="font-size:11.5px;color:var(--muted);">5 bidders shortlisted. Tender closes <b style="color:var(--white);">Jun 03</b>.</div>
+        </div>
+        <div style="border:1px solid var(--line-2);padding:14px;">
+          <div style="font-family:JetBrains Mono;color:var(--cyan);font-size:11px;letter-spacing:0.1em;">PRJ-10 · FIELD STUDIO</div>
+          <div style="font-family:Archivo;font-weight:700;font-size:18px;margin:6px 0 6px;">Bramble Hill</div>
+          <div style="font-size:11.5px;color:var(--muted);">3 bidders. Tender closes <b style="color:var(--white);">Jun 17</b>.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/architect-blueprint/templates/footer.html
+++ b/examples/architect-blueprint/templates/footer.html
@@ -1,0 +1,15 @@
+</div>
+
+<div class="bottom-rule">
+  <div class="seg">STUDIO · <b>DRG-04</b></div>
+  <div class="seg">PRJ · <b>08</b></div>
+  <div class="seg">REV · <b>C</b></div>
+  <div class="seg">DATE · <b>{{ current_date | default("2026-05-22") }}</b></div>
+  <div class="seg">SCALE · <b>1 : 50</b></div>
+  <div class="seg">SIGNED · <b>K.N · O.K</b></div>
+</div>
+
+</div>
+</div>
+</body>
+</html>

--- a/examples/architect-blueprint/templates/header.html
+++ b/examples/architect-blueprint/templates/header.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+</head>
+<body>
+<div class="app">
+
+<aside class="sidebar">
+  <div class="brand">
+    <div class="brand-icon"></div>
+    <div class="brand-text">
+      <div class="name">Architect / Blueprint</div>
+      <div class="sub">STUDIO · DRG-04</div>
+    </div>
+  </div>
+
+  <div class="nav-h"><span>STUDIO</span></div>
+  <a class="nav-link {% if page.url == '/' or not page.url %}active{% endif %}" href="{{ base_url }}/"><span>Drafting Board</span><span class="id">00</span></a>
+  <a class="nav-link {% if page.section == 'projects' %}active{% endif %}" href="{{ base_url }}/projects/"><span>Projects</span><span class="id">01</span></a>
+  <a class="nav-link {% if page.section == 'drawings' %}active{% endif %}" href="{{ base_url }}/drawings/"><span>Drawings</span><span class="id">02</span></a>
+  <a class="nav-link {% if page.section == 'specs' %}active{% endif %}" href="{{ base_url }}/specs/"><span>Specifications</span><span class="id">03</span></a>
+  <a class="nav-link {% if page.section == 'site' %}active{% endif %}" href="{{ base_url }}/site/"><span>Site Reports</span><span class="id">04</span></a>
+
+  <div class="nav-h"><span>OFFICE</span></div>
+  <a class="nav-link {% if page.url == '/about/' %}active{% endif %}" href="{{ base_url }}/about/"><span>About the Studio</span><span class="id">A1</span></a>
+
+  <div class="scale-bar">
+    SCALE 1 : 50 · METRIC
+    <div class="ruler"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div>
+  </div>
+</aside>
+
+<div class="main">
+<div class="titleblock">
+  <div class="tb-cell">
+    <div class="lbl">PROJECT</div>
+    <div class="val cyan">PRJ–08</div>
+  </div>
+  <div class="tb-cell crumb">
+    <div class="lbl">DRAWING</div>
+    <div class="val">
+      {% if page.title and page.url != '/' %}{{ page.title }}
+      {% elif section.title %}{{ section.title }}
+      {% elif taxonomy_name %}{{ taxonomy_name }}
+      {% else %}Drafting <span class="slash">/</span> Board{% endif %}
+    </div>
+  </div>
+  <div class="tb-cell">
+    <div class="lbl">SCALE</div>
+    <div class="val">1 : 50</div>
+  </div>
+  <div class="tb-cell">
+    <div class="lbl">SHEET</div>
+    <div class="val">04 / 12</div>
+  </div>
+  <div class="tb-cell">
+    <div class="lbl">REV · DATE</div>
+    <div class="val">C · {{ current_date | default("2026-05-22") }}</div>
+  </div>
+</div>
+
+<div class="content">

--- a/examples/architect-blueprint/templates/page.html
+++ b/examples/architect-blueprint/templates/page.html
@@ -1,0 +1,41 @@
+{% include "header.html" %}
+
+<div class="drawing-h">
+  <div class="left">
+    <div class="eyebrow"><span class="mark"></span> {{ page.extra and page.extra.eyebrow or "DRAWING" }}</div>
+    <h1>{{ page.title }}</h1>
+    <p>{{ page.description }}</p>
+    <div class="corner-mark">DRAW · <b>{{ page.extra and page.extra.code or "DRG-0000" }}</b><br>REV · <b>{{ page.extra and page.extra.rev or "A" }}</b></div>
+  </div>
+  <div class="right">
+    <div class="cell">
+      <div class="lbl">{{ page.extra and page.extra.metric_label or "STATUS" }}</div>
+      <div class="val cyan">{{ page.extra and page.extra.metric or "—" }}</div>
+      <div class="note">{{ page.extra and page.extra.metric_note or "" }}</div>
+    </div>
+    <div class="cell">
+      <div class="lbl">{{ page.extra and page.extra.metric2_label or "ISSUED" }}</div>
+      <div class="val">{{ page.date | date("%Y-%m-%d") }}</div>
+      <div class="note">{{ page.extra and page.extra.metric2_note or "First issue." }}</div>
+    </div>
+    <div class="cell">
+      <div class="lbl">DRAWN BY</div>
+      <div class="val">{{ page.extra and page.extra.drawn or "K. NAVARRO" }}</div>
+    </div>
+    <div class="cell">
+      <div class="lbl">CHECKED</div>
+      <div class="val">{{ page.extra and page.extra.checked or "O. KIM" }}</div>
+    </div>
+  </div>
+</div>
+
+<div class="panel">
+  <div class="panel-h"><h3>NOTES &amp; DETAIL</h3><span class="meta">SHEET 04 / 12</span></div>
+  <div class="panel-b">
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/architect-blueprint/templates/section.html
+++ b/examples/architect-blueprint/templates/section.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+
+<div class="drawing-h">
+  <div class="left">
+    <div class="eyebrow"><span class="mark"></span> SECTION INDEX · {{ section.pages | length }} ENTRIES</div>
+    <h1>{{ section.title }}</h1>
+    <p>{{ section.description }}</p>
+    <div class="corner-mark">INDEX <b>{{ section.title | upper }}</b><br>SHEETS <b>{{ section.pages | length }}</b></div>
+  </div>
+  <div class="right">
+    <div class="cell">
+      <div class="lbl">SHEETS</div>
+      <div class="val cyan">{{ section.pages | length }}</div>
+    </div>
+    <div class="cell">
+      <div class="lbl">SCALE</div>
+      <div class="val">1 : 50</div>
+    </div>
+    <div class="cell">
+      <div class="lbl">DRAWN</div>
+      <div class="val">K. NAVARRO</div>
+    </div>
+    <div class="cell">
+      <div class="lbl">CHECKED</div>
+      <div class="val">O. KIM</div>
+    </div>
+  </div>
+</div>
+
+<div class="entries">
+{% for p in section.pages %}
+  <a class="e" href="{{ p.url }}">
+    <span class="balloon"><span class="callout">{{ loop.index }}</span></span>
+    <span class="id">{{ p.extra and p.extra.code or "DRG-0000" }}</span>
+    <span class="t"><div>{{ p.title }}</div><div class="desc">{{ p.summary | default(p.description) | strip_html | truncate_words(22) }}</div></span>
+    <span class="meta">{{ p.date | date("%Y-%m-%d") }} · REV {{ p.extra and p.extra.rev or "A" }}</span>
+    <span class="tag"><span class="pill">{{ p.extra and p.extra.tag or "ISSUED" }}</span></span>
+  </a>
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/architect-blueprint/templates/shortcodes/alert.html
+++ b/examples/architect-blueprint/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/architect-blueprint/templates/taxonomy.html
+++ b/examples/architect-blueprint/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="drawing-h"><div class="left"><div class="eyebrow"><span class="mark"></span> INDEX</div><h1>{{ taxonomy_name | capitalize }}</h1><p>All terms.</p></div><div class="right"><div class="cell"><div class="lbl">TERMS</div><div class="val cyan">{{ taxonomy_terms | length }}</div></div></div></div>
+<div class="panel"><div class="panel-b">
+<table class="t">
+{% for term in taxonomy_terms %}
+<tr><td class="mono">{{ term.name }}</td><td class="num">{{ term.pages | length }}</td><td><a href="{{ term.url }}" style="color:var(--cyan);">OPEN ›</a></td></tr>
+{% endfor %}
+</table>
+</div></div>
+{% include "footer.html" %}

--- a/examples/architect-blueprint/templates/taxonomy_term.html
+++ b/examples/architect-blueprint/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<div class="drawing-h"><div class="left"><div class="eyebrow"><span class="mark"></span> TAG</div><h1>{{ taxonomy_term }}</h1></div><div class="right"><div class="cell"><div class="lbl">HITS</div><div class="val cyan">{{ taxonomy_pages | length }}</div></div></div></div>
+<div class="entries">
+{% for p in taxonomy_pages %}
+<a class="e" href="{{ p.url }}">
+  <span class="balloon"><span class="callout">{{ loop.index }}</span></span>
+  <span class="id">{{ p.section | upper }}</span>
+  <span class="t"><div>{{ p.title }}</div><div class="desc">{{ p.summary | default(p.description) | strip_html | truncate_words(20) }}</div></span>
+  <span class="meta">{{ p.date | date("%Y-%m-%d") }}</span>
+  <span class="tag"></span>
+</a>
+{% endfor %}
+</div>
+{% include "footer.html" %}

--- a/examples/editorial-bureau/AGENTS.md
+++ b/examples/editorial-bureau/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/editorial-bureau/archetypes/default.md
+++ b/examples/editorial-bureau/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/editorial-bureau/config.toml
+++ b/examples/editorial-bureau/config.toml
@@ -1,0 +1,193 @@
+title = "Editorial Bureau"
+description = "Editorial-style admin theme for a newsroom — bone paper, serif display numerals, oxblood accents, asymmetric grid and dossier cards."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["dossiers", "desks", "schedule", "notes"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/editorial-bureau/content/about.md
+++ b/examples/editorial-bureau/content/about.md
@@ -1,0 +1,28 @@
++++
+title = "About the Bureau"
+description = "A working newsroom, est. 1947, with a working style sheet and a working morgue."
+[extra]
+eyebrow = "HOUSE NOTE"
+metric_label = "Vol."
+metric = "VI"
+metric_note = "Edition 47 · 2026"
+byline = "The Editors"
++++
+
+The Editorial Bureau has been a working newsroom since the founding editor took the lease on
+the corner office in 1947. The masthead has changed. The desk has not.
+
+## What we run
+
+A weekly long-form edition, a daily city brief, a monthly letters page, and an obituaries
+column that takes as long as it takes. Every dossier on the desk has a name and a state.
+
+## The style sheet
+
+The style sheet is a working document. The sixth revision will run in issue 48. The desk reads
+every change in copy.
+
+## Corrections
+
+We run corrections whenever a reader writes in good faith. That has been the standing answer
+for seventy-eight years and remains the standing answer.

--- a/examples/editorial-bureau/content/desks/_index.md
+++ b/examples/editorial-bureau/content/desks/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Staff & Desks"
+description = "Editors, writers, and the desk each one keeps."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/editorial-bureau/content/desks/j-riese.md
+++ b/examples/editorial-bureau/content/desks/j-riese.md
@@ -1,0 +1,20 @@
++++
+title = "J. Riese · Maps & Archives"
+date = "2026-05-09"
+description = "Cartography and the bureau's working morgue."
+[extra]
+eyebrow = "STAFF · MAPS"
+metric_label = "Desk"
+metric = "IV"
+metric_note = "Maps and archives since 2018."
+byline = "Bureau Staff"
++++
+
+Cartographer by training, archivist by necessity. Keeps the bureau's morgue and runs the
+collaborations with the city archives.
+
+## Standing work
+
+- The Customs Houses walking map.
+- The morgue index, third revision.
+- The standing handshake with the city archives.

--- a/examples/editorial-bureau/content/desks/k-park.md
+++ b/examples/editorial-bureau/content/desks/k-park.md
@@ -1,0 +1,21 @@
++++
+title = "K. Park · Features"
+date = "2026-05-19"
+description = "Long-form features. Photography editor by habit."
+[extra]
+eyebrow = "STAFF · FEATURES"
+metric_label = "Desk"
+metric = "II"
+metric_note = "Features since 2021."
+byline = "Bureau Staff"
++++
+
+Long-form features and the photography pages. Joined the bureau in 2021 from the city
+desk. Keeps two photographers on call for the features pages and a third on the long
+projects.
+
+## Standing work
+
+- The Yellow Hotel feature (held).
+- The features schedule for issues 48 through 52.
+- The standing review of photo captions.

--- a/examples/editorial-bureau/content/desks/m-han.md
+++ b/examples/editorial-bureau/content/desks/m-han.md
@@ -1,0 +1,21 @@
++++
+title = "M. Han · City Editor"
+date = "2026-05-20"
+description = "Keeps the city desk and the river trade series."
+[extra]
+eyebrow = "STAFF · CITY"
+metric_label = "Desk"
+metric = "I"
+metric_note = "City editor since 2019."
+byline = "Bureau Staff"
++++
+
+City editor since 2019. Keeps the river trade series and the long form pieces on the inland
+trade. Came up through the warehouses desk in the early aughts and has not lost the habit
+of checking the manifest before filing.
+
+## Standing work
+
+- River Trade series (parts two through four).
+- Editor's notes for the Friday edition.
+- The city desk's daily brief.

--- a/examples/editorial-bureau/content/desks/s-eller.md
+++ b/examples/editorial-bureau/content/desks/s-eller.md
@@ -1,0 +1,20 @@
++++
+title = "S. Eller · Obituaries"
+date = "2026-05-12"
+description = "The obituaries desk. Writes the long closing notes."
+[extra]
+eyebrow = "STAFF · OBIT"
+metric_label = "Desk"
+metric = "III"
+metric_note = "Obituaries since 2015."
+byline = "Bureau Staff"
++++
+
+Obituaries since 2015. Keeps the standing list of names held back at the family's request
+and writes the long closing notes commissioned by the desk.
+
+## Standing work
+
+- The apothecary's closing note (in review).
+- The monthly column on closing institutions.
+- The standing index of held names.

--- a/examples/editorial-bureau/content/dossiers/_index.md
+++ b/examples/editorial-bureau/content/dossiers/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Dossiers"
+description = "Working dossiers — pieces under copy, in draft, or held in the morgue."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/editorial-bureau/content/dossiers/apothecary.md
+++ b/examples/editorial-bureau/content/dossiers/apothecary.md
@@ -1,0 +1,26 @@
++++
+title = "The Apothecary, Closing Notes"
+date = "2026-05-10"
+description = "An obituary commissioned in the long form."
+[extra]
+eyebrow = "OBITUARIES · LONG"
+metric_label = "Review"
+metric = "II"
+metric_note = "With the family."
+byline = "S. Eller"
++++
+
+The apothecary on the corner of Hill and Crown closed in April with the death of its
+proprietor, who had kept the shop since 1973. The obituaries desk commissioned a long-form
+closing note that runs as a column-and-a-half in issue 49.
+
+## What's in it
+
+- A short life of the proprietor, with the family's notes.
+- The list of regulars who came for the standing prescriptions and stayed for the conversation.
+- A photograph of the shop on closing day, in black and white.
+
+## What is held back
+
+The names of two regulars who asked not to be named. The desk holds the names and
+will not run them. This is, and remains, the standing answer.

--- a/examples/editorial-bureau/content/dossiers/customs-map.md
+++ b/examples/editorial-bureau/content/dossiers/customs-map.md
@@ -1,0 +1,25 @@
++++
+title = "A Walking Map of the Old Customs Houses"
+date = "2026-05-12"
+description = "Cartography in collaboration with the city archives."
+[extra]
+eyebrow = "MAPS · COLLAB"
+metric_label = "Draft"
+metric = "III"
+metric_note = "With the city archives."
+byline = "J. Riese"
++++
+
+The Customs Houses of the river district are mostly gone, but seven still stand and three are
+still in use as offices for civic functions. The walking map will mark all of them, the ones
+demolished, and the ones converted.
+
+## The collaboration
+
+The city archives are providing the historical photographs and the dated plans. We are
+providing the walking notes, the present-day photographs, and the print layout.
+
+## Format
+
+The map will run as a pull-out in issue 49. A reading-room version, larger and with the
+plans, will be available at the archives.

--- a/examples/editorial-bureau/content/dossiers/river-trade.md
+++ b/examples/editorial-bureau/content/dossiers/river-trade.md
@@ -1,0 +1,29 @@
++++
+title = "The Long Quiet of the River Trade"
+date = "2026-05-22"
+description = "A four-part series on inland shipping after the lock closures. Part two tonight."
+[extra]
+eyebrow = "CITY · SERIES"
+metric_label = "Part"
+metric = "II"
+metric_note = "Of four. Filed by M. Han."
+byline = "M. Han"
++++
+
+The lock closures of 2023 turned the inland river trade into a slow business, and a slower
+quiet. We have spent the last year talking to the bargemen, the warehousekeepers, and the
+clerks who keep the manifests in books that smell of damp.
+
+## What this series is
+
+A long look at what a slow river does to the towns that depend on it. Four parts, one per
+edition: the boats, the warehouses, the towns, and the question of what comes next.
+
+## Part Two — The Warehouses
+
+Part one ran two weeks ago and covered the boats. Part two, in tonight's edition, covers the
+warehouses — the ones still in use, the ones held in receivership, and the two that have
+quietly become apartments.
+
+> "We keep the books in case the boats come back. They might."
+> — A warehousekeeper, on the record, in his eighty-first year.

--- a/examples/editorial-bureau/content/dossiers/style-memo.md
+++ b/examples/editorial-bureau/content/dossiers/style-memo.md
@@ -1,0 +1,26 @@
++++
+title = "Memo on the Style Sheet, Sixth Revision"
+date = "2026-05-15"
+description = "A note from the copy desk and the new entries in full."
+[extra]
+eyebrow = "HOUSE · STYLE"
+metric_label = "Rev."
+metric = "VI"
+metric_note = "By the copy desk."
+byline = "Copy Desk"
++++
+
+The style sheet is a working document. The sixth revision will run in issue 48 as the standing
+reference for all desks. This memo is the change list with the desk's reasoning attached.
+
+## What changes
+
+- The serial comma is now standard in all running copy.
+- Place names take the form preferred by the place.
+- We use the term <em>obituary</em> for a person and <em>closing note</em> for an institution.
+- The phrase <em>passed away</em> is reserved for letters. In copy we say <em>died</em>.
+
+## What does not
+
+The standing instruction to run a correction whenever a reader writes in good faith is
+unchanged and stands.

--- a/examples/editorial-bureau/content/dossiers/yellow-hotel.md
+++ b/examples/editorial-bureau/content/dossiers/yellow-hotel.md
@@ -1,0 +1,25 @@
++++
+title = "On the Closing of the Yellow Hotel"
+date = "2026-05-19"
+description = "Photographs and the last residents' names, on the record."
+[extra]
+eyebrow = "FEATURES · LONG FORM"
+metric_label = "Held"
+metric = "II"
+metric_note = "Pending the photographs."
+byline = "K. Park"
++++
+
+The Yellow Hotel closed in March after one hundred and twelve years. The features desk has
+been working on a long piece on the last residents, the photographs of the rooms, and the
+question of what becomes of the building.
+
+## Why we are holding it
+
+We are holding the piece for the photographs. The photographer has been with the residents
+through three weeks of packing and is filing on Monday. The piece runs the edition after.
+
+## The Names
+
+Twelve residents stayed to the last. With permission, we run their names. The list is set, the
+copy desk has read it, and the residents have read their own entries.

--- a/examples/editorial-bureau/content/index.md
+++ b/examples/editorial-bureau/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Today's Desk"
+template = "dashboard"
+description = "Working dossiers, the issue schedule, and the editor's notes for the morning."
++++

--- a/examples/editorial-bureau/content/notes/_index.md
+++ b/examples/editorial-bureau/content/notes/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Editor's Notes"
+description = "Notes from the desk on the state of the bureau and the standing answers."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/editorial-bureau/content/notes/corrections.md
+++ b/examples/editorial-bureau/content/notes/corrections.md
@@ -1,0 +1,19 @@
++++
+title = "On the standing answer to corrections."
+date = "2026-05-08"
+description = "A short note pinned to the city desk this morning."
+[extra]
+eyebrow = "NOTE · HOUSE"
+metric_label = "Note"
+metric = "II"
+metric_note = "From the morgue, May 1958."
+byline = "The Editors"
++++
+
+A two-page memo from the founding editor was found in the May 1958 box in the morgue
+this week. It addresses the question of <em>how often to print a correction</em>.
+
+> Whenever a reader writes in good faith.
+
+That has been the standing answer for seventy-eight years and remains the standing answer.
+We will run the memo as a facsimile in issue 49.

--- a/examples/editorial-bureau/content/notes/filing-late.md
+++ b/examples/editorial-bureau/content/notes/filing-late.md
@@ -1,0 +1,19 @@
++++
+title = "On filing late, and filing clean."
+date = "2026-05-22"
+description = "The features desk filed late Thursday night. We held the page."
+[extra]
+eyebrow = "NOTE · HOUSE"
+metric_label = "Note"
+metric = "I"
+metric_note = "From the Friday morning desk."
+byline = "M. Han"
++++
+
+The features desk filed at eleven last night. The copy desk read it cold. We held the page.
+
+> Late but right is better than early but wrong. We will hold the page if the desk asks. We
+> will not run a sentence we are unsure of.
+
+The piece runs Monday with one footnote and a corrected dateline. The dateline was the
+question that held us. The footnote is the answer.

--- a/examples/editorial-bureau/content/schedule/_index.md
+++ b/examples/editorial-bureau/content/schedule/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Issue Schedule"
+description = "The standing schedule for the weekly long-form edition."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/editorial-bureau/content/schedule/issue-47.md
+++ b/examples/editorial-bureau/content/schedule/issue-47.md
@@ -1,0 +1,25 @@
++++
+title = "Issue No. 47 · May 22, 2026"
+date = "2026-05-22"
+description = "City desk leads with the second part of the river trade series."
+[extra]
+eyebrow = "ISSUE · 47"
+metric_label = "Edition"
+metric = "47"
+metric_note = "Friday, May 22, 2026."
+byline = "The Bureau"
++++
+
+The Friday edition runs the second part of the river trade series, the regular letters page,
+and a held-over column from the features desk that the city desk has read this morning.
+
+## Front
+
+- River Trade, Part Two (city · M. Han).
+- Letters from the Reading Room (letters · Bureau).
+
+## Inside
+
+- Three Letters from the Capital (letters · Bureau).
+- A held-over column on the lock closures (city · M. Han).
+- Editor's note on filing late and filing clean (house · M. Han).

--- a/examples/editorial-bureau/content/schedule/issue-48.md
+++ b/examples/editorial-bureau/content/schedule/issue-48.md
@@ -1,0 +1,25 @@
++++
+title = "Issue No. 48 · May 29, 2026"
+date = "2026-05-29"
+description = "Letters page lead and the sixth revision of the style sheet."
+[extra]
+eyebrow = "ISSUE · 48"
+metric_label = "Edition"
+metric = "48"
+metric_note = "Friday, May 29, 2026."
+byline = "The Bureau"
++++
+
+Issue 48 leads with the letters page — an open letter from the capital and the bureau's
+response. The style memo runs in full, on the spread that used to carry the standing
+correction.
+
+## Front
+
+- A Reader Writes from the Capital (letters · Bureau).
+- House Memo on the Style Sheet, Sixth Revision (house · Copy Desk).
+
+## Inside
+
+- The Yellow Hotel (features · K. Park), if the photographs file in time.
+- A short note on the standing answer to corrections (house · The Editors).

--- a/examples/editorial-bureau/static/css/style.css
+++ b/examples/editorial-bureau/static/css/style.css
@@ -1,0 +1,453 @@
+:root {
+  --paper: #f3ede1;
+  --paper-2: #ebe4d2;
+  --card: #faf5e8;
+  --ink: #161412;
+  --ink-2: #36302a;
+  --rule: #2b251f;
+  --muted: #6d655b;
+  --oxblood: #7b1f2b;
+  --oxblood-dark: #581621;
+  --olive: #5a572f;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Inter", "Söhne", system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+.serif { font-family: "Fraunces", "GT Sectra", "Source Serif 4", Georgia, serif; font-weight: 500; }
+.display { font-family: "Fraunces", "GT Sectra", "Source Serif 4", Georgia, serif; font-style: italic; }
+
+.app {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+}
+
+/* SIDEBAR */
+.sidebar {
+  padding: 28px 26px;
+  background: var(--paper-2);
+  border-right: 1px solid var(--rule);
+  position: sticky; top: 0; height: 100vh;
+  overflow: hidden;
+}
+.brand {
+  border-bottom: 2px solid var(--ink);
+  padding-bottom: 16px;
+  margin-bottom: 22px;
+}
+.brand .row1 { font-size: 10px; letter-spacing: 0.28em; color: var(--muted); }
+.brand .name {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-size: 36px;
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+  margin-top: 8px;
+}
+.brand .name b { font-style: normal; font-weight: 700; }
+.brand .row2 { font-size: 11px; letter-spacing: 0.22em; color: var(--muted); margin-top: 10px; }
+
+.nav-h {
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  color: var(--muted);
+  margin: 18px 0 6px;
+}
+.nav-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(43,37,31,0.15);
+  font-size: 14px;
+}
+.nav-link .id {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-size: 12px;
+  color: var(--muted);
+}
+.nav-link.active {
+  color: var(--oxblood);
+  border-bottom-color: var(--oxblood);
+}
+.nav-link.active .id { color: var(--oxblood); }
+.nav-link:hover { color: var(--oxblood); }
+
+.sidebar-foot {
+  position: absolute;
+  bottom: 22px; left: 26px; right: 26px;
+  font-size: 11px;
+  color: var(--muted);
+  border-top: 1px solid rgba(43,37,31,0.2);
+  padding-top: 14px;
+  font-family: "Fraunces", serif;
+  font-style: italic;
+}
+
+/* MAIN */
+.main { padding: 0; }
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 40px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+}
+.crumb { font-size: 12px; letter-spacing: 0.18em; color: var(--muted); }
+.crumb b { color: var(--ink); font-weight: 500; }
+.crumb .sep { margin: 0 8px; color: var(--muted); }
+.topbar-act { display: flex; gap: 12px; align-items: center; }
+.search {
+  background: var(--card);
+  border: 1px solid var(--rule);
+  padding: 8px 12px;
+  font-family: inherit;
+  font-size: 13px;
+  width: 200px;
+}
+.btn {
+  border: 1px solid var(--ink);
+  background: var(--card);
+  padding: 8px 14px;
+  font-family: inherit;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+.btn.dark { background: var(--ink); color: var(--paper); }
+.btn.oxblood { background: var(--oxblood); color: var(--paper); border-color: var(--oxblood); }
+.btn:hover { background: var(--oxblood); color: var(--paper); border-color: var(--oxblood); }
+
+.content { padding: 36px 44px 80px; max-width: 1280px; }
+
+/* MASTHEAD */
+.masthead {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 32px;
+  border-bottom: 1px solid var(--ink);
+  padding-bottom: 28px;
+  margin-bottom: 36px;
+}
+.masthead .eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  color: var(--oxblood);
+  text-transform: uppercase;
+  margin-bottom: 16px;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+.masthead .eyebrow .dot { width: 6px; height: 6px; background: var(--oxblood); border-radius: 50%; }
+.masthead h1 {
+  font-family: "Fraunces", serif;
+  font-size: 64px;
+  line-height: 0.95;
+  letter-spacing: -0.025em;
+  margin: 0 0 16px;
+  font-weight: 500;
+}
+.masthead h1 em { font-style: italic; color: var(--oxblood); }
+.masthead .lede {
+  font-size: 17px;
+  line-height: 1.55;
+  max-width: 60ch;
+  color: var(--ink-2);
+  font-family: "Fraunces", serif;
+  font-weight: 400;
+}
+.masthead .stat {
+  border-left: 1px solid var(--rule);
+  padding-left: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.masthead .stat .big {
+  font-family: "Fraunces", serif;
+  font-size: 110px;
+  line-height: 0.9;
+  letter-spacing: -0.03em;
+  font-feature-settings: "lnum";
+  margin: 0;
+  font-weight: 500;
+}
+.masthead .stat .big em { font-style: italic; color: var(--oxblood); }
+.masthead .stat .lbl { font-size: 11px; letter-spacing: 0.26em; color: var(--muted); text-transform: uppercase; margin-bottom: 8px; }
+.masthead .stat .meta { font-size: 13px; color: var(--muted); margin-top: 12px; font-family: "Fraunces", serif; font-style: italic; }
+
+/* STAT STRIP */
+.strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  margin: 0 0 36px;
+}
+.strip .item {
+  padding: 22px 26px;
+  border-right: 1px solid var(--rule);
+}
+.strip .item:last-child { border-right: none; }
+.strip .lbl { font-size: 10px; letter-spacing: 0.28em; color: var(--muted); text-transform: uppercase; }
+.strip .val {
+  font-family: "Fraunces", serif;
+  font-size: 44px;
+  line-height: 1;
+  margin-top: 12px;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+}
+.strip .val em { font-style: italic; color: var(--oxblood); }
+.strip .note { font-size: 12px; color: var(--muted); margin-top: 8px; font-family: "Fraunces", serif; font-style: italic; }
+
+/* LAYOUT GRID */
+.row { display: grid; grid-template-columns: 1.5fr 1fr; gap: 36px; margin-bottom: 40px; padding-bottom: 40px; border-bottom: 1px solid var(--rule); }
+.row.three { grid-template-columns: 1fr 1fr 1fr; gap: 28px; }
+.row:last-child { border-bottom: none; }
+
+.section-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 18px;
+  border-bottom: 2px solid var(--ink);
+  padding-bottom: 10px;
+}
+.section-h h2 {
+  font-family: "Fraunces", serif;
+  font-size: 26px;
+  letter-spacing: -0.015em;
+  margin: 0;
+  font-weight: 500;
+}
+.section-h .num {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  color: var(--oxblood);
+  font-size: 14px;
+  letter-spacing: 0.1em;
+}
+
+/* DOSSIER LIST */
+.dossier-list {
+  list-style: none;
+  padding: 0; margin: 0;
+}
+.dossier-list li {
+  display: grid;
+  grid-template-columns: 50px 1fr 130px 110px;
+  gap: 18px;
+  padding: 16px 0;
+  border-bottom: 1px solid rgba(43,37,31,0.18);
+  align-items: baseline;
+}
+.dossier-list li:last-child { border-bottom: none; }
+.dossier-list .n {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  color: var(--oxblood);
+  font-size: 22px;
+  font-weight: 500;
+}
+.dossier-list .t {
+  font-family: "Fraunces", serif;
+  font-size: 18px;
+  line-height: 1.3;
+  font-weight: 500;
+}
+.dossier-list .t .desc { color: var(--muted); font-size: 13px; font-family: "Inter", sans-serif; font-weight: 400; margin-top: 2px; }
+.dossier-list .meta { font-size: 12px; color: var(--muted); letter-spacing: 0.06em; }
+.dossier-list .meta em { color: var(--ink); font-style: italic; }
+.dossier-list .tag { text-align: right; font-size: 11px; letter-spacing: 0.18em; color: var(--oxblood); text-transform: uppercase; }
+
+/* SIDE CARDS */
+.side-card {
+  background: var(--card);
+  border: 1px solid var(--rule);
+  padding: 22px 24px;
+  margin-bottom: 22px;
+}
+.side-card .lbl { font-size: 10px; letter-spacing: 0.28em; color: var(--oxblood); text-transform: uppercase; }
+.side-card h3 {
+  font-family: "Fraunces", serif;
+  font-size: 22px;
+  line-height: 1.2;
+  margin: 8px 0 8px;
+  font-weight: 500;
+}
+.side-card p { font-size: 13.5px; line-height: 1.6; color: var(--ink-2); margin: 0; }
+.side-card .quote {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.4;
+  border-left: 3px solid var(--oxblood);
+  padding-left: 14px;
+  margin: 12px 0 8px;
+  color: var(--ink);
+}
+.side-card .byline {
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  margin-top: 10px;
+  border-top: 1px solid rgba(43,37,31,0.18);
+  padding-top: 8px;
+}
+
+/* DESK GRID */
+.desk-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.desk {
+  display: flex;
+  gap: 18px;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(43,37,31,0.18);
+  align-items: flex-start;
+}
+.desk-circle {
+  width: 56px; height: 56px;
+  border-radius: 50%;
+  background: var(--paper-2);
+  border: 1px solid var(--ink);
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-size: 18px;
+  font-weight: 500;
+}
+.desk-name { font-family: "Fraunces", serif; font-size: 17px; font-weight: 500; line-height: 1.2; }
+.desk-role { font-size: 12px; color: var(--muted); letter-spacing: 0.1em; text-transform: uppercase; margin-top: 4px; }
+.desk-note { font-size: 12.5px; line-height: 1.55; color: var(--ink-2); margin-top: 6px; }
+
+/* SCHEDULE TABLE */
+.schedule { width: 100%; border-collapse: collapse; }
+.schedule th, .schedule td {
+  text-align: left;
+  padding: 12px 14px 12px 0;
+  border-bottom: 1px solid rgba(43,37,31,0.18);
+}
+.schedule th { font-size: 11px; letter-spacing: 0.18em; color: var(--muted); text-transform: uppercase; font-weight: 500; }
+.schedule td { font-size: 14px; }
+.schedule td.iss { font-family: "Fraunces", serif; font-style: italic; font-size: 22px; color: var(--oxblood); width: 80px; }
+.schedule td.t { font-family: "Fraunces", serif; font-size: 17px; font-weight: 500; }
+.pill {
+  display: inline-block;
+  border: 1px solid var(--rule);
+  padding: 2px 8px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.pill.oxblood { background: var(--oxblood); color: var(--paper); border-color: var(--oxblood); }
+.pill.dark { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+
+/* PROSE */
+.prose { font-size: 16px; line-height: 1.75; max-width: 72ch; }
+.prose p:first-of-type::first-letter {
+  font-family: "Fraunces", serif;
+  font-size: 64px;
+  float: left;
+  line-height: 0.85;
+  padding: 6px 10px 0 0;
+  color: var(--oxblood);
+  font-weight: 500;
+}
+.prose h2 { font-family: "Fraunces", serif; font-size: 28px; margin-top: 36px; letter-spacing: -0.01em; }
+.prose h3 { font-family: "Fraunces", serif; font-style: italic; font-size: 19px; margin-top: 28px; color: var(--oxblood); }
+.prose blockquote {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.35;
+  border-left: 4px solid var(--oxblood);
+  padding-left: 18px;
+  margin: 22px 0;
+}
+.prose code { background: var(--card); border: 1px solid var(--rule); padding: 1px 6px; font-size: 14px; }
+.prose pre { background: var(--ink); color: var(--paper); padding: 16px 18px; overflow: auto; }
+.prose ul { padding-left: 18px; }
+.prose ul li::marker { color: var(--oxblood); }
+
+/* CARDS for section listing */
+.card-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.card {
+  display: block;
+  background: var(--card);
+  border: 1px solid var(--rule);
+  padding: 26px 28px 28px;
+  position: relative;
+}
+.card .eyebrow {
+  font-size: 11px; letter-spacing: 0.26em;
+  color: var(--oxblood);
+  text-transform: uppercase;
+  margin-bottom: 12px;
+  display: flex;
+  justify-content: space-between;
+}
+.card h3 {
+  font-family: "Fraunces", serif;
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+  margin: 0 0 10px;
+  font-weight: 500;
+}
+.card h3 em { font-style: italic; color: var(--oxblood); }
+.card .meta { font-size: 12px; color: var(--muted); letter-spacing: 0.06em; margin-bottom: 14px; }
+.card .sum { font-size: 14px; line-height: 1.55; color: var(--ink-2); }
+.card .num-marker {
+  position: absolute;
+  top: 22px; right: 28px;
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  color: var(--oxblood);
+  font-size: 28px;
+  line-height: 1;
+}
+
+/* 404 */
+.f404 { padding: 100px 40px; text-align: center; }
+.f404 .num {
+  font-family: "Fraunces", serif;
+  font-style: italic;
+  font-size: 240px;
+  line-height: 0.85;
+  color: var(--oxblood);
+  margin: 0;
+  letter-spacing: -0.04em;
+}
+.f404 h1 { font-family: "Fraunces", serif; font-size: 38px; margin-top: 12px; font-weight: 500; }
+.f404 p { color: var(--muted); margin: 12px 0 28px; }
+
+@media (max-width: 1100px) {
+  .strip { grid-template-columns: 1fr 1fr; }
+  .strip .item:nth-child(2) { border-right: none; }
+  .strip .item:nth-child(1), .strip .item:nth-child(2) { border-bottom: 1px solid var(--rule); }
+  .masthead { grid-template-columns: 1fr; }
+}
+@media (max-width: 820px) {
+  .app { grid-template-columns: 1fr; }
+  .sidebar { position: relative; height: auto; }
+  .row, .row.three { grid-template-columns: 1fr; }
+  .card-grid, .desk-grid { grid-template-columns: 1fr; }
+}

--- a/examples/editorial-bureau/static/favicon.svg
+++ b/examples/editorial-bureau/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/editorial-bureau/templates/404.html
+++ b/examples/editorial-bureau/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<div class="f404">
+  <div class="num">404</div>
+  <h1><em>The page has gone to press without you.</em></h1>
+  <p>This entry is not on file. The morgue may have an older copy.</p>
+  <p><a class="btn dark" href="{{ base_url }}/">Return to Today's Desk</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/editorial-bureau/templates/dashboard.html
+++ b/examples/editorial-bureau/templates/dashboard.html
@@ -1,0 +1,128 @@
+{% include "header.html" %}
+
+<div class="masthead">
+  <div>
+    <div class="eyebrow"><span class="dot"></span> EDITION OF FRIDAY · MAY 22, 2026</div>
+    <h1>The bureau, as it stands <em>this morning.</em></h1>
+    <p class="lede">Four dossiers on the working schedule, two awaiting a final read from the city desk, one held over from last week's edition. The features desk filed late but filed clean. The schedule for the May 27 edition is set and is on the next page.</p>
+  </div>
+  <div class="stat">
+    <div>
+      <div class="lbl">Open Dossiers</div>
+      <div class="big"><em>14</em></div>
+    </div>
+    <div class="meta">— and three set aside to ripen.</div>
+  </div>
+</div>
+
+<div class="strip">
+  <div class="item">
+    <div class="lbl">Drafts in copy</div>
+    <div class="val">07</div>
+    <div class="note">— two with the desk, five with the writer.</div>
+  </div>
+  <div class="item">
+    <div class="lbl">Filed today</div>
+    <div class="val"><em>11</em></div>
+    <div class="note">— a slow Friday by most accounts.</div>
+  </div>
+  <div class="item">
+    <div class="lbl">Held for review</div>
+    <div class="val">03</div>
+    <div class="note">— one is legal, two are style.</div>
+  </div>
+  <div class="item">
+    <div class="lbl">Words to bed</div>
+    <div class="val">42,108</div>
+    <div class="note">— against a budget of 48,000.</div>
+  </div>
+</div>
+
+<div class="row">
+  <div>
+    <div class="section-h"><h2>Working Dossiers</h2><span class="num">No. I — XIV</span></div>
+    <ul class="dossier-list">
+      <li><span class="n">I</span><span class="t">The Long Quiet of the River Trade<div class="desc">A four-part series on inland shipping after the lock closures.</div></span><span class="meta"><em>City</em> · M. Han</span><span class="tag">In Copy</span></li>
+      <li><span class="n">II</span><span class="t">A Reader Writes from the Capital<div class="desc">Open letter and response, with one editor's footnote.</div></span><span class="meta"><em>Letters</em> · Bureau</span><span class="tag">Filed</span></li>
+      <li><span class="n">III</span><span class="t">On the Closing of the Yellow Hotel<div class="desc">Photographs and the last residents' names, on the record.</div></span><span class="meta"><em>Features</em> · K. Park</span><span class="tag">Held</span></li>
+      <li><span class="n">IV</span><span class="t">Memo on the Style Sheet, Sixth Revision<div class="desc">A note from the copy desk and the new entries in full.</div></span><span class="meta"><em>House</em> · Copy Desk</span><span class="tag">Set</span></li>
+      <li><span class="n">V</span><span class="t">A Walking Map of the Old Customs Houses<div class="desc">Cartography in collaboration with the city archives.</div></span><span class="meta"><em>Maps</em> · J. Riese</span><span class="tag">Draft</span></li>
+      <li><span class="n">VI</span><span class="t">Three Letters from the Reading Room<div class="desc">Curated correspondence from this month's submissions.</div></span><span class="meta"><em>Letters</em> · Bureau</span><span class="tag">In Copy</span></li>
+      <li><span class="n">VII</span><span class="t">The Apothecary, Closing Notes<div class="desc">An obituary commissioned in the long form.</div></span><span class="meta"><em>Obit</em> · S. Eller</span><span class="tag">Review</span></li>
+    </ul>
+  </div>
+
+  <div>
+    <div class="side-card">
+      <div class="lbl">Editor's Note</div>
+      <h3>On filing late, and filing clean.</h3>
+      <div class="quote">Late but right is better than early but wrong. We will hold the page if the desk asks. We will not run a sentence we are unsure of.</div>
+      <p>The features desk filed at 11pm Thursday and the copy desk read it cold. We held the page. The piece runs Monday with one footnote and a corrected dateline.</p>
+      <div class="byline">— M. Han, Friday morning</div>
+    </div>
+
+    <div class="side-card">
+      <div class="lbl">From the Morgue</div>
+      <h3>A note found in the May 1958 box.</h3>
+      <p>A two-page memo from the founding editor on the question of <em>how often to print a correction</em>. The answer, in his hand: <em>whenever a reader writes in good faith.</em> Pinned to the city desk this morning.</p>
+      <div class="byline">— Archive Drawer 47, Bin C</div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div>
+    <div class="section-h"><h2>Issue Schedule · Week of May 22</h2><span class="num">No. 47 — 49</span></div>
+    <table class="schedule">
+      <thead><tr><th>Issue</th><th>Section · Title</th><th>Desk</th><th>State</th></tr></thead>
+      <tbody>
+        <tr><td class="iss">47</td><td class="t">City · River Trade, Part Two</td><td>M. Han</td><td><span class="pill oxblood">Tonight</span></td></tr>
+        <tr><td class="iss">47</td><td class="t">Features · Yellow Hotel</td><td>K. Park</td><td><span class="pill">Held</span></td></tr>
+        <tr><td class="iss">48</td><td class="t">Letters · From the Capital</td><td>Bureau</td><td><span class="pill dark">Locked</span></td></tr>
+        <tr><td class="iss">48</td><td class="t">House · Style Memo VI</td><td>Copy Desk</td><td><span class="pill">Drafting</span></td></tr>
+        <tr><td class="iss">49</td><td class="t">Maps · Old Customs Houses</td><td>J. Riese</td><td><span class="pill">Drafting</span></td></tr>
+        <tr><td class="iss">49</td><td class="t">Obit · The Apothecary</td><td>S. Eller</td><td><span class="pill oxblood">Review</span></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div>
+    <div class="section-h"><h2>The Desks, On Call</h2><span class="num">No. III</span></div>
+    <div class="desk-grid">
+      <div class="desk">
+        <div class="desk-circle">MH</div>
+        <div>
+          <div class="desk-name">M. Han</div>
+          <div class="desk-role">City Editor</div>
+          <div class="desk-note">River Trade series · part two tonight.</div>
+        </div>
+      </div>
+      <div class="desk">
+        <div class="desk-circle">KP</div>
+        <div>
+          <div class="desk-name">K. Park</div>
+          <div class="desk-role">Features</div>
+          <div class="desk-note">Yellow Hotel · held pending photographs.</div>
+        </div>
+      </div>
+      <div class="desk">
+        <div class="desk-circle">SE</div>
+        <div>
+          <div class="desk-name">S. Eller</div>
+          <div class="desk-role">Obituaries</div>
+          <div class="desk-note">Long-form on the apothecary in review.</div>
+        </div>
+      </div>
+      <div class="desk">
+        <div class="desk-circle">JR</div>
+        <div>
+          <div class="desk-name">J. Riese</div>
+          <div class="desk-role">Maps &amp; Archives</div>
+          <div class="desk-note">Drafting the Customs Houses walking map.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/editorial-bureau/templates/footer.html
+++ b/examples/editorial-bureau/templates/footer.html
@@ -1,0 +1,5 @@
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/examples/editorial-bureau/templates/header.html
+++ b/examples/editorial-bureau/templates/header.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,700;1,9..144,400;1,9..144,500&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+</head>
+<body>
+<div class="app">
+
+<aside class="sidebar">
+  <div class="brand">
+    <div class="row1">EST · 1947 · NO. CCCXII</div>
+    <div class="name">The <em><b>Editorial</b></em><br>Bureau</div>
+    <div class="row2">A WORKING NEWSROOM</div>
+  </div>
+
+  <div class="nav-h">Newsroom</div>
+  <a class="nav-link {% if page.url == '/' or not page.url %}active{% endif %}" href="{{ base_url }}/"><span>Today's Desk</span><span class="id">I</span></a>
+  <a class="nav-link {% if page.section == 'dossiers' %}active{% endif %}" href="{{ base_url }}/dossiers/"><span>Dossiers</span><span class="id">II</span></a>
+  <a class="nav-link {% if page.section == 'desks' %}active{% endif %}" href="{{ base_url }}/desks/"><span>Staff &amp; Desks</span><span class="id">III</span></a>
+  <a class="nav-link {% if page.section == 'schedule' %}active{% endif %}" href="{{ base_url }}/schedule/"><span>Issue Schedule</span><span class="id">IV</span></a>
+  <a class="nav-link {% if page.section == 'notes' %}active{% endif %}" href="{{ base_url }}/notes/"><span>Editor's Notes</span><span class="id">V</span></a>
+
+  <div class="nav-h">House</div>
+  <a class="nav-link {% if page.url == '/about/' %}active{% endif %}" href="{{ base_url }}/about/"><span>About the Bureau</span><span class="id">VI</span></a>
+
+  <div class="sidebar-foot">— Vol. {{ current_year }} · No. 47</div>
+</aside>
+
+<div class="main">
+<header class="topbar">
+  <div class="crumb">
+    <span>BUREAU</span><span class="sep">/</span>
+    {% if page.title and page.url != '/' %}<b>{{ page.title }}</b>
+    {% elif section.title %}<b>{{ section.title }}</b>
+    {% elif taxonomy_name %}<b>{{ taxonomy_name }}</b>
+    {% else %}<b>Today's Desk</b>{% endif %}
+  </div>
+  <div class="topbar-act">
+    <input class="search" placeholder="Search the morgue…">
+    <button class="btn">Edition</button>
+    <button class="btn oxblood">Open Dossier</button>
+  </div>
+</header>
+<div class="content">

--- a/examples/editorial-bureau/templates/page.html
+++ b/examples/editorial-bureau/templates/page.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="masthead">
+  <div>
+    <div class="eyebrow"><span class="dot"></span> {{ page.extra and page.extra.eyebrow or "ENTRY" }}</div>
+    <h1>{{ page.title }}</h1>
+    <p class="lede">{{ page.description }}</p>
+  </div>
+  <div class="stat">
+    <div>
+      <div class="lbl">{{ page.extra and page.extra.metric_label or "Section" }}</div>
+      <div class="big"><em>{{ page.extra and page.extra.metric or "I" }}</em></div>
+    </div>
+    <div class="meta">{{ page.extra and page.extra.metric_note or "Filed by the desk." }}</div>
+  </div>
+</div>
+
+<div class="prose">
+{{ content | safe }}
+</div>
+
+{% include "footer.html" %}

--- a/examples/editorial-bureau/templates/section.html
+++ b/examples/editorial-bureau/templates/section.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<div class="masthead">
+  <div>
+    <div class="eyebrow"><span class="dot"></span> SECTION · {{ section.pages | length }} ENTRIES</div>
+    <h1>{{ section.title }}</h1>
+    <p class="lede">{{ section.description }}</p>
+  </div>
+  <div class="stat">
+    <div>
+      <div class="lbl">Entries</div>
+      <div class="big"><em>{{ section.pages | length }}</em></div>
+    </div>
+    <div class="meta">Sorted by most recent. Tags filter the listing.</div>
+  </div>
+</div>
+
+<div class="card-grid">
+{% for p in section.pages %}
+  <a class="card" href="{{ p.url }}">
+    <div class="num-marker">{{ loop.index }}</div>
+    <div class="eyebrow"><span>{{ p.extra and p.extra.eyebrow or "ITEM" }}</span><span>{{ p.date | date("%b %d") }}</span></div>
+    <h3>{{ p.title }}</h3>
+    <div class="meta">{{ p.extra and p.extra.byline or "Bureau Staff" }} · {{ p.date | date("%B %d, %Y") }}</div>
+    <div class="sum">{{ p.summary | default(p.description) | strip_html | truncate_words(32) }}</div>
+  </a>
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/editorial-bureau/templates/shortcodes/alert.html
+++ b/examples/editorial-bureau/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/editorial-bureau/templates/taxonomy.html
+++ b/examples/editorial-bureau/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<div class="masthead"><div><div class="eyebrow"><span class="dot"></span> INDEX</div><h1>{{ taxonomy_name | capitalize }}</h1><p class="lede">All terms in this index.</p></div><div class="stat"><div><div class="lbl">Terms</div><div class="big"><em>{{ taxonomy_terms | length }}</em></div></div></div></div>
+<ul class="dossier-list">
+{% for term in taxonomy_terms %}
+<li><span class="n">{{ loop.index }}</span><span class="t">{{ term.name }}</span><span class="meta">{{ term.pages | length }} entries</span><span class="tag"><a href="{{ term.url }}">Open ›</a></span></li>
+{% endfor %}
+</ul>
+{% include "footer.html" %}

--- a/examples/editorial-bureau/templates/taxonomy_term.html
+++ b/examples/editorial-bureau/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+<div class="masthead"><div><div class="eyebrow"><span class="dot"></span> TAG</div><h1>{{ taxonomy_term }}</h1></div><div class="stat"><div><div class="lbl">Results</div><div class="big"><em>{{ taxonomy_pages | length }}</em></div></div></div></div>
+<div class="card-grid">
+{% for p in taxonomy_pages %}
+<a class="card" href="{{ p.url }}">
+  <div class="num-marker">{{ loop.index }}</div>
+  <div class="eyebrow"><span>{{ p.section | upper }}</span><span>{{ p.date | date("%b %d") }}</span></div>
+  <h3>{{ p.title }}</h3>
+  <div class="sum">{{ p.summary | default(p.description) | strip_html | truncate_words(26) }}</div>
+</a>
+{% endfor %}
+</div>
+{% include "footer.html" %}

--- a/examples/mainframe-luxe/AGENTS.md
+++ b/examples/mainframe-luxe/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/mainframe-luxe/archetypes/default.md
+++ b/examples/mainframe-luxe/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/mainframe-luxe/config.toml
+++ b/examples/mainframe-luxe/config.toml
@@ -1,0 +1,193 @@
+title = "MAINFRAME // LUXE"
+description = "Premium dark terminal admin theme — Bloomberg-density trading desk with amber phosphor accents, hairline rules and function-key footer."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["positions", "orders", "feeds", "desk"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/mainframe-luxe/content/about.md
+++ b/examples/mainframe-luxe/content/about.md
@@ -1,0 +1,28 @@
++++
+title = "About"
+description = "Mainframe // Luxe is the dense terminal admin for desks that read in monospace."
+[extra]
+eyebrow = "ABOUT"
+metric_label = "BUILD"
+metric = "3.41a"
+metric_note = "Premium dark theme"
+metric2_label = "TYPEFACE"
+metric2 = "JBM"
+tag = "STABLE"
++++
+
+Mainframe // Luxe is a dense terminal admin theme for teams that prefer to read in monospace
+and don't mind their dashboard looking like the bridge of a ship.
+
+## What it covers
+
+- Mark-to-last position grids with side, P&amp;L and sparklines.
+- Open order book with limit prices.
+- A news/feed pane with timestamped sources.
+- Margin and price-band alerts with the operator's call to act.
+
+## Design notes
+
+- Amber on near-black, with a single phosphor green for "up" and red for "down".
+- One typeface only — `JetBrains Mono`.
+- Hairline rules everywhere, no rounded corners, no gradients.

--- a/examples/mainframe-luxe/content/desk/_index.md
+++ b/examples/mainframe-luxe/content/desk/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Desk Settings"
+description = "Per-desk operating parameters — caps, stops, alerts and the standing risk limits."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/mainframe-luxe/content/desk/limits.md
+++ b/examples/mainframe-luxe/content/desk/limits.md
@@ -1,0 +1,35 @@
++++
+title = "Standing Risk Limits · 2026 Q2"
+date = "2026-04-01"
+description = "Per-name caps, exposure ceilings and margin notice thresholds for the desk."
+[extra]
+eyebrow = "POLICY"
+code = "RISK"
+metric_label = "VaR · LIMIT"
+metric = "$300k"
+metric2_label = "USED"
+metric2 = "71%"
+metric2_class = "down"
+tag = "POLICY"
++++
+
+Standing risk limits for 2026 Q2. The desk operates inside these caps without further notice.
+Anything that would cross a cap requires a memo to the risk desk.
+
+## Per-name cap
+
+- 1.5% of standing NAV by mark.
+- Hard ceiling **$200k** notional per name.
+- Concentration test: no two names above 1.0% may share a primary risk factor.
+
+## Exposure ceilings
+
+- Long: 95% of NAV.
+- Short: 30% of NAV.
+- Cash: minimum 5% of NAV.
+
+## Margin and notices
+
+- Margin notice at **40%**.
+- Action threshold at **60%** — reduce to bring margin under 50% within the session.
+- Hard stop at **75%** — desk officer is paged.

--- a/examples/mainframe-luxe/content/feeds/_index.md
+++ b/examples/mainframe-luxe/content/feeds/_index.md
@@ -1,0 +1,7 @@
++++
+title = "News & Feeds"
+description = "News-wire posts, tape blocks and desk-internal memos from the standing feed."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/mainframe-luxe/content/feeds/cld-downgrade.md
+++ b/examples/mainframe-luxe/content/feeds/cld-downgrade.md
@@ -1,0 +1,26 @@
++++
+title = "CLD · Buy-side desk downgrades"
+date = "2026-05-22 04:22"
+description = "Buy-side note flags inventory build at CLD, moves the name to neutral."
+[extra]
+eyebrow = "NEWSWIRE · BBG"
+code = "BBG"
+metric_label = "TIME"
+metric = "04:22"
+metric2_label = "TAPE"
+metric2 = "-0.38%"
+metric2_class = "down"
+tag = "NEWS"
++++
+
+Bloomberg posted a buy-side note this morning flagging the inventory build at CLD over the
+last two quarters. The desk that wrote it moved the name to neutral from buy.
+
+## Desk read
+
+The note matches the position memo from last Friday. We are already half-sized and the
+working stop is at 55.40. No change to plan.
+
+## Action
+
+None. Standing stop holds.

--- a/examples/mainframe-luxe/content/feeds/nxr-blocks.md
+++ b/examples/mainframe-luxe/content/feeds/nxr-blocks.md
@@ -1,0 +1,26 @@
++++
+title = "NXR · Block prints clear 480k"
+date = "2026-05-22 04:18"
+description = "Tape report — two block prints at 17.91 and 17.96, total 480,000 shares."
+[extra]
+eyebrow = "TAPE · NXR"
+code = "TAPE"
+metric_label = "PRICE 1"
+metric = "17.91"
+metric2_label = "PRICE 2"
+metric2 = "17.96"
+tag = "BLOCK"
++++
+
+Two large prints on NXR cleared the tape at 04:18. First print at **17.91** for 220k shares,
+second at **17.96** for 260k. Total **480k shares** on the morning print.
+
+## Desk read
+
+Sets a confirmed level at 17.91. The desk added through the print on the standing working
+order and is now at full position.
+
+## Action
+
+Working scale-out order #41206 at 18.40, 4,000 shares. Remainder of the position held into
+close.

--- a/examples/mainframe-luxe/content/feeds/prx-guidance.md
+++ b/examples/mainframe-luxe/content/feeds/prx-guidance.md
@@ -1,0 +1,28 @@
++++
+title = "PRX · Revised guidance raises FY range"
+date = "2026-05-22 04:31"
+description = "Newswire note on PRX revising the full-year range to +18%, citing the new contract."
+[extra]
+eyebrow = "NEWSWIRE · REUT"
+code = "REUT"
+metric_label = "TIME"
+metric = "04:31"
+metric2_label = "TAPE"
+metric2 = "+0.84%"
+metric2_class = "up"
+tag = "NEWS"
++++
+
+The wire dropped at 04:31 local. PRX raised the full-year revenue range from +12-15% to
+**+16-18%**, citing the new contract announced on May 19. The note also reaffirmed margin
+guidance.
+
+## Desk read
+
+The number is at the top of the buy-side range. Consensus was +14, so the print is a clean
+upside surprise. Existing long stays.
+
+## Risk
+
+Watch the closing bid into the afternoon. If the print rolls under 140 with selling volume the
+desk reduces to half.

--- a/examples/mainframe-luxe/content/index.md
+++ b/examples/mainframe-luxe/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Overview"
+template = "dashboard"
+description = "Trading desk overview — positions, order book, news ticker, alerts."
++++

--- a/examples/mainframe-luxe/content/orders/41206-nxr.md
+++ b/examples/mainframe-luxe/content/orders/41206-nxr.md
@@ -1,0 +1,21 @@
++++
+title = "#41206 · SELL NXR @ 18.40"
+date = "2026-05-22 08:42"
+description = "Limit sell at 18.40, 4,000 shares. First scale-out tranche on the working long."
+[extra]
+eyebrow = "WORKING ORDER · SELL"
+code = "#41206"
+metric_label = "LIMIT"
+metric = "18.40"
+metric2_label = "QTY"
+metric2 = "4,000"
+tag = "OPEN"
++++
+
+First scale-out tranche on the working NXR long. Sized so that a fill brings the position back
+to standing cap without a follow-up memo.
+
+## Order intent
+
+Resting passive offer. The desk expects the print to test 18.40 in the next two sessions; if it
+doesn't, the order resets at close.

--- a/examples/mainframe-luxe/content/orders/41207-vrt.md
+++ b/examples/mainframe-luxe/content/orders/41207-vrt.md
@@ -1,0 +1,21 @@
++++
+title = "#41207 · SELL VRT @ 312.00"
+date = "2026-05-22 09:12"
+description = "Limit sell at 312.00, 200 shares. Skim into strength on the working long."
+[extra]
+eyebrow = "WORKING ORDER · SELL"
+code = "#41207"
+metric_label = "LIMIT"
+metric = "312.00"
+metric2_label = "QTY"
+metric2 = "200"
+tag = "OPEN"
++++
+
+Skim sell, taking 200 shares off the working long into the standing resistance at 312. Order
+is resting on the book and will be cancelled on a confirmed break above with volume.
+
+## Order intent
+
+If filled the long size on VRT drops to 750 shares. The remainder is held into close on the
+standing thesis.

--- a/examples/mainframe-luxe/content/orders/41208-prx.md
+++ b/examples/mainframe-luxe/content/orders/41208-prx.md
@@ -1,0 +1,21 @@
++++
+title = "#41208 · BUY PRX @ 141.20"
+date = "2026-05-22 09:30"
+description = "Limit buy at 141.20, 800 shares. Working since open. Resting on book."
+[extra]
+eyebrow = "WORKING ORDER · BUY"
+code = "#41208"
+metric_label = "LIMIT"
+metric = "141.20"
+metric2_label = "QTY"
+metric2 = "800"
+tag = "OPEN"
++++
+
+Working limit buy. The standing accumulation level is 141.20 and the desk wants to top up
+half-size on a pullback before pushing the position above the standing cap.
+
+## Order intent
+
+Resting passive bid. If filled it brings the working long size on PRX to 5,000. Order is good
+for the session and converts to GTC if untouched at close.

--- a/examples/mainframe-luxe/content/orders/_index.md
+++ b/examples/mainframe-luxe/content/orders/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Orders"
+description = "Working, filled and cancelled orders across the session."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/mainframe-luxe/content/positions/_index.md
+++ b/examples/mainframe-luxe/content/positions/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Positions"
+description = "Open positions across all venues with mark-to-last and intraday P&L."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/mainframe-luxe/content/positions/brg.md
+++ b/examples/mainframe-luxe/content/positions/brg.md
@@ -1,0 +1,29 @@
++++
+title = "BRG · 22,000 long · UNDER WATER"
+date = "2026-05-22 03:58"
+description = "Long position underwater after the support break at 9.10. Carrying -8.1k unrealised."
+[extra]
+eyebrow = "POSITION · STRESSED"
+code = "BRG"
+metric_label = "MARK"
+metric = "9.04"
+metric_class = "down"
+metric2_label = "P&L"
+metric2 = "-8,140"
+metric2_class = "down"
+tag = "STRESS"
++++
+
+BRG broke 9.10 support at 03:58 and tripped the lower price band shortly after. Position is
+the largest single-name long on the book by share count, so a full exit needs a memo to the
+risk desk.
+
+## Reduce / hold
+
+The standing rule is to reduce to half on a confirmed support break with volume. Volume is
+there. We are reducing to **11,000** at the open of the next session and reassessing.
+
+## Stop
+
+Hard stop at **8.80** for the residual. If the print pierces, the rest comes off into the morning
+liquidity.

--- a/examples/mainframe-luxe/content/positions/nxr.md
+++ b/examples/mainframe-luxe/content/positions/nxr.md
@@ -1,0 +1,30 @@
++++
+title = "NXR · 12,800 long"
+date = "2026-05-22 04:18"
+description = "Block accumulation through the morning, average 16.91. Mark 18.04, intraday up 6.68%."
+[extra]
+eyebrow = "POSITION · LONG"
+code = "NXR"
+metric_label = "MARK"
+metric = "18.04"
+metric_class = "up"
+metric2_label = "P&L"
+metric2 = "+14,464"
+metric2_class = "up"
+tag = "LONG"
++++
+
+NXR was a quiet name until two block prints at 04:18 cleared 480k shares on the tape. We
+were already in for half size at 16.40; the desk added through the print into our standing
+working order.
+
+## Thesis
+
+Industry letter dated Tuesday flagged the inventory turn as the leading indicator and the
+print this morning is consistent with it. We expect the working order at 17.91 to be the floor
+for the rest of the session.
+
+## Order plan
+
+One scale-out tranche at 18.40, second at 18.80. The remainder is held into close unless the
+tape rolls over.

--- a/examples/mainframe-luxe/content/positions/prx.md
+++ b/examples/mainframe-luxe/content/positions/prx.md
@@ -1,0 +1,29 @@
++++
+title = "PRX · 4,200 long"
+date = "2026-05-22 09:30"
+description = "Long position taken in three tranches at average 138.41. Mark 142.18, intraday up 2.72%."
+[extra]
+eyebrow = "POSITION · LONG"
+code = "PRX"
+metric_label = "MARK"
+metric = "142.18"
+metric_class = "up"
+metric2_label = "P&L"
+metric2 = "+15,834"
+metric2_class = "up"
+tag = "LONG"
++++
+
+PRX has been a slow accumulation since 134 in early April. Three tranches taken at 134.20,
+137.84 and 142.91, average cost 138.41. Standing thesis is that the revised guidance from
+this morning's release confirms the run-rate the desk expected at entry.
+
+## Why we're still in it
+
+The revised guidance came in above the higher end of the buy-side range. Newsflow this
+afternoon should keep the bid steady, and the desk is comfortable holding into close.
+
+## Risk
+
+Position is sized at the standing per-name cap. Any add would require a memo to the risk
+desk. If the print closes back under 140 we will reduce to half.

--- a/examples/mainframe-luxe/static/css/style.css
+++ b/examples/mainframe-luxe/static/css/style.css
@@ -1,0 +1,427 @@
+:root {
+  --ink: #050507;
+  --panel: #0d0d10;
+  --panel-2: #15151a;
+  --rule: #2a2a31;
+  --rule-2: #1d1d23;
+  --txt: #d8d6cc;
+  --txt-2: #8a8881;
+  --amber: #ffb627;
+  --amber-dim: #b27815;
+  --phosphor: #6dffa4;
+  --red: #ff4d4d;
+  --cyan: #6ec6ff;
+  --paper: #f6f2e3;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0;
+  background: var(--ink);
+  color: var(--txt);
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* horizontal scanning rules */
+body::before {
+  content: "";
+  position: fixed; inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(0deg, transparent 0 2px, rgba(255,182,39,0.018) 2px 3px);
+  z-index: 0;
+}
+
+.shell {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+  position: relative;
+  z-index: 1;
+}
+
+/* TOPBAR */
+.bar {
+  display: grid;
+  grid-template-columns: 280px 1fr auto;
+  align-items: stretch;
+  border-bottom: 1px solid var(--rule);
+  background: #08080a;
+  height: 44px;
+}
+.brand {
+  display: flex; align-items: center; gap: 12px;
+  padding: 0 18px;
+  border-right: 1px solid var(--rule);
+}
+.brand .mark {
+  width: 14px; height: 14px;
+  background: var(--amber);
+  position: relative;
+}
+.brand .mark::after{
+  content:""; position:absolute; inset:3px;
+  background: var(--ink);
+}
+.brand .name {
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  font-size: 13px;
+  color: var(--txt);
+}
+.brand .slash { color: var(--amber); }
+.brand .ver { color: var(--txt-2); margin-left: 6px; font-size: 10px; }
+
+.crumb {
+  display: flex; align-items: center;
+  padding: 0 20px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--txt-2);
+  gap: 14px;
+}
+.crumb b { color: var(--amber); font-weight: 700; }
+.crumb .sep { opacity: 0.5; }
+
+.bar-actions {
+  display: flex; align-items: stretch;
+}
+.bar-actions .ind {
+  display: flex; align-items: center;
+  padding: 0 16px;
+  border-left: 1px solid var(--rule);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  gap: 8px;
+  color: var(--txt-2);
+}
+.ind .dot { width: 8px; height: 8px; background: var(--phosphor); border-radius: 50%; }
+.ind .dot.red { background: var(--red); }
+.ind .dot.amber { background: var(--amber); }
+.ind .v { color: var(--txt); }
+
+/* LAYOUT */
+.layout { display: grid; grid-template-columns: 220px 1fr; }
+
+.nav {
+  border-right: 1px solid var(--rule);
+  background: #08080a;
+  padding: 14px 0;
+  min-height: calc(100vh - 88px);
+}
+.nav-h {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  padding: 8px 18px 6px;
+  color: var(--txt-2);
+}
+.nav-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px 8px 18px;
+  font-size: 12px;
+  color: var(--txt);
+  border-left: 3px solid transparent;
+}
+.nav-link .id { font-size: 10px; color: var(--txt-2); letter-spacing: 0.1em; }
+.nav-link:hover { background: rgba(255,182,39,0.05); }
+.nav-link.active {
+  background: rgba(255,182,39,0.08);
+  border-left-color: var(--amber);
+  color: var(--amber);
+}
+
+.nav-h.divider {
+  border-top: 1px solid var(--rule);
+  margin-top: 10px;
+  padding-top: 14px;
+}
+
+/* CONTENT */
+.main { padding: 14px; min-width: 0; }
+
+/* PAGE BAND */
+.band {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  border: 1px solid var(--rule);
+  background: var(--panel);
+  margin-bottom: 12px;
+}
+.band > .cell {
+  padding: 14px 18px;
+  border-right: 1px solid var(--rule);
+}
+.band > .cell:last-child { border-right: none; }
+.band .eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  color: var(--txt-2);
+}
+.band .t { font-size: 22px; color: var(--amber); margin-top: 6px; letter-spacing: 0.02em; font-weight: 700; }
+.band .desc { font-size: 11px; color: var(--txt-2); margin-top: 8px; line-height: 1.6; }
+.band .num { font-size: 28px; font-weight: 700; margin-top: 6px; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; color: var(--txt); }
+.band .num.up { color: var(--phosphor); }
+.band .num.down { color: var(--red); }
+.band .sub { font-size: 11px; color: var(--txt-2); }
+
+/* PANELS */
+.grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.grid.three { grid-template-columns: 1fr 1fr 1fr; }
+.grid.fixed-left { grid-template-columns: 1fr 280px; }
+
+.pane {
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+}
+.pane-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 30px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--rule);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--txt-2);
+  background: #0a0a0d;
+}
+.pane-h .title { color: var(--amber); font-weight: 700; }
+.pane-h .meta { font-variant-numeric: tabular-nums; }
+.pane-b { padding: 12px 14px 14px; }
+
+/* TABLE */
+.tbl { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+.tbl th, .tbl td {
+  text-align: right;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--rule-2);
+  font-size: 11.5px;
+}
+.tbl th { color: var(--txt-2); font-weight: 500; letter-spacing: 0.12em; font-size: 10px; padding-bottom: 8px; }
+.tbl th:first-child, .tbl td:first-child { text-align: left; }
+.tbl td.sym { color: var(--amber); font-weight: 700; }
+.tbl td.up { color: var(--phosphor); }
+.tbl td.down { color: var(--red); }
+.tbl tr:last-child td { border-bottom: none; }
+.tbl tr:hover td { background: rgba(255,182,39,0.04); }
+
+.tbl-tag {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  border: 1px solid var(--rule);
+}
+.tbl-tag.long { color: var(--phosphor); border-color: var(--phosphor); }
+.tbl-tag.short { color: var(--red); border-color: var(--red); }
+.tbl-tag.open { color: var(--amber); border-color: var(--amber); }
+.tbl-tag.cancel { color: var(--txt-2); }
+
+/* SPARK */
+.spark {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 22px;
+  width: 60px;
+}
+.spark span {
+  flex: 1;
+  background: var(--amber);
+}
+.spark.green span { background: var(--phosphor); }
+.spark.red span { background: var(--red); }
+
+/* CHART */
+.chart {
+  height: 200px;
+  position: relative;
+  border-bottom: 1px solid var(--rule);
+  padding: 18px 6px 22px;
+}
+.chart .line {
+  position: absolute;
+  left: 0; right: 0; bottom: 22px;
+  height: 1px;
+  background: var(--rule);
+}
+.chart .line.h1 { bottom: 60px; }
+.chart .line.h2 { bottom: 100px; }
+.chart .line.h3 { bottom: 140px; }
+.chart .bars {
+  height: 160px;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  position: relative;
+  z-index: 2;
+}
+.chart .bars span { flex: 1; background: var(--amber); }
+.chart .bars span.down { background: var(--red); }
+.chart .labels {
+  position: absolute;
+  bottom: 2px;
+  left: 0; right: 0;
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--txt-2);
+  letter-spacing: 0.14em;
+  padding: 0 6px;
+}
+
+/* TICKER */
+.ticker {
+  display: flex;
+  align-items: center;
+  height: 30px;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: #08080a;
+  margin: 12px 0;
+  overflow: hidden;
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.ticker .lbl {
+  padding: 0 14px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  background: var(--amber);
+  color: var(--ink);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+}
+.ticker .row {
+  padding: 0 14px;
+  display: flex;
+  gap: 22px;
+  overflow: hidden;
+}
+.ticker .item .s { color: var(--amber); font-weight: 700; margin-right: 6px; }
+.ticker .item .up { color: var(--phosphor); }
+.ticker .item .down { color: var(--red); }
+
+/* NEWS / LOG */
+.feed { font-size: 11.5px; line-height: 1.7; }
+.feed .row { display: flex; gap: 14px; padding: 6px 0; border-bottom: 1px solid var(--rule-2); }
+.feed .row:last-child { border-bottom: none; }
+.feed .ts { color: var(--amber); width: 56px; flex: none; font-weight: 700; }
+.feed .src { color: var(--txt-2); width: 70px; flex: none; letter-spacing: 0.1em; }
+.feed .msg { color: var(--txt); }
+.feed .msg b { color: var(--amber); }
+
+/* BIG NUMBERS */
+.kbig {
+  font-size: 38px;
+  line-height: 1;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  color: var(--amber);
+}
+.klbl { font-size: 10px; letter-spacing: 0.28em; color: var(--txt-2); margin-bottom: 6px; }
+
+/* GAUGE list */
+.gauge { margin: 8px 0 12px; font-size: 11px; }
+.gauge .row { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
+.gauge .lbl { width: 100px; color: var(--txt-2); letter-spacing: 0.06em; }
+.gauge .track { flex: 1; height: 6px; background: var(--rule); position: relative; }
+.gauge .fill { height: 100%; background: var(--amber); }
+.gauge .fill.green { background: var(--phosphor); }
+.gauge .fill.red { background: var(--red); }
+.gauge .val { width: 56px; text-align: right; font-variant-numeric: tabular-nums; }
+
+/* PROSE */
+.prose { font-size: 13px; line-height: 1.75; max-width: 76ch; color: var(--txt); }
+.prose h2 { color: var(--amber); font-size: 16px; letter-spacing: 0.2em; text-transform: uppercase; border-bottom: 1px solid var(--rule); padding-bottom: 6px; margin-top: 28px; }
+.prose h3 { color: var(--txt); font-size: 13px; letter-spacing: 0.16em; text-transform: uppercase; margin-top: 22px; }
+.prose code { background: var(--panel-2); padding: 1px 6px; border: 1px solid var(--rule); color: var(--amber); font-size: 11px; }
+.prose pre { background: var(--panel-2); border: 1px solid var(--rule); padding: 12px 14px; overflow-x: auto; color: var(--txt); }
+.prose blockquote { border-left: 3px solid var(--amber); padding-left: 14px; color: var(--txt-2); }
+.prose ul li::marker { color: var(--amber); }
+
+/* SECTION grid */
+.entries {
+  border: 1px solid var(--rule);
+  background: var(--panel);
+}
+.entries .e {
+  display: grid;
+  grid-template-columns: 80px 1fr 120px 90px 80px;
+  gap: 14px;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--rule-2);
+  font-size: 12px;
+}
+.entries .e:last-child { border-bottom: none; }
+.entries .e:hover { background: rgba(255,182,39,0.04); }
+.entries .id { color: var(--amber); font-weight: 700; letter-spacing: 0.08em; }
+.entries .t { color: var(--txt); }
+.entries .t .desc { color: var(--txt-2); font-size: 11px; margin-top: 2px; }
+.entries .meta { color: var(--txt-2); font-size: 11px; letter-spacing: 0.06em; }
+.entries .v { font-variant-numeric: tabular-nums; text-align: right; color: var(--txt); }
+.entries .v.up { color: var(--phosphor); }
+.entries .v.down { color: var(--red); }
+.entries .tag { font-size: 10px; letter-spacing: 0.18em; text-align: right; }
+
+/* function key bar */
+.fnbar {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  border-top: 1px solid var(--rule);
+  background: #060608;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--txt-2);
+}
+.fnbar .key {
+  padding: 10px 14px;
+  border-right: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.fnbar .key:last-child { border-right: none; }
+.fnbar .key .k {
+  display: inline-block;
+  background: var(--panel-2);
+  border: 1px solid var(--rule);
+  padding: 1px 6px;
+  color: var(--amber);
+  font-weight: 700;
+}
+
+/* 404 */
+.f404 { padding: 80px 40px; text-align: center; }
+.f404 .code { font-size: 11px; letter-spacing: 0.3em; color: var(--amber); margin-bottom: 12px; }
+.f404 h1 { font-size: 120px; margin: 0; color: var(--amber); font-weight: 700; letter-spacing: -0.04em; }
+.f404 .desc { color: var(--txt-2); margin: 14px 0 26px; letter-spacing: 0.12em; }
+.f404 a { border: 1px solid var(--amber); color: var(--amber); padding: 10px 18px; letter-spacing: 0.2em; font-size: 11px; }
+
+@media (max-width: 1200px) {
+  .band { grid-template-columns: 1fr 1fr; }
+  .band > .cell { border-bottom: 1px solid var(--rule); }
+  .grid, .grid.three, .grid.fixed-left { grid-template-columns: 1fr; }
+}
+@media (max-width: 800px) {
+  .bar { grid-template-columns: 1fr; height: auto; }
+  .layout { grid-template-columns: 1fr; }
+  .nav { min-height: auto; }
+}

--- a/examples/mainframe-luxe/static/favicon.svg
+++ b/examples/mainframe-luxe/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/mainframe-luxe/templates/404.html
+++ b/examples/mainframe-luxe/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<div class="f404">
+  <div class="code">ERR · TICKER NOT FOUND</div>
+  <h1>404</h1>
+  <div class="desc">No symbol matches that identifier on any venue we trade.</div>
+  <a href="{{ base_url }}/">RETURN TO DESK</a>
+</div>
+{% include "footer.html" %}

--- a/examples/mainframe-luxe/templates/dashboard.html
+++ b/examples/mainframe-luxe/templates/dashboard.html
@@ -1,0 +1,153 @@
+{% include "header.html" %}
+
+<div class="band">
+  <div class="cell">
+    <div class="eyebrow">DESK · OVERVIEW</div>
+    <div class="t">Navarro · L4</div>
+    <div class="desc">Session opened 04:00 desk time. 11 active positions across 4 venues. Two alerts outstanding — one margin notice, one price band trip.</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">NAV · MARK</div>
+    <div class="num">$ 8,142,309</div>
+    <div class="sub">+ 2.13% vs prior close</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">P&amp;L · INTRADAY</div>
+    <div class="num up">+ $172,401</div>
+    <div class="sub">11 winners / 4 losers</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">RISK · VaR 95</div>
+    <div class="num down">- $214,800</div>
+    <div class="sub">below limit · 71% utilised</div>
+  </div>
+</div>
+
+<div class="ticker">
+  <span class="lbl">LIVE</span>
+  <div class="row">
+    <span class="item"><span class="s">PRX</span> 142.18 <span class="up">+0.84%</span></span>
+    <span class="item"><span class="s">QLN</span> 87.04 <span class="down">-1.12%</span></span>
+    <span class="item"><span class="s">VRT</span> 309.71 <span class="up">+2.41%</span></span>
+    <span class="item"><span class="s">CLD</span> 56.22 <span class="down">-0.38%</span></span>
+    <span class="item"><span class="s">ATM</span> 412.55 <span class="up">+0.16%</span></span>
+    <span class="item"><span class="s">NXR</span> 18.04 <span class="up">+3.92%</span></span>
+    <span class="item"><span class="s">RLT</span> 71.88 <span class="down">-2.04%</span></span>
+    <span class="item"><span class="s">MVN</span> 233.17 <span class="up">+1.18%</span></span>
+    <span class="item"><span class="s">BRG</span> 9.04 <span class="down">-4.41%</span></span>
+  </div>
+</div>
+
+<div class="grid">
+  <div class="pane">
+    <div class="pane-h"><span class="title">POSITIONS · MARK TO LAST</span><span class="meta">11 OPEN · 04:32:18</span></div>
+    <div class="pane-b">
+      <table class="tbl">
+        <thead><tr><th>SYM</th><th>SIDE</th><th>QTY</th><th>AVG</th><th>LAST</th><th>P&amp;L</th><th>Δ%</th><th></th></tr></thead>
+        <tbody>
+          <tr><td class="sym">PRX</td><td><span class="tbl-tag long">L</span></td><td>4,200</td><td>138.41</td><td>142.18</td><td class="up">+15,834</td><td class="up">+2.72%</td><td><span class="spark green"><span style="height:30%"></span><span style="height:40%"></span><span style="height:60%"></span><span style="height:80%"></span><span style="height:100%"></span></span></td></tr>
+          <tr><td class="sym">QLN</td><td><span class="tbl-tag short">S</span></td><td>1,800</td><td>88.20</td><td>87.04</td><td class="up">+2,088</td><td class="up">+1.32%</td><td><span class="spark green"><span style="height:60%"></span><span style="height:50%"></span><span style="height:70%"></span><span style="height:55%"></span><span style="height:90%"></span></span></td></tr>
+          <tr><td class="sym">VRT</td><td><span class="tbl-tag long">L</span></td><td>950</td><td>299.84</td><td>309.71</td><td class="up">+9,376</td><td class="up">+3.29%</td><td><span class="spark green"><span style="height:40%"></span><span style="height:70%"></span><span style="height:90%"></span><span style="height:80%"></span><span style="height:100%"></span></span></td></tr>
+          <tr><td class="sym">CLD</td><td><span class="tbl-tag long">L</span></td><td>6,400</td><td>57.18</td><td>56.22</td><td class="down">-6,144</td><td class="down">-1.68%</td><td><span class="spark red"><span style="height:70%"></span><span style="height:50%"></span><span style="height:40%"></span><span style="height:30%"></span><span style="height:20%"></span></span></td></tr>
+          <tr><td class="sym">ATM</td><td><span class="tbl-tag long">L</span></td><td>520</td><td>404.92</td><td>412.55</td><td class="up">+3,968</td><td class="up">+1.88%</td><td><span class="spark green"><span style="height:50%"></span><span style="height:60%"></span><span style="height:55%"></span><span style="height:70%"></span><span style="height:80%"></span></span></td></tr>
+          <tr><td class="sym">NXR</td><td><span class="tbl-tag long">L</span></td><td>12,800</td><td>16.91</td><td>18.04</td><td class="up">+14,464</td><td class="up">+6.68%</td><td><span class="spark green"><span style="height:20%"></span><span style="height:40%"></span><span style="height:80%"></span><span style="height:95%"></span><span style="height:100%"></span></span></td></tr>
+          <tr><td class="sym">RLT</td><td><span class="tbl-tag short">S</span></td><td>2,100</td><td>72.41</td><td>71.88</td><td class="up">+1,113</td><td class="up">+0.73%</td><td><span class="spark green"><span style="height:60%"></span><span style="height:65%"></span><span style="height:55%"></span><span style="height:70%"></span><span style="height:62%"></span></span></td></tr>
+          <tr><td class="sym">MVN</td><td><span class="tbl-tag long">L</span></td><td>900</td><td>228.04</td><td>233.17</td><td class="up">+4,617</td><td class="up">+2.24%</td><td><span class="spark green"><span style="height:50%"></span><span style="height:55%"></span><span style="height:70%"></span><span style="height:78%"></span><span style="height:82%"></span></span></td></tr>
+          <tr><td class="sym">BRG</td><td><span class="tbl-tag long">L</span></td><td>22,000</td><td>9.41</td><td>9.04</td><td class="down">-8,140</td><td class="down">-3.93%</td><td><span class="spark red"><span style="height:80%"></span><span style="height:70%"></span><span style="height:45%"></span><span style="height:30%"></span><span style="height:20%"></span></span></td></tr>
+          <tr><td class="sym">TYR</td><td><span class="tbl-tag long">L</span></td><td>1,400</td><td>54.18</td><td>55.04</td><td class="up">+1,204</td><td class="up">+1.58%</td><td><span class="spark green"><span style="height:50%"></span><span style="height:60%"></span><span style="height:62%"></span><span style="height:70%"></span><span style="height:72%"></span></span></td></tr>
+          <tr><td class="sym">OXN</td><td><span class="tbl-tag short">S</span></td><td>1,100</td><td>211.04</td><td>208.78</td><td class="up">+2,486</td><td class="up">+1.07%</td><td><span class="spark green"><span style="height:60%"></span><span style="height:55%"></span><span style="height:60%"></span><span style="height:70%"></span><span style="height:74%"></span></span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="pane">
+    <div class="pane-h"><span class="title">NAV CURVE · 30D</span><span class="meta">+ 4.12%</span></div>
+    <div class="pane-b">
+      <div class="chart">
+        <div class="line h1"></div>
+        <div class="line h2"></div>
+        <div class="line h3"></div>
+        <div class="bars">
+          <span style="height:42%"></span>
+          <span style="height:51%"></span>
+          <span style="height:39%" class="down"></span>
+          <span style="height:62%"></span>
+          <span style="height:48%"></span>
+          <span style="height:34%" class="down"></span>
+          <span style="height:71%"></span>
+          <span style="height:60%"></span>
+          <span style="height:78%"></span>
+          <span style="height:54%" class="down"></span>
+          <span style="height:81%"></span>
+          <span style="height:67%"></span>
+          <span style="height:88%"></span>
+          <span style="height:72%"></span>
+          <span style="height:94%"></span>
+        </div>
+        <div class="labels"><span>APR 22</span><span>APR 29</span><span>MAY 06</span><span>MAY 13</span><span>MAY 20</span></div>
+      </div>
+
+      <div class="gauge" style="margin-top:18px;">
+        <div class="row"><span class="lbl">EXPOSURE · L</span><div class="track"><div class="fill green" style="width:71%"></div></div><span class="val">71%</span></div>
+        <div class="row"><span class="lbl">EXPOSURE · S</span><div class="track"><div class="fill red" style="width:18%"></div></div><span class="val">18%</span></div>
+        <div class="row"><span class="lbl">CASH</span><div class="track"><div class="fill" style="width:11%"></div></div><span class="val">11%</span></div>
+        <div class="row"><span class="lbl">MARGIN USED</span><div class="track"><div class="fill" style="width:42%"></div></div><span class="val">42%</span></div>
+        <div class="row"><span class="lbl">VaR · 95</span><div class="track"><div class="fill" style="width:71%"></div></div><span class="val">71%</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="grid three">
+  <div class="pane">
+    <div class="pane-h"><span class="title">ORDER BOOK · OPEN</span><span class="meta">07 · LIVE</span></div>
+    <div class="pane-b">
+      <table class="tbl">
+        <thead><tr><th>ID</th><th>SYM</th><th>SIDE</th><th>QTY</th><th>LIMIT</th></tr></thead>
+        <tbody>
+          <tr><td>#41208</td><td class="sym">PRX</td><td><span class="tbl-tag long">BUY</span></td><td>800</td><td>141.20</td></tr>
+          <tr><td>#41207</td><td class="sym">VRT</td><td><span class="tbl-tag short">SELL</span></td><td>200</td><td>312.00</td></tr>
+          <tr><td>#41206</td><td class="sym">NXR</td><td><span class="tbl-tag short">SELL</span></td><td>4,000</td><td>18.40</td></tr>
+          <tr><td>#41205</td><td class="sym">ATM</td><td><span class="tbl-tag long">BUY</span></td><td>120</td><td>410.50</td></tr>
+          <tr><td>#41204</td><td class="sym">CLD</td><td><span class="tbl-tag short">SELL</span></td><td>1,600</td><td>57.80</td></tr>
+          <tr><td>#41203</td><td class="sym">OXN</td><td><span class="tbl-tag long">BUY</span></td><td>400</td><td>208.20</td></tr>
+          <tr><td>#41202</td><td class="sym">TYR</td><td><span class="tbl-tag long">BUY</span></td><td>900</td><td>54.50</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="pane">
+    <div class="pane-h"><span class="title">NEWS · 15M</span><span class="meta">04:32 RUNNING</span></div>
+    <div class="pane-b">
+      <div class="feed">
+        <div class="row"><span class="ts">04:31</span><span class="src">REUT</span><span class="msg">PRX · revised guidance raises FY range to <b>+18%</b>, citing new contract</span></div>
+        <div class="row"><span class="ts">04:28</span><span class="src">DJN</span><span class="msg">VRT · breaks above 309 with above-average flow, watch <b>312</b> resistance</span></div>
+        <div class="row"><span class="ts">04:22</span><span class="src">BBG</span><span class="msg">CLD · supply chain note flags inventory build, <b>downgrade</b> from buy-side desk</span></div>
+        <div class="row"><span class="ts">04:18</span><span class="src">TAPE</span><span class="msg">NXR · two block prints at <b>17.91</b> and <b>17.96</b>, total 480k shares</span></div>
+        <div class="row"><span class="ts">04:11</span><span class="src">DESK</span><span class="msg">RLT · short cover stop tightened to <b>72.10</b> per overnight memo</span></div>
+        <div class="row"><span class="ts">03:58</span><span class="src">REUT</span><span class="msg">MVN · earnings ahead Thu, consensus <b>$2.14</b> EPS</span></div>
+        <div class="row"><span class="ts">03:42</span><span class="src">TAPE</span><span class="msg">BRG · sustained sell pressure, breaks <b>9.10</b> support</span></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="pane">
+    <div class="pane-h"><span class="title">ALERTS · OPEN</span><span class="meta">02</span></div>
+    <div class="pane-b">
+      <div style="margin-bottom:18px;">
+        <div class="klbl">A-21 · MARGIN NOTICE</div>
+        <div class="kbig">42%</div>
+        <div style="font-size:11px;color:var(--txt-2);margin-top:6px;line-height:1.6;">Crossed the 40% notice threshold at 03:11. Action required if it climbs past 60% — desk officer has been pinged.</div>
+      </div>
+      <div style="border-top:1px solid var(--rule);padding-top:14px;">
+        <div class="klbl">A-22 · PRICE BAND · BRG</div>
+        <div class="kbig" style="color:var(--red);">9.04</div>
+        <div style="font-size:11px;color:var(--txt-2);margin-top:6px;line-height:1.6;">Tripped lower band 9.10 at 03:58. Position carries -8.1k unrealised. Reduce / hold decision before close.</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/mainframe-luxe/templates/footer.html
+++ b/examples/mainframe-luxe/templates/footer.html
@@ -1,0 +1,17 @@
+  </main>
+</div>
+
+<div class="fnbar">
+  <div class="key"><span class="k">F1</span> OVERVIEW</div>
+  <div class="key"><span class="k">F2</span> POSITIONS</div>
+  <div class="key"><span class="k">F3</span> ORDERS</div>
+  <div class="key"><span class="k">F4</span> FEEDS</div>
+  <div class="key"><span class="k">F5</span> CHART</div>
+  <div class="key"><span class="k">F6</span> SEARCH</div>
+  <div class="key"><span class="k">F7</span> SETTINGS</div>
+  <div class="key"><span class="k">F8</span> ABOUT</div>
+</div>
+
+</div>
+</body>
+</html>

--- a/examples/mainframe-luxe/templates/header.html
+++ b/examples/mainframe-luxe/templates/header.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+</head>
+<body>
+<div class="shell">
+
+<div class="bar">
+  <div class="brand">
+    <div class="mark"></div>
+    <div>
+      <span class="name">MAINFRAME<span class="slash">//</span>LUXE</span>
+      <span class="ver">v3.41a</span>
+    </div>
+  </div>
+  <div class="crumb">
+    <span>DESK</span><span class="sep">/</span>
+    {% if page.title and page.url != '/' %}<b>{{ page.title | upper }}</b>
+    {% elif section.title %}<b>{{ section.title | upper }}</b>
+    {% elif taxonomy_name %}<b>{{ taxonomy_name | upper }}</b>
+    {% else %}<b>OVERVIEW</b>{% endif %}
+  </div>
+  <div class="bar-actions">
+    <div class="ind"><span class="dot"></span> FEED <span class="v">LIVE</span></div>
+    <div class="ind"><span class="dot amber"></span> LAT <span class="v">12 ms</span></div>
+    <div class="ind"><span class="dot"></span> SESS <span class="v">04:32:18</span></div>
+    <div class="ind"><span class="dot red"></span> ALERT <span class="v">2</span></div>
+  </div>
+</div>
+
+<div class="layout">
+  <aside class="nav">
+    <div class="nav-h">DESK</div>
+    <a class="nav-link {% if page.url == '/' or not page.url %}active{% endif %}" href="{{ base_url }}/"><span>Overview</span><span class="id">F1</span></a>
+    <a class="nav-link {% if page.section == 'positions' %}active{% endif %}" href="{{ base_url }}/positions/"><span>Positions</span><span class="id">F2</span></a>
+    <a class="nav-link {% if page.section == 'orders' %}active{% endif %}" href="{{ base_url }}/orders/"><span>Orders</span><span class="id">F3</span></a>
+    <a class="nav-link {% if page.section == 'feeds' %}active{% endif %}" href="{{ base_url }}/feeds/"><span>News &amp; Feeds</span><span class="id">F4</span></a>
+
+    <div class="nav-h divider">CONFIG</div>
+    <a class="nav-link {% if page.section == 'desk' %}active{% endif %}" href="{{ base_url }}/desk/"><span>Desk Settings</span><span class="id">F7</span></a>
+    <a class="nav-link {% if page.url == '/about/' %}active{% endif %}" href="{{ base_url }}/about/"><span>About</span><span class="id">F8</span></a>
+
+    <div class="nav-h divider">OPERATOR</div>
+    <div class="nav-link" style="opacity:0.7;cursor:default;"><span>K. NAVARRO</span><span class="id">L4</span></div>
+  </aside>
+
+  <main class="main">

--- a/examples/mainframe-luxe/templates/page.html
+++ b/examples/mainframe-luxe/templates/page.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<div class="band">
+  <div class="cell">
+    <div class="eyebrow">{{ page.extra and page.extra.eyebrow or "ENTRY" }}</div>
+    <div class="t">{{ page.title }}</div>
+    <div class="desc">{{ page.description }}</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">{{ page.extra and page.extra.metric_label or "VALUE" }}</div>
+    <div class="num {{ page.extra and page.extra.metric_class or '' }}">{{ page.extra and page.extra.metric or "—" }}</div>
+    <div class="sub">{{ page.extra and page.extra.metric_note or "" }}</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">{{ page.extra and page.extra.metric2_label or "Δ 24H" }}</div>
+    <div class="num {{ page.extra and page.extra.metric2_class or '' }}">{{ page.extra and page.extra.metric2 or "—" }}</div>
+    <div class="sub">{{ page.extra and page.extra.metric2_note or "" }}</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">UPDATED</div>
+    <div class="num">{{ page.date | date("%m/%d") }}</div>
+    <div class="sub">{{ page.date | date("%H:%M") }} desk time</div>
+  </div>
+</div>
+
+<div class="pane">
+  <div class="pane-h"><span class="title">DETAIL</span><span class="meta">{{ page.extra and page.extra.tag or "ENTRY" }}</span></div>
+  <div class="pane-b">
+    <div class="prose">{{ content | safe }}</div>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/mainframe-luxe/templates/section.html
+++ b/examples/mainframe-luxe/templates/section.html
@@ -1,0 +1,38 @@
+{% include "header.html" %}
+
+<div class="band">
+  <div class="cell">
+    <div class="eyebrow">SECTION · {{ section.pages | length }} ENTRIES</div>
+    <div class="t">{{ section.title }}</div>
+    <div class="desc">{{ section.description }}</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">DESK</div>
+    <div class="num">K.NAVARRO</div>
+    <div class="sub">L4 clearance · session 04:32</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">SCAN</div>
+    <div class="num">{{ section.pages | length }}</div>
+    <div class="sub">filtered by recency</div>
+  </div>
+  <div class="cell">
+    <div class="eyebrow">REGION</div>
+    <div class="num">GLOBAL</div>
+    <div class="sub">all venues</div>
+  </div>
+</div>
+
+<div class="entries">
+{% for p in section.pages %}
+  <a class="e" href="{{ p.url }}">
+    <span class="id">{{ p.extra and p.extra.code or "0000" }}</span>
+    <span class="t"><div>{{ p.title }}</div><div class="desc">{{ p.summary | default(p.description) | strip_html | truncate_words(20) }}</div></span>
+    <span class="meta">{{ p.date | date("%Y-%m-%d %H:%M") }}</span>
+    <span class="v {{ p.extra and p.extra.metric_class or '' }}">{{ p.extra and p.extra.metric or "—" }}</span>
+    <span class="tag">{{ p.extra and p.extra.tag or "" }}</span>
+  </a>
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/mainframe-luxe/templates/shortcodes/alert.html
+++ b/examples/mainframe-luxe/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/mainframe-luxe/templates/taxonomy.html
+++ b/examples/mainframe-luxe/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="band"><div class="cell"><div class="eyebrow">INDEX</div><div class="t">{{ taxonomy_name | capitalize }}</div><div class="desc">All terms.</div></div><div class="cell"><div class="eyebrow">COUNT</div><div class="num">{{ taxonomy_terms | length }}</div></div><div class="cell"></div><div class="cell"></div></div>
+<div class="pane"><div class="pane-b">
+<table class="tbl">
+{% for term in taxonomy_terms %}
+<tr><td class="sym">{{ term.name }}</td><td>{{ term.pages | length }}</td><td><a href="{{ term.url }}" style="color:var(--amber);">OPEN ›</a></td></tr>
+{% endfor %}
+</table>
+</div></div>
+{% include "footer.html" %}

--- a/examples/mainframe-luxe/templates/taxonomy_term.html
+++ b/examples/mainframe-luxe/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<div class="band"><div class="cell"><div class="eyebrow">TAG</div><div class="t">{{ taxonomy_term }}</div></div><div class="cell"><div class="eyebrow">HITS</div><div class="num">{{ taxonomy_pages | length }}</div></div><div class="cell"></div><div class="cell"></div></div>
+<div class="entries">
+{% for p in taxonomy_pages %}
+<a class="e" href="{{ p.url }}">
+  <span class="id">{{ p.section | upper }}</span>
+  <span class="t"><div>{{ p.title }}</div><div class="desc">{{ p.summary | default(p.description) | strip_html | truncate_words(18) }}</div></span>
+  <span class="meta">{{ p.date | date("%Y-%m-%d") }}</span>
+  <span class="v"></span>
+  <span class="tag"></span>
+</a>
+{% endfor %}
+</div>
+{% include "footer.html" %}

--- a/examples/prism-console/AGENTS.md
+++ b/examples/prism-console/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/prism-console/archetypes/default.md
+++ b/examples/prism-console/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/prism-console/config.toml
+++ b/examples/prism-console/config.toml
@@ -1,0 +1,193 @@
+title = "Prism Console"
+description = "Bold-block Memphis-inspired admin theme — cobalt, mustard, hot-pink and mint flat panels with oversized type, geometric markers and zero gradients."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["projects", "team", "billing", "log"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/prism-console/content/about.md
+++ b/examples/prism-console/content/about.md
@@ -1,0 +1,32 @@
++++
+title = "About Prism"
+description = "What Prism Console is, who it's for, and the design language behind it."
+[extra]
+eyebrow = "ABOUT"
+metric_label = "VERSION"
+metric = "0.7.3"
+metric_note = "Beta · last release May 18, 2026"
+tag = "Stable"
++++
+
+Prism Console is the admin surface for small teams who ship in colour. It sits on top of your data
+and refuses to look like every other dashboard you've ever opened.
+
+## Who it's for
+
+- Studios who want a back-office that doesn't apologise for itself.
+- Founders managing four products and one billing cycle.
+- Teams who'd rather scan a colour-coded grid than parse a wall of grey rows.
+
+## Design language
+
+We picked four flat colours and committed. **Cobalt** for the leading metric. **Mustard** for the
+working state. **Hot pink** for things that need a human. **Mint** for things you can stop worrying
+about. Everything is bordered in black and casts a hard shadow.
+
+> No gradients. No emoji. No "delightful" micro-interactions that take 600ms to dismiss.
+
+## Build
+
+Built on Hwaro and a single 300-line stylesheet. Type is Archivo Black for headlines and Space
+Grotesk for everything else.

--- a/examples/prism-console/content/billing/_index.md
+++ b/examples/prism-console/content/billing/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Billing"
+description = "Invoice runs, outstanding amounts and the standing reconciliation log."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/prism-console/content/billing/april-2026.md
+++ b/examples/prism-console/content/billing/april-2026.md
@@ -1,0 +1,20 @@
++++
+title = "April 2026 · Closed"
+date = "2026-05-01"
+description = "April cycle closed clean. Reconciliation co-signed May 1."
+[extra]
+eyebrow = "CYCLE · APRIL 2026 · CLOSED"
+owner = "Billing"
+metric_label = "TOTAL · APR"
+metric = "$42.9k"
+metric_note = "+9.1% vs March"
+tag = "Closed"
++++
+
+April closed clean. All invoices settled on or ahead of terms, reconciliation co-signed by the
+billing and operations leads on May 1.
+
+## Notes
+
+- One invoice (Coastal Library) paid eight days early.
+- Two customers moved to annual, which lifts the next two months' MRR comparison.

--- a/examples/prism-console/content/billing/may-2026.md
+++ b/examples/prism-console/content/billing/may-2026.md
@@ -1,0 +1,26 @@
++++
+title = "May 2026 · Cycle"
+date = "2026-05-20"
+description = "The May billing cycle — paid, outstanding, and the watch-list."
+[extra]
+eyebrow = "CYCLE · MAY 2026"
+owner = "Billing"
+metric_label = "OUTSTANDING"
+metric = "$15.4k"
+metric_note = "Closes Friday May 23"
+tag = "Open"
++++
+
+The May cycle is on its standing schedule. Most invoices have settled; the outstanding column is
+mostly tracking with the public-sector pilot's NET-30 terms.
+
+## Headline
+
+- **Paid**: $32.8k
+- **Outstanding**: $15.4k
+- **Overdue (one invoice)**: Westside Bank #2405
+
+## Watch list
+
+The Westside invoice is two weeks past due. Reach out before Friday or we move it to the formal
+collections track on Monday.

--- a/examples/prism-console/content/index.md
+++ b/examples/prism-console/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Overview"
+template = "dashboard"
+description = "Workspace overview — projects, revenue, team activity, billing."
++++

--- a/examples/prism-console/content/log/2026-05-10.md
+++ b/examples/prism-console/content/log/2026-05-10.md
@@ -1,0 +1,26 @@
++++
+title = "Warehouse Maintenance · May 10"
+date = "2026-05-10"
+description = "Scheduled warehouse maintenance, all read traffic paused for 11 minutes."
+[extra]
+eyebrow = "OPS · MAINTENANCE"
+owner = "Platform"
+metric_label = "DURATION"
+metric = "11m"
+metric_note = "Within the 15m window"
+tag = "Closed"
++++
+
+Scheduled warehouse maintenance. Read traffic was paused for 11 minutes between 02:00 and
+02:11 UTC. No customer-visible incidents.
+
+## What we did
+
+- Promoted the new read replica.
+- Switched the export pipeline over to the new endpoint.
+- Verified the standing dashboards picked up the change without restart.
+
+## What's next
+
+The full migration switchover is scheduled for early June, with a 30-minute window we'll
+publish next week.

--- a/examples/prism-console/content/log/2026-05-18.md
+++ b/examples/prism-console/content/log/2026-05-18.md
@@ -1,0 +1,26 @@
++++
+title = "Release 0.7.3"
+date = "2026-05-18"
+description = "Console release 0.7.3 — UI polish, search shortcuts, billing fixes."
+[extra]
+eyebrow = "RELEASE · 0.7.3"
+owner = "Console Team"
+metric_label = "VERSION"
+metric = "0.7.3"
+metric_note = "Beta channel"
+tag = "Shipped"
++++
+
+Console release 0.7.3 went out to the beta channel this morning. Three weeks of work in a
+single bundle, mostly polish but two billing fixes that have been pending since April.
+
+## What's in it
+
+- Search now respects workspace scope by default.
+- The overview page no longer reloads when you star a project.
+- Two billing edge cases (proration, mid-cycle plan change) fixed end-to-end.
+
+## What's not
+
+- Polaris Settings is still drafted; it'll land in 0.8.
+- Pinwheel Docs section 4 isn't published yet.

--- a/examples/prism-console/content/log/_index.md
+++ b/examples/prism-console/content/log/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Activity Log"
+description = "Console-wide changes — releases, approvals, and standing audit events."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/prism-console/content/projects/_index.md
+++ b/examples/prism-console/content/projects/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Projects"
+description = "All workspaces, products and side bets the team is shipping this quarter."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/prism-console/content/projects/atlas-billing.md
+++ b/examples/prism-console/content/projects/atlas-billing.md
@@ -1,0 +1,26 @@
++++
+title = "Atlas Billing"
+date = "2026-05-12"
+description = "Subscription billing layer for the Atlas tenancy. v2.4 ships this week."
+[extra]
+eyebrow = "REVIEW · AT RISK"
+owner = "R. West"
+metric_label = "INVOICE LOAD"
+metric = "1.2k"
+metric_note = "Past 30d · 7 retries pending"
+tag = "Review"
++++
+
+Atlas Billing handles the subscription side of the Atlas tenancy product. v2.4 closes the loop on
+proration and adds two enterprise invoice formats that legal asked for last quarter.
+
+## Open items
+
+- **Proration on mid-cycle plan change** — fix landed, awaiting QA sign-off from O. Anwar.
+- **NET-30 invoice template** for the public-sector pilot.
+- **Retries log** — 7 invoices stuck on stripe `requires_action`. Manual review scheduled Wednesday.
+
+## Why this is at risk
+
+The release date is Friday and the QA queue is full from Lighthouse Mobile. We may push to
+Monday rather than ship without the standing dry-run.

--- a/examples/prism-console/content/projects/lighthouse-mobile.md
+++ b/examples/prism-console/content/projects/lighthouse-mobile.md
@@ -1,0 +1,35 @@
++++
+title = "Lighthouse Mobile"
+date = "2026-05-18"
+description = "The companion app for Lighthouse — offline-first, low-power, ships May 24."
+[extra]
+eyebrow = "ACTIVE · PRIORITY 01"
+owner = "J. Kang"
+metric_label = "BUILD"
+metric = "117"
+metric_note = "Ships May 24 · TestFlight rolling"
+tag = "Shipping"
++++
+
+Lighthouse Mobile is the field companion for the dashboard team. Engineers carry it into
+manufacturing floors that don't always have signal, so the whole thing was rebuilt on a local
+queue this cycle.
+
+## Status
+
+- **Build 117** rolled to TestFlight this morning, 96 internal seats.
+- Last week's regression in the offline sync queue is fixed and confirmed by two manufacturing
+  partners.
+- Public release scheduled for **May 24**.
+
+## What changed in 117
+
+- Background sync now defers to a 2-minute window instead of running on every wake.
+- The site picker remembers the last three filters per device.
+- Battery drain on iPad Air 5 dropped 14% in the standing test.
+
+## What's next
+
+We need to make a call about whether the Android tablet build follows in the same release or
+ships a week behind. The build itself is ready; the question is whether the support team can
+absorb both at once.

--- a/examples/prism-console/content/projects/mosaic-export.md
+++ b/examples/prism-console/content/projects/mosaic-export.md
@@ -1,0 +1,25 @@
++++
+title = "Mosaic Data Export"
+date = "2026-05-06"
+description = "Bulk data export pipeline for Mosaic — blocked on the warehouse migration."
+[extra]
+eyebrow = "BLOCKED"
+owner = "O. Anwar"
+metric_label = "RECORDS / RUN"
+metric = "2.1M"
+metric_note = "Blocked on warehouse migration"
+tag = "Blocked"
++++
+
+Mosaic Data Export is the bulk download pipeline for Mosaic customers who want their full
+history out in a single archive. Standing build is healthy; we're waiting on the warehouse team.
+
+## What's blocking us
+
+The warehouse migration was supposed to land week of May 4 but slipped to "early June." We
+can't promote the new exporter without it because the schema reads on the new tables.
+
+## Workaround
+
+For the two large customers asking this week, we're running the legacy exporter on a manual
+schedule. It's slow but it works. Owen owns the on-call rotation.

--- a/examples/prism-console/content/projects/pinwheel-docs.md
+++ b/examples/prism-console/content/projects/pinwheel-docs.md
@@ -1,0 +1,28 @@
++++
+title = "Pinwheel Docs"
+date = "2026-05-09"
+description = "Public documentation site for Pinwheel SDK — section 4 in draft."
+[extra]
+eyebrow = "DRAFTING"
+owner = "S. Moon"
+metric_label = "SECTIONS"
+metric = "4 / 9"
+metric_note = "Draft due Jun 3"
+tag = "Drafting"
++++
+
+Public documentation for the Pinwheel SDK. The shape of the site is set; we're filling in the API
+reference one section at a time and rotating drafts through the small writers' group.
+
+## Sections complete
+
+1. Getting started
+2. Installation &amp; setup
+3. The Pinwheel object model
+4. **Authentication &amp; sessions** (in draft)
+
+## Notes from the writers' room
+
+Section 4 needs a "common failures" sidebar — three or four examples that map to the most
+common support tickets. Owen pulled the top five from the last 30 days and they're surprisingly
+boring, which is good.

--- a/examples/prism-console/content/projects/polaris-settings.md
+++ b/examples/prism-console/content/projects/polaris-settings.md
@@ -1,0 +1,27 @@
++++
+title = "Polaris Settings"
+date = "2026-04-28"
+description = "Per-workspace settings surface, opening up the parts of the console that used to live in code."
+[extra]
+eyebrow = "DRAFTING"
+owner = "C. Doan"
+metric_label = "DRAFT"
+metric = "v0.3"
+metric_note = "Spec review Jun 18"
+tag = "Drafting"
++++
+
+Polaris is the settings surface. The console has been growing knobs in code for two years and
+they're starting to need a home. v0.3 is the first draft that maps everything to a single page.
+
+## Why now
+
+Support has been carrying a quiet load of "can you flip this for me" tickets. The shape of the
+fix is to put the knobs where the user can find them, not to add a new admin escalation path.
+
+## Open design questions
+
+- Should workspace-level and project-level settings live on the same page with a toggle, or
+  on two separate pages?
+- Per-seat preferences (notification cadence, default views) — are those settings, or are they
+  the user profile?

--- a/examples/prism-console/content/projects/wren-api.md
+++ b/examples/prism-console/content/projects/wren-api.md
@@ -1,0 +1,32 @@
++++
+title = "Wren API v3"
+date = "2026-05-02"
+description = "Third-generation public API for Wren. Six routes done, three to go."
+[extra]
+eyebrow = "ACTIVE"
+owner = "T. Lerner"
+metric_label = "ROUTES"
+metric = "6 / 9"
+metric_note = "Public preview Jun 11"
+tag = "Active"
++++
+
+Wren API v3 is the third public iteration. We're keeping v2 alive until end of year and shipping
+v3 as a side-by-side namespace. Existing customers will move on a schedule of their choosing.
+
+## Done
+
+- `/v3/objects` · list and detail
+- `/v3/events` · stream and replay
+- `/v3/keys` · create, rotate, revoke
+
+## Remaining
+
+- `/v3/webhooks` — design is set, work starts Thursday.
+- `/v3/exports` — depends on Mosaic landing.
+- `/v3/audit` — last route, planned for the final sprint.
+
+## Open question
+
+We have not decided whether v3 ships with an HMAC signing scheme or rotates over to JWTs.
+Tor will write up a one-pager this week.

--- a/examples/prism-console/content/team/_index.md
+++ b/examples/prism-console/content/team/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Team"
+description = "Active members across the workspace, their roles and the projects they own."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/examples/prism-console/content/team/j-kang.md
+++ b/examples/prism-console/content/team/j-kang.md
@@ -1,0 +1,26 @@
++++
+title = "J. Kang · Lead"
+date = "2026-05-18"
+description = "Engineering lead, currently owns Lighthouse Mobile."
+[extra]
+eyebrow = "LEAD · ENGINEERING"
+owner = "J. Kang"
+metric_label = "OWNS"
+metric = "3"
+metric_note = "Lighthouse, Wren, Polaris"
+tag = "Online"
++++
+
+Joined the studio in 2022 from the mobile team at a hardware company. Owns the mobile and
+API surfaces. Has standing meetings with manufacturing on Tuesdays.
+
+## Currently leading
+
+- Lighthouse Mobile (ships May 24)
+- Wren API v3 (preview Jun 11)
+- Polaris Settings (spec review Jun 18)
+
+## Standing time
+
+Tuesdays 10:00 — manufacturing standup. Open to invitations otherwise; check the workspace
+calendar before booking.

--- a/examples/prism-console/content/team/o-anwar.md
+++ b/examples/prism-console/content/team/o-anwar.md
@@ -1,0 +1,21 @@
++++
+title = "O. Anwar · Engineering"
+date = "2026-05-09"
+description = "Data engineer owning the warehouse and the export pipeline."
+[extra]
+eyebrow = "ENGINEERING"
+owner = "O. Anwar"
+metric_label = "PIPELINES"
+metric = "4"
+metric_note = "Mosaic, Wren, Atlas, Pinwheel"
+tag = "Online"
++++
+
+Owns the warehouse and the data export side of the console. Working through the migration
+that's currently blocking Mosaic.
+
+## Standing work
+
+- Warehouse migration — running the parallel writes, switchover in early June.
+- Mosaic exporter — promotion blocked behind the migration.
+- Atlas Billing QA — covering this week while QA is full.

--- a/examples/prism-console/content/team/r-west.md
+++ b/examples/prism-console/content/team/r-west.md
@@ -1,0 +1,21 @@
++++
+title = "R. West · Design"
+date = "2026-05-16"
+description = "Product designer covering billing and the customer-facing surfaces."
+[extra]
+eyebrow = "DESIGN"
+owner = "R. West"
+metric_label = "REVIEWS"
+metric = "12"
+metric_note = "Past 30d"
+tag = "Online"
++++
+
+Designs the billing surface and most of the customer-facing pages. Reviewer of last resort on
+visual changes that touch invoicing.
+
+## Recent
+
+- Atlas Billing v2.4 — approved this morning.
+- Polaris Settings — gave feedback on the v0.3 draft, two open threads.
+- The console's overview page — owns the type stack we use in headings.

--- a/examples/prism-console/content/team/s-moon.md
+++ b/examples/prism-console/content/team/s-moon.md
@@ -1,0 +1,21 @@
++++
+title = "S. Moon · Docs"
+date = "2026-05-12"
+description = "Technical writer for the SDK and the public API."
+[extra]
+eyebrow = "DOCS"
+owner = "S. Moon"
+metric_label = "PAGES SHIPPED"
+metric = "47"
+metric_note = "Q2 so far"
+tag = "Online"
++++
+
+Writes the public-facing documentation. Owns the Pinwheel SDK docs and edits the API reference
+the engineers draft.
+
+## In the pipeline
+
+- Pinwheel Docs — section 4 (auth) in draft.
+- Wren API v3 — reviewing the route descriptions Tor writes.
+- "Common failures" sidebar — pulling examples from support tickets.

--- a/examples/prism-console/static/css/style.css
+++ b/examples/prism-console/static/css/style.css
@@ -1,0 +1,447 @@
+:root {
+  --bg: #faf6ee;
+  --ink: #111111;
+  --ink-2: #1d1d1d;
+  --cobalt: #2756e6;
+  --mustard: #fbc02d;
+  --pink: #ff4d8d;
+  --mint: #2ee0a8;
+  --paper: #ffffff;
+  --line: #111111;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+a { color: inherit; text-decoration: none; }
+
+.app {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+}
+
+/* SIDEBAR */
+.sidebar {
+  background: var(--ink);
+  color: var(--bg);
+  padding: 24px 22px;
+  border-right: 4px solid var(--ink);
+  position: sticky; top: 0; height: 100vh;
+  overflow: hidden;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 28px;
+}
+.brand-block {
+  width: 40px; height: 40px;
+  background: var(--mustard);
+  border: 3px solid var(--bg);
+  position: relative;
+}
+.brand-block::after{
+  content:""; position:absolute; right:-10px; bottom:-10px;
+  width: 22px; height: 22px; background: var(--pink);
+  border: 3px solid var(--bg);
+}
+.brand-name {
+  font-family: "Archivo Black", "Space Grotesk", sans-serif;
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.brand-sub {
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  opacity: 0.65;
+  margin-top: 4px;
+}
+
+.nav-section {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  opacity: 0.55;
+  margin: 18px 0 6px;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  margin: 0 -12px;
+  border-radius: 0;
+  font-weight: 500;
+  font-size: 14px;
+  border-left: 4px solid transparent;
+}
+.nav-link:hover { background: rgba(255,255,255,0.06); }
+.nav-link.active {
+  background: var(--bg);
+  color: var(--ink);
+  border-left-color: var(--pink);
+}
+.nav-link.active.c { border-left-color: var(--cobalt); }
+.nav-link.active.m { border-left-color: var(--mustard); }
+.nav-link.active.g { border-left-color: var(--mint); }
+.nav-dot { width: 8px; height: 8px; background: var(--mustard); }
+.nav-dot.c { background: var(--cobalt); }
+.nav-dot.p { background: var(--pink); }
+.nav-dot.g { background: var(--mint); }
+
+.sidebar-foot {
+  position: absolute;
+  bottom: 22px; left: 22px; right: 22px;
+  font-size: 11px; opacity: 0.6;
+  border-top: 2px solid rgba(250,246,238,0.2);
+  padding-top: 14px;
+}
+
+/* MAIN */
+.main { min-width: 0; }
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 36px;
+  border-bottom: 3px solid var(--ink);
+  background: var(--bg);
+  position: sticky; top: 0; z-index: 5;
+}
+.crumbs { font-size: 13px; letter-spacing: 0.02em; }
+.crumbs span.sep { margin: 0 8px; opacity: 0.4; }
+.crumbs b { font-weight: 700; }
+.topbar-actions { display: flex; gap: 10px; align-items: center; }
+.search {
+  border: 2.5px solid var(--ink);
+  background: var(--paper);
+  padding: 8px 14px;
+  font-size: 13px;
+  font-family: inherit;
+  width: 220px;
+}
+.btn {
+  border: 2.5px solid var(--ink);
+  background: var(--bg);
+  padding: 8px 16px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
+  box-shadow: 4px 4px 0 var(--ink);
+  transition: transform 0.05s, box-shadow 0.05s;
+}
+.btn:hover { transform: translate(2px,2px); box-shadow: 2px 2px 0 var(--ink); }
+.btn.pink { background: var(--pink); color: var(--ink); }
+.btn.cobalt { background: var(--cobalt); color: var(--bg); }
+.btn.mustard { background: var(--mustard); }
+.btn.mint { background: var(--mint); }
+
+.content { padding: 32px 36px 72px; max-width: 1320px; }
+
+/* PAGE HEAD */
+.head {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 24px;
+  align-items: stretch;
+  margin-bottom: 28px;
+}
+.head .title-card {
+  background: var(--paper);
+  border: 3px solid var(--ink);
+  padding: 28px 30px;
+  box-shadow: 8px 8px 0 var(--ink);
+  position: relative;
+}
+.head .title-card .eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  background: var(--mustard);
+  display: inline-block;
+  padding: 3px 8px;
+  border: 2px solid var(--ink);
+  margin-bottom: 14px;
+  font-weight: 700;
+}
+.head .title-card h1 {
+  font-family: "Archivo Black", sans-serif;
+  font-size: 52px;
+  line-height: 0.95;
+  letter-spacing: -0.025em;
+  margin: 0 0 12px;
+}
+.head .title-card p { max-width: 50ch; margin: 0; font-size: 14px; }
+.head .title-card .corner-shape {
+  position: absolute;
+  top: -3px; right: -3px;
+  width: 56px; height: 56px;
+  background: var(--pink);
+  border: 3px solid var(--ink);
+}
+
+.head .stat-block {
+  background: var(--cobalt);
+  border: 3px solid var(--ink);
+  color: var(--bg);
+  padding: 24px 26px;
+  box-shadow: 8px 8px 0 var(--ink);
+  position: relative;
+}
+.head .stat-block .label { font-size: 11px; letter-spacing: 0.3em; opacity: 0.85; text-transform: uppercase; }
+.head .stat-block .big { font-family: "Archivo Black", sans-serif; font-size: 88px; line-height: 0.95; letter-spacing: -0.03em; margin: 8px 0 0; }
+.head .stat-block .delta { font-size: 13px; margin-top: 6px; }
+.head .stat-block .circle {
+  position: absolute; top: 14px; right: 14px;
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  background: var(--mint);
+  border: 3px solid var(--ink);
+}
+
+/* STAT ROW */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+  margin-bottom: 28px;
+}
+.stat {
+  background: var(--paper);
+  border: 3px solid var(--ink);
+  padding: 18px 20px 20px;
+  box-shadow: 5px 5px 0 var(--ink);
+  position: relative;
+}
+.stat.pink { background: var(--pink); }
+.stat.mustard { background: var(--mustard); }
+.stat.mint { background: var(--mint); }
+.stat .label { font-size: 10px; letter-spacing: 0.28em; font-weight: 700; text-transform: uppercase; }
+.stat .v { font-family: "Archivo Black", sans-serif; font-size: 36px; letter-spacing: -0.02em; margin-top: 6px; line-height: 1; }
+.stat .d { font-size: 12px; margin-top: 6px; opacity: 0.78; }
+.stat .badge {
+  position: absolute; top: 12px; right: 12px;
+  background: var(--ink); color: var(--bg);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  padding: 2px 6px;
+  font-weight: 700;
+}
+
+/* PANEL */
+.row { display: grid; grid-template-columns: 1.7fr 1fr; gap: 22px; margin-bottom: 28px; }
+.row.three { grid-template-columns: 1fr 1fr 1fr; }
+
+.panel {
+  background: var(--paper);
+  border: 3px solid var(--ink);
+  box-shadow: 6px 6px 0 var(--ink);
+}
+.panel.tilt { transform: rotate(-0.4deg); }
+.panel.tilt-r { transform: rotate(0.4deg); }
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 20px;
+  border-bottom: 3px solid var(--ink);
+  background: var(--bg);
+}
+.panel-head h3 {
+  font-family: "Archivo Black", sans-serif;
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+.panel-head .chip {
+  background: var(--mustard);
+  border: 2px solid var(--ink);
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+.panel-head .chip.cobalt { background: var(--cobalt); color: var(--bg); }
+.panel-head .chip.pink { background: var(--pink); }
+.panel-head .chip.mint { background: var(--mint); }
+.panel-body { padding: 18px 22px 22px; }
+
+/* TABLE */
+table.t { width: 100%; border-collapse: collapse; }
+table.t th, table.t td { text-align: left; padding: 12px 8px; border-bottom: 2px solid var(--ink); }
+table.t th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; }
+table.t tr:last-child td { border-bottom: none; }
+table.t td b { font-family: "Archivo Black", sans-serif; }
+
+/* TAG/PILL */
+.pill {
+  display: inline-block;
+  background: var(--paper);
+  border: 2px solid var(--ink);
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+.pill.cobalt { background: var(--cobalt); color: var(--bg); }
+.pill.pink { background: var(--pink); }
+.pill.mustard { background: var(--mustard); }
+.pill.mint { background: var(--mint); }
+
+/* BAR CHART */
+.bars {
+  height: 180px;
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  padding-bottom: 26px;
+  border-bottom: 3px solid var(--ink);
+}
+.bar {
+  flex: 1;
+  border: 2.5px solid var(--ink);
+  position: relative;
+  background: var(--mustard);
+}
+.bar:nth-child(2) { background: var(--cobalt); }
+.bar:nth-child(3) { background: var(--pink); }
+.bar:nth-child(4) { background: var(--mint); }
+.bar:nth-child(5) { background: var(--mustard); }
+.bar:nth-child(6) { background: var(--cobalt); }
+.bar:nth-child(7) { background: var(--pink); }
+.bar::after {
+  content: attr(data-l);
+  position: absolute;
+  bottom: -24px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+}
+.bar::before {
+  content: attr(data-v);
+  position: absolute;
+  top: -22px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+/* SHAPE */
+.shape-strip {
+  display: flex;
+  gap: 8px;
+  margin-top: 18px;
+}
+.shape-strip > * { border: 2.5px solid var(--ink); }
+.shape-strip .sq { width: 32px; height: 32px; background: var(--mustard); }
+.shape-strip .ci { width: 32px; height: 32px; border-radius: 50%; background: var(--cobalt); }
+.shape-strip .tr { width: 0; height: 0; border-left: 18px solid transparent; border-right: 18px solid transparent; border-bottom: 32px solid var(--pink); border-top: none; }
+.shape-strip .rc { width: 60px; height: 32px; background: var(--mint); }
+
+/* AVATAR */
+.avatar {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  border: 2.5px solid var(--ink);
+  background: var(--mustard);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Archivo Black", sans-serif;
+  font-size: 13px;
+}
+.avatar.cobalt { background: var(--cobalt); color: var(--bg); }
+.avatar.pink { background: var(--pink); }
+.avatar.mint { background: var(--mint); }
+
+/* PROSE */
+.prose { font-size: 15px; line-height: 1.7; max-width: 72ch; }
+.prose h2 { font-family: "Archivo Black", sans-serif; font-size: 26px; margin-top: 32px; }
+.prose h3 { font-family: "Archivo Black", sans-serif; font-size: 18px; margin-top: 24px; }
+.prose blockquote {
+  border-left: 6px solid var(--cobalt);
+  background: var(--paper);
+  border: 3px solid var(--ink);
+  padding: 14px 20px;
+  margin: 18px 0;
+  box-shadow: 5px 5px 0 var(--ink);
+}
+.prose code { background: var(--mustard); padding: 1px 6px; font-size: 13px; border: 1.5px solid var(--ink); }
+.prose pre { background: var(--ink); color: var(--bg); padding: 16px 18px; overflow: auto; border: 3px solid var(--ink); box-shadow: 5px 5px 0 var(--cobalt); }
+.prose pre code { background: transparent; border: none; color: var(--mustard); }
+.prose ul li::marker { color: var(--pink); }
+
+/* CARD GRID for section listings */
+.card-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px; }
+.card {
+  background: var(--paper);
+  border: 3px solid var(--ink);
+  box-shadow: 6px 6px 0 var(--ink);
+  padding: 24px 26px;
+  position: relative;
+  min-height: 200px;
+  display: block;
+}
+.card.tilt { transform: rotate(-0.3deg); }
+.card.tilt-r { transform: rotate(0.3deg); }
+.card .corner {
+  position: absolute;
+  top: -3px; right: -3px;
+  width: 44px; height: 44px;
+  background: var(--mustard);
+  border: 3px solid var(--ink);
+}
+.card.pink .corner { background: var(--pink); }
+.card.cobalt .corner { background: var(--cobalt); }
+.card.mint .corner { background: var(--mint); }
+.card .eyebrow {
+  font-size: 10px; letter-spacing: 0.3em; text-transform: uppercase;
+  font-weight: 700; margin-bottom: 8px;
+}
+.card h3 {
+  font-family: "Archivo Black", sans-serif;
+  margin: 0 0 8px;
+  font-size: 22px;
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+}
+.card .meta { font-size: 12px; opacity: 0.7; margin-bottom: 10px; }
+.card .summary { font-size: 13.5px; line-height: 1.55; }
+
+/* 404 */
+.f404 { padding: 100px 60px; text-align: center; }
+.f404 h1 { font-family: "Archivo Black", sans-serif; font-size: 200px; line-height: 0.85; letter-spacing: -0.04em; margin: 0; }
+.f404 .stack { display: inline-flex; gap: 12px; margin: 18px 0 26px; }
+.f404 .stack > * { border: 3px solid var(--ink); padding: 8px 14px; font-weight: 700; letter-spacing: 0.18em; }
+.f404 .stack .a { background: var(--cobalt); color: var(--bg); }
+.f404 .stack .b { background: var(--pink); }
+.f404 .stack .c { background: var(--mustard); }
+
+@media (max-width: 1100px) {
+  .stat-row { grid-template-columns: 1fr 1fr; }
+  .head { grid-template-columns: 1fr; }
+}
+@media (max-width: 800px) {
+  .app { grid-template-columns: 1fr; }
+  .sidebar { position: relative; height: auto; }
+  .row, .row.three { grid-template-columns: 1fr; }
+  .card-grid { grid-template-columns: 1fr; }
+}

--- a/examples/prism-console/static/favicon.svg
+++ b/examples/prism-console/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/prism-console/templates/404.html
+++ b/examples/prism-console/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<div class="f404">
+  <h1>404</h1>
+  <div class="stack"><span class="a">PAGE</span><span class="b">NOT</span><span class="c">FOUND</span></div>
+  <p>This route doesn't ship in your current console build.</p>
+  <p style="margin-top:24px;"><a class="btn cobalt" href="{{ base_url }}/">Back to Overview</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/prism-console/templates/dashboard.html
+++ b/examples/prism-console/templates/dashboard.html
@@ -1,0 +1,135 @@
+{% include "header.html" %}
+
+<div class="head">
+  <div class="title-card">
+    <div class="corner-shape"></div>
+    <div class="eyebrow">CONSOLE · OVERVIEW</div>
+    <h1>Good morning,<br>Workspace A.</h1>
+    <p>Four projects shipping this week, two awaiting review, and a billing window closes Friday. Pinned items and last-touched files are below — start where you left off.</p>
+    <div class="shape-strip"><div class="sq"></div><div class="ci"></div><div class="tr"></div><div class="rc"></div></div>
+  </div>
+  <div class="stat-block">
+    <div class="circle"></div>
+    <div class="label">MRR · MAY</div>
+    <div class="big">$48.2k</div>
+    <div class="delta">+12.4% vs April · 138 paying seats</div>
+  </div>
+</div>
+
+<div class="stat-row">
+  <div class="stat mustard">
+    <div class="badge">01</div>
+    <div class="label">Active Projects</div>
+    <div class="v">14</div>
+    <div class="d">3 shipping this week</div>
+  </div>
+  <div class="stat pink">
+    <div class="badge">02</div>
+    <div class="label">Open Reviews</div>
+    <div class="v">07</div>
+    <div class="d">2 awaiting your sign-off</div>
+  </div>
+  <div class="stat mint">
+    <div class="badge">03</div>
+    <div class="label">Tickets Closed · 7D</div>
+    <div class="v">132</div>
+    <div class="d">Median 4.1h to resolve</div>
+  </div>
+  <div class="stat">
+    <div class="badge">04</div>
+    <div class="label">Storage · Workspace</div>
+    <div class="v">61.4 GB</div>
+    <div class="d">of 250 GB · 24.6% used</div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="panel">
+    <div class="panel-head"><h3>Active Projects</h3><span class="chip cobalt">14 LIVE</span></div>
+    <div class="panel-body">
+      <table class="t">
+        <thead><tr><th>Project</th><th>Owner</th><th>State</th><th>Deadline</th><th>Health</th></tr></thead>
+        <tbody>
+          <tr><td><b>Lighthouse mobile</b></td><td><span class="avatar cobalt">JK</span> J. Kang</td><td><span class="pill mustard">In progress</span></td><td>May 24</td><td><span class="pill mint">On track</span></td></tr>
+          <tr><td><b>Atlas billing</b></td><td><span class="avatar pink">RW</span> R. West</td><td><span class="pill cobalt">Review</span></td><td>May 22</td><td><span class="pill mustard">At risk</span></td></tr>
+          <tr><td><b>Pinwheel docs</b></td><td><span class="avatar">SM</span> S. Moon</td><td><span class="pill">Drafting</span></td><td>Jun 03</td><td><span class="pill mint">On track</span></td></tr>
+          <tr><td><b>Mosaic data export</b></td><td><span class="avatar mint">OA</span> O. Anwar</td><td><span class="pill pink">Blocked</span></td><td>May 27</td><td><span class="pill pink">Delayed</span></td></tr>
+          <tr><td><b>Wren API v3</b></td><td><span class="avatar mustard">TL</span> T. Lerner</td><td><span class="pill mustard">In progress</span></td><td>Jun 11</td><td><span class="pill mint">On track</span></td></tr>
+          <tr><td><b>Polaris settings</b></td><td><span class="avatar cobalt">CD</span> C. Doan</td><td><span class="pill">Drafting</span></td><td>Jun 18</td><td><span class="pill mint">On track</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="panel tilt-r">
+    <div class="panel-head"><h3>Revenue · 7D</h3><span class="chip pink">CHART</span></div>
+    <div class="panel-body">
+      <div class="bars">
+        <div class="bar" data-l="MON" data-v="4.1" style="height:48%"></div>
+        <div class="bar" data-l="TUE" data-v="5.7" style="height:62%"></div>
+        <div class="bar" data-l="WED" data-v="6.2" style="height:74%"></div>
+        <div class="bar" data-l="THU" data-v="3.9" style="height:42%"></div>
+        <div class="bar" data-l="FRI" data-v="7.1" style="height:84%"></div>
+        <div class="bar" data-l="SAT" data-v="2.4" style="height:28%"></div>
+        <div class="bar" data-l="SUN" data-v="3.0" style="height:36%"></div>
+      </div>
+      <div style="margin-top:42px;font-size:12px;display:flex;justify-content:space-between;">
+        <span><b>Best:</b> Fri $7.1k</span>
+        <span><b>Avg:</b> $4.6k</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row three">
+  <div class="panel">
+    <div class="panel-head"><h3>Team</h3><span class="chip mint">11 ONLINE</span></div>
+    <div class="panel-body">
+      <table class="t">
+        <tbody>
+          <tr><td><span class="avatar cobalt">JK</span> J. Kang</td><td><span class="pill cobalt">Lead</span></td></tr>
+          <tr><td><span class="avatar pink">RW</span> R. West</td><td><span class="pill pink">Design</span></td></tr>
+          <tr><td><span class="avatar">SM</span> S. Moon</td><td><span class="pill mustard">Docs</span></td></tr>
+          <tr><td><span class="avatar mint">OA</span> O. Anwar</td><td><span class="pill mint">Eng</span></td></tr>
+          <tr><td><span class="avatar mustard">TL</span> T. Lerner</td><td><span class="pill">Eng</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="panel tilt">
+    <div class="panel-head"><h3>Activity</h3><span class="chip">LIVE</span></div>
+    <div class="panel-body" style="font-size:13px;line-height:1.85;">
+      <div><span class="pill cobalt">09:14</span> &nbsp; <b>R. West</b> approved <i>Atlas billing — v2.4</i></div>
+      <div><span class="pill">09:02</span> &nbsp; <b>J. Kang</b> shipped <i>Lighthouse mobile · build 117</i></div>
+      <div><span class="pill mustard">08:48</span> &nbsp; <b>S. Moon</b> drafted <i>Pinwheel docs — sec 4</i></div>
+      <div><span class="pill pink">08:31</span> &nbsp; <b>O. Anwar</b> reported a block on <i>Mosaic data export</i></div>
+      <div><span class="pill mint">07:58</span> &nbsp; <b>T. Lerner</b> merged <i>Wren API v3 #418</i></div>
+      <div><span class="pill">07:22</span> &nbsp; <b>C. Doan</b> opened <i>Polaris settings — v0.3</i></div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-head"><h3>Billing · May</h3><span class="chip mustard">DUE FRI</span></div>
+    <div class="panel-body">
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:14px;">
+        <div style="background:var(--mint);border:2.5px solid var(--ink);padding:14px;">
+          <div style="font-size:10px;letter-spacing:0.22em;font-weight:700;">PAID</div>
+          <div style="font-family:Archivo Black;font-size:28px;line-height:1;margin-top:6px;">$32.8k</div>
+        </div>
+        <div style="background:var(--pink);border:2.5px solid var(--ink);padding:14px;">
+          <div style="font-size:10px;letter-spacing:0.22em;font-weight:700;">OUTSTANDING</div>
+          <div style="font-family:Archivo Black;font-size:28px;line-height:1;margin-top:6px;">$15.4k</div>
+        </div>
+      </div>
+      <div style="font-size:12px;line-height:1.7;">
+        <div>Invoice <b>#2403</b> — Acme Co. · <span class="pill mustard">DUE</span></div>
+        <div>Invoice <b>#2404</b> — Bramble &amp; Hatch · <span class="pill mint">PAID</span></div>
+        <div>Invoice <b>#2405</b> — Westside Bank · <span class="pill pink">OVERDUE</span></div>
+        <div>Invoice <b>#2406</b> — Coastal Library · <span class="pill mint">PAID</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/prism-console/templates/footer.html
+++ b/examples/prism-console/templates/footer.html
@@ -1,0 +1,5 @@
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/examples/prism-console/templates/header.html
+++ b/examples/prism-console/templates/header.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+</head>
+<body>
+<div class="app">
+
+<aside class="sidebar">
+  <div class="brand">
+    <div class="brand-block"></div>
+    <div>
+      <div class="brand-name">Prism<br>Console</div>
+      <div class="brand-sub">WORKSPACE · A</div>
+    </div>
+  </div>
+
+  <div class="nav-section">Workspace</div>
+  <a href="{{ base_url }}/" class="nav-link {% if page.url == '/' or not page.url %}active{% endif %}"><span class="nav-dot"></span>Overview</a>
+  <a href="{{ base_url }}/projects/" class="nav-link c {% if page.section == 'projects' %}active c{% endif %}"><span class="nav-dot c"></span>Projects</a>
+  <a href="{{ base_url }}/team/" class="nav-link {% if page.section == 'team' %}active{% endif %}"><span class="nav-dot p"></span>Team</a>
+  <a href="{{ base_url }}/billing/" class="nav-link g {% if page.section == 'billing' %}active g{% endif %}"><span class="nav-dot g"></span>Billing</a>
+  <a href="{{ base_url }}/log/" class="nav-link m {% if page.section == 'log' %}active m{% endif %}"><span class="nav-dot"></span>Activity Log</a>
+
+  <div class="nav-section" style="margin-top:22px;">Account</div>
+  <a href="{{ base_url }}/about/" class="nav-link"><span class="nav-dot p"></span>About</a>
+
+  <div class="sidebar-foot">v0.7.3 — beta · {{ current_year }}</div>
+</aside>
+
+<div class="main">
+<header class="topbar">
+  <div class="crumbs">
+    <span>Console</span><span class="sep">/</span>
+    {% if page.title and page.url != '/' %}<b>{{ page.title }}</b>
+    {% elif section.title %}<b>{{ section.title }}</b>
+    {% elif taxonomy_name %}<b>{{ taxonomy_name }}</b>
+    {% else %}<b>Overview</b>{% endif %}
+  </div>
+  <div class="topbar-actions">
+    <input class="search" placeholder="Search ⌘K">
+    <button class="btn mustard">Invite</button>
+    <button class="btn pink">+ New Project</button>
+  </div>
+</header>
+<div class="content">

--- a/examples/prism-console/templates/page.html
+++ b/examples/prism-console/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+
+<div class="head">
+  <div class="title-card">
+    <div class="corner-shape"></div>
+    <div class="eyebrow">{{ page.extra and page.extra.eyebrow or "DETAIL" }}</div>
+    <h1>{{ page.title }}</h1>
+    <p>{{ page.description }}</p>
+    <div class="shape-strip"><div class="sq"></div><div class="ci"></div><div class="tr"></div><div class="rc"></div></div>
+  </div>
+  <div class="stat-block">
+    <div class="circle"></div>
+    <div class="label">{{ page.extra and page.extra.metric_label or "STATUS" }}</div>
+    <div class="big">{{ page.extra and page.extra.metric or "OK" }}</div>
+    <div class="delta">{{ page.extra and page.extra.metric_note or "All systems nominal." }}</div>
+  </div>
+</div>
+
+<div class="panel">
+  <div class="panel-head"><h3>Details</h3><span class="chip pink">{{ page.extra and page.extra.tag or "Live" }}</span></div>
+  <div class="panel-body">
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/prism-console/templates/section.html
+++ b/examples/prism-console/templates/section.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+
+<div class="head">
+  <div class="title-card">
+    <div class="corner-shape"></div>
+    <div class="eyebrow">SECTION · {{ section.pages | length }} ITEMS</div>
+    <h1>{{ section.title }}</h1>
+    <p>{{ section.description }}</p>
+    <div class="shape-strip"><div class="sq"></div><div class="ci"></div><div class="tr"></div><div class="rc"></div></div>
+  </div>
+  <div class="stat-block">
+    <div class="circle"></div>
+    <div class="label">ENTRIES</div>
+    <div class="big">{{ section.pages | length }}</div>
+    <div class="delta">Sorted by recency. Filter via tags.</div>
+  </div>
+</div>
+
+<div class="card-grid">
+{% for p in section.pages %}
+  <a class="card {% if loop.index % 4 == 0 %}pink tilt{% elif loop.index % 3 == 0 %}cobalt tilt-r{% elif loop.index % 2 == 0 %}mint{% endif %}" href="{{ p.url }}">
+    <div class="corner"></div>
+    <div class="eyebrow">{{ p.extra and p.extra.eyebrow or "ITEM" }}</div>
+    <h3>{{ p.title }}</h3>
+    <div class="meta">{{ p.date | date("%b %d, %Y") }} · {{ p.extra and p.extra.owner or "Console" }}</div>
+    <div class="summary">{{ p.summary | default(p.description) | strip_html | truncate_words(26) }}</div>
+  </a>
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/prism-console/templates/shortcodes/alert.html
+++ b/examples/prism-console/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/prism-console/templates/taxonomy.html
+++ b/examples/prism-console/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<div class="head"><div class="title-card"><div class="corner-shape"></div><div class="eyebrow">INDEX</div><h1>{{ taxonomy_name | capitalize }}</h1><p>All terms in this taxonomy.</p></div><div class="stat-block"><div class="circle"></div><div class="label">TERMS</div><div class="big">{{ taxonomy_terms | length }}</div></div></div>
+<div class="panel"><div class="panel-body"><ul style="list-style:none;padding:0;margin:0;">
+{% for term in taxonomy_terms %}
+<li style="padding:12px 0;border-bottom:2px solid var(--ink);"><a href="{{ term.url }}" style="display:flex;justify-content:space-between;font-weight:600;"><span>{{ term.name }}</span><span class="pill cobalt">{{ term.pages | length }}</span></a></li>
+{% endfor %}
+</ul></div></div>
+{% include "footer.html" %}

--- a/examples/prism-console/templates/taxonomy_term.html
+++ b/examples/prism-console/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<div class="head"><div class="title-card"><div class="corner-shape"></div><div class="eyebrow">TAG</div><h1>{{ taxonomy_term }}</h1></div><div class="stat-block"><div class="circle"></div><div class="label">RESULTS</div><div class="big">{{ taxonomy_pages | length }}</div></div></div>
+<div class="card-grid">
+{% for p in taxonomy_pages %}
+<a class="card {% if loop.index % 3 == 0 %}cobalt{% elif loop.index % 2 == 0 %}pink{% endif %}" href="{{ p.url }}">
+  <div class="corner"></div>
+  <div class="eyebrow">{{ p.section | upper }}</div>
+  <h3>{{ p.title }}</h3>
+  <div class="meta">{{ p.date | date("%b %d, %Y") }}</div>
+  <div class="summary">{{ p.summary | default(p.description) | strip_html | truncate_words(24) }}</div>
+</a>
+{% endfor %}
+</div>
+{% include "footer.html" %}

--- a/examples/redaction-ops/AGENTS.md
+++ b/examples/redaction-ops/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/redaction-ops/archetypes/default.md
+++ b/examples/redaction-ops/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/redaction-ops/config.toml
+++ b/examples/redaction-ops/config.toml
@@ -1,0 +1,193 @@
+title = "REDACTION//OPS"
+description = "Declassified-archive admin theme — operations console for case files, field agents and directives. Crimson stamps, redacted bars, monospace dossier."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["agents", "files", "directives"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/redaction-ops/content/about.md
+++ b/examples/redaction-ops/content/about.md
@@ -1,0 +1,28 @@
++++
+title = "Bureau"
+description = "About the Bureau, its mandate and operational principles."
+[extra]
+eyebrow = "ABOUT THE BUREAU"
+file_no = "B-0001"
+status = "PUBLIC"
++++
+
+The Bureau exists to handle case files that fall outside the comfort of ordinary recordkeeping. We
+file, redact, and revisit. Where the public record is silent we keep the working notes — typed,
+stamped, and indexed by hand.
+
+## Mandate
+
+We maintain the standing directives, rotate the cover identities, and reconcile the vault on a
+quarterly schedule. Nothing leaves the room without two signatures and a stamp.
+
+## Principles
+
+- One file, one cabinet, one handler.
+- Redactions are permanent; rewrites are not.
+- The record outlives the operator.
+
+## Contact
+
+Correspondence to **Form 47-B**. Allow eight working days for reply. Out-of-hours dossiers are
+sealed until the next shift.

--- a/examples/redaction-ops/content/agents/_index.md
+++ b/examples/redaction-ops/content/agents/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Field Agents"
+description = "Active roster, cover identities, and handler assignments."
+sort_by = "date"
+reverse = true
+template = "section"
+[extra]
+index = "II"
+vol = "II"
++++

--- a/examples/redaction-ops/content/agents/a-04-navarro.md
+++ b/examples/redaction-ops/content/agents/a-04-navarro.md
@@ -1,0 +1,30 @@
++++
+title = "Agent A-04 · Navarro, K."
+date = "2026-04-22"
+description = "Field handler · western corridor cell. Clearance L4."
+[extra]
+eyebrow = "FIELD AGENT DOSSIER"
+file_no = "A-04"
+status = "ACTIVE"
+handler = "K. NAVARRO"
+stamp = "ACTIVE"
++++
+
+Recruited 2019 out of the corridor desk. Five tours of standing duty, none formally noted in
+the public personnel file. Operates the western cell out of Safehouse C.
+
+## Cover identity
+
+Maintains the **Ms. Helene Brandt** cover — small-business consultant, two residences, no
+dependents. Cover refreshed annually under Directive D-005.
+
+## Recent activity
+
+- 2026-04-21 — Hand-off of dossier R-0817 to handler O. KIM.
+- 2026-04-12 — Standing meet with asset 31 (final).
+- 2026-03-30 — Western corridor camera relocation, see R-0793.
+
+## Handler note
+
+> "Navarro takes notes that read like a novel. We let her. The files come back complete."
+> — Bureau Officer, 2026-Q1 review

--- a/examples/redaction-ops/content/agents/a-07-pryce.md
+++ b/examples/redaction-ops/content/agents/a-07-pryce.md
@@ -1,0 +1,25 @@
++++
+title = "Agent A-07 · Pryce, D."
+date = "2026-04-15"
+description = "Field handler · surveillance and signals. Clearance L3."
+[extra]
+eyebrow = "FIELD AGENT DOSSIER"
+file_no = "A-07"
+status = "ACTIVE"
+handler = "D. PRYCE"
+stamp = "ACTIVE"
++++
+
+Signals specialist. Maintains the corridor camera grid and the off-network listening posts.
+Joined from the Bureau's Signal Office in 2021.
+
+## Cover identity
+
+Operates without standing cover — Bureau-attached technical contractor. Movements
+are routinely cross-checked against Form 47-B/3.
+
+## Recent activity
+
+- 2026-04-14 — Western corridor surveillance log filed (R-0816).
+- 2026-04-03 — Listening post 7 brought online.
+- 2026-03-22 — Recovered backup tapes from cold storage A-3.

--- a/examples/redaction-ops/content/agents/a-09-kim.md
+++ b/examples/redaction-ops/content/agents/a-09-kim.md
@@ -1,0 +1,20 @@
++++
+title = "Agent A-09 · Kim, O."
+date = "2026-04-10"
+description = "Senior handler · case review and debrief. Clearance L4."
+[extra]
+eyebrow = "SENIOR HANDLER"
+file_no = "A-09"
+status = "ACTIVE"
+handler = "O. KIM"
+stamp = "REVIEW"
++++
+
+Senior handler, ten years on the desk. Receives in-coming hand-offs from field agents and
+runs the debrief schedule. Co-signs all sealed dossiers.
+
+## Standing assignments
+
+- Dossier R-0814 — Asset 31 final debrief.
+- Standing review of Directive D-002 (egress · safehouse C).
+- Quarterly vault reconciliation (D-004), co-signed with Bureau.

--- a/examples/redaction-ops/content/agents/a-12-redacted.md
+++ b/examples/redaction-ops/content/agents/a-12-redacted.md
@@ -1,0 +1,18 @@
++++
+title = "Agent A-12 · [REDACTED]"
+date = "2026-04-01"
+description = "Cover-identity operative. Clearance L5."
+[extra]
+eyebrow = "DEEP-COVER OPERATIVE"
+file_no = "A-12"
+status = "SEALED"
+handler = "REDACTED"
+stamp = "SEALED"
++++
+
+This dossier is held under seal by order of the Director. Operational notes are kept on paper
+only and are not entered into the digital archive.
+
+> Authorised access requires two countersignatures and is logged under Form 47-B/9.
+
+For all enquiries route through the Bureau Officer on shift.

--- a/examples/redaction-ops/content/archive/_index.md
+++ b/examples/redaction-ops/content/archive/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Cold Storage"
+description = "Closed dossiers held in the cold archive."
+sort_by = "date"
+reverse = true
+template = "section"
+[extra]
+index = "A"
+vol = "A"
++++

--- a/examples/redaction-ops/content/archive/r-0701-closed.md
+++ b/examples/redaction-ops/content/archive/r-0701-closed.md
@@ -1,0 +1,17 @@
++++
+title = "R-0701 · Corridor desk · 2025 close"
+date = "2026-01-15"
+description = "Closing dossier for the corridor desk's 2025 operational year."
+[extra]
+eyebrow = "ARCHIVED FILE"
+file_no = "R-0701"
+status = "CLOSED"
+handler = "BUREAU"
+stamp = "CLOSED"
++++
+
+Closing dossier for the corridor desk's 2025 year. Hand-off paperwork complete, vault
+reconciliation co-signed, final memos to Director filed under R-0688 through R-0700.
+
+The dossier is now held in cold storage and may be retrieved by request with two-signature
+authorisation.

--- a/examples/redaction-ops/content/directives/_index.md
+++ b/examples/redaction-ops/content/directives/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Directives"
+description = "Standing directives, protocols, and operational orders."
+sort_by = "date"
+reverse = true
+template = "section"
+[extra]
+index = "IV"
+vol = "IV"
++++

--- a/examples/redaction-ops/content/directives/d-001-rotation.md
+++ b/examples/redaction-ops/content/directives/d-001-rotation.md
@@ -1,0 +1,25 @@
++++
+title = "D-001 · Cell-rotation protocol"
+date = "2025-11-04"
+description = "Nine-month rotation of handlers between cells."
+[extra]
+eyebrow = "STANDING DIRECTIVE"
+file_no = "D-001"
+status = "EFFECTIVE"
+handler = "BUREAU"
+stamp = "EFFECTIVE"
++++
+
+Handlers rotate between cells on a nine-month schedule. Rotation dates are published the
+quarter before they take effect and may be brought forward only by the Bureau Officer.
+
+## Schedule
+
+- Quarter 1 — corridor cell.
+- Quarter 4 — port cell.
+- Quarter 7 — quiet desk.
+
+## Hand-off paperwork
+
+Every rotation is accompanied by Form 47-B/3, countersigned by both the outgoing and
+incoming handler. The hand-off dossier is filed within five working days.

--- a/examples/redaction-ops/content/directives/d-002-egress.md
+++ b/examples/redaction-ops/content/directives/d-002-egress.md
@@ -1,0 +1,25 @@
++++
+title = "D-002 · Emergency egress · Safehouse C"
+date = "2025-12-18"
+description = "Standing egress procedure for the corridor safehouse."
+[extra]
+eyebrow = "CRITICAL DIRECTIVE"
+file_no = "D-002"
+status = "CRITICAL"
+handler = "BUREAU"
+stamp = "CRITICAL"
++++
+
+Egress procedure for Safehouse C, applicable to all cells that operate through the corridor.
+The route is rehearsed quarterly and is not to be published outside the Bureau.
+
+## Trigger conditions
+
+- Listening post 7 reports two consecutive misses.
+- Camera grid C-04 / C-07 / C-11 down for over four minutes.
+- Handler call sign returns unanswered.
+
+## Procedure
+
+Walk-out only. No vehicles. Handler carries the file cabinet key and the corridor map.
+Asset proceeds to the corridor exit and waits ten minutes.

--- a/examples/redaction-ops/content/directives/d-003-sealed.md
+++ b/examples/redaction-ops/content/directives/d-003-sealed.md
@@ -1,0 +1,15 @@
++++
+title = "D-003 · [REDACTED DIRECTIVE]"
+date = "2026-01-10"
+description = "Sealed directive · access by Director's order only."
+[extra]
+eyebrow = "SEALED DIRECTIVE"
+file_no = "D-003"
+status = "SEALED"
+handler = "REDACTED"
+stamp = "SEALED"
++++
+
+This directive is held under seal. The text is not entered into the digital archive.
+
+> Access by Director's order only. Log via Form 47-B/9.

--- a/examples/redaction-ops/content/directives/d-004-vault.md
+++ b/examples/redaction-ops/content/directives/d-004-vault.md
@@ -1,0 +1,21 @@
++++
+title = "D-004 · Quarterly vault reconciliation"
+date = "2026-01-02"
+description = "Standing process for reconciling the physical and digital vaults."
+[extra]
+eyebrow = "ROUTINE DIRECTIVE"
+file_no = "D-004"
+status = "ROUTINE"
+handler = "BUREAU"
+stamp = "ROUTINE"
++++
+
+The physical and digital vaults are reconciled on a quarterly cadence. Co-signed by the
+Bureau Officer and the senior handler. Discrepancies are filed under Form 47-B/12.
+
+## Schedule
+
+- Q1 · 2026-01 — complete.
+- Q2 · 2026-04 — scheduled, R-0813.
+- Q3 · 2026-07 — pending.
+- Q4 · 2026-10 — pending.

--- a/examples/redaction-ops/content/files/_index.md
+++ b/examples/redaction-ops/content/files/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Case Files"
+description = "Active and recently-closed dossiers across all desks."
+sort_by = "date"
+reverse = true
+template = "section"
+[extra]
+index = "III"
+vol = "III"
++++

--- a/examples/redaction-ops/content/files/r-0814-asset-31.md
+++ b/examples/redaction-ops/content/files/r-0814-asset-31.md
@@ -1,0 +1,26 @@
++++
+title = "R-0814 · Asset 31 — Final Debrief"
+date = "2026-04-04"
+description = "Closing dossier for asset 31, transcripts and recommendations."
+[extra]
+eyebrow = "CLOSING FILE"
+file_no = "R-0814"
+status = "REVIEW"
+handler = "O. KIM"
+stamp = "REVIEW"
++++
+
+Asset 31 was activated in 2018 and ran continuously through Q1 2026. The closing dossier
+contains the standing-meet transcripts, the financial reconciliation, and the recommended
+pension provision.
+
+## Transcripts
+
+Eleven transcripts, dates from 2018-11 through 2026-03. Transcribed on the desk and held
+in the corridor cabinet. Cross-referenced with Form 47-B/3.
+
+## Recommendations
+
+- Settle final tranche on Quarter 3 schedule.
+- Maintain cover identity for twelve months past closure.
+- Hand standing meet schedule to A-04 for monitoring.

--- a/examples/redaction-ops/content/files/r-0815-sealed.md
+++ b/examples/redaction-ops/content/files/r-0815-sealed.md
@@ -1,0 +1,18 @@
++++
+title = "R-0815 · [SUBJECT REDACTED]"
+date = "2026-04-09"
+description = "Sealed dossier · two-signature access required."
+[extra]
+eyebrow = "SEALED FILE"
+file_no = "R-0815"
+status = "SEALED"
+handler = "REDACTED"
+stamp = "SEALED"
++++
+
+This file is held under seal. The subject line, handler name, and operational notes have
+been redacted pursuant to Directive D-003.
+
+> Access logs are kept on paper only. Two countersignatures required for review.
+
+Routine queries should be directed to the Bureau Officer on shift, not to the handler of record.

--- a/examples/redaction-ops/content/files/r-0816-corridor.md
+++ b/examples/redaction-ops/content/files/r-0816-corridor.md
@@ -1,0 +1,26 @@
++++
+title = "R-0816 · Western Corridor Surveillance"
+date = "2026-04-14"
+description = "Standing camera and listening-post log for the western corridor."
+[extra]
+eyebrow = "CASE FILE"
+file_no = "R-0816"
+status = "OPEN"
+handler = "D. PRYCE"
+stamp = "OPEN"
++++
+
+Standing surveillance file for the western corridor grid. Maintained on a fortnightly cadence;
+the present entry covers 2026-04-01 through 2026-04-14.
+
+## Camera state
+
+- C-04 · operational
+- C-07 · relocated 2026-03-30, calibrating
+- C-11 · offline 11m (06:55, 2026-04-14)
+- C-14 · operational
+
+## Listening posts
+
+Posts 4, 5, 6 nominal. Post 7 brought online 2026-04-03 and is on observation only until
+the calibration log clears.

--- a/examples/redaction-ops/content/files/r-0817-marigold.md
+++ b/examples/redaction-ops/content/files/r-0817-marigold.md
@@ -1,0 +1,29 @@
++++
+title = "R-0817 · Operation Marigold (Handover)"
+date = "2026-04-21"
+description = "Hand-off of corridor cell operations, Navarro to Kim."
+[extra]
+eyebrow = "CASE FILE"
+file_no = "R-0817"
+status = "URGENT"
+handler = "K. NAVARRO → O. KIM"
+stamp = "URGENT"
++++
+
+Hand-off file. The corridor cell rotates handlers per Directive D-001 every nine months.
+Marigold runs from the corridor desk and currently holds twelve open lines.
+
+## Open lines
+
+| Line | Subject | Status |
+|---|---|---|
+| 04 | Asset 31 — closing notes | review |
+| 07 | Listening post 7 calibration | open |
+| 11 | <span style="background:#0a0a0a;color:#0a0a0a;padding:0 4px;">redacted subject line</span> | sealed |
+| 12 | Vault transfer · Q2 | scheduled |
+
+## Outstanding paperwork
+
+- Form 47-B/3 (cover refresh) — due 2026-05-02.
+- Form 47-B/9 (sealed access log) — current.
+- Memo to Director · appendix 4 (R-0812) — pending signature.

--- a/examples/redaction-ops/content/index.md
+++ b/examples/redaction-ops/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Dashboard"
+template = "dashboard"
+description = "Bureau operations console — case files, field agents, directives."
++++

--- a/examples/redaction-ops/static/css/style.css
+++ b/examples/redaction-ops/static/css/style.css
@@ -1,0 +1,442 @@
+:root {
+  --bone: #f1ece0;
+  --bone-2: #e8e1cf;
+  --ink: #0a0a0a;
+  --ink-2: #1a1a1a;
+  --paper: #f6f2e7;
+  --rule: #2b2620;
+  --crimson: #c8102e;
+  --crimson-dark: #8a0a1f;
+  --olive: #4d4a32;
+  --stamp: #1a1a1a;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* paper grain overlay via repeating lines (no gradients) */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(0deg, transparent 0 23px, rgba(10,10,10,0.04) 23px 24px);
+  z-index: 1;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+  position: relative;
+  z-index: 2;
+}
+
+/* SIDEBAR */
+.sidebar {
+  background: var(--ink);
+  color: var(--bone);
+  padding: 28px 22px 32px;
+  border-right: 6px double var(--ink);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.sidebar-mark {
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  color: var(--crimson);
+  margin-bottom: 6px;
+}
+
+.sidebar-title {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  margin: 0 0 4px;
+}
+
+.sidebar-title .slash { color: var(--crimson); }
+
+.sidebar-sub {
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  opacity: 0.6;
+  margin-bottom: 28px;
+  border-bottom: 1px dashed rgba(241,236,224,0.25);
+  padding-bottom: 16px;
+}
+
+.sidebar-section {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  color: var(--bone-2);
+  opacity: 0.55;
+  margin: 22px 0 8px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.sidebar-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 9px 10px 9px 12px;
+  margin: 2px -10px;
+  border-left: 3px solid transparent;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.sidebar-link:hover { background: rgba(241,236,224,0.06); }
+
+.sidebar-link.active {
+  background: rgba(200,16,46,0.12);
+  border-left-color: var(--crimson);
+  color: var(--bone);
+}
+
+.sidebar-link .id {
+  font-size: 10px;
+  opacity: 0.5;
+  font-variant-numeric: tabular-nums;
+}
+
+.sidebar-foot {
+  position: absolute;
+  bottom: 22px;
+  left: 22px;
+  right: 22px;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: var(--bone-2);
+  opacity: 0.55;
+  border-top: 1px dashed rgba(241,236,224,0.25);
+  padding-top: 14px;
+}
+
+/* MAIN */
+.main { padding: 0; }
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  border-bottom: 2px solid var(--ink);
+  background: var(--paper);
+  padding: 0;
+}
+
+.crumbs {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  padding: 18px 32px;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+
+.crumbs .slash { color: var(--crimson); }
+
+.topbar-actions {
+  display: flex;
+  align-items: stretch;
+}
+
+.topbar-btn {
+  padding: 0 22px;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  border-left: 2px solid var(--ink);
+  display: flex;
+  align-items: center;
+  background: var(--paper);
+  cursor: pointer;
+}
+
+.topbar-btn.crimson {
+  background: var(--ink);
+  color: var(--bone);
+}
+
+.topbar-btn:hover { background: var(--ink); color: var(--bone); }
+.topbar-btn.crimson:hover { background: var(--crimson); }
+
+.content { padding: 36px 40px 80px; max-width: 1280px; }
+
+/* CLASSIFIED BANNER */
+.classified {
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  padding: 14px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  margin-bottom: 28px;
+}
+
+.classified strong { color: var(--crimson); letter-spacing: 0.4em; }
+.classified .meta { font-variant-numeric: tabular-nums; opacity: 0.7; letter-spacing: 0.2em; }
+
+/* PAGE HEAD */
+.page-head { margin: 8px 0 28px; display: flex; justify-content: space-between; align-items: flex-end; gap: 28px; }
+.page-eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  color: var(--crimson);
+  margin-bottom: 8px;
+}
+.page-title {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 44px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  margin: 0;
+}
+.page-desc { font-size: 13px; max-width: 56ch; margin-top: 14px; opacity: 0.78; }
+
+.dossier-no {
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-align: right;
+  border: 1px solid var(--ink);
+  padding: 10px 14px;
+  white-space: nowrap;
+  background: var(--paper);
+}
+.dossier-no b { color: var(--crimson); }
+
+/* STAT GRID */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  margin-bottom: 28px;
+}
+.stat {
+  padding: 22px 22px 24px;
+  border-right: 1px solid var(--ink);
+  position: relative;
+}
+.stat:last-child { border-right: none; }
+.stat .label { font-size: 10px; letter-spacing: 0.28em; opacity: 0.7; }
+.stat .value { font-size: 38px; font-weight: 700; line-height: 1.05; margin-top: 12px; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
+.stat .delta { font-size: 11px; letter-spacing: 0.18em; margin-top: 8px; }
+.stat .delta.up { color: var(--crimson); }
+.stat .delta.flat { opacity: 0.55; }
+.stat .corner {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  background: var(--ink);
+  color: var(--bone);
+  padding: 2px 6px;
+}
+.stat .corner.red { background: var(--crimson); }
+
+/* REDACTED BAR */
+.redacted {
+  display: inline-block;
+  background: var(--ink);
+  color: transparent;
+  padding: 0 6px;
+  user-select: none;
+  letter-spacing: 0.1em;
+}
+.redacted.red { background: var(--crimson); }
+
+/* TWO COLUMN */
+.row { display: grid; grid-template-columns: 1.4fr 1fr; gap: 24px; margin-bottom: 28px; }
+.row.three { grid-template-columns: 1fr 1fr 1fr; }
+
+.panel {
+  border: 2px solid var(--ink);
+  background: var(--paper);
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--ink);
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  background: var(--ink);
+  color: var(--bone);
+}
+.panel-head .badge {
+  background: var(--crimson);
+  color: var(--bone);
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  padding: 2px 7px;
+}
+
+.panel-body { padding: 18px 20px 22px; }
+
+/* TABLE-LIKE LIST */
+.dossier-list { width: 100%; border-collapse: collapse; font-size: 12px; }
+.dossier-list th, .dossier-list td {
+  text-align: left;
+  padding: 11px 12px;
+  border-bottom: 1px dashed rgba(10,10,10,0.2);
+  font-variant-numeric: tabular-nums;
+}
+.dossier-list th { font-size: 10px; letter-spacing: 0.22em; opacity: 0.6; padding-top: 0; padding-bottom: 8px; }
+.dossier-list tr:last-child td { border-bottom: none; }
+.dossier-list .id { color: var(--crimson); font-weight: 700; letter-spacing: 0.05em; }
+.tag {
+  display: inline-block;
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  padding: 2px 7px;
+  border: 1px solid var(--ink);
+}
+.tag.crimson { background: var(--crimson); color: var(--bone); border-color: var(--crimson); }
+.tag.ink { background: var(--ink); color: var(--bone); border-color: var(--ink); }
+
+/* STAMPS */
+.stamp {
+  position: absolute;
+  top: 16px;
+  right: 24px;
+  border: 3px solid var(--crimson);
+  color: var(--crimson);
+  padding: 8px 14px;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  transform: rotate(-6deg);
+  opacity: 0.85;
+  pointer-events: none;
+  background: rgba(241,236,224,0.5);
+}
+
+/* LOG STREAM */
+.log {
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.02em;
+}
+.log .ts { color: var(--crimson); margin-right: 10px; font-weight: 700; }
+.log .lvl { display: inline-block; min-width: 60px; opacity: 0.7; }
+
+/* CHART (bars) */
+.bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 140px;
+  border-bottom: 1px solid var(--ink);
+  padding-bottom: 8px;
+}
+.bar {
+  flex: 1;
+  background: var(--ink);
+  position: relative;
+}
+.bar.red { background: var(--crimson); }
+.bar:after {
+  content: attr(data-l);
+  position: absolute;
+  bottom: -22px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  opacity: 0.6;
+}
+
+/* DETAILS PAGE */
+.fileheader {
+  border-top: 4px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding: 18px 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+  margin-bottom: 28px;
+}
+.fileheader .label { font-size: 10px; letter-spacing: 0.24em; opacity: 0.6; }
+.fileheader .val { font-size: 14px; font-weight: 700; margin-top: 4px; }
+
+/* PROSE */
+.prose { font-size: 13px; line-height: 1.7; max-width: 72ch; }
+.prose h2 { font-size: 18px; letter-spacing: 0.18em; text-transform: uppercase; border-bottom: 1px solid var(--ink); padding-bottom: 6px; margin-top: 32px; }
+.prose h3 { font-size: 13px; letter-spacing: 0.22em; text-transform: uppercase; margin-top: 24px; }
+.prose code { background: var(--ink); color: var(--bone); padding: 1px 6px; font-size: 11px; }
+.prose pre { background: var(--ink); color: var(--bone); padding: 14px 16px; overflow-x: auto; }
+.prose blockquote { border-left: 4px solid var(--crimson); padding-left: 14px; margin-left: 0; opacity: 0.8; font-style: italic; }
+.prose ul li::marker { color: var(--crimson); }
+
+/* SECTION LIST */
+.case-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.case-card {
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  padding: 20px 22px 22px;
+  position: relative;
+  min-height: 200px;
+}
+.case-card .num { font-size: 10px; letter-spacing: 0.24em; color: var(--crimson); margin-bottom: 8px; }
+.case-card h3 { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; margin: 0 0 8px; line-height: 1.2; }
+.case-card .meta { font-size: 11px; letter-spacing: 0.16em; opacity: 0.7; margin-bottom: 12px; }
+.case-card .summary { font-size: 12px; line-height: 1.6; }
+.case-card .stamp-mini {
+  position: absolute;
+  top: 18px;
+  right: 22px;
+  border: 2px solid var(--crimson);
+  color: var(--crimson);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  padding: 3px 8px;
+  transform: rotate(-4deg);
+}
+
+/* 404 */
+.f404 { padding: 80px 40px; text-align: center; }
+.f404 h1 { font-size: 120px; margin: 0; font-weight: 700; letter-spacing: -0.04em; }
+.f404 .stamp404 {
+  display: inline-block;
+  border: 4px solid var(--crimson);
+  color: var(--crimson);
+  padding: 10px 20px;
+  font-size: 18px;
+  letter-spacing: 0.3em;
+  transform: rotate(-3deg);
+  margin: 16px 0 24px;
+}
+
+@media (max-width: 900px) {
+  .app { grid-template-columns: 1fr; }
+  .sidebar { position: relative; height: auto; }
+  .stats { grid-template-columns: 1fr 1fr; }
+  .stat:nth-child(2) { border-right: none; }
+  .stat:nth-child(1), .stat:nth-child(2) { border-bottom: 1px solid var(--ink); }
+  .row, .row.three { grid-template-columns: 1fr; }
+  .case-grid { grid-template-columns: 1fr; }
+}

--- a/examples/redaction-ops/static/favicon.svg
+++ b/examples/redaction-ops/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/redaction-ops/templates/404.html
+++ b/examples/redaction-ops/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<div class="f404">
+  <div class="stamp404">FILE NOT FOUND</div>
+  <h1>404</h1>
+  <p style="letter-spacing:0.24em;font-size:11px;opacity:0.7;">THIS DOSSIER HAS BEEN <span class="redacted">REDACTED OR DESTROYED</span></p>
+  <p style="margin-top:24px;"><a href="{{ base_url }}/" style="border:2px solid var(--ink);padding:10px 18px;letter-spacing:0.2em;font-size:11px;">RETURN TO INDEX</a></p>
+</div>
+{% include "footer.html" %}

--- a/examples/redaction-ops/templates/dashboard.html
+++ b/examples/redaction-ops/templates/dashboard.html
@@ -1,0 +1,145 @@
+{% include "header.html" %}
+
+<div class="classified">
+  <span><strong>CLASSIFIED</strong> &nbsp; · &nbsp; LEVEL 4 CLEARANCE REQUIRED</span>
+  <span class="meta">SHIFT 04:00–12:00 · OPERATOR <span class="redacted">REDACTED</span></span>
+</div>
+
+<div class="page-head">
+  <div>
+    <div class="page-eyebrow">OPERATIONS CONSOLE</div>
+    <h1 class="page-title">Bureau Dashboard</h1>
+    <p class="page-desc">Active case files, field agent status, and directive throughput for the present operational window. All readings are point-in-time and subject to revision by the Operations Officer.</p>
+  </div>
+  <div class="dossier-no">SHIFT <b>04 / 06</b><br>OPS GREEN</div>
+</div>
+
+<div class="stats">
+  <div class="stat">
+    <div class="corner">01</div>
+    <div class="label">ACTIVE FILES</div>
+    <div class="value">428</div>
+    <div class="delta up">+12 / 24H</div>
+  </div>
+  <div class="stat">
+    <div class="corner red">02</div>
+    <div class="label">FIELD AGENTS</div>
+    <div class="value">37</div>
+    <div class="delta flat">0 STD-DEV</div>
+  </div>
+  <div class="stat">
+    <div class="corner">03</div>
+    <div class="label">DIRECTIVES ISSUED</div>
+    <div class="value">1,204</div>
+    <div class="delta up">+8.3 %</div>
+  </div>
+  <div class="stat">
+    <div class="corner red">04</div>
+    <div class="label">REDACTIONS</div>
+    <div class="value"><span class="redacted">XXXXX</span></div>
+    <div class="delta flat">CLASSIFIED</div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="panel">
+    <div class="panel-head"><span>RECENT FILES · STREAM</span><span class="badge">LIVE</span></div>
+    <div class="panel-body">
+      <table class="dossier-list">
+        <thead><tr><th>FILE</th><th>SUBJECT</th><th>HANDLER</th><th>STATUS</th></tr></thead>
+        <tbody>
+          <tr><td class="id">R-0817</td><td>Operation Marigold — handover</td><td>K. NAVARRO</td><td><span class="tag crimson">URGENT</span></td></tr>
+          <tr><td class="id">R-0816</td><td>Western corridor surveillance log</td><td>D. PRYCE</td><td><span class="tag">OPEN</span></td></tr>
+          <tr><td class="id">R-0815</td><td><span class="redacted">REDACTED SUBJECT LINE</span></td><td>—</td><td><span class="tag ink">SEALED</span></td></tr>
+          <tr><td class="id">R-0814</td><td>Asset 31 — final debrief</td><td>O. KIM</td><td><span class="tag">REVIEW</span></td></tr>
+          <tr><td class="id">R-0813</td><td>Vault inventory · 2-Q reconciliation</td><td>BUREAU</td><td><span class="tag">CLOSED</span></td></tr>
+          <tr><td class="id">R-0812</td><td>Memo to Director — appendix 4</td><td>S. ELLER</td><td><span class="tag crimson">URGENT</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-head"><span>CASE FLOW · 7D</span><span class="badge">CHART</span></div>
+    <div class="panel-body">
+      <div class="bars">
+        <div class="bar" style="height:38%" data-l="MON"></div>
+        <div class="bar" style="height:52%" data-l="TUE"></div>
+        <div class="bar red" style="height:78%" data-l="WED"></div>
+        <div class="bar" style="height:64%" data-l="THU"></div>
+        <div class="bar" style="height:46%" data-l="FRI"></div>
+        <div class="bar" style="height:30%" data-l="SAT"></div>
+        <div class="bar red" style="height:84%" data-l="SUN"></div>
+      </div>
+      <div style="margin-top:34px;font-size:11px;letter-spacing:0.18em;display:flex;justify-content:space-between;">
+        <span>PEAK · SUN 84%</span>
+        <span style="color:var(--crimson);">URGENT IN RED</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row three">
+  <div class="panel">
+    <div class="panel-head"><span>AGENT ROSTER</span><span class="badge">37 ACTIVE</span></div>
+    <div class="panel-body">
+      <table class="dossier-list">
+        <tbody>
+          <tr><td class="id">A-04</td><td>K. NAVARRO</td><td><span class="tag">FIELD</span></td></tr>
+          <tr><td class="id">A-07</td><td>D. PRYCE</td><td><span class="tag">FIELD</span></td></tr>
+          <tr><td class="id">A-09</td><td>O. KIM</td><td><span class="tag">HQ</span></td></tr>
+          <tr><td class="id">A-12</td><td><span class="redacted">REDACTED</span></td><td><span class="tag crimson">COVER</span></td></tr>
+          <tr><td class="id">A-14</td><td>S. ELLER</td><td><span class="tag">FIELD</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-head"><span>DIRECTIVE LOG</span><span class="badge">FEED</span></div>
+    <div class="panel-body">
+      <div class="log">
+        <div><span class="ts">04:18</span><span class="lvl">[INFO]</span> Directive 47-B initialised, dossier locked.</div>
+        <div><span class="ts">04:32</span><span class="lvl">[WARN]</span> Asset 31 inbound, prepare safehouse C.</div>
+        <div><span class="ts">05:01</span><span class="lvl">[CRIT]</span> <span class="redacted red">SUBJECT REDACTED ON ORDER</span></div>
+        <div><span class="ts">05:44</span><span class="lvl">[INFO]</span> Vault inventory verified · sealed.</div>
+        <div><span class="ts">06:12</span><span class="lvl">[INFO]</span> Memo dispatched to Director.</div>
+        <div><span class="ts">06:55</span><span class="lvl">[WARN]</span> Western corridor camera offline 11m.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-head"><span>VAULT STATUS</span><span class="badge">SEAL · GREEN</span></div>
+    <div class="panel-body">
+      <div style="font-size:11px;letter-spacing:0.2em;opacity:0.7;">PHYSICAL EVIDENCE</div>
+      <div style="font-size:40px;font-weight:700;line-height:1;margin:8px 0 18px;font-variant-numeric:tabular-nums;">8,114</div>
+
+      <div style="font-size:11px;letter-spacing:0.2em;opacity:0.7;">DIGITAL ARCHIVE · GB</div>
+      <div style="font-size:40px;font-weight:700;line-height:1;margin:8px 0 18px;font-variant-numeric:tabular-nums;">412.7</div>
+
+      <div style="border-top:1px dashed rgba(10,10,10,0.2);padding-top:14px;margin-top:10px;font-size:11px;letter-spacing:0.18em;">
+        SEAL VERIFIED · {{ current_date | default("2026-05-22") }} 04:00
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="panel" style="margin-bottom:28px;">
+  <div class="panel-head"><span>STANDING DIRECTIVES</span><span class="badge">06</span></div>
+  <div class="panel-body">
+    <table class="dossier-list">
+      <thead><tr><th>DIR</th><th>TITLE</th><th>ISSUED</th><th>CLEARANCE</th><th>STATE</th></tr></thead>
+      <tbody>
+        <tr><td class="id">D-001</td><td>Cell-rotation protocol</td><td>2025-11-04</td><td>L3</td><td><span class="tag">EFFECTIVE</span></td></tr>
+        <tr><td class="id">D-002</td><td>Emergency egress · safehouse C</td><td>2025-12-18</td><td>L4</td><td><span class="tag crimson">CRITICAL</span></td></tr>
+        <tr><td class="id">D-003</td><td><span class="redacted">REDACTED DIRECTIVE</span></td><td>—</td><td>L5</td><td><span class="tag ink">SEALED</span></td></tr>
+        <tr><td class="id">D-004</td><td>Quarterly vault reconciliation</td><td>2026-01-02</td><td>L2</td><td><span class="tag">ROUTINE</span></td></tr>
+        <tr><td class="id">D-005</td><td>Cover-identity refresh window</td><td>2026-03-15</td><td>L3</td><td><span class="tag">EFFECTIVE</span></td></tr>
+        <tr><td class="id">D-006</td><td>Press-leak containment plan</td><td>2026-04-01</td><td>L4</td><td><span class="tag crimson">ACTIVE</span></td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/examples/redaction-ops/templates/footer.html
+++ b/examples/redaction-ops/templates/footer.html
@@ -1,0 +1,5 @@
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/examples/redaction-ops/templates/header.html
+++ b/examples/redaction-ops/templates/header.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ page.description | default(site.description) }}">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ base_url }}/css/style.css">
+{{ og_all_tags | safe }}
+{{ canonical_tag | safe }}
+</head>
+<body>
+<div class="app">
+
+<aside class="sidebar">
+  <div class="sidebar-mark">// CLEARANCE :: L4</div>
+  <h1 class="sidebar-title">REDACTION<span class="slash">//</span>OPS</h1>
+  <div class="sidebar-sub">FIELD ADMIN CONSOLE</div>
+
+  <div class="sidebar-section"><span>INDEX</span><span>0X</span></div>
+  <a href="{{ base_url }}/" class="sidebar-link {% if page.url == '/' or not page.url %}active{% endif %}"><span>Dashboard</span><span class="id">01</span></a>
+  <a href="{{ base_url }}/agents/" class="sidebar-link {% if page.section == 'agents' %}active{% endif %}"><span>Field Agents</span><span class="id">02</span></a>
+  <a href="{{ base_url }}/files/" class="sidebar-link {% if page.section == 'files' %}active{% endif %}"><span>Case Files</span><span class="id">03</span></a>
+  <a href="{{ base_url }}/directives/" class="sidebar-link {% if page.section == 'directives' %}active{% endif %}"><span>Directives</span><span class="id">04</span></a>
+
+  <div class="sidebar-section"><span>ARCHIVE</span><span>XX</span></div>
+  <a href="{{ base_url }}/archive/" class="sidebar-link {% if page.section == 'archive' %}active{% endif %}"><span>Cold Storage</span><span class="id">A1</span></a>
+  <a href="{{ base_url }}/about/" class="sidebar-link {% if page.url == '/about/' %}active{% endif %}"><span>Bureau</span><span class="id">B0</span></a>
+
+  <div class="sidebar-foot">FORM 47-B · REV {{ current_year }}</div>
+</aside>
+
+<div class="main">
+<header class="topbar">
+  <div class="crumbs">
+    <span>BUREAU</span><span class="slash">//</span>
+    {% if page.title and page.url != '/' %}<span>{{ page.title | upper }}</span>
+    {% elif section.title %}<span>{{ section.title | upper }}</span>
+    {% elif taxonomy_name %}<span>{{ taxonomy_name | upper }}</span>
+    {% else %}<span>DASHBOARD</span>{% endif %}
+  </div>
+  <div class="topbar-actions">
+    <button class="topbar-btn">SEARCH FILE</button>
+    <button class="topbar-btn">EXPORT</button>
+    <button class="topbar-btn crimson">NEW DOSSIER</button>
+  </div>
+</header>
+<div class="content">

--- a/examples/redaction-ops/templates/page.html
+++ b/examples/redaction-ops/templates/page.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+
+<div class="classified">
+  <span><strong>CLASSIFIED</strong> &nbsp; · &nbsp; INTERNAL USE ONLY</span>
+  <span class="meta">DOSSIER NO. {{ page.extra and page.extra.dossier or "47-B-2271" }} · REV {{ current_year }}</span>
+</div>
+
+<div class="page-head">
+  <div>
+    <div class="page-eyebrow">{{ page.extra and page.extra.eyebrow or "BUREAU NOTE" }}</div>
+    <h1 class="page-title">{{ page.title }}</h1>
+    {% if page.description %}<p class="page-desc">{{ page.description }}</p>{% endif %}
+  </div>
+  <div class="dossier-no">FILE <b>{{ page.extra and page.extra.file_no or "R-0817" }}</b><br>STATUS {{ page.extra and page.extra.status or "ACTIVE" }}</div>
+</div>
+
+<div class="prose">
+{{ content | safe }}
+</div>
+
+{% include "footer.html" %}

--- a/examples/redaction-ops/templates/section.html
+++ b/examples/redaction-ops/templates/section.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+
+<div class="classified">
+  <span><strong>SECTION</strong> &nbsp; · &nbsp; {{ section.title | upper }}</span>
+  <span class="meta">{{ section.pages | length }} ITEMS · INDEX {{ section.extra and section.extra.index or "II" }}</span>
+</div>
+
+<div class="page-head">
+  <div>
+    <div class="page-eyebrow">SECTION INDEX</div>
+    <h1 class="page-title">{{ section.title }}</h1>
+    <p class="page-desc">{{ section.description }}</p>
+  </div>
+  <div class="dossier-no">VOL <b>{{ section.extra and section.extra.vol or "II" }}</b><br>ENTRIES {{ section.pages | length }}</div>
+</div>
+
+<div class="case-grid">
+{% for p in section.pages %}
+  <a href="{{ p.url }}" class="case-card">
+    <div class="num">FILE NO. {{ p.extra and p.extra.file_no or "R-0000" }}</div>
+    <h3>{{ p.title }}</h3>
+    <div class="meta">{{ p.date | date("%Y · %m · %d") }} · {{ p.extra and p.extra.handler or "BUREAU" }}</div>
+    <div class="summary">{{ p.summary | default(p.description) | strip_html | truncate_words(28) }}</div>
+    {% if p.extra and p.extra.stamp %}<div class="stamp-mini">{{ p.extra.stamp }}</div>{% endif %}
+  </a>
+{% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/examples/redaction-ops/templates/shortcodes/alert.html
+++ b/examples/redaction-ops/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/redaction-ops/templates/taxonomy.html
+++ b/examples/redaction-ops/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<div class="page-head"><div><div class="page-eyebrow">INDEX</div><h1 class="page-title">{{ taxonomy_name | capitalize }}</h1></div></div>
+<div class="panel"><div class="panel-body">
+<ul style="list-style:none;padding:0;margin:0;">
+{% for term in taxonomy_terms %}
+<li style="padding:10px 0;border-bottom:1px dashed rgba(10,10,10,0.2);"><a href="{{ term.url }}" style="display:flex;justify-content:space-between;"><span>{{ term.name }}</span><span style="color:var(--crimson);">{{ term.pages | length }}</span></a></li>
+{% endfor %}
+</ul>
+</div></div>
+{% include "footer.html" %}

--- a/examples/redaction-ops/templates/taxonomy_term.html
+++ b/examples/redaction-ops/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+<div class="page-head"><div><div class="page-eyebrow">TAG</div><h1 class="page-title">{{ taxonomy_term }}</h1></div></div>
+<div class="case-grid">
+{% for p in taxonomy_pages %}
+<a href="{{ p.url }}" class="case-card">
+  <div class="num">FILE · {{ p.section | upper }}</div>
+  <h3>{{ p.title }}</h3>
+  <div class="meta">{{ p.date | date("%Y · %m · %d") }}</div>
+  <div class="summary">{{ p.summary | default(p.description) | strip_html | truncate_words(24) }}</div>
+</a>
+{% endfor %}
+</div>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -43,13 +43,6 @@
     "blog",
     "cyberpunk"
   ],
-  "acid-poster": [
-    "landing",
-    "light",
-    "rave",
-    "neo-brutalist",
-    "punk"
-  ],
   "acid-zine": [
     "dark",
     "blog",
@@ -240,13 +233,6 @@
     "minimal",
     "playfair"
   ],
-  "antiform": [
-    "landing",
-    "light",
-    "editorial",
-    "brutalist",
-    "swiss"
-  ],
   "antimatter": [
     "dark",
     "blog",
@@ -344,6 +330,13 @@
     "dark",
     "landing",
     "hub"
+  ],
+  "architect-blueprint": [
+    "dark",
+    "admin",
+    "blueprint",
+    "technical",
+    "monospace"
   ],
   "architecture-digest": [
     "refined",
@@ -475,13 +468,6 @@
     "light",
     "portfolio",
     "agency"
-  ],
-  "atelier-letterpress": [
-    "light",
-    "paper",
-    "letterpress",
-    "classical",
-    "foundry"
   ],
   "athena": [
     "elegant",
@@ -983,12 +969,6 @@
     "docs",
     "disaster-recovery"
   ],
-  "bunker-deck": [
-    "landing",
-    "dark",
-    "industrial",
-    "stencil"
-  ],
   "bureau": [
     "light",
     "docs",
@@ -1113,13 +1093,6 @@
     "dark",
     "gallery",
     "minimal"
-  ],
-  "carbon-form": [
-    "light",
-    "paper",
-    "archive",
-    "typewriter",
-    "bureaucratic"
   ],
   "carnival": [
     "dark",
@@ -2470,11 +2443,12 @@
     "celestial",
     "dramatic"
   ],
-  "eclipse-tape": [
-    "dark",
-    "dashboard",
-    "trading",
-    "monospace"
+  "editorial-bureau": [
+    "light",
+    "admin",
+    "editorial",
+    "serif",
+    "newsroom"
   ],
   "editorial-letter": [
     "paper",
@@ -2930,19 +2904,6 @@
     "neon",
     "pop-art"
   ],
-  "flux-foundry": [
-    "light",
-    "dashboard",
-    "brutalist",
-    "industrial"
-  ],
-  "folded": [
-    "light",
-    "paper",
-    "minimal",
-    "architecture",
-    "origami"
-  ],
   "folio": [
     "light",
     "portfolio"
@@ -3377,12 +3338,6 @@
     "glassmorphism",
     "minimal"
   ],
-  "glyph-orbital": [
-    "dark",
-    "dashboard",
-    "scientific",
-    "monospace"
-  ],
   "glyphic": [
     "dark",
     "blog",
@@ -3599,13 +3554,6 @@
     "dark",
     "permanent",
     "unna"
-  ],
-  "harvest-moon": [
-    "landing",
-    "light",
-    "fashion",
-    "editorial",
-    "fraunces"
   ],
   "haute-couture": [
     "elegant",
@@ -3893,13 +3841,6 @@
     "blog",
     "creative",
     "elegant",
-    "serif"
-  ],
-  "ink-manifesto": [
-    "light",
-    "paper",
-    "editorial",
-    "brutalist",
     "serif"
   ],
   "ink-press": [
@@ -4684,6 +4625,13 @@
     "main-event",
     "confrontation"
   ],
+  "mainframe-luxe": [
+    "dark",
+    "admin",
+    "terminal",
+    "monospace",
+    "finance"
+  ],
   "mainstage": [
     "event",
     "dark",
@@ -5165,12 +5113,6 @@
     "blog",
     "magazine"
   ],
-  "mosaic-bionics": [
-    "dark",
-    "dashboard",
-    "scientific",
-    "lab"
-  ],
   "mosaic-wall": [
     "structured",
     "tile-inspired",
@@ -5267,13 +5209,6 @@
     "dark",
     "blog",
     "nautical"
-  ],
-  "navy-syndicate": [
-    "landing",
-    "dark",
-    "editorial",
-    "luxury",
-    "playfair"
   ],
   "nebula": [
     "dark",
@@ -5658,13 +5593,6 @@
     "light",
     "spacious",
     "garamond"
-  ],
-  "null-protocol": [
-    "landing",
-    "dark",
-    "terminal",
-    "cyberpunk",
-    "mono"
   ],
   "null-result": [
     "paper",
@@ -6414,12 +6342,12 @@
     "vibrant",
     "creative"
   ],
-  "prism-cut": [
-    "landing",
+  "prism-console": [
     "light",
+    "admin",
+    "memphis",
     "bold",
-    "neo-brutalist",
-    "geometric"
+    "neo-brutalism"
   ],
   "prism-docs": [
     "docs",
@@ -6809,6 +6737,13 @@
     "glamour",
     "fashion"
   ],
+  "redaction-ops": [
+    "dark",
+    "admin",
+    "classified",
+    "monospace",
+    "editorial"
+  ],
   "redline-spec": [
     "geometric",
     "standard",
@@ -6934,13 +6869,6 @@
     "bold",
     "bangers"
   ],
-  "riso-zine": [
-    "light",
-    "paper",
-    "risograph",
-    "zine",
-    "bold"
-  ],
   "riverbank": [
     "light",
     "blog",
@@ -6985,13 +6913,6 @@
     "light",
     "docs",
     "i18n"
-  ],
-  "rosetta-script": [
-    "landing",
-    "light",
-    "i18n",
-    "editorial",
-    "multilingual"
   ],
   "rosewood": [
     "blog",
@@ -8351,13 +8272,6 @@
     "tribal",
     "vertical-stack"
   ],
-  "trail-bureau": [
-    "landing",
-    "light",
-    "outdoor",
-    "cartography",
-    "editorial"
-  ],
   "travel-journal": [
     "travel-inspired",
     "adventurous",
@@ -8552,13 +8466,6 @@
     "neon",
     "futuristic"
   ],
-  "velvet-protocol": [
-    "landing",
-    "dark",
-    "luxury",
-    "editorial",
-    "italiana"
-  ],
   "velvet-rope": [
     "event",
     "gala",
@@ -8601,12 +8508,6 @@
     "spread",
     "contrast",
     "editorial"
-  ],
-  "vertex-prism": [
-    "light",
-    "dashboard",
-    "isometric",
-    "geometric"
   ],
   "vertigo": [
     "dark",
@@ -8981,121 +8882,5 @@
     "glassmorphism",
     "elegant",
     "cyberpunk"
-  ],
-  "risograph-codex": [
-    "light",
-    "docs",
-    "editorial"
-  ],
-  "transit-codex": [
-    "light",
-    "docs",
-    "sidebar"
-  ],
-  "slab-cathedral": [
-    "light",
-    "docs",
-    "editorial"
-  ],
-  "dictation-log": [
-    "dark",
-    "docs",
-    "sidebar"
-  ],
-  "dieter-docs": [
-    "light",
-    "docs",
-    "minimal"
-  ],
-  "riso-folio": [
-    "light",
-    "portfolio",
-    "editorial",
-    "print"
-  ],
-  "kinetic-manifesto": [
-    "light",
-    "portfolio",
-    "editorial",
-    "typography"
-  ],
-  "photocopy-folio": [
-    "light",
-    "portfolio",
-    "editorial",
-    "minimal"
-  ],
-  "slab-folio": [
-    "dark",
-    "portfolio",
-    "brutalist",
-    "minimal"
-  ],
-  "cutout-folio": [
-    "light",
-    "portfolio",
-    "collage",
-    "editorial"
-  ],
-  "broadsheet-riot": [
-    "light",
-    "blog",
-    "editorial",
-    "brutalist",
-    "bodoni"
-  ],
-  "cut-paper-zine": [
-    "light",
-    "blog",
-    "editorial",
-    "risograph",
-    "collage"
-  ],
-  "monogram-quarterly": [
-    "light",
-    "blog",
-    "editorial",
-    "minimal",
-    "museum"
-  ],
-  "samizdat": [
-    "light",
-    "blog",
-    "typewriter",
-    "underground",
-    "monospace"
-  ],
-  "anti-pattern": [
-    "light",
-    "blog",
-    "editorial",
-    "anti-design",
-    "experimental"
-  ],
-  "shadow-mass": [
-    "dark",
-    "blog",
-    "editorial",
-    "minimal"
-  ],
-  "null-state": [
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
-  "midnight-press": [
-    "dark",
-    "blog",
-    "editorial"
-  ],
-  "circuit-noir": [
-    "dark",
-    "docs",
-    "sidebar"
-  ],
-  "glyph-cipher": [
-    "dark",
-    "blog",
-    "minimal"
   ]
 }


### PR DESCRIPTION
## Summary

Five distinct admin / control-panel example sites, each committing to a strong, opinionated aesthetic rather than the usual generic dashboard. All five honour the house style (no gradients, no emoji), share no CSS between them, and cover a balanced mix of light/dark and visual languages.

- **redaction-ops** — declassified-archive admin with crimson stamps and REDACTED bars on bone paper, monospace dossier layout.
- **prism-console** — Memphis-inspired neo-brutalist console with flat cobalt / mustard / hot-pink / mint blocks and oversized Archivo Black headlines.
- **mainframe-luxe** — dense Bloomberg-style trading-desk terminal in pure black with amber phosphor accents, scanning rules and a function-key footer.
- **editorial-bureau** — newsroom admin in Fraunces serif on bone paper, oxblood accents, oversized italic numerals as display, asymmetric editorial grid.
- **architect-blueprint** — navy drafting-room admin with cyan technical lines, inline SVG floor-plan drawing, callout balloons and a drawing-pack title block.

Each site ships an admin dashboard, three to four content sections, custom page / section / taxonomy / 404 templates, and a populated `tags.json` entry (14-20 pages per site, 87 pages total).

## Test plan

- [x] `hwaro build` succeeds in every new site
- [x] `hwaro doctor --fix` clean on every new site
- [x] `tags.json` updated with one entry per site (sorted)
- [x] No gradients, no emoji anywhere in the new sites
- [x] Each site has its own dashboard, sections, page detail and 404