### PR TITLE
Add five more bold landing example sites

### DIFF
--- a/examples/acid-poster/AGENTS.md
+++ b/examples/acid-poster/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/acid-poster/archetypes/default.md
+++ b/examples/acid-poster/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/acid-poster/config.toml
+++ b/examples/acid-poster/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "ACID POSTER"
+description = "An independent music label and party series printing the loudest record of the year — and the flyer to match."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/acid-poster/content/about.md
+++ b/examples/acid-poster/content/about.md
@@ -1,0 +1,25 @@
++++
+title = "About the Label"
+description = "ACID POSTER — what we press, where we party, and how to get on the desk."
++++
+
+## What we press
+
+We press records. Twelve-inch, forty-fives, the occasional tape. **Five hundred numbered copies** per edition. When they're gone, they're gone — we don't repress.
+
+## Where we party
+
+Once a quarter, in a basement off Itaewon-ro. Doors at 22:00. The room is small on purpose. The flyer is loud because the room is small.
+
+## How to send us a tape
+
+> Send the tape. Don't send the deck.
+
+A physical tape, a written note, and the side-B you're proudest of. We listen to every submission on the second Friday of the month, in order of arrival. We answer within thirty days, in handwriting if it deserves it.
+
+## How to find us
+
+- **Desk** — `desk@acid.poster`
+- **Bookings** — `mo@acid.poster`
+- **DMs** — closed. Always have been.
+- **Press kit** — printed on request, never emailed.

--- a/examples/acid-poster/content/index.md
+++ b/examples/acid-poster/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "ACID POSTER — an independent music label and party series printing the loudest record of the year and the flyer to match."
+template = "index"
++++

--- a/examples/acid-poster/static/css/style.css
+++ b/examples/acid-poster/static/css/style.css
@@ -1,0 +1,482 @@
+/* ACID POSTER — rave-flyer punk landing */
+
+:root {
+  --paper: #ece4d3;
+  --paper-2: #d9cfb7;
+  --ink: #0a0a0a;
+  --ink-2: #1a1a1a;
+  --acid: #b6ff1f;
+  --acid-deep: #6fa912;
+  --hot: #ff2bd1;
+  --hot-deep: #c11697;
+  --cy: #2c5cff;
+  --or: #ff7a18;
+  --rule: #0a0a0a;
+  --grit-yellow: #ffe24a;
+  --sans: "Space Grotesk", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --display: "Anton", "Bebas Neue", "Oswald", "Arial Narrow", sans-serif;
+  --serif: "Roboto Serif", "Times New Roman", Georgia, serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--paper); color: var(--ink); overflow-x: hidden; }
+
+body {
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='4'><circle cx='1' cy='1' r='0.5' fill='%230a0a0a'/></svg>");
+  background-size: 4px 4px;
+}
+
+a { color: var(--ink); text-decoration: none; border-bottom: 2px solid var(--hot); font-weight: 700; }
+a:hover { background: var(--hot); color: var(--paper); }
+
+::selection { background: var(--acid); color: var(--ink); }
+
+/* TOP STRIP */
+.strip-top {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 12px 24px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  border-bottom: 4px solid var(--acid);
+}
+.strip-top a { color: var(--paper); border: none; }
+.strip-top a:hover { color: var(--acid); background: none; }
+.strip-top .mid b { color: var(--acid); font-family: var(--display); letter-spacing: 0.08em; font-size: 18px; font-weight: 400; }
+.strip-top nav { display: flex; gap: 22px; justify-content: flex-end; }
+
+/* POSTER HERO */
+.poster {
+  position: relative;
+  padding: 24px 24px 56px;
+  border-bottom: 4px solid var(--ink);
+  overflow: hidden;
+}
+
+/* sticker stack */
+.sticker {
+  position: absolute;
+  font-family: var(--display);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 10px 16px;
+  border: 3px solid var(--ink);
+  background: var(--acid);
+  box-shadow: 5px 5px 0 var(--ink);
+  font-weight: 400;
+  font-size: 22px;
+  z-index: 5;
+  transform: rotate(-6deg);
+}
+.sticker.hot { background: var(--hot); color: var(--paper); transform: rotate(7deg); top: 60px; right: 36px; }
+.sticker.cy { background: var(--cy); color: var(--paper); transform: rotate(-3deg); top: 120px; right: 200px; font-size: 16px; padding: 6px 12px; }
+.sticker.or { background: var(--or); color: var(--ink); transform: rotate(4deg); bottom: 24px; left: 48px; }
+.sticker.gr { background: var(--paper); color: var(--ink); transform: rotate(-9deg); bottom: 120px; right: 60px; font-size: 14px; padding: 6px 12px; }
+
+/* mega type */
+.poster .mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+.poster .mark .pip { width: 14px; height: 14px; background: var(--hot); border: 2px solid var(--ink); }
+.poster .mark b { background: var(--ink); color: var(--paper); padding: 4px 8px; }
+
+.poster h1 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(72px, 16vw, 260px);
+  line-height: 0.82;
+  letter-spacing: -0.005em;
+  margin: 0;
+  text-transform: uppercase;
+  color: var(--ink);
+  position: relative;
+}
+.poster h1 .l1 { display: block; }
+.poster h1 .l1 .grow { color: var(--hot); font-style: italic; }
+.poster h1 .l2 { display: block; }
+.poster h1 .l2 .out {
+  -webkit-text-stroke: 3px var(--ink);
+  color: var(--paper);
+}
+.poster h1 .l3 { display: block; }
+.poster h1 .l3 .hi { background: var(--acid); padding: 0 0.12em; }
+.poster h1 .l3 .x {
+  display: inline-block;
+  background: var(--ink);
+  color: var(--acid);
+  transform: skewX(-12deg) translateY(-0.04em);
+  padding: 0 0.18em;
+  margin-left: 0.06em;
+}
+.poster h1 sup { font-family: var(--mono); font-size: 16px; vertical-align: super; color: var(--hot); margin-left: 8px; letter-spacing: 0; text-transform: none; }
+
+/* poster fact card */
+.facts {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 36px;
+  margin-top: 44px;
+  padding-top: 28px;
+  border-top: 3px solid var(--ink);
+}
+.facts .lede {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.4;
+  max-width: 50ch;
+  margin: 0;
+  color: var(--ink);
+}
+.facts .lede b { background: var(--acid); padding: 1px 6px; font-style: normal; font-weight: 700; font-family: var(--sans); }
+.facts .lede em { color: var(--hot); font-style: italic; font-weight: 700; }
+.facts .specs {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 22px 24px;
+  border: 3px solid var(--ink);
+  box-shadow: 8px 8px 0 var(--hot);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  row-gap: 8px;
+  align-self: start;
+}
+.facts .specs b { color: var(--acid); }
+
+.poster .cta { margin-top: 32px; display: flex; gap: 0; flex-wrap: wrap; }
+.btn {
+  border: 3px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  padding: 16px 22px;
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 18px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 6px 6px 0 var(--ink);
+  transition: transform 0.1s ease, box-shadow 0.1s ease, background 0.1s ease, color 0.1s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.btn + .btn { margin-left: 14px; }
+.btn:hover { transform: translate(-2px, -2px); box-shadow: 9px 9px 0 var(--ink); background: var(--acid); }
+.btn:active { transform: translate(3px, 3px); box-shadow: 2px 2px 0 var(--ink); }
+.btn.hot { background: var(--hot); color: var(--paper); }
+.btn.hot:hover { background: var(--acid); color: var(--ink); }
+.btn.cy { background: var(--cy); color: var(--paper); }
+.btn .ar { font-family: var(--mono); font-size: 14px; }
+
+/* MARQUEE */
+.marq {
+  background: var(--hot);
+  color: var(--paper);
+  padding: 18px 0;
+  border-top: 4px solid var(--ink);
+  border-bottom: 4px solid var(--ink);
+  overflow: hidden;
+  white-space: nowrap;
+}
+.marq .track {
+  display: inline-flex;
+  gap: 36px;
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 38px;
+  letter-spacing: -0.005em;
+  text-transform: uppercase;
+  font-style: italic;
+  animation: drift 28s linear infinite;
+}
+.marq .track span { color: var(--paper); }
+.marq .track .alt { color: var(--acid); -webkit-text-stroke: 1px var(--ink); }
+.marq .track .star {
+  display: inline-block;
+  width: 22px; height: 22px;
+  background: var(--ink);
+  margin: 0 6px;
+  transform: rotate(45deg) translateY(-3px);
+}
+@keyframes drift { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* LINEUP */
+.lineup { padding: 64px 24px; border-bottom: 4px solid var(--ink); }
+.lineup .wrap { max-width: 1240px; margin: 0 auto; }
+.lineup .hd {
+  display: flex; align-items: end; justify-content: space-between; gap: 24px;
+  margin-bottom: 28px;
+}
+.lineup .hd h2 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(48px, 8vw, 120px);
+  letter-spacing: -0.005em;
+  line-height: 0.85;
+  margin: 0;
+  text-transform: uppercase;
+  font-style: italic;
+}
+.lineup .hd h2 .hi { background: var(--cy); color: var(--paper); padding: 0 0.16em; font-style: normal; }
+.lineup .hd .index {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 10px 14px;
+}
+
+.acts { display: grid; grid-template-columns: repeat(6, 1fr); gap: 14px; }
+.act {
+  border: 3px solid var(--ink);
+  background: var(--paper);
+  padding: 18px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 5px 5px 0 var(--ink);
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.act.a1 { grid-column: span 3; background: var(--ink); color: var(--paper); }
+.act.a2 { grid-column: span 3; background: var(--acid); }
+.act.a3 { grid-column: span 2; background: var(--paper-2); }
+.act.a4 { grid-column: span 2; background: var(--hot); color: var(--paper); }
+.act.a5 { grid-column: span 2; background: var(--cy); color: var(--paper); }
+.act .meta { font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em; text-transform: uppercase; opacity: 0.9; }
+.act h3 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(30px, 3.6vw, 56px);
+  letter-spacing: -0.005em;
+  line-height: 0.9;
+  margin: 14px 0 0;
+  text-transform: uppercase;
+}
+.act h3 a { color: inherit; border: none; }
+.act h3 a:hover { color: inherit; opacity: 0.7; background: none; }
+.act p { font-size: 13.5px; line-height: 1.45; margin: 12px 0 0; }
+.act .stamp {
+  position: absolute;
+  right: -22px; top: 18px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  background: var(--ink);
+  color: var(--acid);
+  padding: 6px 28px;
+  transform: rotate(8deg);
+}
+.act.a2 .stamp { color: var(--hot); }
+.act.a3 .stamp { color: var(--cy); }
+
+/* MANIFESTO */
+.shout {
+  background: var(--acid);
+  color: var(--ink);
+  border-bottom: 4px solid var(--ink);
+  padding: 84px 24px;
+  position: relative;
+  overflow: hidden;
+}
+.shout::before {
+  content: "";
+  position: absolute;
+  top: 0; bottom: 0; left: 0;
+  width: 36%;
+  background: var(--hot);
+  clip-path: polygon(0 0, 100% 0, 70% 100%, 0 100%);
+  opacity: 1;
+}
+.shout::after {
+  content: "";
+  position: absolute;
+  top: 0; bottom: 0; right: 0;
+  width: 22%;
+  background: var(--ink);
+  clip-path: polygon(40% 0, 100% 0, 100% 100%, 0 100%);
+}
+.shout .wrap {
+  position: relative;
+  z-index: 2;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.shout .label {
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase;
+  display: inline-block; background: var(--ink); color: var(--acid); padding: 6px 12px; margin-bottom: 24px;
+}
+.shout h2 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(40px, 7vw, 96px);
+  letter-spacing: -0.005em;
+  line-height: 0.95;
+  text-transform: uppercase;
+  margin: 0;
+  font-style: italic;
+}
+.shout h2 .out { -webkit-text-stroke: 3px var(--ink); color: var(--paper); }
+.shout h2 .x { background: var(--ink); color: var(--acid); padding: 0 0.14em; }
+.shout .sign { margin-top: 28px; font-family: var(--mono); font-size: 12px; letter-spacing: 0.32em; text-transform: uppercase; }
+
+/* TICKER */
+.ticker {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  background: var(--ink);
+  color: var(--paper);
+  border-bottom: 4px solid var(--ink);
+}
+.ticker > div { padding: 36px 22px; border-right: 4px solid var(--paper); }
+.ticker > div:last-child { border-right: none; }
+.ticker .n {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 72px;
+  letter-spacing: -0.005em;
+  line-height: 1;
+  color: var(--acid);
+}
+.ticker .n sup { font-size: 18px; color: var(--hot); vertical-align: super; }
+.ticker .l { font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; margin-top: 10px; color: var(--paper); }
+
+/* JOURNAL */
+.zine { padding: 64px 24px; background: var(--paper); }
+.zine .wrap { max-width: 1240px; margin: 0 auto; }
+.zine .hd { display: flex; align-items: end; justify-content: space-between; gap: 24px; border-bottom: 3px solid var(--ink); padding-bottom: 16px; }
+.zine .hd h2 {
+  font-family: var(--display); font-weight: 400; font-style: italic; font-size: clamp(36px, 5vw, 72px);
+  text-transform: uppercase; letter-spacing: -0.005em; margin: 0;
+}
+.zine .hd h2 .hi { background: var(--hot); color: var(--paper); padding: 0 0.14em; font-style: normal; }
+.zine .row {
+  display: grid;
+  grid-template-columns: 120px 1fr auto;
+  gap: 22px;
+  align-items: center;
+  padding: 22px 0;
+  border-bottom: 2px dashed var(--ink);
+  transition: background 0.12s ease;
+}
+.zine .row:hover { background: var(--acid); }
+.zine .d { font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; }
+.zine .t {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(22px, 2.6vw, 32px);
+  letter-spacing: -0.005em;
+  text-transform: uppercase;
+  line-height: 1.05;
+}
+.zine .t a { border: none; color: var(--ink); }
+.zine .ar { font-family: var(--display); font-size: 32px; }
+
+/* PROSE */
+.prose {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 64px 24px 80px;
+  font-size: 17px;
+  line-height: 1.7;
+}
+.prose h1 { font-family: var(--display); font-weight: 400; font-style: italic; font-size: 64px; line-height: 0.94; margin: 0 0 28px; text-transform: uppercase; letter-spacing: -0.005em; }
+.prose h2 { font-family: var(--display); font-weight: 400; font-size: 32px; text-transform: uppercase; margin-top: 1.8em; letter-spacing: -0.005em; }
+.prose h2 .hi { background: var(--hot); color: var(--paper); padding: 0 0.12em; }
+.prose h3 { font-family: var(--mono); font-size: 12px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--ink); background: var(--acid); display: inline-block; padding: 4px 10px; margin-top: 1.6em; }
+.prose p { margin: 0 0 1.1em; }
+.prose blockquote { border-left: 5px solid var(--hot); padding: 4px 0 4px 18px; margin: 1.4em 0; font-weight: 700; color: var(--ink); font-size: 22px; font-family: var(--serif); font-style: italic; }
+.prose code { background: var(--ink); color: var(--acid); padding: 2px 6px; font-family: var(--mono); font-size: 0.9em; }
+.prose pre { background: var(--ink); color: var(--paper); padding: 18px 22px; overflow-x: auto; border: 3px solid var(--ink); box-shadow: 6px 6px 0 var(--hot); }
+.prose pre code { background: none; color: inherit; padding: 0; }
+
+/* FOOTER */
+.foot {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 80px 24px 28px;
+  border-top: 4px solid var(--acid);
+  position: relative;
+  overflow: hidden;
+}
+.foot .wrap { max-width: 1240px; margin: 0 auto; }
+.foot .big {
+  font-family: var(--display); font-weight: 400; font-style: italic;
+  font-size: clamp(80px, 18vw, 280px); line-height: 0.84; letter-spacing: -0.005em;
+  text-transform: uppercase;
+  color: var(--acid);
+  margin: 0 0 36px;
+}
+.foot .big .out { -webkit-text-stroke: 3px var(--paper); color: transparent; }
+.foot .big .hi { background: var(--hot); color: var(--paper); padding: 0 0.12em; -webkit-text-stroke: 0; }
+.foot .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 28px;
+  padding-top: 28px;
+  border-top: 3px solid var(--paper);
+}
+.foot h4 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--acid); margin: 0 0 12px; }
+.foot a { display: block; color: var(--paper); padding: 4px 0; border: none; font-weight: 400; }
+.foot a:hover { color: var(--acid); background: none; }
+.foot .copy { grid-column: 1 / -1; padding-top: 22px; border-top: 1px dashed var(--paper); font-family: var(--mono); font-size: 11px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--paper-2); display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { padding: 32px 24px; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; }
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  font-family: var(--display); font-weight: 400;
+  padding: 10px 18px; border: 3px solid var(--ink); background: var(--paper); color: var(--ink);
+  box-shadow: 4px 4px 0 var(--ink); text-transform: uppercase; letter-spacing: 0.04em; font-size: 16px;
+}
+nav.pagination a:hover { background: var(--hot); color: var(--paper); }
+.pagination-current span { background: var(--acid); }
+.pagination-disabled span { background: var(--paper-2); color: var(--ink); box-shadow: none; }
+
+/* RESPONSIVE */
+@media (max-width: 960px) {
+  .acts { grid-template-columns: repeat(2, 1fr); }
+  .act.a1, .act.a2, .act.a3, .act.a4, .act.a5 { grid-column: span 2; }
+  .ticker { grid-template-columns: 1fr 1fr; }
+  .ticker > div:nth-child(2n) { border-right: none; }
+  .foot .grid { grid-template-columns: 1fr 1fr; }
+  .facts { grid-template-columns: 1fr; }
+  .sticker.cy { display: none; }
+}
+@media (max-width: 600px) {
+  .strip-top { grid-template-columns: 1fr 1fr; padding: 10px 16px; }
+  .strip-top .mid { display: none; }
+  .poster { padding: 20px 18px 36px; }
+  .sticker.gr, .sticker.or { display: none; }
+  .zine .row { grid-template-columns: 1fr; gap: 6px; }
+  .zine .ar { display: none; }
+  .foot .grid { grid-template-columns: 1fr; }
+  .foot .copy { flex-direction: column; gap: 8px; }
+}

