### PR TITLE
fix(ethereal-shimmer): resolve 404 on home page posts link

### DIFF
--- a/examples/ethereal-shimmer/content/index.md
+++ b/examples/ethereal-shimmer/content/index.md
@@ -5,4 +5,4 @@ description = "Home page"
 
 Welcome to Ethereal Shimmer. This is a dark-themed glassmorphism aesthetic featuring flowing, shimmering gradients and frosted glass elements.
 
-You can browse the [posts](/posts) to see more content.
+You can browse the [posts](posts/) to see more content.


### PR DESCRIPTION
This PR fixes a 404 broken link in the `ethereal-shimmer` example.

The home page (`index.md`) contained an absolute path link to `[posts](/posts)`. In a Hwaro project deployed to a subdirectory, this fails to resolve correctly as it attempts to access the root domain. The link has been updated to use a relative path `[posts](posts/)` instead, ensuring correct resolution and functionality without causing a 404.

---
*PR created automatically by Jules for task [9532428818315549375](https://jules.google.com/task/9532428818315549375) started by @chei-l*