### PR TITLE
Fix 404 for /tags/ in vector-os

### DIFF
--- a/examples/vector-os/content/tags/_index.md
+++ b/examples/vector-os/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+description = "All tags"
++++


### PR DESCRIPTION
Created missing _index.md for the tags taxonomy in vector-os to fix a 404 error when navigating to /tags/.

---
*PR created automatically by Jules for task [11368342395413219835](https://jules.google.com/task/11368342395413219835) started by @hahwul*