--- a/examples/acid-poster/static/favicon.svg
+++ b/examples/acid-poster/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/acid-poster/templates/404.html
+++ b/examples/acid-poster/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 // OFF THE FLYER.</h1>
+  <p>This page didn't make the press run. Maybe it sold out, maybe it never existed, maybe the printer ran out of magenta. Try the front again.</p>
+  <p><a href="{{ base_url }}/">&laquo; back to the front</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/acid-poster/templates/footer.html
+++ b/examples/acid-poster/templates/footer.html
@@ -1,0 +1,39 @@
+  <footer class="foot">
+    <div class="wrap">
+      <div class="big">ACID<br><span class="out">POSTER</span><br><span class="hi">/ {{ current_year }}</span></div>
+      <div class="grid">
+        <div>
+          <h4>// label</h4>
+          <a href="#">Releases &mdash; vinyl &amp; tape</a>
+          <a href="#">Sub.scribe &mdash; monthly</a>
+          <a href="#">Press kit</a>
+        </div>
+        <div>
+          <h4>// parties</h4>
+          <a href="#">Acid Night &mdash; quarterly</a>
+          <a href="#">Door policy</a>
+          <a href="#">Lost &amp; found</a>
+        </div>
+        <div>
+          <h4>// zine</h4>
+          <a href="{{ base_url }}/tags/">Back issues</a>
+          <a href="#">Submit a tape</a>
+          <a href="#">Stockists</a>
+        </div>
+        <div>
+          <h4>// reach</h4>
+          <a href="#">desk@acid.poster</a>
+          <a href="#">Bookings &mdash; mo</a>
+          <a href="#">DMs are closed</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} ACID POSTER &middot; printed loud, shipped fast</span>
+          <span>Hwaro build &middot; press {{ current_year }}.04</span>
+        </div>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/acid-poster/templates/header.html
+++ b/examples/acid-poster/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Roboto+Serif:ital,wght@0,400;0,700;1,400&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <a href="{{ base_url }}/">// home / index</a>
+    <span class="mid"><b>ACID POSTER</b> &middot; label // party series // record press</span>
+    <nav>
+      <a href="{{ base_url }}/about/">about</a>
+      <a href="{{ base_url }}/tags/">zine</a>
+      <a href="#lineup">lineup</a>
+    </nav>
+  </header>

--- a/examples/acid-poster/templates/index.html
+++ b/examples/acid-poster/templates/index.html
@@ -1,0 +1,126 @@
+{% include "header.html" %}
+
+<section class="poster">
+  <span class="sticker">N&deg; 14 // {{ current_year }}</span>
+  <span class="sticker hot">LOUDER / Y</span>
+  <span class="sticker cy">22:00 &mdash; LATE</span>
+  <span class="sticker gr">12&Prime; / 33 rpm</span>
+  <span class="sticker or">DOORS NEVER LOCK</span>
+
+  <div class="mark"><span class="pip"></span><b>PRESS 14</b> // VOL.IV // ALL AGES</div>
+
+  <h1>
+    <span class="l1">PRINT IT <span class="grow">LOUD.</span></span>
+    <span class="l2">PRESS IT <span class="out">FAST.</span></span>
+    <span class="l3">PLAY IT <span class="hi">TONIGHT</span><span class="x">@22:00</span><sup>*</sup></span>
+  </h1>
+
+  <div class="facts">
+    <p class="lede">An independent music label and party series. We <b>press records</b>, <em>throw nights,</em> and print the flyer ourselves &mdash; with whatever ink the shop has left.</p>
+    <div class="specs">
+      <span>EDITION</span><b>14 / 24</b>
+      <span>FORMAT</span><b>12&Prime; / TAPE / DIG</b>
+      <span>SHOP</span><b>FRI &mdash; SUN</b>
+      <span>BASE</span><b>SEOUL &middot; SE-04</b>
+      <span>RUN</span><b>500 NUMBERED</b>
+    </div>
+  </div>
+
+  <div class="cta">
+    <a class="btn hot" href="#lineup">SEE THE LINEUP <span class="ar">&gt;&gt;</span></a>
+    <a class="btn cy" href="#"> SHOP / PRESS 14 <span class="ar">&gt;&gt;</span></a>
+    <a class="btn" href="{{ base_url }}/about/">ABOUT THE LABEL <span class="ar">&gt;&gt;</span></a>
+  </div>
+</section>
+
+<div class="marq" aria-hidden="true">
+  <div class="track">
+    <span>NEVER QUIET</span><span class="star"></span><span class="alt">NEVER POLITE</span><span class="star"></span><span>NEVER LATE</span><span class="star"></span><span class="alt">NEVER SOBER</span><span class="star"></span>
+    <span>NEVER QUIET</span><span class="star"></span><span class="alt">NEVER POLITE</span><span class="star"></span><span>NEVER LATE</span><span class="star"></span><span class="alt">NEVER SOBER</span><span class="star"></span>
+  </div>
+</div>
+
+<section class="lineup" id="lineup">
+  <div class="wrap">
+    <div class="hd">
+      <h2>The <span class="hi">Lineup</span><br>/ press 14 / live.</h2>
+      <div class="index">14 ACTS &middot; 1 NIGHT &middot; 1 ROOM</div>
+    </div>
+    <div class="acts">
+      <article class="act a1">
+        <div class="meta">/ HEADLINER &middot; LIVE / 02:00</div>
+        <h3><a href="#">CHARCOAL<br>CHURCH</a></h3>
+        <p>The act that closed Press 11 returns with a 90-minute live set built on a single broken synth and three angry monitors.</p>
+        <span class="stamp">LIVE / 60M</span>
+      </article>
+      <article class="act a2">
+        <div class="meta">/ SUPPORT &middot; DJ / 23:00</div>
+        <h3><a href="#">NEON<br>SECRETARY</a></h3>
+        <p>Edits, jams, and one bootleg you've heard nowhere else. Bring a notebook; she names every record.</p>
+        <span class="stamp">DJ / 120M</span>
+      </article>
+      <article class="act a3">
+        <div class="meta">/ OPENER &middot; LIVE / 22:00</div>
+        <h3><a href="#">ROOM<br>NINETEEN</a></h3>
+        <p>Tape-loop quartet. New EP on the press table.</p>
+        <span class="stamp">LIVE / 30M</span>
+      </article>
+      <article class="act a4">
+        <div class="meta">/ AFTER &middot; DJ / 03:30</div>
+        <h3><a href="#">B-SIDE<br>OF B</a></h3>
+        <p>Strictly the second sides. Nothing you came for.</p>
+      </article>
+      <article class="act a5">
+        <div class="meta">/ VISUALS</div>
+        <h3><a href="#">FAST<br>FILM CO</a></h3>
+        <p>Three projectors, two loops, one warning sign.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="shout">
+  <div class="wrap">
+    <div class="label">// MANIFESTO &middot; SIDE A &middot; PRESS 14</div>
+    <h2>
+      WE <span class="x">PRESS</span> RECORDS.<br>
+      WE <span class="out">THROW</span> NIGHTS.<br>
+      WE DO NOT <span class="x">SOFTEN</span> THE EDGE.<br>
+      WE DO NOT <span class="out">FOLLOW</span> THE RIDER.
+    </h2>
+    <div class="sign">&mdash; the desk // signed // {{ current_year }}.04</div>
+  </div>
+</section>
+
+<section class="ticker">
+  <div><div class="n">14<sup>th</sup></div><div class="l">PRESS / EDITION</div></div>
+  <div><div class="n">500</div><div class="l">COPIES / NUMBERED</div></div>
+  <div><div class="n">04</div><div class="l">NIGHTS / YEAR</div></div>
+  <div><div class="n">00</div><div class="l">SPONSORS / EVER</div></div>
+</section>
+
+<section class="zine">
+  <div class="wrap">
+    <div class="hd">
+      <h2>From the <span class="hi">zine.</span></h2>
+      <a class="btn hot" href="{{ base_url }}/tags/">ALL ISSUES <span class="ar">&gt;&gt;</span></a>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} / 04</div>
+      <div class="t"><a href="#">THE TAPE THAT BROKE THE SECOND DECK &mdash; A POSTMORTEM</a></div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} / 02</div>
+      <div class="t"><a href="#">SIDE B IS THE REAL ALBUM &mdash; ALWAYS HAS BEEN</a></div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">2025 / 11</div>
+      <div class="t"><a href="#">FIELD NOTES &mdash; PRESS 13 IN ONE NIGHT</a></div>
+      <div class="ar">&rarr;</div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/acid-poster/templates/page.html
+++ b/examples/acid-poster/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/acid-poster/templates/section.html
+++ b/examples/acid-poster/templates/section.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<section class="zine">
+  <div class="wrap">
+    <div class="hd">
+      {% if page.title is present %}<h2>{{ page.title | e | upper }}</h2>{% endif %}
+    </div>
+    {{ content | safe }}
+    {% for post in section.pages %}
+    <div class="row">
+      <div class="d">{{ post.date | date(format="%Y / %m") }}</div>
+      <div class="t"><a href="{{ post.url }}">{{ post.title | e | upper }}</a></div>
+      <div class="ar">&rarr;</div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/acid-poster/templates/shortcodes/alert.html
+++ b/examples/acid-poster/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/acid-poster/templates/taxonomy.html
+++ b/examples/acid-poster/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Index of subjects across the zine.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/acid-poster/templates/taxonomy_term.html
+++ b/examples/acid-poster/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Entries pressed under this stamp.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/navy-syndicate/AGENTS.md
+++ b/examples/navy-syndicate/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/navy-syndicate/archetypes/default.md
+++ b/examples/navy-syndicate/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/navy-syndicate/config.toml
+++ b/examples/navy-syndicate/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "The Navy Syndicate"
+description = "A private capital house for the long century — quiet, deliberate, and answerable only to the people we already know."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/navy-syndicate/content/about.md
+++ b/examples/navy-syndicate/content/about.md
@@ -1,0 +1,29 @@
++++
+title = "The Charter"
+description = "The original charter of the Navy Syndicate, abridged, with notes from the present house."
++++
+
+## §I — The House
+
+The Navy Syndicate was founded in 1928 as a limited partnership of friends. It has remained a partnership ever since. We have never taken outside capital. We have never accepted a mandate that required us to be louder than we wished.
+
+## §II — The Four Disciplines
+
+The Syndicate operates in four disciplines and no more:
+
+- **Permanent capital** — companies we will hold for the century.
+- **Credit, carefully** — senior secured paper to operators we know by name.
+- **The Library** — research, quarterly letters, one annual address.
+- **The Roll** — the members, the stewards, the secretaries.
+
+We decline mandates adjacent to these disciplines as a matter of policy.
+
+## §III — The Membership
+
+> Membership is by invitation. The roll closed once in 1971 and once in 2003. We are not in a hurry to reopen it.
+
+We have one hundred and twelve members. We have not advertised the house in ninety-eight years and do not intend to begin.
+
+## §IV — Correspondence
+
+The secretary answers mail in the order it arrives, and in working hours. Letters of introduction are read, replied to, and filed. Our line is `house@navy.syndicate`.

--- a/examples/navy-syndicate/content/index.md
+++ b/examples/navy-syndicate/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "The Navy Syndicate — a private capital house, quiet by design, answerable only to its members."
+template = "index"
++++

--- a/examples/navy-syndicate/static/css/style.css
+++ b/examples/navy-syndicate/static/css/style.css
@@ -1,0 +1,488 @@
+/* The Navy Syndicate — quiet-luxury private capital */
+
+:root {
+  --navy: #0e1c2c;
+  --navy-2: #15273b;
+  --navy-3: #1d3148;
+  --cream: #f1e9d6;
+  --cream-2: #ddd2b4;
+  --paper: #f7f1de;
+  --ink: #060a10;
+  --ink-soft: #1a2433;
+  --brass: #c69a4c;
+  --brass-deep: #8d6a2c;
+  --bordeaux: #6c2b27;
+  --hair: #2a3c52;
+  --rule: rgba(241, 233, 214, 0.18);
+  --serif: "Cormorant Garamond", "EB Garamond", Georgia, "Times New Roman", serif;
+  --display: "Playfair Display", "Cormorant Garamond", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--navy); color: var(--cream); }
+
+body {
+  font-family: var(--serif);
+  font-size: 18px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--brass); text-decoration: none; border-bottom: 1px solid currentColor; }
+a:hover { color: var(--cream); }
+
+::selection { background: var(--brass); color: var(--navy); }
+
+.shell { max-width: 1240px; margin: 0 auto; padding: 0 48px; }
+
+/* TOP BAR */
+.bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 24px 0 18px;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+}
+.bar .est b { color: var(--brass); font-weight: 600; }
+.bar nav { display: flex; gap: 28px; justify-content: flex-end; }
+.bar nav a { color: var(--cream); border: none; }
+.bar nav a:hover { color: var(--brass); }
+.bar .crest {
+  font-family: var(--display);
+  font-weight: 400;
+  font-style: italic;
+  text-transform: none;
+  font-size: 24px;
+  color: var(--cream);
+  letter-spacing: 0.01em;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+.bar .crest .seal {
+  width: 26px; height: 26px;
+  border: 1px solid var(--brass);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--display);
+  font-size: 14px;
+  color: var(--brass);
+  font-style: normal;
+}
+
+/* COVER */
+.cover {
+  position: relative;
+  padding: 64px 0 56px;
+  border-bottom: 1px solid var(--rule);
+}
+.cover .meta {
+  position: absolute;
+  top: 64px; right: 0;
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+  text-align: right;
+  line-height: 2;
+}
+.cover .meta b { color: var(--brass); font-weight: 600; }
+
+.cover .kicker {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+  color: var(--brass);
+  margin-bottom: 22px;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+.cover .kicker::before, .cover .kicker::after {
+  content: "";
+  width: 26px;
+  height: 1px;
+  background: var(--brass);
+}
+
+.cover h1 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(60px, 11vw, 168px);
+  line-height: 0.94;
+  letter-spacing: -0.025em;
+  margin: 0;
+  color: var(--cream);
+}
+.cover h1 .roman { font-style: normal; font-weight: 700; letter-spacing: -0.035em; }
+.cover h1 .amp { color: var(--brass); font-style: italic; padding: 0 0.1em; }
+.cover h1 small {
+  display: block;
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+  margin-top: 20px;
+  font-weight: 500;
+}
+
+.cover .row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 56px;
+  margin-top: 44px;
+  padding-top: 28px;
+  border-top: 1px solid var(--rule);
+  align-items: end;
+}
+.cover .lede {
+  font-size: 22px;
+  line-height: 1.5;
+  color: var(--cream);
+  font-style: italic;
+  max-width: 56ch;
+  margin: 0;
+}
+.cover .lede em { color: var(--brass); font-style: normal; font-family: var(--display); font-weight: 600; }
+.cover .principles {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  row-gap: 12px;
+  align-self: end;
+}
+.cover .principles b { color: var(--brass); font-weight: 600; }
+
+.cover .cta {
+  margin-top: 36px;
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 26px;
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  border: 1px solid var(--cream);
+  color: var(--cream);
+  background: transparent;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+.btn:hover { background: var(--cream); color: var(--navy); }
+.btn.brass { border-color: var(--brass); color: var(--navy); background: var(--brass); }
+.btn.brass:hover { background: var(--cream); border-color: var(--cream); color: var(--navy); }
+.btn .ar { font-family: var(--display); font-style: italic; font-size: 14px; line-height: 1; letter-spacing: 0; }
+
+/* RIBBON */
+.ribbon {
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 22px 0;
+  overflow: hidden;
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 30px;
+  letter-spacing: -0.01em;
+  color: var(--brass);
+  white-space: nowrap;
+}
+.ribbon .track { display: inline-flex; gap: 56px; animation: drift 40s linear infinite; }
+.ribbon .track span small {
+  font-family: var(--sans);
+  font-style: normal;
+  font-size: 12px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+  margin-left: 18px;
+}
+.ribbon .track .dot {
+  display: inline-block;
+  width: 6px; height: 6px;
+  border: 1px solid var(--brass);
+  background: var(--brass);
+  border-radius: 50%;
+  margin: 0 24px;
+  transform: translateY(-6px);
+}
+@keyframes drift { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* PRACTICE */
+.practice { padding: 84px 0; border-bottom: 1px solid var(--rule); }
+.practice .hd {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 56px;
+  align-items: end;
+  margin-bottom: 44px;
+}
+.practice .hd h2 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(40px, 6vw, 76px);
+  letter-spacing: -0.025em;
+  line-height: 1;
+  margin: 0;
+}
+.practice .hd h2 b { font-weight: 700; font-style: normal; color: var(--brass); }
+.practice .hd p { margin: 0; font-size: 18px; color: var(--cream-2); }
+
+.disciplines {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--rule);
+}
+.discipline {
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 32px 28px 36px;
+  transition: background 0.2s ease;
+}
+.discipline:nth-child(4n) { border-right: none; }
+.discipline:hover { background: var(--navy-2); }
+.discipline .ix {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--brass);
+  margin-bottom: 24px;
+}
+.discipline .ix b { color: var(--cream); font-weight: 500; }
+.discipline h3 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 28px;
+  letter-spacing: -0.01em;
+  margin: 0 0 12px;
+  color: var(--cream);
+}
+.discipline p { margin: 0; color: var(--cream-2); font-size: 15.5px; }
+.discipline .figure {
+  margin-top: 22px;
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 46px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--brass);
+}
+.discipline .figure small {
+  display: block;
+  font-family: var(--sans);
+  font-style: normal;
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+  margin-top: 8px;
+}
+
+/* LETTER */
+.letter {
+  display: grid;
+  grid-template-columns: 1fr 1.6fr;
+  gap: 64px;
+  padding: 96px 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: start;
+}
+.letter .from {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--brass);
+}
+.letter .from .sect { color: var(--cream); margin-right: 12px; }
+.letter .from .sig {
+  margin-top: 28px;
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--cream);
+}
+.letter .from .sig small {
+  display: block;
+  font-family: var(--sans);
+  font-style: normal;
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+  margin-top: 4px;
+}
+.letter .body {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(24px, 3vw, 36px);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  color: var(--cream);
+}
+.letter .body p:first-child::first-letter {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 5em;
+  float: left;
+  line-height: 0.86;
+  margin: 0.08em 0.1em 0 0;
+  color: var(--brass);
+}
+.letter .body p + p { margin-top: 0.9em; }
+.letter .body em { color: var(--brass); }
+
+/* LEDGER */
+.ledger {
+  padding: 84px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.ledger .hd {
+  display: flex; justify-content: space-between; align-items: end; gap: 24px;
+  margin-bottom: 28px;
+}
+.ledger .hd h2 {
+  font-family: var(--display); font-style: italic; font-weight: 400;
+  font-size: clamp(40px, 6vw, 72px); letter-spacing: -0.025em; margin: 0;
+}
+.ledger .hd .legend { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--cream-2); }
+.ledger .hd .legend b { color: var(--brass); font-weight: 600; }
+
+.entries { border-top: 1px solid var(--rule); }
+.entries .row {
+  display: grid;
+  grid-template-columns: 90px 1.4fr 1fr 140px 80px;
+  gap: 28px;
+  align-items: center;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+}
+.entries .row:hover .t a { color: var(--brass); }
+.entries .row .yr { color: var(--brass); }
+.entries .row .t a { font-family: var(--display); font-style: italic; font-weight: 400; font-size: 26px; letter-spacing: -0.01em; color: var(--cream); border: none; text-transform: none; }
+.entries .row .t small {
+  display: block;
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--cream-2);
+  margin-top: 4px;
+}
+.entries .row .role { color: var(--cream); }
+.entries .row .ar { font-family: var(--display); font-style: italic; font-size: 28px; text-align: right; color: var(--brass); }
+.entries .row .am { font-family: var(--display); font-weight: 700; font-size: 22px; letter-spacing: -0.02em; color: var(--cream); text-transform: none; }
+
+/* PROSE */
+.prose {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 72px 0 80px;
+  font-size: 19px;
+  line-height: 1.75;
+  color: var(--cream-2);
+}
+.prose h1 { font-family: var(--display); font-weight: 400; font-style: italic; font-size: 64px; line-height: 0.95; margin: 0 0 28px; letter-spacing: -0.025em; color: var(--cream); }
+.prose h2 { font-family: var(--display); font-weight: 400; font-style: italic; font-size: 32px; margin-top: 2em; color: var(--cream); letter-spacing: -0.015em; }
+.prose h3 { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--brass); margin-top: 1.8em; }
+.prose p { margin: 0 0 1.1em; }
+.prose blockquote { border-left: 2px solid var(--brass); padding-left: 22px; margin: 1.4em 0; font-family: var(--display); font-style: italic; font-size: 24px; color: var(--cream); }
+.prose code { background: var(--navy-2); padding: 2px 6px; font-family: var(--mono); font-size: 0.85em; color: var(--brass); border: 1px solid var(--rule); }
+.prose pre { background: var(--navy-3); border: 1px solid var(--hair); padding: 20px 22px; overflow-x: auto; }
+.prose pre code { background: none; border: none; color: var(--cream); }
+.prose a { color: var(--brass); border-bottom: 1px solid var(--brass); }
+
+/* FOOTER */
+.foot {
+  padding: 84px 0 36px;
+  border-top: 1px solid var(--rule);
+  background: var(--navy);
+}
+.foot .big {
+  font-family: var(--display); font-style: italic; font-weight: 400;
+  font-size: clamp(60px, 12vw, 168px);
+  letter-spacing: -0.03em;
+  line-height: 0.94;
+  color: var(--cream);
+  margin: 0 0 40px;
+}
+.foot .big .b { font-style: normal; font-weight: 700; color: var(--brass); }
+.foot .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 36px;
+  padding-top: 32px;
+  border-top: 1px solid var(--rule);
+}
+.foot h4 { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--brass); margin: 0 0 14px; }
+.foot a { display: block; color: var(--cream); border: none; padding: 4px 0; font-family: var(--serif); font-size: 17px; }
+.foot a:hover { color: var(--brass); }
+.foot .copy { grid-column: 1 / -1; padding-top: 24px; border-top: 1px solid var(--rule); font-family: var(--sans); font-size: 11px; letter-spacing: 0.24em; text-transform: uppercase; color: var(--cream-2); display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { margin: 40px 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; }
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase;
+  padding: 10px 18px; border: 1px solid var(--rule); color: var(--cream); border-bottom: 1px solid var(--rule);
+}
+nav.pagination a:hover { background: var(--cream); color: var(--navy); border-color: var(--cream); }
+.pagination-current span { background: var(--brass); border-color: var(--brass); color: var(--navy); }
+.pagination-disabled span { color: var(--cream-2); }
+
+/* RESPONSIVE */
+@media (max-width: 980px) {
+  .shell { padding: 0 24px; }
+  .cover .row { grid-template-columns: 1fr; gap: 24px; }
+  .cover .meta { position: static; text-align: left; margin-top: 14px; }
+  .disciplines { grid-template-columns: 1fr 1fr; }
+  .discipline:nth-child(2n) { border-right: none; }
+  .discipline:nth-child(4n) { border-right: 1px solid var(--rule); }
+  .letter { grid-template-columns: 1fr; gap: 24px; }
+  .entries .row { grid-template-columns: 70px 1fr; gap: 12px; }
+  .entries .row .role, .entries .row .am, .entries .row .ar { display: none; }
+  .foot .grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 600px) {
+  .bar { grid-template-columns: 1fr 1fr; }
+  .bar .est { display: none; }
+  .disciplines { grid-template-columns: 1fr; }
+  .discipline { border-right: none !important; }
+  .foot .grid { grid-template-columns: 1fr; }
+  .foot .copy { flex-direction: column; gap: 8px; }
+}

--- a/examples/navy-syndicate/static/favicon.svg
+++ b/examples/navy-syndicate/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/navy-syndicate/templates/404.html
+++ b/examples/navy-syndicate/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &mdash; <i>An Item Not in the Library</i></h1>
+  <p>This entry is not on the shelves. It may have been withdrawn, mis-filed, or never accessioned at all.</p>
+  <p><a href="{{ base_url }}/">Return to the House &rarr;</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/navy-syndicate/templates/footer.html
+++ b/examples/navy-syndicate/templates/footer.html
@@ -1,0 +1,38 @@
+    <footer class="foot">
+      <div class="big">The Navy <span class="b">Syndicate.</span></div>
+      <div class="grid">
+        <div>
+          <h4>The House</h4>
+          <a href="{{ base_url }}/about/">Charter &amp; Practice</a>
+          <a href="#">Member Roster</a>
+          <a href="#">Recent Investments</a>
+        </div>
+        <div>
+          <h4>The Library</h4>
+          <a href="{{ base_url }}/tags/">Quarterly Letters</a>
+          <a href="#">Annual Address</a>
+          <a href="#">Selected Memoranda</a>
+        </div>
+        <div>
+          <h4>Membership</h4>
+          <a href="#">By Invitation Only</a>
+          <a href="#">Sponsoring Member</a>
+          <a href="#">Junior Roll &mdash; closed</a>
+        </div>
+        <div>
+          <h4>Correspondence</h4>
+          <a href="#">house@navy.syndicate</a>
+          <a href="#">Secretary &mdash; Mrs. Halloway</a>
+          <a href="#">London &middot; Seoul &middot; Lisbon</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} The Navy Syndicate &middot; A Limited Partnership of Members</span>
+          <span>Set in Playfair &amp; Cormorant &middot; Quietly Compiled</span>
+        </div>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/navy-syndicate/templates/header.html
+++ b/examples/navy-syndicate/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Playfair+Display:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="bar">
+      <div class="est">Established <b>MCMXXVIII</b> &middot; Member House</div>
+      <a href="{{ base_url }}/" class="crest"><span class="seal">N</span>The Navy Syndicate</a>
+      <nav>
+        <a href="{{ base_url }}/">House</a>
+        <a href="{{ base_url }}/about/">Charter</a>
+        <a href="{{ base_url }}/tags/">Library</a>
+      </nav>
+    </header>

--- a/examples/navy-syndicate/templates/index.html
+++ b/examples/navy-syndicate/templates/index.html
@@ -1,0 +1,123 @@
+{% include "header.html" %}
+
+<section class="cover">
+  <div class="meta">
+    <div>Volume <b>XIV</b></div>
+    <div>{{ current_year }} &middot; Spring Address</div>
+    <div>Members &middot; <b>112</b></div>
+    <div>Capital &middot; <b>USD 4.2bn</b></div>
+  </div>
+  <div class="kicker">A Private Capital House &mdash; Est. MCMXXVIII</div>
+  <h1>
+    Patience<span class="amp">,</span><br>
+    <span class="roman">Discretion</span><br>
+    <em>&amp; Care.</em>
+    <small>An address to the membership &mdash; Volume XIV, Spring</small>
+  </h1>
+  <div class="row">
+    <p class="lede">For ninety-eight years the Syndicate has answered to one constituency: the people we already know. We invest <em>slowly</em>, write <em>honestly</em>, and refuse the room when the room is wrong.</p>
+    <div class="principles">
+      <span>I.</span><span><b>Patience</b> over pace. We wait for the right business at the right price.</span>
+      <span>II.</span><span><b>Plain language.</b> Every letter is one page. Every page is signed.</span>
+      <span>III.</span><span><b>Membership over scale.</b> We have closed the junior roll twice this century.</span>
+    </div>
+  </div>
+  <div class="cta">
+    <a class="btn brass" href="{{ base_url }}/about/">Read the Charter<span class="ar">&rarr;</span></a>
+    <a class="btn" href="#letter">Spring Address<span class="ar">&rarr;</span></a>
+  </div>
+</section>
+
+<div class="ribbon" aria-hidden="true">
+  <div class="track">
+    <span>Patience over Pace.<small>MCMXXVIII</small></span><span class="dot"></span>
+    <span>Plain language, plainly stated.<small>VOL. XIV</small></span><span class="dot"></span>
+    <span>By invitation only.<small>112 MEMBERS</small></span><span class="dot"></span>
+    <span>Patience over Pace.<small>MCMXXVIII</small></span><span class="dot"></span>
+    <span>Plain language, plainly stated.<small>VOL. XIV</small></span><span class="dot"></span>
+    <span>By invitation only.<small>112 MEMBERS</small></span><span class="dot"></span>
+  </div>
+</div>
+
+<section class="practice">
+  <div class="hd">
+    <h2>Four <b>Disciplines</b>, kept narrow.</h2>
+    <p>The Syndicate operates in four disciplines and no more. We have declined adjacent mandates twice in the last decade. Each discipline reports to the full membership at the annual.</p>
+  </div>
+  <div class="disciplines">
+    <article class="discipline">
+      <div class="ix"><b>I.</b> Permanent Capital</div>
+      <h3>Companies for the century.</h3>
+      <p>Founding-family businesses, taken into joint stewardship. No exit clock; no quarterly drumbeat.</p>
+      <div class="figure">11<small>&mdash; portfolio holdings</small></div>
+    </article>
+    <article class="discipline">
+      <div class="ix"><b>II.</b> Credit, Carefully</div>
+      <h3>Lending where the line is honest.</h3>
+      <p>Senior secured paper to operators we know by name. The deck stays small; the diligence stays long.</p>
+      <div class="figure">4&middot;2<small>&mdash; USD bn outstanding</small></div>
+    </article>
+    <article class="discipline">
+      <div class="ix"><b>III.</b> The Library</div>
+      <h3>Research &amp; correspondence.</h3>
+      <p>The Library publishes one quarterly letter and one annual address. Both arrive on paper.</p>
+      <div class="figure">98<small>&mdash; quarterly letters published</small></div>
+    </article>
+    <article class="discipline">
+      <div class="ix"><b>IV.</b> The Roll</div>
+      <h3>Members &amp; stewardship.</h3>
+      <p>One hundred and twelve members. No marketing. No conference circuit. We answer the letters we are sent.</p>
+      <div class="figure">112<small>&mdash; members of record</small></div>
+    </article>
+  </div>
+</section>
+
+<section class="letter" id="letter">
+  <div class="from">
+    <div><span class="sect">&sect; II</span>The Spring Address</div>
+    <div class="sig">&mdash; Augustus M. Halloway<small>Chairman of the House</small></div>
+  </div>
+  <div class="body">
+    <p>To the membership: another year, another quiet account. We invested in three businesses and declined twenty-seven. We added one member and removed none. We answered every letter sent to us in working hours, and most of those sent at night.</p>
+    <p>The world is not <em>slowing</em> on our behalf. We will continue to. We will write the next letter when there is something to say, and not before.</p>
+  </div>
+</section>
+
+<section class="ledger">
+  <div class="hd">
+    <h2>From the <i>Ledger</i> &mdash; {{ current_year }}</h2>
+    <div class="legend">Selected entries &middot; <b>Library &middot; Volume XIV</b></div>
+  </div>
+  <div class="entries">
+    <div class="row">
+      <div class="yr">{{ current_year }} &middot; II</div>
+      <div class="t"><a href="#">A Note on Permanence &mdash; The Halloway Address, Spring</a><small>Address &middot; Library</small></div>
+      <div class="role">Chairman</div>
+      <div class="am">28 pp.</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="yr">{{ current_year }} &middot; I</div>
+      <div class="t"><a href="#">Quiet Capital in a Loud Year &mdash; Quarterly Letter XCVIII</a><small>Letter &middot; Library</small></div>
+      <div class="role">Library</div>
+      <div class="am">12 pp.</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="yr">2025 &middot; IV</div>
+      <div class="t"><a href="#">On Declining the Room &mdash; A Note for the Junior Roll</a><small>Memorandum &middot; House</small></div>
+      <div class="role">Secretary</div>
+      <div class="am">06 pp.</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="yr">2025 &middot; III</div>
+      <div class="t"><a href="#">The 2025 Annual &mdash; Holdings, Names &amp; Hours</a><small>Annual &middot; Library</small></div>
+      <div class="role">House</div>
+      <div class="am">64 pp.</div>
+      <div class="ar">&rarr;</div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/navy-syndicate/templates/page.html
+++ b/examples/navy-syndicate/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/navy-syndicate/templates/section.html
+++ b/examples/navy-syndicate/templates/section.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<section class="ledger">
+  <div class="hd">
+    {% if page.title is present %}<h2><i>{{ page.title | e }}</i></h2>{% endif %}
+    <div class="legend">Library &middot; <b>Index</b></div>
+  </div>
+  <div class="entries">
+    {% for post in section.pages %}
+    <div class="row">
+      <div class="yr">{{ post.date | date(format="%Y &middot; %m") | safe }}</div>
+      <div class="t"><a href="{{ post.url }}">{{ post.title | e }}</a><small>{{ post.section | default("library") }}</small></div>
+      <div class="role">Library</div>
+      <div class="am">&mdash; pp.</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/navy-syndicate/templates/shortcodes/alert.html
+++ b/examples/navy-syndicate/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/navy-syndicate/templates/taxonomy.html
+++ b/examples/navy-syndicate/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><i>{{ page.title | e }}</i></h1>
+  <p>An index of subjects from the Library &mdash; entries arranged for quiet reading.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/navy-syndicate/templates/taxonomy_term.html
+++ b/examples/navy-syndicate/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><i>{{ page.title | e }}</i></h1>
+  <p>Entries filed under this subject.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/rosetta-script/AGENTS.md
+++ b/examples/rosetta-script/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/rosetta-script/archetypes/default.md
+++ b/examples/rosetta-script/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/rosetta-script/config.toml
+++ b/examples/rosetta-script/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Rosetta Script"
+description = "A reading-first language app — short pieces in Korean, Japanese, French and Arabic, translated by ear, not by machine."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/rosetta-script/content/about.md
+++ b/examples/rosetta-script/content/about.md
@@ -1,0 +1,31 @@
++++
+title = "The Method"
+description = "Rosetta Script — how we translate, who translates, and why we ship one page a day."
++++
+
+## §I — A reading-first practice
+
+Rosetta Script is not a flashcard app. It is a reading practice. Each day it hands you one short piece in the language you are learning, with the original on one side and a careful english on the other.
+
+There are no streaks, no levels to climb, no leaderboard. There is only today's page, and the friend in the margin who has read it before.
+
+## §II — Translated by people who actually read
+
+> Every piece passes through two readers and one editor before it is set.
+
+We do not use machine drafts. The translator's name is on the page, the editor's name is on the page, and the choices we had to make are in a public note at the bottom of the page.
+
+## §III — Four scripts, on purpose
+
+We started with four:
+
+- **Korean** — modern and literary Hangul, with kanji-style hanja when the piece uses it.
+- **Japanese** — kanji + kana, paced for a reader, not a tester.
+- **French** — from the XIXᵉ siècle to the day before yesterday.
+- **Arabic** — Modern Standard, with the literary register noted when it appears.
+
+A fifth (likely classical Chinese) is on the desk. We add a script when we have at least four named translators willing to commit to a full season.
+
+## §IV — Correspondence
+
+The desk is at `desk@rosetta.script`. Translators may apply through the circle's page; office hours are every Tuesday afternoon, in Seoul time.

--- a/examples/rosetta-script/content/index.md
+++ b/examples/rosetta-script/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Rosetta Script — a reading-first language app in Korean, Japanese, French and Arabic. Translated by people who actually read."
+template = "index"
++++

--- a/examples/rosetta-script/static/css/style.css
+++ b/examples/rosetta-script/static/css/style.css
@@ -1,0 +1,547 @@
+/* Rosetta Script — multilingual reading app landing */
+
+:root {
+  --paper: #f6efe1;
+  --paper-2: #ece2cb;
+  --paper-3: #d8c9a8;
+  --ink: #0d130c;
+  --ink-soft: #1f2a1c;
+  --ink-mute: #6a7461;
+  --mint: #1cbb88;
+  --mint-deep: #0e7e5c;
+  --persimmon: #d94724;
+  --persimmon-deep: #a13418;
+  --indigo: #1a2c4a;
+  --hair: #c8bb98;
+  --rule: #0d130c;
+  --serif: "Source Serif 4", "EB Garamond", Georgia, serif;
+  --display: "Source Serif 4", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+  --kr: "Noto Serif KR", "Source Serif 4", serif;
+  --jp: "Noto Serif JP", "Source Serif 4", serif;
+  --ar: "Amiri", "Noto Serif", serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--paper); color: var(--ink); }
+
+body {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--persimmon); text-decoration: none; border-bottom: 1px solid var(--persimmon); }
+a:hover { color: var(--mint-deep); border-bottom-color: var(--mint-deep); }
+
+::selection { background: var(--mint); color: var(--ink); }
+
+.shell { max-width: 1240px; margin: 0 auto; padding: 0 40px; }
+
+/* TOP BAR */
+.bar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  padding: 22px 0 18px;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.bar .mark {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  text-transform: none;
+  color: var(--ink);
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+.bar .mark .glyph {
+  font-family: var(--kr);
+  background: var(--ink);
+  color: var(--paper);
+  padding: 4px 10px;
+  font-size: 14px;
+  letter-spacing: 0;
+}
+.bar .lang { text-align: center; color: var(--ink); }
+.bar .lang b { color: var(--persimmon); }
+.bar nav { display: flex; gap: 22px; justify-content: flex-end; }
+.bar nav a { color: var(--ink); border: none; }
+.bar nav a:hover { color: var(--persimmon); }
+
+/* COVER */
+.cover {
+  padding: 80px 0 64px;
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+}
+
+.cover .kicker {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--persimmon);
+  margin-bottom: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+.cover .kicker::before {
+  content: "";
+  width: 26px; height: 1px;
+  background: var(--persimmon);
+}
+.cover .kicker b { background: var(--mint); color: var(--ink); padding: 3px 8px; letter-spacing: 0.2em; }
+
+.cover h1 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(56px, 10vw, 152px);
+  line-height: 0.94;
+  letter-spacing: -0.025em;
+  margin: 0;
+  color: var(--ink);
+}
+.cover h1 .it { font-style: italic; font-weight: 400; color: var(--ink-soft); }
+.cover h1 .glyph-ko {
+  display: inline-block;
+  font-family: var(--kr);
+  font-weight: 800;
+  color: var(--persimmon);
+  letter-spacing: -0.02em;
+  padding: 0 0.08em;
+  transform: translateY(-0.04em);
+}
+.cover h1 .glyph-jp {
+  display: inline-block;
+  font-family: var(--jp);
+  font-weight: 800;
+  color: var(--indigo);
+  background: var(--mint);
+  padding: 0 0.12em;
+  margin-left: 0.04em;
+}
+.cover h1 .glyph-ar {
+  display: inline-block;
+  font-family: var(--ar);
+  font-weight: 700;
+  color: var(--mint-deep);
+  letter-spacing: 0;
+}
+
+.cover .row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 56px;
+  margin-top: 44px;
+  padding-top: 28px;
+  border-top: 1px solid var(--rule);
+  align-items: end;
+}
+.cover .lede {
+  font-size: 21px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  margin: 0;
+}
+.cover .lede em { color: var(--persimmon); font-style: italic; font-weight: 600; }
+.cover .lede b { background: var(--mint); padding: 1px 6px; font-weight: 600; }
+
+.cover .scripts {
+  border: 1px solid var(--rule);
+  padding: 24px;
+  background: var(--paper-2);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  align-self: start;
+  position: relative;
+}
+.cover .scripts::before {
+  content: "SCRIPTS";
+  position: absolute;
+  top: -10px; left: 14px;
+  background: var(--paper);
+  padding: 0 8px;
+  font-size: 10px;
+  color: var(--persimmon);
+}
+.cover .scripts .item {
+  display: grid;
+  grid-template-columns: 56px 1fr 80px;
+  gap: 14px;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--hair);
+  align-items: center;
+}
+.cover .scripts .item:last-child { border-bottom: none; }
+.cover .scripts .g {
+  font-family: var(--serif);
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--ink);
+  text-align: center;
+  letter-spacing: 0;
+}
+.cover .scripts .g.ko { font-family: var(--kr); }
+.cover .scripts .g.jp { font-family: var(--jp); }
+.cover .scripts .g.ar { font-family: var(--ar); }
+.cover .scripts b { color: var(--ink); font-weight: 600; }
+.cover .scripts .count { color: var(--persimmon); font-family: var(--display); font-size: 18px; text-align: right; }
+
+.cover .cta { margin-top: 36px; display: flex; gap: 14px; flex-wrap: wrap; }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 26px;
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  border: 1px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  font-weight: 600;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+.btn:hover { background: var(--ink); color: var(--paper); }
+.btn.mint { background: var(--mint); color: var(--ink); border-color: var(--mint); }
+.btn.mint:hover { background: var(--ink); border-color: var(--ink); color: var(--paper); }
+.btn.persim { background: var(--persimmon); color: var(--paper); border-color: var(--persimmon); }
+.btn.persim:hover { background: var(--ink); border-color: var(--ink); }
+.btn .ar { font-family: var(--display); font-size: 18px; line-height: 1; letter-spacing: 0; }
+
+/* MARQUEE */
+.ribbon {
+  border-bottom: 1px solid var(--rule);
+  padding: 22px 0;
+  overflow: hidden;
+  white-space: nowrap;
+  background: var(--mint);
+}
+.ribbon .track {
+  display: inline-flex;
+  gap: 64px;
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 600;
+  font-size: 30px;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  animation: drift 36s linear infinite;
+}
+.ribbon .track .ko { font-family: var(--kr); font-style: normal; }
+.ribbon .track .jp { font-family: var(--jp); font-style: normal; }
+.ribbon .track .ar { font-family: var(--ar); font-style: normal; }
+.ribbon .track .dot {
+  display: inline-block;
+  width: 8px; height: 8px;
+  background: var(--ink);
+  border-radius: 50%;
+  margin: 0 16px;
+  transform: translateY(-6px);
+}
+@keyframes drift { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* PAGES SECTION */
+.pages-grid { padding: 80px 0; border-bottom: 1px solid var(--rule); }
+.pages-grid .hd {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 48px;
+  align-items: end;
+  margin-bottom: 36px;
+}
+.pages-grid .hd h2 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(40px, 6vw, 76px);
+  letter-spacing: -0.025em;
+  line-height: 1;
+  margin: 0;
+}
+.pages-grid .hd h2 em { font-style: italic; font-weight: 400; color: var(--persimmon); }
+.pages-grid .hd p { margin: 0; font-size: 18px; color: var(--ink-soft); }
+
+.papers {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 28px;
+}
+.paper-card {
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  padding: 28px 26px 30px;
+  position: relative;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+.paper-card:hover { transform: translateY(-3px); background: var(--paper); }
+.paper-card .meta {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--persimmon);
+}
+.paper-card .meta b { color: var(--ink); }
+.paper-card .glyph-line {
+  margin: 14px 0 8px;
+  font-size: 36px;
+  line-height: 1.1;
+  color: var(--ink);
+  letter-spacing: -0.005em;
+}
+.paper-card.ko .glyph-line { font-family: var(--kr); font-weight: 700; }
+.paper-card.jp .glyph-line { font-family: var(--jp); font-weight: 700; }
+.paper-card.fr .glyph-line { font-family: var(--display); font-style: italic; font-weight: 500; }
+.paper-card.ar .glyph-line { font-family: var(--ar); font-weight: 700; direction: rtl; text-align: right; }
+.paper-card .romanization {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--ink-mute);
+  margin-bottom: 14px;
+}
+.paper-card .translation {
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 19px;
+  color: var(--ink-soft);
+  line-height: 1.4;
+  margin: 0 0 18px;
+}
+.paper-card h3 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  margin: 0 0 6px;
+  color: var(--ink);
+}
+.paper-card h3 a { color: inherit; border: none; }
+.paper-card h3 a:hover { color: var(--persimmon); }
+.paper-card .source {
+  font-family: var(--sans);
+  font-size: 12px;
+  color: var(--ink-mute);
+  letter-spacing: 0.02em;
+}
+.paper-card .badge {
+  position: absolute;
+  top: 18px; right: 22px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 4px 10px;
+}
+.paper-card.jp .badge { background: var(--indigo); }
+.paper-card.fr .badge { background: var(--persimmon); }
+.paper-card.ar .badge { background: var(--mint-deep); color: var(--paper); }
+
+/* PRACTICE */
+.method {
+  display: grid;
+  grid-template-columns: 1fr 1.6fr;
+  gap: 56px;
+  padding: 90px 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: start;
+}
+.method .from { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--persimmon); }
+.method .from .ix { color: var(--ink); margin-right: 12px; }
+.method .from .sig {
+  margin-top: 28px;
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink);
+}
+.method .from .sig small {
+  display: block;
+  font-family: var(--sans);
+  font-style: normal;
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-top: 4px;
+}
+.method .body {
+  font-family: var(--display);
+  font-size: clamp(24px, 3.2vw, 40px);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+.method .body p:first-child::first-letter {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 5em;
+  float: left;
+  line-height: 0.86;
+  margin: 0.08em 0.1em 0 0;
+  color: var(--persimmon);
+}
+.method .body p + p { margin-top: 0.7em; }
+.method .body em { color: var(--mint-deep); font-style: italic; }
+
+/* COUNTS */
+.counts {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  background: var(--ink);
+  color: var(--paper);
+  border-bottom: 1px solid var(--rule);
+}
+.counts > div { padding: 32px 22px; border-right: 1px solid var(--ink-soft); }
+.counts > div:last-child { border-right: none; }
+.counts .n {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 62px;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--mint);
+}
+.counts .n sup { font-size: 16px; color: var(--persimmon); }
+.counts .l { font-family: var(--sans); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; margin-top: 10px; color: var(--paper); opacity: 0.78; }
+
+/* JOURNAL */
+.journal { padding: 80px 0; border-bottom: 1px solid var(--rule); }
+.journal .hd {
+  display: flex; justify-content: space-between; align-items: end; gap: 24px;
+  margin-bottom: 26px;
+}
+.journal .hd h2 {
+  font-family: var(--display); font-weight: 600;
+  font-size: clamp(40px, 6vw, 72px); letter-spacing: -0.025em; margin: 0;
+}
+.journal .hd h2 em { font-style: italic; font-weight: 400; color: var(--mint-deep); }
+
+.journal .list { border-top: 1px solid var(--rule); }
+.journal .row {
+  display: grid;
+  grid-template-columns: 100px 1fr 140px 80px 60px;
+  gap: 28px;
+  align-items: center;
+  padding: 22px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.journal .row .d { font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); }
+.journal .row .t { font-family: var(--display); font-weight: 600; font-size: 23px; letter-spacing: -0.01em; }
+.journal .row .t a { color: var(--ink); border: none; }
+.journal .row .t a:hover { color: var(--persimmon); }
+.journal .row .t small {
+  display: block;
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-top: 4px;
+  font-weight: 500;
+}
+.journal .row .lang { font-family: var(--mono); font-size: 13px; color: var(--mint-deep); font-weight: 600; }
+.journal .row .lvl { font-family: var(--sans); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--persimmon); }
+.journal .row .ar { font-family: var(--display); font-size: 28px; text-align: right; }
+
+/* PROSE */
+.prose {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 64px 0 80px;
+  font-size: 18px;
+  line-height: 1.75;
+  color: var(--ink-soft);
+}
+.prose h1 { font-family: var(--display); font-weight: 600; font-size: 56px; line-height: 0.96; margin: 0 0 28px; letter-spacing: -0.025em; color: var(--ink); }
+.prose h1 em { font-style: italic; font-weight: 400; color: var(--persimmon); }
+.prose h2 { font-family: var(--display); font-weight: 600; font-size: 30px; margin-top: 1.8em; color: var(--ink); letter-spacing: -0.015em; }
+.prose h3 { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--persimmon); margin-top: 1.6em; }
+.prose p { margin: 0 0 1.1em; }
+.prose blockquote { border-left: 3px solid var(--mint); padding-left: 22px; margin: 1.4em 0; font-style: italic; color: var(--ink); }
+.prose code { background: var(--paper-2); padding: 2px 6px; font-family: var(--mono); font-size: 0.9em; color: var(--mint-deep); }
+.prose pre { background: var(--ink); color: var(--paper); padding: 18px 22px; overflow-x: auto; }
+.prose pre code { background: none; color: inherit; }
+.prose hr { border: none; border-top: 1px dashed var(--rule); margin: 2em 0; }
+
+/* FOOTER */
+.foot {
+  padding: 80px 0 36px;
+  border-top: 1px solid var(--rule);
+  background: var(--paper);
+}
+.foot .big {
+  font-family: var(--display); font-weight: 600;
+  font-size: clamp(56px, 12vw, 168px);
+  letter-spacing: -0.03em;
+  line-height: 0.94;
+  color: var(--ink);
+  margin: 0 0 36px;
+}
+.foot .big em { font-style: italic; font-weight: 400; color: var(--persimmon); }
+.foot .big small { font-family: var(--sans); font-size: 12px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--mint-deep); display: block; margin-top: 12px; font-weight: 600; }
+.foot .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px;
+  padding-top: 32px;
+  border-top: 1px solid var(--rule);
+}
+.foot h4 { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--persimmon); margin: 0 0 14px; }
+.foot a { display: block; color: var(--ink); border: none; padding: 4px 0; }
+.foot a:hover { color: var(--persimmon); }
+.foot .copy { grid-column: 1 / -1; padding-top: 24px; border-top: 1px solid var(--hair); font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { margin: 32px 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  font-family: var(--sans); font-size: 11px; letter-spacing: 0.24em; text-transform: uppercase;
+  padding: 10px 16px; border: 1px solid var(--ink); color: var(--ink); font-weight: 600; border-bottom: 1px solid var(--ink);
+}
+nav.pagination a:hover { background: var(--mint); border-color: var(--mint); }
+.pagination-current span { background: var(--persimmon); border-color: var(--persimmon); color: var(--paper); }
+.pagination-disabled span { color: var(--ink-mute); border-color: var(--hair); }
+
+/* RESPONSIVE */
+@media (max-width: 980px) {
+  .papers { grid-template-columns: 1fr 1fr; }
+  .cover .row { grid-template-columns: 1fr; gap: 24px; }
+  .method { grid-template-columns: 1fr; gap: 24px; }
+  .counts { grid-template-columns: 1fr 1fr; }
+  .counts > div:nth-child(2n) { border-right: none; }
+  .journal .row { grid-template-columns: 80px 1fr; gap: 12px; }
+  .journal .row .lang, .journal .row .lvl, .journal .row .ar { display: none; }
+  .foot .grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 580px) {
+  .shell { padding: 0 22px; }
+  .bar { grid-template-columns: 1fr 1fr; }
+  .bar .lang { display: none; }
+  .papers { grid-template-columns: 1fr; }
+  .foot .grid { grid-template-columns: 1fr; }
+  .foot .copy { flex-direction: column; gap: 8px; }
+  .counts { grid-template-columns: 1fr; }
+  .counts > div { border-right: none; }
+}

--- a/examples/rosetta-script/static/favicon.svg
+++ b/examples/rosetta-script/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/rosetta-script/templates/404.html
+++ b/examples/rosetta-script/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &mdash; <em>untranslated.</em></h1>
+  <p>This page is not in any of the four scripts the reader knows. It may have moved, been retired, or never been set.</p>
+  <p><a href="{{ base_url }}/">Back to today&apos;s page &rarr;</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/rosetta-script/templates/footer.html
+++ b/examples/rosetta-script/templates/footer.html
@@ -1,0 +1,38 @@
+    <footer class="foot">
+      <div class="big">Rosetta <em>Script.</em><small>Reading-first &middot; translated by ear</small></div>
+      <div class="grid">
+        <div>
+          <h4>The Reader</h4>
+          <a href="{{ base_url }}/">Today&apos;s page</a>
+          <a href="#">Daily extract &mdash; mailing</a>
+          <a href="#">Levels A1&ndash;C1</a>
+        </div>
+        <div>
+          <h4>The Library</h4>
+          <a href="{{ base_url }}/tags/">All scripts</a>
+          <a href="#">Translators</a>
+          <a href="#">Submissions</a>
+        </div>
+        <div>
+          <h4>The Method</h4>
+          <a href="{{ base_url }}/about/">How we translate</a>
+          <a href="#">The reading practice</a>
+          <a href="#">Why no machine</a>
+        </div>
+        <div>
+          <h4>Correspondence</h4>
+          <a href="#">desk@rosetta.script</a>
+          <a href="#">Translators&apos; circle</a>
+          <a href="#">Office hours &mdash; Tuesdays</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} Rosetta Script &middot; A reading practice in five tongues</span>
+          <span>Set in Source Serif, Noto Serif KR / JP &amp; Amiri</span>
+        </div>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/rosetta-script/templates/header.html
+++ b/examples/rosetta-script/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Inter:wght@400;500;600&family=Noto+Serif+JP:wght@400;700;800&family=Noto+Serif+KR:wght@400;700;800&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400;1,8..60,500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="bar">
+      <a href="{{ base_url }}/" class="mark"><span class="glyph">&#46553;</span>Rosetta Script</a>
+      <div class="lang">EN &middot; <b>KO</b> &middot; JA &middot; FR &middot; AR</div>
+      <nav>
+        <a href="{{ base_url }}/">Reader</a>
+        <a href="{{ base_url }}/about/">Method</a>
+        <a href="{{ base_url }}/tags/">Library</a>
+      </nav>
+    </header>

--- a/examples/rosetta-script/templates/index.html
+++ b/examples/rosetta-script/templates/index.html
@@ -1,0 +1,158 @@
+{% include "header.html" %}
+
+<section class="cover">
+  <div class="kicker">Volume IV &middot; <b>{{ current_year }} Spring</b> &middot; reading-first</div>
+  <h1>
+    Learn the<br>
+    <span class="it">language</span> by<br>
+    reading the <span class="glyph-ko">&#48148;&#46160;</span>,<br>
+    the <span class="glyph-jp">&#28023;</span>
+    &amp; the <span class="glyph-ar">&#1576;&#1581;&#1585;</span>.
+  </h1>
+  <div class="row">
+    <p class="lede">Rosetta Script is a small reading app for adults &mdash; short pieces in Korean, Japanese, French and Arabic, <em>translated by people who actually read</em>, with the original on one side and the english on the other. <b>No flashcards.</b> No streaks.</p>
+    <div class="scripts">
+      <div class="item"><span class="g ko">&#54620;&#44397;&#50612;</span><span><b>Hangul</b> &middot; modern &amp; literary</span><span class="count">312 pages</span></div>
+      <div class="item"><span class="g jp">&#26085;&#26412;&#35486;</span><span><b>Japanese</b> &middot; kanji + kana</span><span class="count">208 pages</span></div>
+      <div class="item"><span class="g">FR</span><span><b>French</b> &middot; XIX&shy;<sup>e</sup> &mdash; today</span><span class="count">414 pages</span></div>
+      <div class="item"><span class="g ar">&#1593;&#1585;&#1576;&#1610;</span><span><b>Arabic</b> &middot; standard &amp; literary</span><span class="count">96 pages</span></div>
+    </div>
+  </div>
+  <div class="cta">
+    <a class="btn persim" href="#today">Read today&apos;s page<span class="ar">&rarr;</span></a>
+    <a class="btn mint" href="{{ base_url }}/about/">The method<span class="ar">&rarr;</span></a>
+    <a class="btn" href="{{ base_url }}/tags/">Open the library<span class="ar">&rarr;</span></a>
+  </div>
+</section>
+
+<div class="ribbon" aria-hidden="true">
+  <div class="track">
+    <span class="ko">&#48148;&#46160;&#45716; &#46117;&#50640; &#51080;&#45796;.</span><span class="dot"></span>
+    <span class="jp">&#28023;&#12399;&#38632;&#12398;&#19979;&#12395;&#12290;</span><span class="dot"></span>
+    <span>La mer est sous la pluie.</span><span class="dot"></span>
+    <span class="ar">&#1575;&#1604;&#1576;&#1581;&#1585; &#1578;&#1581;&#1578; &#1575;&#1604;&#1605;&#1591;&#1585;.</span><span class="dot"></span>
+    <span class="ko">&#48148;&#46160;&#45716; &#46117;&#50640; &#51080;&#45796;.</span><span class="dot"></span>
+    <span class="jp">&#28023;&#12399;&#38632;&#12398;&#19979;&#12395;&#12290;</span><span class="dot"></span>
+    <span>La mer est sous la pluie.</span><span class="dot"></span>
+    <span class="ar">&#1575;&#1604;&#1576;&#1581;&#1585; &#1578;&#1581;&#1578; &#1575;&#1604;&#1605;&#1591;&#1585;.</span><span class="dot"></span>
+  </div>
+</div>
+
+<section class="pages-grid" id="today">
+  <div class="hd">
+    <h2>Today&apos;s <em>reader.</em></h2>
+    <p>Four pieces, one a day. Each comes with the original, a romanization where it helps, a careful translation, and a note from the translator on what they chose to lose.</p>
+  </div>
+  <div class="papers">
+    <article class="paper-card ko">
+      <span class="badge">KO &middot; A2</span>
+      <div class="meta"><b>Plate I</b> &middot; Modern Korean &middot; Short prose</div>
+      <div class="glyph-line">&#48148;&#46160;&#45716; &#46117;&#50640; &#51080;&#46160;&#45716; &#52380; &#48708;&#44032; &#50741;&#45796;.</div>
+      <div class="romanization">badaneun deudae itneunde cheoeum biga onda</div>
+      <p class="translation">The sea is on the field &mdash; and the rain has just begun.</p>
+      <h3><a href="#">A note on the field, the sea, and a verb that means both</a></h3>
+      <div class="source">From <i>The Field Atlas</i> &middot; Kim Min-su, 2017</div>
+    </article>
+    <article class="paper-card jp">
+      <span class="badge">JA &middot; B1</span>
+      <div class="meta"><b>Plate II</b> &middot; Contemporary Japanese</div>
+      <div class="glyph-line">&#28023;&#12399;&#19979;&#12395;&#12289;<br>&#38632;&#12399;&#26412;&#12398;&#19978;&#12395;&#12290;</div>
+      <div class="romanization">umi wa shita ni, ame wa hon no ue ni</div>
+      <p class="translation">The sea is below; the rain is on the book.</p>
+      <h3><a href="#">Two postpositions, one quiet afternoon</a></h3>
+      <div class="source">From <i>Notebooks of a Bookseller</i> &middot; Yamamoto Aiko</div>
+    </article>
+    <article class="paper-card fr">
+      <span class="badge">FR &middot; B2</span>
+      <div class="meta"><b>Plate III</b> &middot; XIX&shy;<sup>e</sup> si&egrave;cle</div>
+      <div class="glyph-line">La mer est sous le ciel et la lampe sous la table.</div>
+      <p class="translation">The sea is under the sky and the lamp under the table.</p>
+      <h3><a href="#">On a sentence that hides another inside it</a></h3>
+      <div class="source">From <i>Lettres de Bretagne</i> &middot; Anonymous, 1881</div>
+    </article>
+    <article class="paper-card ar">
+      <span class="badge">AR &middot; A1</span>
+      <div class="meta"><b>Plate IV</b> &middot; Modern Standard</div>
+      <div class="glyph-line">&#1575;&#1604;&#1576;&#1581;&#1585; &#1578;&#1581;&#1578; &#1575;&#1604;&#1605;&#1591;&#1585;.</div>
+      <div class="romanization">al-bahru ta&hbar;ta al-ma&hbar;ar</div>
+      <p class="translation">The sea is under the rain.</p>
+      <h3><a href="#">The simplest sentence, and the room it makes</a></h3>
+      <div class="source">From <i>Beginners&apos; Pieces</i> &middot; Layla Karim</div>
+    </article>
+    <article class="paper-card ko">
+      <span class="badge">KO &middot; C1</span>
+      <div class="meta"><b>Plate V</b> &middot; Literary Korean &middot; 1960</div>
+      <div class="glyph-line">&#48148;&#46300;&#54616;&#44256; &#51664;&#51008; &#49324;&#46983;&#46308;&#51060; &#44512;&#51008; &#48155;&#51012; &#54616;&#45716; &#54620; &#51652; &#44033;&#54616;&#46300;.</div>
+      <div class="romanization">bandeushago jjalbeun saramdeuli gineun bameul haneun han iri gakhadeo</div>
+      <p class="translation">For the upright and short-of-stature, a long night was a kind of work.</p>
+      <h3><a href="#">A long sentence about a long night</a></h3>
+      <div class="source">From the archive, 1962 &middot; trans. Park J.</div>
+    </article>
+    <article class="paper-card jp">
+      <span class="badge">JA &middot; C1</span>
+      <div class="meta"><b>Plate VI</b> &middot; Sh&omacr;wa essay</div>
+      <div class="glyph-line">&#19968;&#26412;&#12398;&#26408;&#12398;&#19979;&#12391;&#12289;&#12354;&#12373;&#12434;&#24453;&#12390;&#12356;&#12383;&#12290;</div>
+      <div class="romanization">ippon no ki no shita de, asa o matte ita</div>
+      <p class="translation">Under one tree, I waited for the morning.</p>
+      <h3><a href="#">A single counter and an entire night</a></h3>
+      <div class="source">From <i>Essays of the Quiet Press</i> &middot; 1958</div>
+    </article>
+  </div>
+</section>
+
+<section class="method">
+  <div class="from">
+    <div><span class="ix">&sect; II</span>FROM THE TRANSLATORS&apos; CIRCLE</div>
+    <div class="sig">&mdash; Park Ji-yeon &amp; Layla Karim<small>Translators &middot; Volume IV</small></div>
+  </div>
+  <div class="body">
+    <p>We translate <em>by ear,</em> not by machine. Every piece passes through two readers and one editor before it is set, and we keep a public note on every choice we had to make.</p>
+    <p>The app does not test you. It does not rank you. It hands you one page a day, and a friend in the margin to read it with.</p>
+  </div>
+</section>
+
+<section class="counts">
+  <div><div class="n">04</div><div class="l">SCRIPTS / READ DAILY</div></div>
+  <div><div class="n">1,030<sup>+</sup></div><div class="l">PAGES / IN THE LIBRARY</div></div>
+  <div><div class="n">12</div><div class="l">TRANSLATORS / NAMED</div></div>
+  <div><div class="n">00</div><div class="l">MACHINE-DRAFTS / EVER</div></div>
+</section>
+
+<section class="journal">
+  <div class="hd">
+    <h2>From the <em>translator&apos;s journal.</em></h2>
+    <a class="btn" href="{{ base_url }}/tags/">All entries &rarr;</a>
+  </div>
+  <div class="list">
+    <div class="row">
+      <div class="d">{{ current_year }} / 04</div>
+      <div class="t"><a href="#">On translating &#48148;&#46160; &mdash; a noun with a quiet history</a><small>Notes &middot; Lexicon</small></div>
+      <div class="lang">KO &rarr; EN</div>
+      <div class="lvl">A2</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} / 03</div>
+      <div class="t"><a href="#">Why we kept the Japanese counter, and how it changed the page</a><small>Notes &middot; Grammar</small></div>
+      <div class="lang">JA &rarr; EN</div>
+      <div class="lvl">B1</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} / 02</div>
+      <div class="t"><a href="#">Letters from Brittany &mdash; the strange comfort of XIX&shy;<sup>e</sup> French</a><small>Editorial</small></div>
+      <div class="lang">FR &rarr; EN</div>
+      <div class="lvl">B2</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">2025 / 12</div>
+      <div class="t"><a href="#">A small piece in Arabic, after a long absence</a><small>Field</small></div>
+      <div class="lang">AR &rarr; EN</div>
+      <div class="lvl">A1</div>
+      <div class="ar">&rarr;</div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/rosetta-script/templates/page.html
+++ b/examples/rosetta-script/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/rosetta-script/templates/section.html
+++ b/examples/rosetta-script/templates/section.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<section class="journal">
+  <div class="hd">
+    {% if page.title is present %}<h2><em>{{ page.title | e }}</em></h2>{% endif %}
+  </div>
+  {{ content | safe }}
+  <div class="list">
+    {% for post in section.pages %}
+    <div class="row">
+      <div class="d">{{ post.date | date(format="%Y / %m") }}</div>
+      <div class="t"><a href="{{ post.url }}">{{ post.title | e }}</a><small>{{ post.section | default("library") }}</small></div>
+      <div class="lang">&mdash;</div>
+      <div class="lvl">&mdash;</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/rosetta-script/templates/shortcodes/alert.html
+++ b/examples/rosetta-script/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/rosetta-script/templates/taxonomy.html
+++ b/examples/rosetta-script/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>An index of subjects from the translator&apos;s journal and the library.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/rosetta-script/templates/taxonomy_term.html
+++ b/examples/rosetta-script/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>Pages and entries from the library, filed under this subject.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/trail-bureau/AGENTS.md
+++ b/examples/trail-bureau/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/trail-bureau/archetypes/default.md
+++ b/examples/trail-bureau/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/trail-bureau/config.toml
+++ b/examples/trail-bureau/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Trail Bureau"
+description = "A small outfitter and field office for the long walk — maps, gear, and reports from the country between cities."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/trail-bureau/content/about.md
+++ b/examples/trail-bureau/content/about.md
@@ -1,0 +1,25 @@
++++
+title = "The Charter"
+description = "Trail Bureau — what we make, what we mend, and the rules of the field office."
++++
+
+## §I — The Office
+
+Trail Bureau is a small outfitter and field office for the long walk. We sell what we have walked with, we map what we have re-walked, and we mend what we have sold. The office is open Wednesday to Sunday on a quiet street in Seoul.
+
+## §II — The Goods
+
+- Hand-checked maps of the SE-37 quadrangle, printed three times a year.
+- Waxed-cotton shells and oak-framed packs, made in a workshop outside Daegu.
+- A quarterly printed journal of routes, conditions, and the weather we got wrong.
+- A repair counter every Tuesday for anything we have sold, regardless of when.
+
+## §III — The Practice
+
+> A map is only as honest as the last person who walked it. We try to be that person.
+
+We do not stock anything we have not used for at least two seasons. We do not refuse a repair on something we made, even if the owner is the third person to carry it. We update the maps on foot.
+
+## §IV — Correspondence
+
+Reach the office at `office@trail.bureau`. The weekly conditions postcard is `&#8361; 24,000` a year, posted on Fridays. We answer mail in the order it arrives.

--- a/examples/trail-bureau/content/index.md
+++ b/examples/trail-bureau/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Trail Bureau — a small outfitter and field office for the long walk. Maps, gear, and reports from the country between cities."
+template = "index"
++++

--- a/examples/trail-bureau/static/css/style.css
+++ b/examples/trail-bureau/static/css/style.css
@@ -1,0 +1,510 @@
+/* Trail Bureau — outdoor cartography, contour & compass motifs */
+
+:root {
+  --paper: #efe7d3;
+  --paper-2: #e3d7b8;
+  --paper-3: #d5c697;
+  --ink: #1a1f17;
+  --ink-soft: #2d3326;
+  --ink-mute: #6a6b58;
+  --moss: #2f4a2a;
+  --moss-deep: #1f3219;
+  --pine: #1c3326;
+  --brick: #a83823;
+  --brick-deep: #6e2516;
+  --ochre: #c08a2a;
+  --hair: #c9be9a;
+  --rule: #1a1f17;
+  --contour: rgba(26, 31, 23, 0.18);
+  --serif: "Source Serif 4", "EB Garamond", Georgia, "Times New Roman", serif;
+  --display: "Source Serif 4", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--paper); color: var(--ink); }
+
+body {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='140' viewBox='0 0 240 140'><g fill='none' stroke='%231a1f17' stroke-opacity='0.07' stroke-width='1'><path d='M0,80 Q40,40 80,70 T160,60 T240,80'/><path d='M0,100 Q40,60 80,90 T160,80 T240,100'/><path d='M0,60 Q40,20 80,50 T160,40 T240,60'/><path d='M0,120 Q40,80 80,110 T160,100 T240,120'/></g></svg>");
+}
+
+a { color: var(--brick); text-decoration: none; border-bottom: 1px solid var(--brick); }
+a:hover { color: var(--moss); border-bottom-color: var(--moss); }
+
+::selection { background: var(--moss); color: var(--paper); }
+
+.shell { max-width: 1200px; margin: 0 auto; padding: 0 32px; }
+
+/* TOP BAR */
+.bar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 18px;
+  padding: 18px 0 14px;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.bar .crest {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  text-transform: none;
+  color: var(--ink);
+  border: none;
+}
+.bar .crest .compass {
+  width: 30px; height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.bar .crest .compass svg { width: 100%; height: 100%; }
+.bar .lat { text-align: center; color: var(--ink); }
+.bar .lat b { color: var(--brick); }
+.bar nav { display: flex; gap: 22px; justify-content: flex-end; }
+.bar nav a { color: var(--ink); border: none; }
+.bar nav a:hover { color: var(--brick); }
+
+/* HERO MAP */
+.field {
+  position: relative;
+  padding: 64px 0 56px;
+  border-bottom: 1px solid var(--rule);
+  overflow: hidden;
+}
+.field .compass-rose {
+  position: absolute;
+  right: 0; top: 56px;
+  width: 220px; height: 220px;
+  opacity: 0.92;
+  z-index: 1;
+}
+.field .compass-rose svg { width: 100%; height: 100%; }
+
+.field .kicker {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--brick);
+  margin-bottom: 22px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.field .kicker::before {
+  content: "";
+  width: 26px; height: 1px;
+  background: var(--brick);
+}
+
+.field h1 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: clamp(56px, 10vw, 152px);
+  line-height: 0.92;
+  letter-spacing: -0.025em;
+  margin: 0;
+  color: var(--ink);
+  max-width: 16ch;
+  position: relative;
+  z-index: 2;
+}
+.field h1 .italic { font-style: italic; font-weight: 400; color: var(--moss); }
+.field h1 .amp { color: var(--brick); }
+.field h1 small {
+  display: block;
+  font-family: var(--sans);
+  font-size: 13px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-top: 18px;
+  font-weight: 500;
+}
+
+.field .row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 56px;
+  margin-top: 44px;
+  padding-top: 28px;
+  border-top: 1px solid var(--rule);
+  align-items: end;
+  position: relative;
+  z-index: 2;
+}
+.field .lede {
+  font-size: 21px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  margin: 0;
+}
+.field .lede em { color: var(--brick); font-style: italic; }
+.field .stamp {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  border: 1px solid var(--ink);
+  padding: 18px 22px;
+  background: var(--paper-2);
+  position: relative;
+}
+.field .stamp::before {
+  content: "FIELD STAMP";
+  position: absolute;
+  top: -9px; left: 14px;
+  background: var(--paper);
+  padding: 0 8px;
+  font-size: 10px;
+  color: var(--brick);
+}
+.field .stamp b { color: var(--ink); font-weight: 700; }
+.field .stamp .grid-spec {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  row-gap: 6px;
+  column-gap: 14px;
+}
+
+.field .cta { margin-top: 32px; display: flex; gap: 14px; flex-wrap: wrap; }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 24px;
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  border: 1px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  font-weight: 600;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+.btn:hover { background: var(--ink); color: var(--paper); }
+.btn.moss { background: var(--moss); color: var(--paper); border-color: var(--moss); }
+.btn.moss:hover { background: var(--ink); border-color: var(--ink); }
+.btn.brick { background: var(--brick); color: var(--paper); border-color: var(--brick); }
+.btn.brick:hover { background: var(--ink); border-color: var(--ink); }
+.btn .ar { font-family: var(--mono); font-size: 14px; }
+
+/* LEGEND BAR */
+.legend {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper-2);
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.legend > div { padding: 16px 18px; border-right: 1px solid var(--rule); display: flex; align-items: center; gap: 10px; }
+.legend > div:last-child { border-right: none; }
+.legend i {
+  width: 18px; height: 18px;
+  display: inline-block;
+  background: var(--moss);
+  border: 1px solid var(--ink);
+}
+.legend i.b { background: var(--brick); }
+.legend i.o { background: var(--ochre); }
+.legend i.c { background: var(--paper); position: relative; }
+.legend i.c::after { content: ""; position: absolute; inset: 3px; border: 1px dashed var(--ink); }
+.legend i.k { background: var(--ink); }
+
+/* SHELVES */
+.shelves { padding: 84px 0; border-bottom: 1px solid var(--rule); }
+.shelves .hd {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 48px;
+  align-items: end;
+  margin-bottom: 32px;
+}
+.shelves .hd h2 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: clamp(40px, 6vw, 76px);
+  letter-spacing: -0.025em;
+  line-height: 1;
+  margin: 0;
+}
+.shelves .hd h2 em { font-weight: 400; font-style: italic; color: var(--moss); }
+.shelves .hd p { margin: 0; color: var(--ink-soft); font-size: 18px; }
+
+.kit {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--rule);
+}
+.kit .item {
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 28px 24px 32px;
+  background: var(--paper);
+  transition: background 0.2s ease;
+  position: relative;
+}
+.kit .item:nth-child(3n) { border-right: none; }
+.kit .item:hover { background: var(--paper-2); }
+.kit .item .no {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--brick);
+}
+.kit .item .no b { color: var(--ink); }
+.kit .item h3 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 26px;
+  letter-spacing: -0.01em;
+  margin: 16px 0 6px;
+  color: var(--ink);
+}
+.kit .item h3 a { color: inherit; border: none; }
+.kit .item h3 a:hover { color: var(--brick); }
+.kit .item p { margin: 0; color: var(--ink-soft); font-size: 15.5px; }
+.kit .item .spec {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--hair);
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  row-gap: 4px;
+  column-gap: 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.kit .item .spec b { color: var(--ink); font-weight: 600; }
+.kit .item .price {
+  position: absolute;
+  top: 28px; right: 24px;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 22px;
+  color: var(--brick);
+}
+
+/* DISPATCH */
+.dispatch {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 64px;
+  padding: 96px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.dispatch .from { font-family: var(--sans); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--brick); }
+.dispatch .from .ix { color: var(--ink); margin-right: 12px; }
+.dispatch .from .sig {
+  margin-top: 28px;
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink);
+}
+.dispatch .from .sig small {
+  display: block;
+  font-family: var(--sans);
+  font-style: normal;
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-top: 4px;
+}
+.dispatch .body {
+  font-family: var(--display);
+  font-size: clamp(24px, 3vw, 36px);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+.dispatch .body p:first-child::first-letter {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 5em;
+  float: left;
+  line-height: 0.86;
+  margin: 0.08em 0.1em 0 0;
+  color: var(--brick);
+}
+.dispatch .body p + p { margin-top: 0.7em; }
+.dispatch .body em { color: var(--moss); font-style: italic; }
+
+/* WAYPOINTS */
+.waypoints {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--rule);
+  background: var(--moss-deep);
+  color: var(--paper);
+}
+.waypoints > div { padding: 32px 22px; border-right: 1px solid #2c4626; }
+.waypoints > div:last-child { border-right: none; }
+.waypoints .n {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 58px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--paper);
+}
+.waypoints .n sup { font-size: 18px; color: var(--ochre); vertical-align: super; }
+.waypoints .l { font-family: var(--sans); font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; margin-top: 10px; color: var(--paper); opacity: 0.8; }
+
+/* REPORTS LIST */
+.reports { padding: 84px 0; border-bottom: 1px solid var(--rule); }
+.reports .hd {
+  display: flex; justify-content: space-between; align-items: end; gap: 24px;
+  margin-bottom: 22px;
+}
+.reports .hd h2 {
+  font-family: var(--display); font-weight: 700; font-size: clamp(40px, 6vw, 72px);
+  letter-spacing: -0.025em; margin: 0;
+}
+.reports .hd h2 em { font-style: italic; font-weight: 400; color: var(--brick); }
+
+.reports .list { border-top: 1px solid var(--rule); }
+.reports .row {
+  display: grid;
+  grid-template-columns: 100px 1fr 140px 80px 60px;
+  gap: 28px;
+  align-items: center;
+  padding: 22px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.reports .row .d { font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); }
+.reports .row .t { font-family: var(--display); font-weight: 700; font-size: 24px; letter-spacing: -0.01em; }
+.reports .row .t a { color: var(--ink); border: none; }
+.reports .row .t a:hover { color: var(--brick); }
+.reports .row .t small {
+  display: block;
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-top: 4px;
+  font-weight: 500;
+}
+.reports .row .by { font-family: var(--sans); font-size: 11px; letter-spacing: 0.24em; text-transform: uppercase; color: var(--ink-mute); }
+.reports .row .by b { color: var(--ink); }
+.reports .row .dist { font-family: var(--mono); font-size: 13px; color: var(--moss); font-weight: 600; }
+.reports .row .ar { font-family: var(--display); font-size: 28px; text-align: right; color: var(--brick); }
+
+/* PROSE */
+.prose {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 64px 32px 80px;
+  font-size: 18px;
+  line-height: 1.75;
+  color: var(--ink-soft);
+}
+.prose h1 { font-family: var(--display); font-weight: 700; font-size: 56px; line-height: 0.96; margin: 0 0 28px; letter-spacing: -0.025em; color: var(--ink); }
+.prose h1 em { font-style: italic; font-weight: 400; color: var(--moss); }
+.prose h2 { font-family: var(--display); font-weight: 700; font-size: 30px; margin-top: 1.8em; color: var(--ink); letter-spacing: -0.015em; }
+.prose h3 { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--brick); margin-top: 1.6em; }
+.prose p { margin: 0 0 1.1em; }
+.prose blockquote { border-left: 3px solid var(--moss); padding-left: 22px; margin: 1.4em 0; font-style: italic; color: var(--ink); }
+.prose code { background: var(--paper-2); padding: 2px 6px; font-family: var(--mono); font-size: 0.9em; color: var(--moss-deep); }
+.prose pre { background: var(--ink); color: var(--paper); padding: 18px 22px; overflow-x: auto; }
+.prose pre code { background: none; color: inherit; }
+.prose hr { border: none; border-top: 1px dashed var(--rule); margin: 2em 0; }
+
+/* FOOTER */
+.foot {
+  padding: 80px 0 32px;
+  border-top: 1px solid var(--rule);
+  background: var(--paper);
+}
+.foot .big {
+  font-family: var(--display); font-weight: 700;
+  font-size: clamp(56px, 12vw, 160px);
+  letter-spacing: -0.03em;
+  line-height: 0.94;
+  color: var(--ink);
+  margin: 0 0 36px;
+}
+.foot .big em { font-style: italic; font-weight: 400; color: var(--moss); }
+.foot .big small { font-family: var(--sans); font-size: 12px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--brick); display: block; margin-top: 12px; font-weight: 600; }
+.foot .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px;
+  padding-top: 32px;
+  border-top: 1px solid var(--rule);
+}
+.foot h4 { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--brick); margin: 0 0 14px; }
+.foot a { display: block; color: var(--ink); border: none; padding: 4px 0; }
+.foot a:hover { color: var(--brick); }
+.foot .copy { grid-column: 1 / -1; padding-top: 24px; border-top: 1px solid var(--hair); font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { margin: 32px 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  font-family: var(--sans); font-size: 11px; letter-spacing: 0.24em; text-transform: uppercase;
+  padding: 10px 16px; border: 1px solid var(--ink); color: var(--ink); border-bottom: 1px solid var(--ink); font-weight: 600;
+}
+nav.pagination a:hover { background: var(--ink); color: var(--paper); }
+.pagination-current span { background: var(--brick); border-color: var(--brick); color: var(--paper); }
+.pagination-disabled span { color: var(--ink-mute); border-color: var(--hair); }
+
+/* RESPONSIVE */
+@media (max-width: 980px) {
+  .field .compass-rose { width: 140px; height: 140px; top: 36px; right: 8px; opacity: 0.6; }
+  .field .row { grid-template-columns: 1fr; gap: 24px; }
+  .kit { grid-template-columns: 1fr 1fr; }
+  .kit .item:nth-child(3n) { border-right: 1px solid var(--rule); }
+  .kit .item:nth-child(2n) { border-right: none; }
+  .dispatch { grid-template-columns: 1fr; gap: 24px; }
+  .reports .row { grid-template-columns: 80px 1fr; gap: 12px; }
+  .reports .row .by, .reports .row .dist, .reports .row .ar { display: none; }
+  .waypoints { grid-template-columns: 1fr 1fr; }
+  .waypoints > div:nth-child(2n) { border-right: none; }
+  .legend { grid-template-columns: 1fr 1fr; }
+  .legend > div { border-bottom: 1px solid var(--rule); }
+  .legend > div:nth-child(2n) { border-right: none; }
+  .foot .grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 580px) {
+  .shell { padding: 0 20px; }
+  .bar { grid-template-columns: 1fr 1fr; }
+  .bar .lat { display: none; }
+  .kit { grid-template-columns: 1fr; }
+  .kit .item { border-right: none !important; }
+  .foot .grid { grid-template-columns: 1fr; }
+  .foot .copy { flex-direction: column; gap: 8px; }
+  .waypoints { grid-template-columns: 1fr; }
+  .waypoints > div { border-right: none; }
+}

--- a/examples/trail-bureau/static/favicon.svg
+++ b/examples/trail-bureau/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/trail-bureau/templates/404.html
+++ b/examples/trail-bureau/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &mdash; <em>off the sheet</em></h1>
+  <p>This route is not on the map you&apos;re holding. It may have been retired, re-named, or marked for a later edition.</p>
+  <p><a href="{{ base_url }}/">Back to the field office &rarr;</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/trail-bureau/templates/footer.html
+++ b/examples/trail-bureau/templates/footer.html
@@ -1,0 +1,38 @@
+    <footer class="foot">
+      <div class="big">Trail <em>Bureau.</em><small>Field office for the long walk &mdash; est. 2014</small></div>
+      <div class="grid">
+        <div>
+          <h4>Office</h4>
+          <a href="{{ base_url }}/about/">Charter &amp; Practice</a>
+          <a href="#">Field staff</a>
+          <a href="#">Visit the office</a>
+        </div>
+        <div>
+          <h4>Goods</h4>
+          <a href="#">Maps &amp; charts</a>
+          <a href="#">Pack &amp; shell</a>
+          <a href="#">Repair counter</a>
+        </div>
+        <div>
+          <h4>Reports</h4>
+          <a href="{{ base_url }}/tags/">Field journal</a>
+          <a href="#">Conditions today</a>
+          <a href="#">Quarterly index</a>
+        </div>
+        <div>
+          <h4>Correspondence</h4>
+          <a href="#">office@trail.bureau</a>
+          <a href="#">Telegraph &mdash; newsletter</a>
+          <a href="#">Hours &mdash; Wed&ndash;Sun</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} Trail Bureau &middot; Field office, small outfitter</span>
+          <span>Set in Source Serif &middot; Printed on paper that survives the weather</span>
+        </div>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/trail-bureau/templates/header.html
+++ b/examples/trail-bureau/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400;1,8..60,600&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="bar">
+      <a href="{{ base_url }}/" class="crest">
+        <span class="compass" aria-hidden="true">
+          <svg viewBox="0 0 30 30" fill="none">
+            <circle cx="15" cy="15" r="13.5" stroke="#1a1f17" stroke-width="1.2"/>
+            <circle cx="15" cy="15" r="1.6" fill="#a83823"/>
+            <path d="M15 2 L18 15 L15 28 L12 15 Z" fill="#1a1f17"/>
+            <path d="M15 2 L18 15 L15 15 Z" fill="#a83823"/>
+            <path d="M2 15 L15 12 L28 15 L15 18 Z" fill="#1a1f17" opacity="0.3"/>
+          </svg>
+        </span>
+        Trail Bureau
+      </a>
+      <div class="lat">N 37&deg;33' &middot; E 126&deg;58' &middot; ELEV. <b>284 M</b></div>
+      <nav>
+        <a href="{{ base_url }}/">Field</a>
+        <a href="{{ base_url }}/about/">Charter</a>
+        <a href="{{ base_url }}/tags/">Reports</a>
+      </nav>
+    </header>

--- a/examples/trail-bureau/templates/index.html
+++ b/examples/trail-bureau/templates/index.html
@@ -1,0 +1,180 @@
+{% include "header.html" %}
+
+<section class="field">
+  <div class="compass-rose" aria-hidden="true">
+    <svg viewBox="0 0 220 220" fill="none">
+      <circle cx="110" cy="110" r="106" stroke="#1a1f17" stroke-width="1.2"/>
+      <circle cx="110" cy="110" r="92" stroke="#1a1f17" stroke-width="0.8" stroke-dasharray="2 4"/>
+      <circle cx="110" cy="110" r="68" stroke="#1a1f17" stroke-width="0.6"/>
+      <circle cx="110" cy="110" r="3" fill="#a83823"/>
+      <path d="M110 12 L120 110 L110 208 L100 110 Z" fill="#1a1f17"/>
+      <path d="M110 12 L120 110 L110 110 Z" fill="#a83823"/>
+      <path d="M12 110 L110 100 L208 110 L110 120 Z" fill="#1a1f17" opacity="0.55"/>
+      <path d="M40 40 L116 106 L180 180 L104 114 Z" fill="#1a1f17" opacity="0.3"/>
+      <path d="M180 40 L114 106 L40 180 L106 114 Z" fill="#1a1f17" opacity="0.3"/>
+      <text x="110" y="8" text-anchor="middle" font-family="Source Serif 4" font-size="14" font-weight="700" fill="#1a1f17">N</text>
+      <text x="110" y="220" text-anchor="middle" font-family="Source Serif 4" font-size="14" font-weight="700" fill="#1a1f17">S</text>
+      <text x="6" y="115" text-anchor="middle" font-family="Source Serif 4" font-size="14" font-weight="700" fill="#1a1f17">W</text>
+      <text x="214" y="115" text-anchor="middle" font-family="Source Serif 4" font-size="14" font-weight="700" fill="#1a1f17">E</text>
+    </svg>
+  </div>
+  <div class="kicker">Field Office &mdash; Sheet IV &middot; Quadrangle SE-37</div>
+  <h1>Walk the<br><span class="italic">country</span><br>between<br>cities <span class="amp">&amp;</span> seasons.<small>A small outfitter and field journal for the long walk</small></h1>
+  <div class="row">
+    <p class="lede">Trail Bureau is a field office: a counter that mends a torn pack, a press that prints a small honest map, and a journal of <em>conditions</em>, <em>routes</em>, and <em>weather we got wrong.</em></p>
+    <div class="stamp">
+      <div class="grid-spec">
+        <span>SHEET</span><b>IV / XII</b>
+        <span>QUAD</span><b>SE-37</b>
+        <span>SCALE</span><b>1 : 24 000</b>
+        <span>ELEV</span><b>284 &mdash; 1,612 m</b>
+        <span>UPDATED</span><b>{{ current_date | default(current_year) }}</b>
+      </div>
+    </div>
+  </div>
+  <div class="cta">
+    <a class="btn moss" href="#kit">See the kit<span class="ar">&rarr;</span></a>
+    <a class="btn brick" href="{{ base_url }}/tags/">Read the reports<span class="ar">&rarr;</span></a>
+    <a class="btn" href="{{ base_url }}/about/">Visit the office<span class="ar">&rarr;</span></a>
+  </div>
+</section>
+
+<div class="legend" aria-hidden="true">
+  <div><i></i>Marked trail</div>
+  <div><i class="b"></i>Bureau outpost</div>
+  <div><i class="o"></i>Open shelter</div>
+  <div><i class="c"></i>Seasonal route</div>
+  <div><i class="k"></i>Closed &mdash; ask first</div>
+</div>
+
+<section class="shelves" id="kit">
+  <div class="hd">
+    <h2>The Kit &mdash; <em>shelved &amp; ready.</em></h2>
+    <p>Everything in the shop is something the office has carried for at least two seasons. We do not sell what we have not walked with. We will repair anything we sold you, regardless of when you bought it.</p>
+  </div>
+  <div class="kit">
+    <article class="item">
+      <div class="no"><b>K-01</b> &middot; CARTOGRAPHY</div>
+      <h3><a href="#">Sheet IV &mdash; Late Spring Edition</a></h3>
+      <p>A hand-checked 1:24 000 map of the SE-37 quadrangle, printed on tear-resistant paper. Updated three times a year by foot.</p>
+      <div class="spec">
+        <span>SCALE</span><b>1:24 000</b>
+        <span>SIZE</span><b>620 &times; 880 mm</b>
+        <span>ED.</span><b>SPRING 4</b>
+      </div>
+      <div class="price">&#8361; 18,000</div>
+    </article>
+    <article class="item">
+      <div class="no"><b>K-02</b> &middot; SHELL</div>
+      <h3><a href="#">The Two-Pocket Shell</a></h3>
+      <p>A waxed-cotton shell with two field-pockets, taped seams, and a hood that fits over a knit cap. Made in a small workshop outside Daegu.</p>
+      <div class="spec">
+        <span>FABRIC</span><b>14 oz waxed</b>
+        <span>WEIGHT</span><b>820 g</b>
+        <span>MENDABLE</span><b>YES, ALWAYS</b>
+      </div>
+      <div class="price">&#8361; 380,000</div>
+    </article>
+    <article class="item">
+      <div class="no"><b>K-03</b> &middot; PACK</div>
+      <h3><a href="#">Day Pack &mdash; 22L</a></h3>
+      <p>A small frame pack for a single overnight or a long Sunday. Roll-top closure, hipbelt detachable, hand-stitched on the inside.</p>
+      <div class="spec">
+        <span>VOLUME</span><b>22 L</b>
+        <span>FRAME</span><b>OAK BATTEN</b>
+        <span>WARRANTY</span><b>30 YEARS</b>
+      </div>
+      <div class="price">&#8361; 240,000</div>
+    </article>
+    <article class="item">
+      <div class="no"><b>K-04</b> &middot; PRESS</div>
+      <h3><a href="#">The Quarterly Journal</a></h3>
+      <p>A 64-page printed report of routes walked, conditions found, and weather we got wrong. Posted to subscribers four times a year.</p>
+      <div class="spec">
+        <span>FORMAT</span><b>A5 / sewn</b>
+        <span>RUN</span><b>800 numbered</b>
+        <span>SUB.</span><b>4 / year</b>
+      </div>
+      <div class="price">&#8361; 96,000</div>
+    </article>
+    <article class="item">
+      <div class="no"><b>K-05</b> &middot; REPAIR</div>
+      <h3><a href="#">Bring the Old Pack Counter</a></h3>
+      <p>Tuesdays at the office. We re-wax shells, re-stitch packs, and re-thread laces. We do not refuse a repair on something we made.</p>
+      <div class="spec">
+        <span>OPEN</span><b>TUE 09&ndash;17</b>
+        <span>WAIT</span><b>2 WEEKS</b>
+        <span>COST</span><b>BY THE HOUR</b>
+      </div>
+      <div class="price">By hour</div>
+    </article>
+    <article class="item">
+      <div class="no"><b>K-06</b> &middot; TELEGRAPH</div>
+      <h3><a href="#">Conditions Today &mdash; By Mail</a></h3>
+      <p>A short paper note posted weekly on Friday afternoon. Trail conditions, the river depth, what we&apos;ve seen on the ridge.</p>
+      <div class="spec">
+        <span>FREQ</span><b>WEEKLY</b>
+        <span>FORMAT</span><b>POSTCARD</b>
+        <span>YEAR</span><b>&#8361; 24,000</b>
+      </div>
+      <div class="price">&#8361; 24,000</div>
+    </article>
+  </div>
+</section>
+
+<section class="dispatch">
+  <div class="from">
+    <div><span class="ix">&sect; II</span>FROM THE DESK</div>
+    <div class="sig">&mdash; Marin Cho<small>Field Officer, SE-37</small></div>
+  </div>
+  <div class="body">
+    <p>The ridge cleared last Thursday and the wildflowers are early this year. We re-walked sheet IV in two days and corrected three switchbacks; the printer has the update on the press.</p>
+    <p>The river is <em>two hands higher</em> than the season&apos;s average. If you are heading north before May, take the high path and bring the second pair of socks.</p>
+  </div>
+</section>
+
+<section class="waypoints">
+  <div><div class="n">11<sup>yr</sup></div><div class="l">FIELD OFFICE / OPEN</div></div>
+  <div><div class="n">04</div><div class="l">SHEETS / IN PRINT</div></div>
+  <div><div class="n">112</div><div class="l">KM WALKED / THIS WEEK</div></div>
+  <div><div class="n">SE-37</div><div class="l">QUADRANGLE / SERVED</div></div>
+</section>
+
+<section class="reports">
+  <div class="hd">
+    <h2>From the field <em>journal.</em></h2>
+    <a class="btn" href="{{ base_url }}/tags/">All reports &rarr;</a>
+  </div>
+  <div class="list">
+    <div class="row">
+      <div class="d">{{ current_year }} / 04</div>
+      <div class="t"><a href="#">A note on the SE-37 ridge &mdash; the early wildflower season</a><small>Field &middot; Conditions</small></div>
+      <div class="by"><b>Marin</b></div>
+      <div class="dist">11.4 km</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} / 03</div>
+      <div class="t"><a href="#">Re-walking sheet IV &mdash; three switchbacks corrected</a><small>Cartography</small></div>
+      <div class="by"><b>Jin-ho</b></div>
+      <div class="dist">22.0 km</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} / 02</div>
+      <div class="t"><a href="#">The river at the second bridge &mdash; two hands higher than the average</a><small>Conditions</small></div>
+      <div class="by"><b>Office</b></div>
+      <div class="dist">4.8 km</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">2025 / 11</div>
+      <div class="t"><a href="#">On waxing the shell in the wrong season &mdash; a postmortem</a><small>Practice</small></div>
+      <div class="by"><b>Marin</b></div>
+      <div class="dist">&mdash;</div>
+      <div class="ar">&rarr;</div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/trail-bureau/templates/page.html
+++ b/examples/trail-bureau/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/trail-bureau/templates/section.html
+++ b/examples/trail-bureau/templates/section.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<section class="reports">
+  <div class="hd">
+    {% if page.title is present %}<h2><em>{{ page.title | e }}</em></h2>{% endif %}
+  </div>
+  {{ content | safe }}
+  <div class="list">
+    {% for post in section.pages %}
+    <div class="row">
+      <div class="d">{{ post.date | date(format="%Y / %m") }}</div>
+      <div class="t"><a href="{{ post.url }}">{{ post.title | e }}</a><small>{{ post.section | default("field") }}</small></div>
+      <div class="by"><b>Bureau</b></div>
+      <div class="dist">&mdash;</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/trail-bureau/templates/shortcodes/alert.html
+++ b/examples/trail-bureau/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/trail-bureau/templates/taxonomy.html
+++ b/examples/trail-bureau/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>An index of subjects from the field journal.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/trail-bureau/templates/taxonomy_term.html
+++ b/examples/trail-bureau/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>Reports filed under this subject.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/velvet-protocol/AGENTS.md
+++ b/examples/velvet-protocol/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/velvet-protocol/archetypes/default.md
+++ b/examples/velvet-protocol/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/velvet-protocol/config.toml
+++ b/examples/velvet-protocol/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Velvet Protocol"
+description = "A nocturnal house of perfume and spirit — distilled by hand, bottled by appointment, and posted with a letter."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/velvet-protocol/content/about.md
+++ b/examples/velvet-protocol/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "The Protocol"
+description = "Velvet Protocol — the practice, the hours, and the rules of the house."
++++
+
+## §I — The House
+
+Velvet Protocol is a small house of perfume and spirit. We were founded in 2021, in a basement off Rua de Norte, and we have kept the basement. The house holds two distillers, one printer, one secretary, and a black cat who answers to no one.
+
+## §II — The Hours
+
+The house opens at twenty-two and closes at four. The still is lit at midnight. The bottles are labelled at three. We answer the door, the letter, and the telephone — in that order, and only at the appointed hour.
+
+## §III — The Lots
+
+We release four bottles a lot, four lots a year. Each lot is distilled in the months before release and labelled by the person who finished it. When a lot is gone, the next lot begins. We do not repress; we do not re-issue.
+
+## §IV — Correspondence
+
+> Write first. Visit by appointment. Wear something that survives the kitchen.
+
+The house can be reached at `house@velvet.protocol`, by post at 04 Rua de Norte, or by telephone between twenty-two and four (and only then). We answer in the order mail arrives, which is also the order it was sent.

--- a/examples/velvet-protocol/content/index.md
+++ b/examples/velvet-protocol/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Velvet Protocol — a nocturnal house of perfume and spirit, distilled by hand and bottled by appointment."
+template = "index"
++++

--- a/examples/velvet-protocol/static/css/style.css
+++ b/examples/velvet-protocol/static/css/style.css
@@ -1,0 +1,521 @@
+/* Velvet Protocol — nocturnal perfumery / spirit house */
+
+:root {
+  --night: #110813;
+  --night-2: #1b0f1d;
+  --night-3: #251625;
+  --plum: #3a1a3a;
+  --plum-deep: #200a20;
+  --bone: #efe6d4;
+  --bone-2: #d9cab1;
+  --bone-3: #b9a98c;
+  --gold: #c4a467;
+  --gold-deep: #8a7340;
+  --rouge: #963048;
+  --hair: rgba(239, 230, 212, 0.16);
+  --serif: "Cormorant Garamond", "EB Garamond", Georgia, serif;
+  --display: "Italiana", "Cormorant Garamond", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--night); color: var(--bone); }
+
+body {
+  font-family: var(--serif);
+  font-size: 18px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='4'><circle cx='1' cy='1' r='0.4' fill='%231b0f1d'/></svg>");
+  background-size: 4px 4px;
+}
+
+a { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(--gold); }
+a:hover { color: var(--bone); border-bottom-color: var(--bone); }
+
+::selection { background: var(--gold); color: var(--night); }
+
+.shell { max-width: 1240px; margin: 0 auto; padding: 0 56px; }
+
+/* TOP BAR */
+.bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 28px 0 22px;
+  border-bottom: 1px solid var(--hair);
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: var(--bone-3);
+}
+.bar .est b { color: var(--gold); }
+.bar nav { display: flex; gap: 30px; justify-content: flex-end; }
+.bar nav a { color: var(--bone); border: none; }
+.bar nav a:hover { color: var(--gold); }
+.bar .mark {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 28px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bone);
+  border: none;
+}
+.bar .mark .vp {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+.bar .mark .seal {
+  width: 30px; height: 30px;
+  border: 1px solid var(--gold);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--display);
+  font-size: 14px;
+  color: var(--gold);
+  letter-spacing: 0;
+}
+
+/* COVER */
+.cover {
+  position: relative;
+  padding: 100px 0 84px;
+  border-bottom: 1px solid var(--hair);
+  text-align: center;
+  overflow: hidden;
+}
+.cover::before {
+  content: "";
+  position: absolute;
+  top: 50%; left: 50%;
+  width: 480px; height: 480px;
+  border: 1px solid var(--gold-deep);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.4;
+  z-index: 0;
+}
+.cover::after {
+  content: "";
+  position: absolute;
+  top: 50%; left: 50%;
+  width: 280px; height: 280px;
+  border: 1px solid var(--gold-deep);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.5;
+  z-index: 0;
+}
+.cover > * { position: relative; z-index: 1; }
+
+.cover .kicker {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 36px;
+  display: inline-flex;
+  align-items: center;
+  gap: 18px;
+}
+.cover .kicker::before, .cover .kicker::after {
+  content: "";
+  width: 40px; height: 1px;
+  background: var(--gold);
+}
+
+.cover h1 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(72px, 14vw, 220px);
+  letter-spacing: 0.02em;
+  line-height: 0.92;
+  margin: 0;
+  color: var(--bone);
+  text-transform: uppercase;
+}
+.cover h1 .second { font-style: italic; font-family: var(--serif); font-weight: 400; display: block; }
+.cover h1 .gold { color: var(--gold); }
+.cover h1 sub {
+  font-family: var(--sans);
+  font-size: 14px;
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  display: block;
+  margin-top: 28px;
+  color: var(--bone-3);
+  font-weight: 500;
+  vertical-align: baseline;
+}
+
+.cover .lede {
+  max-width: 56ch;
+  margin: 36px auto 0;
+  font-size: 22px;
+  line-height: 1.5;
+  color: var(--bone-2);
+  font-style: italic;
+}
+.cover .lede em { color: var(--gold); font-style: normal; font-family: var(--display); }
+
+.cover .cta { margin-top: 44px; display: inline-flex; gap: 16px; flex-wrap: wrap; }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 32px;
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  border: 1px solid var(--bone);
+  color: var(--bone);
+  background: transparent;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.btn:hover { background: var(--bone); color: var(--night); }
+.btn.gold { background: var(--gold); color: var(--night); border-color: var(--gold); }
+.btn.gold:hover { background: var(--bone); border-color: var(--bone); }
+.btn .ar { font-family: var(--display); font-size: 18px; letter-spacing: 0; line-height: 1; }
+
+/* RIBBON */
+.ribbon {
+  border-bottom: 1px solid var(--hair);
+  padding: 22px 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--display);
+  font-size: 24px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+.ribbon .track { display: inline-flex; gap: 56px; animation: drift 44s linear infinite; }
+.ribbon .track span small {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  color: var(--bone-3);
+  margin-left: 18px;
+}
+.ribbon .track .dot {
+  display: inline-block;
+  width: 6px; height: 6px;
+  background: var(--gold);
+  border-radius: 50%;
+  margin: 0 24px;
+  transform: translateY(-6px);
+}
+@keyframes drift { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* COLLECTION */
+.collection { padding: 96px 0; border-bottom: 1px solid var(--hair); }
+.collection .hd {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 56px;
+  align-items: end;
+  margin-bottom: 56px;
+}
+.collection .hd h2 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(48px, 7vw, 96px);
+  letter-spacing: 0.02em;
+  line-height: 1;
+  margin: 0;
+  text-transform: uppercase;
+  color: var(--bone);
+}
+.collection .hd h2 em { font-family: var(--serif); font-style: italic; color: var(--gold); }
+.collection .hd p { margin: 0; color: var(--bone-2); font-size: 18px; font-style: italic; }
+
+.bottles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 36px; }
+.bottle {
+  padding-bottom: 28px;
+  border-bottom: 1px solid var(--hair);
+  transition: transform 0.3s ease;
+}
+.bottle:hover { transform: translateY(-4px); }
+.bottle .vessel {
+  position: relative;
+  height: 320px;
+  background: var(--night-2);
+  border: 1px solid var(--hair);
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.bottle .vessel svg { width: 64%; height: 86%; opacity: 0.95; }
+.bottle .vessel .ix {
+  position: absolute;
+  top: 14px; left: 14px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+.bottle .vessel .vol {
+  position: absolute;
+  bottom: 14px; right: 14px;
+  font-family: var(--display);
+  font-size: 16px;
+  color: var(--bone-3);
+  letter-spacing: 0.1em;
+}
+.bottle .meta { font-family: var(--sans); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--gold); }
+.bottle h3 {
+  margin: 8px 0 6px;
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 32px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--bone);
+}
+.bottle h3 a { color: inherit; border: none; }
+.bottle h3 a:hover { color: var(--gold); }
+.bottle p { margin: 0; color: var(--bone-2); font-style: italic; font-size: 16px; }
+.bottle .notes {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+.bottle .notes span {
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--bone-3);
+  border: 1px solid var(--gold-deep);
+  padding: 4px 10px;
+}
+
+/* PROTOCOL */
+.protocol {
+  display: grid;
+  grid-template-columns: 1fr 1.6fr;
+  gap: 64px;
+  padding: 110px 0;
+  border-bottom: 1px solid var(--hair);
+}
+.protocol .from {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+.protocol .from .ix { color: var(--bone); margin-right: 14px; }
+.protocol .from .sig {
+  margin-top: 32px;
+  font-family: var(--display);
+  font-size: 26px;
+  letter-spacing: 0.04em;
+  color: var(--bone);
+  text-transform: uppercase;
+}
+.protocol .from .sig small {
+  display: block;
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.4em;
+  color: var(--bone-3);
+  margin-top: 8px;
+  font-weight: 500;
+}
+.protocol .body {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(28px, 3.4vw, 44px);
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+  color: var(--bone);
+  text-transform: uppercase;
+}
+.protocol .body p:first-child::first-letter {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 4.6em;
+  float: left;
+  line-height: 0.86;
+  margin: 0.06em 0.1em 0 0;
+  color: var(--gold);
+}
+.protocol .body p + p { margin-top: 0.7em; }
+.protocol .body em { font-family: var(--serif); font-style: italic; text-transform: none; color: var(--gold); }
+
+/* HOUSE NUMBERS */
+.numbers {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--hair);
+  background: var(--plum-deep);
+}
+.numbers > div { padding: 36px 22px; border-right: 1px solid var(--hair); text-align: center; }
+.numbers > div:last-child { border-right: none; }
+.numbers .n {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 68px;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  color: var(--gold);
+  text-transform: uppercase;
+}
+.numbers .n sup { font-size: 18px; color: var(--bone); }
+.numbers .l { font-family: var(--sans); font-size: 10px; letter-spacing: 0.4em; text-transform: uppercase; margin-top: 14px; color: var(--bone-3); }
+
+/* LEDGER */
+.ledger { padding: 96px 0; border-bottom: 1px solid var(--hair); }
+.ledger .hd {
+  display: flex; justify-content: space-between; align-items: end; gap: 24px;
+  margin-bottom: 30px;
+}
+.ledger .hd h2 {
+  font-family: var(--display); font-weight: 400; font-size: clamp(40px, 6vw, 76px);
+  letter-spacing: 0.02em; margin: 0; text-transform: uppercase; color: var(--bone);
+}
+.ledger .hd h2 em { font-family: var(--serif); font-style: italic; color: var(--gold); }
+
+.ledger .entries { border-top: 1px solid var(--hair); }
+.ledger .row {
+  display: grid;
+  grid-template-columns: 100px 1fr 140px 60px;
+  gap: 28px;
+  align-items: center;
+  padding: 26px 0;
+  border-bottom: 1px solid var(--hair);
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--bone-3);
+}
+.ledger .row:hover .t a { color: var(--gold); }
+.ledger .row .d { color: var(--gold); }
+.ledger .row .t a {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 28px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--bone);
+  border: none;
+}
+.ledger .row .t small {
+  display: block;
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.4em;
+  margin-top: 4px;
+  color: var(--bone-3);
+}
+.ledger .row .by { color: var(--bone); }
+.ledger .row .ar { font-family: var(--display); font-size: 28px; color: var(--gold); text-align: right; }
+
+/* PROSE */
+.prose {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 80px 0 96px;
+  font-size: 19px;
+  line-height: 1.8;
+  color: var(--bone-2);
+}
+.prose h1 { font-family: var(--display); font-weight: 400; font-size: 60px; line-height: 1; margin: 0 0 28px; letter-spacing: 0.02em; color: var(--bone); text-transform: uppercase; }
+.prose h2 { font-family: var(--display); font-weight: 400; font-size: 30px; margin-top: 2em; color: var(--bone); letter-spacing: 0.04em; text-transform: uppercase; }
+.prose h3 { font-family: var(--sans); font-size: 11px; letter-spacing: 0.4em; text-transform: uppercase; color: var(--gold); margin-top: 1.8em; }
+.prose p { margin: 0 0 1.1em; }
+.prose blockquote { border-left: 1px solid var(--gold); padding-left: 22px; margin: 1.6em 0; font-style: italic; color: var(--bone); font-family: var(--display); font-size: 24px; line-height: 1.4; }
+.prose code { background: var(--night-2); padding: 2px 6px; font-family: var(--mono); font-size: 0.85em; color: var(--gold); border: 1px solid var(--hair); }
+.prose pre { background: var(--night-3); border: 1px solid var(--hair); padding: 22px; overflow-x: auto; }
+.prose pre code { background: none; border: none; color: var(--bone); padding: 0; }
+.prose hr { border: none; border-top: 1px solid var(--hair); margin: 2.4em 0; }
+
+/* FOOTER */
+.foot {
+  padding: 96px 0 36px;
+  border-top: 1px solid var(--hair);
+  background: var(--plum-deep);
+  text-align: center;
+}
+.foot .big {
+  font-family: var(--display); font-weight: 400;
+  font-size: clamp(64px, 13vw, 200px);
+  letter-spacing: 0.04em;
+  line-height: 0.9;
+  color: var(--bone);
+  margin: 0 0 22px;
+  text-transform: uppercase;
+}
+.foot .big em { font-family: var(--serif); font-style: italic; color: var(--gold); }
+.foot .seal {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  color: var(--bone-3);
+  margin-bottom: 48px;
+}
+.foot .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 36px;
+  padding-top: 40px;
+  border-top: 1px solid var(--hair);
+  text-align: left;
+}
+.foot h4 { font-family: var(--sans); font-size: 10px; letter-spacing: 0.4em; text-transform: uppercase; color: var(--gold); margin: 0 0 16px; }
+.foot a { display: block; color: var(--bone); padding: 6px 0; font-family: var(--serif); font-size: 17px; border: none; }
+.foot a:hover { color: var(--gold); }
+.foot .copy { grid-column: 1 / -1; padding-top: 28px; border-top: 1px solid var(--hair); font-family: var(--sans); font-size: 10px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--bone-3); display: flex; justify-content: space-between; }
+
+/* PAGINATION */
+nav.pagination { margin: 40px 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; }
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  font-family: var(--sans); font-size: 10px; letter-spacing: 0.4em; text-transform: uppercase;
+  padding: 10px 18px; border: 1px solid var(--hair); color: var(--bone); font-weight: 500;
+}
+nav.pagination a:hover { background: var(--bone); color: var(--night); border-color: var(--bone); }
+.pagination-current span { background: var(--gold); border-color: var(--gold); color: var(--night); }
+.pagination-disabled span { color: var(--bone-3); }
+
+/* RESPONSIVE */
+@media (max-width: 980px) {
+  .shell { padding: 0 28px; }
+  .bottles { grid-template-columns: 1fr 1fr; }
+  .protocol { grid-template-columns: 1fr; gap: 28px; }
+  .ledger .row { grid-template-columns: 80px 1fr; gap: 12px; }
+  .ledger .row .by, .ledger .row .ar { display: none; }
+  .numbers { grid-template-columns: 1fr 1fr; }
+  .numbers > div:nth-child(2n) { border-right: none; }
+  .foot .grid { grid-template-columns: 1fr 1fr; }
+  .collection .hd { grid-template-columns: 1fr; gap: 18px; }
+}
+@media (max-width: 580px) {
+  .bar { grid-template-columns: 1fr 1fr; }
+  .bar .est { display: none; }
+  .bottles { grid-template-columns: 1fr; }
+  .cover { padding: 64px 0 56px; }
+  .cover::before { width: 320px; height: 320px; }
+  .cover::after { width: 200px; height: 200px; }
+  .foot .grid { grid-template-columns: 1fr; }
+  .foot .copy { flex-direction: column; gap: 8px; }
+  .numbers { grid-template-columns: 1fr; }
+  .numbers > div { border-right: none; }
+}

--- a/examples/velvet-protocol/static/favicon.svg
+++ b/examples/velvet-protocol/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/velvet-protocol/templates/404.html
+++ b/examples/velvet-protocol/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &mdash; <em>the door is closed.</em></h1>
+  <p>This page is not on the maison&apos;s list tonight. The address may have been retired, the bottle finished, or the hour simply wrong.</p>
+  <p><a href="{{ base_url }}/">Return to the Maison &rarr;</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/velvet-protocol/templates/footer.html
+++ b/examples/velvet-protocol/templates/footer.html
@@ -1,0 +1,39 @@
+    <footer class="foot">
+      <div class="big">Velvet <em>Protocol.</em></div>
+      <div class="seal">An Hourless House &mdash; Seoul &middot; Lisbon &middot; Late</div>
+      <div class="grid">
+        <div>
+          <h4>The Maison</h4>
+          <a href="{{ base_url }}/about/">The Protocol</a>
+          <a href="#">The Distillery</a>
+          <a href="#">Visit by appointment</a>
+        </div>
+        <div>
+          <h4>The Bottles</h4>
+          <a href="#">Eau de Nuit &mdash; 50ml</a>
+          <a href="#">Spirits, in small lots</a>
+          <a href="#">Subscriptions, closed</a>
+        </div>
+        <div>
+          <h4>The Ledger</h4>
+          <a href="{{ base_url }}/tags/">Letters &amp; Field Notes</a>
+          <a href="#">Press &amp; Editorial</a>
+          <a href="#">Stockists, by city</a>
+        </div>
+        <div>
+          <h4>Correspondence</h4>
+          <a href="#">house@velvet.protocol</a>
+          <a href="#">By post &mdash; 04 Rua de Norte</a>
+          <a href="#">After 22:00 / before 04:00</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} Velvet Protocol &middot; A nocturnal house, bottled by appointment</span>
+          <span>Set in Italiana &amp; Cormorant &middot; Posted with a letter</span>
+        </div>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/velvet-protocol/templates/header.html
+++ b/examples/velvet-protocol/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Italiana&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="shell">
+    <header class="bar">
+      <div class="est">Distilled in small lots &middot; <b>House MMXXI</b></div>
+      <a href="{{ base_url }}/" class="mark"><span class="vp"><span class="seal">V</span>Velvet Protocol</span></a>
+      <nav>
+        <a href="{{ base_url }}/">Maison</a>
+        <a href="{{ base_url }}/about/">Protocol</a>
+        <a href="{{ base_url }}/tags/">Ledger</a>
+      </nav>
+    </header>

--- a/examples/velvet-protocol/templates/index.html
+++ b/examples/velvet-protocol/templates/index.html
@@ -1,0 +1,142 @@
+{% include "header.html" %}
+
+<section class="cover">
+  <div class="kicker">Lot IV &middot; Late Hour &middot; {{ current_year }}</div>
+  <h1>
+    Velvet
+    <span class="second"><span class="gold">Protocol</span></span>
+    <sub>An hourless house of perfume &amp; spirit</sub>
+  </h1>
+  <p class="lede">Bottled by appointment, posted with a letter. The house operates between <em>twenty-two</em> and <em>four</em>, and answers nothing in between.</p>
+  <div class="cta">
+    <a class="btn gold" href="#collection">View the Lot<span class="ar">&rarr;</span></a>
+    <a class="btn" href="{{ base_url }}/about/">Read the Protocol<span class="ar">&rarr;</span></a>
+  </div>
+</section>
+
+<div class="ribbon" aria-hidden="true">
+  <div class="track">
+    <span>Distilled by hand.<small>HOUSE MMXXI</small></span><span class="dot"></span>
+    <span>Bottled by appointment.<small>LOT IV</small></span><span class="dot"></span>
+    <span>Posted with a letter.<small>SEOUL &middot; LISBON</small></span><span class="dot"></span>
+    <span>Distilled by hand.<small>HOUSE MMXXI</small></span><span class="dot"></span>
+    <span>Bottled by appointment.<small>LOT IV</small></span><span class="dot"></span>
+    <span>Posted with a letter.<small>SEOUL &middot; LISBON</small></span><span class="dot"></span>
+  </div>
+</div>
+
+<section class="collection" id="collection">
+  <div class="hd">
+    <h2>The Lot &mdash;<br><em>four bottles for the late hour.</em></h2>
+    <p>Each lot contains four bottles, distilled in the months before release and labelled by the person who finished them. We do not repress a lot; when it is gone, the next lot begins.</p>
+  </div>
+  <div class="bottles">
+    <article class="bottle">
+      <div class="vessel" aria-hidden="true">
+        <span class="ix">N&deg; 01</span>
+        <span class="vol">50 ml</span>
+        <svg viewBox="0 0 100 160" fill="none" stroke="#c4a467" stroke-width="1.2">
+          <rect x="42" y="6" width="16" height="22" rx="2"/>
+          <rect x="38" y="28" width="24" height="10"/>
+          <path d="M30 40 Q26 56 26 84 L26 140 Q26 154 50 154 Q74 154 74 140 L74 84 Q74 56 70 40 Z"/>
+          <rect x="34" y="80" width="32" height="36" stroke-opacity="0.5"/>
+          <text x="50" y="98" text-anchor="middle" font-family="Italiana" font-size="9" fill="#c4a467">VELVET</text>
+          <text x="50" y="108" text-anchor="middle" font-family="Italiana" font-size="6" fill="#c4a467">N&#176; 01</text>
+        </svg>
+      </div>
+      <div class="meta">// EAU DE NUIT</div>
+      <h3><a href="#">Salon Velours</a></h3>
+      <p>Rose absolute, smoked oud, and the last hour of a winter party.</p>
+      <div class="notes"><span>Rose</span><span>Oud</span><span>Smoke</span></div>
+    </article>
+    <article class="bottle">
+      <div class="vessel" aria-hidden="true">
+        <span class="ix">N&deg; 02</span>
+        <span class="vol">50 ml</span>
+        <svg viewBox="0 0 100 160" fill="none" stroke="#c4a467" stroke-width="1.2">
+          <rect x="44" y="6" width="12" height="26" rx="2"/>
+          <path d="M28 36 L72 36 L66 56 L34 56 Z"/>
+          <path d="M34 56 L34 142 Q34 154 50 154 Q66 154 66 142 L66 56 Z"/>
+          <rect x="38" y="92" width="24" height="32" stroke-opacity="0.5"/>
+          <text x="50" y="108" text-anchor="middle" font-family="Italiana" font-size="9" fill="#c4a467">NOIR</text>
+          <text x="50" y="118" text-anchor="middle" font-family="Italiana" font-size="6" fill="#c4a467">N&#176; 02</text>
+        </svg>
+      </div>
+      <div class="meta">// SPIRIT</div>
+      <h3><a href="#">Noir, Distilled</a></h3>
+      <p>An aged grain spirit, infused with bitter orange and the night air of late October.</p>
+      <div class="notes"><span>Grain</span><span>Bitter Orange</span><span>Cold Air</span></div>
+    </article>
+    <article class="bottle">
+      <div class="vessel" aria-hidden="true">
+        <span class="ix">N&deg; 03</span>
+        <span class="vol">100 ml</span>
+        <svg viewBox="0 0 100 160" fill="none" stroke="#c4a467" stroke-width="1.2">
+          <circle cx="50" cy="20" r="8"/>
+          <path d="M42 26 L58 26 L60 40 L40 40 Z"/>
+          <ellipse cx="50" cy="98" rx="36" ry="50"/>
+          <ellipse cx="50" cy="98" rx="24" ry="34" stroke-opacity="0.4"/>
+          <text x="50" y="102" text-anchor="middle" font-family="Italiana" font-size="9" fill="#c4a467">VEL.</text>
+          <text x="50" y="112" text-anchor="middle" font-family="Italiana" font-size="6" fill="#c4a467">N&#176; 03</text>
+        </svg>
+      </div>
+      <div class="meta">// PARFUM</div>
+      <h3><a href="#">L&apos;Heure du Loup</a></h3>
+      <p>A heavier composition: tobacco, ambrette seed, and the dark hour before dawn.</p>
+      <div class="notes"><span>Tobacco</span><span>Ambrette</span><span>Honey</span></div>
+    </article>
+  </div>
+</section>
+
+<section class="protocol">
+  <div class="from">
+    <div><span class="ix">&sect; II</span>The Protocol &mdash; Abridged</div>
+    <div class="sig">&mdash; Marin Velasco<small>House Distiller</small></div>
+  </div>
+  <div class="body">
+    <p>The house opens at <em>twenty-two,</em> the still is lit at midnight, the bottles are labelled at <em>three.</em> We answer the door, the letter, and the telephone &mdash; in that order, and only at the appointed hour.</p>
+    <p>Everything else is filed for the morning, which the house leaves to others.</p>
+  </div>
+</section>
+
+<section class="numbers">
+  <div><div class="n">04</div><div class="l">BOTTLES / PER LOT</div></div>
+  <div><div class="n">11</div><div class="l">LOTS / IN THE HOUSE</div></div>
+  <div><div class="n">22<sup>&mdash;04</sup></div><div class="l">HOURS / OPEN</div></div>
+  <div><div class="n">02</div><div class="l">CITIES / SE &middot; LX</div></div>
+</section>
+
+<section class="ledger">
+  <div class="hd">
+    <h2>From the <em>ledger.</em></h2>
+    <a class="btn" href="{{ base_url }}/tags/">All entries &rarr;</a>
+  </div>
+  <div class="entries">
+    <div class="row">
+      <div class="d">{{ current_year }} / IV</div>
+      <div class="t"><a href="#">A Letter on the Rose, and the Hour We Pick It</a><small>Distillery &middot; Field Note</small></div>
+      <div class="by">Marin</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">{{ current_year }} / II</div>
+      <div class="t"><a href="#">On Bottling After Midnight &mdash; The House Method</a><small>Protocol</small></div>
+      <div class="by">House</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">2025 / XI</div>
+      <div class="t"><a href="#">Lot III, Posted with a Letter to Forty-Seven Houses</a><small>Ledger</small></div>
+      <div class="by">Secretary</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    <div class="row">
+      <div class="d">2025 / IX</div>
+      <div class="t"><a href="#">The Late Hour, Defended &mdash; A Note on the Trade</a><small>Editorial</small></div>
+      <div class="by">Marin</div>
+      <div class="ar">&rarr;</div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/velvet-protocol/templates/page.html
+++ b/examples/velvet-protocol/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/velvet-protocol/templates/section.html
+++ b/examples/velvet-protocol/templates/section.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<section class="ledger">
+  <div class="hd">
+    {% if page.title is present %}<h2><em>{{ page.title | e }}</em></h2>{% endif %}
+  </div>
+  {{ content | safe }}
+  <div class="entries">
+    {% for post in section.pages %}
+    <div class="row">
+      <div class="d">{{ post.date | date(format="%Y / %m") }}</div>
+      <div class="t"><a href="{{ post.url }}">{{ post.title | e }}</a><small>{{ post.section | default("ledger") }}</small></div>
+      <div class="by">House</div>
+      <div class="ar">&rarr;</div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/velvet-protocol/templates/shortcodes/alert.html
+++ b/examples/velvet-protocol/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/velvet-protocol/templates/taxonomy.html
+++ b/examples/velvet-protocol/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>An index of subjects from the house ledger.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/velvet-protocol/templates/taxonomy_term.html
+++ b/examples/velvet-protocol/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>Entries filed under this subject.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -43,6 +43,13 @@
     "blog",
     "cyberpunk"
   ],
+  "acid-poster": [
+    "landing",
+    "light",
+    "rave",
+    "neo-brutalist",
+    "punk"
+  ],
   "acid-zine": [
     "dark",
     "blog",
@@ -5261,6 +5268,13 @@
     "blog",
     "nautical"
   ],
+  "navy-syndicate": [
+    "landing",
+    "dark",
+    "editorial",
+    "luxury",
+    "playfair"
+  ],
   "nebula": [
     "dark",
     "gallery",
@@ -6972,6 +6986,13 @@
     "docs",
     "i18n"
   ],
+  "rosetta-script": [
+    "landing",
+    "light",
+    "i18n",
+    "editorial",
+    "multilingual"
+  ],
   "rosewood": [
     "blog",
     "dark",
@@ -8330,6 +8351,13 @@
     "tribal",
     "vertical-stack"
   ],
+  "trail-bureau": [
+    "landing",
+    "light",
+    "outdoor",
+    "cartography",
+    "editorial"
+  ],
   "travel-journal": [
     "travel-inspired",
     "adventurous",
@@ -8523,6 +8551,13 @@
     "dark",
     "neon",
     "futuristic"
+  ],
+  "velvet-protocol": [
+    "landing",
+    "dark",
+    "luxury",
+    "editorial",
+    "italiana"
   ],
   "velvet-rope": [
     "event",


### PR DESCRIPTION
## Summary

Five additional landing examples — each a contrasting aesthetic, none overlapping with the previous batch:

- **acid-poster** — Rave-flyer punk. Highlighter green + magenta + ink, mixed type, sticker stack, Anton display.
- **navy-syndicate** — Quiet-luxury private capital house. Navy + cream + brass, Playfair + Cormorant, vol/ribbon motifs.
- **rosetta-script** — Multilingual reading app. Mint + persimmon + ink, four scripts (KO/JA/FR/AR), specimen cards with original + romanization + translation.
- **trail-bureau** — Outdoor cartography. Forest + brick + cream, inline SVG compass rose, contour-line page background, kit/repair shop layout.
- **velvet-protocol** — Nocturnal perfumery. Plum + bone + matte gold, Italiana display, inline SVG bottle illustrations, hours-of-the-house framing.

Each site ships:
- Full template set (`index`, `page`, `section`, `taxonomy`, `taxonomy_term`, `404`, header/footer)
- Content (`index.md` + `about.md`)
- Extracted CSS in `static/css/style.css`
- Tag entry in `tags.json` (alphabetically inserted)

## Test plan

- [x] `hwaro doctor --fix` passes on each site
- [x] `hwaro build` succeeds on each site
- [x] `tags.json` validates (`jq` parses; all five new keys present)
- [x] Verified no \`linear-gradient\` / \`radial-gradient\` / \`conic-gradient\` and no emoji characters across the five sites (per repo conventions)
- [ ] Spot-check screenshots after CI deploy