### PR TITLE
Add 20 sensational landing example sites

### DIFF
--- a/examples/arcade-token/AGENTS.md
+++ b/examples/arcade-token/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/arcade-token/archetypes/default.md
+++ b/examples/arcade-token/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/arcade-token/config.toml
+++ b/examples/arcade-token/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "TOKEN & JOYSTICK"
+description = "A coin-op arcade restoration shop — CRT realignment, PCB swaps, cabinet refits, and refurbished machines from Lot 7."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/arcade-token/content/about.md
+++ b/examples/arcade-token/content/about.md
@@ -1,0 +1,35 @@
++++
+title = "About the Shop"
+description = "TOKEN & JOYSTICK — who we are, what we fix, what's in the parts library, and when to come by."
++++
+
+## The shop
+
+Token &amp; Joystick lives at the back of Lot 7, behind the laundromat. One bench, two CRT bays, a parts wall, and twenty-odd cabinets in rotation. We opened in 2016 because no one else in the neighborhood would touch a tube monitor. We never advertised. Word travels through arcade league chats.
+
+We do not sell new cabinets. We sell the ones we restore, when they're done, in the order they were finished. If a machine isn't on the floor yet, it isn't for sale.
+
+## What we fix
+
+Three things, mostly. **CRTs** &mdash; convergence, purity, geometry, dead caps, dim screens. **PCBs** &mdash; board-level diagnosis, ROM socketing, cap kits, battery swaps on backup-RAM boards. **Cabinets** &mdash; side-art touch-up (never repaint), T-molding, control panel rewires, marquee reprints on cast acrylic.
+
+We don't do home conversions, we don't build MAME bartops, and we don't fix flat-panel "retro arcades" from big-box stores. We will tell you, kindly, where to take those.
+
+## The parts library
+
+Everything in the parts room is logged. About four thousand line items: bezel glass by size, T-molding by color and thickness, joysticks (Wico, Happ, Sanwa, JLF), buttons by depth and snap, ROM blanks, cap kits per board, and a small CRT graveyard for chassis spares.
+
+If you need a part and we don't have it, we'll usually know who does, somewhere within two ZIP codes.
+
+## Custom builds
+
+Once or twice a year we'll take on a custom cabinet build. Usually a tribute &mdash; a sit-down Spy Hunter, a faithful Tempest reproduction with original side-art scans. Six-month wait. Tokens up front.
+
+## Opening hours
+
+> Wednesday through Friday, 2 PM to 9 PM. Saturday and Sunday, noon to 10. Mondays and Tuesdays the bench is closed and we do board work behind the locked door &mdash; please don't ring.
+
+- **Bench &middot;** `bench@token-joystick`
+- **Parts inquiries &middot;** `parts@token-joystick`
+- **Phone &middot;** we don't have one and we like it that way
+- **Address &middot;** Lot 7, east alley, ring the bell once

--- a/examples/arcade-token/content/index.md
+++ b/examples/arcade-token/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "TOKEN & JOYSTICK — a coin-op arcade restoration shop in Lot 7. CRT realignment, PCB swaps, cabinet refits, and refurbished machines."
+template = "index"
++++

--- a/examples/arcade-token/static/css/style.css
+++ b/examples/arcade-token/static/css/style.css
@@ -1,0 +1,857 @@
+/* =============================================================================
+   TOKEN & JOYSTICK — Arcade restoration shop
+   Aesthetic: 1980s arcade marquee + pixel-block sprites + coin-op bezel
+   Rules: NO gradients. NO emoji. Hard neon flat colors only.
+   ============================================================================= */
+
+/* ---------- Palette ---------- */
+:root {
+  --cabinet-black: #0a0a0a;
+  --panel-black:   #1a1a1a;
+  --arcade-cyan:    #00d0d4;
+  --arcade-magenta: #ff2bb5;
+  --arcade-red:     #ff2839;
+  --arcade-yellow:  #ffcb1f;
+  --arcade-green:   #2cd34b;
+  --arcade-blue:    #2c64ff;
+  --coin-gold:      #d6a52a;
+  --bone-pixel:     #f4ecd6;
+  --brown:          #6b3a1f;
+
+  --pixel: 4px;      /* base hero pixel size */
+  --pixel-sm: 3px;   /* small pixel for cabinet titles */
+  --pixel-art: 14px; /* art sprite cell size */
+}
+
+/* ---------- Reset ---------- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  font-family: 'VT323', monospace;
+  font-size: 20px;
+  line-height: 1.4;
+  color: var(--bone-pixel);
+  background: var(--panel-black);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><rect width='32' height='32' fill='%231a1a1a'/><rect x='0' y='0' width='32' height='1' fill='%23222'/><rect x='0' y='0' width='1' height='32' fill='%23222'/></svg>");
+  background-repeat: repeat;
+  background-size: 32px 32px;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+img, svg { display: block; max-width: 100%; }
+
+a {
+  color: var(--arcade-cyan);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+}
+a:hover { color: var(--arcade-yellow); border-bottom-color: var(--arcade-yellow); }
+
+::selection { background: var(--arcade-magenta); color: var(--cabinet-black); }
+
+/* ---------- Top strip ---------- */
+.strip-top {
+  background: var(--cabinet-black);
+  border-bottom: 4px solid var(--arcade-cyan);
+  padding: 12px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.strip-home {
+  color: var(--arcade-cyan);
+  border-bottom: none;
+}
+.strip-home:hover { color: var(--arcade-yellow); border-bottom: none; }
+
+.strip-mid {
+  color: var(--bone-pixel);
+  opacity: 0.7;
+  font-size: 9px;
+  flex: 1;
+  text-align: center;
+}
+
+.strip-nav {
+  display: flex;
+  gap: 18px;
+}
+.strip-nav a {
+  color: var(--bone-pixel);
+  border-bottom: none;
+  font-size: 9px;
+  padding: 4px 8px;
+  background: var(--panel-black);
+  border: 2px solid var(--bone-pixel);
+}
+.strip-nav a:hover {
+  color: var(--cabinet-black);
+  background: var(--arcade-yellow);
+  border-color: var(--arcade-yellow);
+}
+
+/* ---------- Marquee / Hero ---------- */
+.marquee {
+  padding: 40px 24px 60px;
+  background: var(--cabinet-black);
+  position: relative;
+  border-bottom: 6px solid var(--coin-gold);
+}
+
+.marquee-frame {
+  max-width: 1280px;
+  margin: 0 auto;
+  position: relative;
+  background: var(--panel-black);
+  border: 6px solid var(--coin-gold);
+  padding: 60px 56px;
+  min-height: 540px;
+}
+
+.marquee-bolts {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.marquee-bolts i {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: var(--coin-gold);
+  border: 2px solid var(--cabinet-black);
+}
+.marquee-bolts i:nth-child(1) { top: 10px; left: 10px; }
+.marquee-bolts i:nth-child(2) { top: 10px; right: 10px; }
+.marquee-bolts i:nth-child(3) { bottom: 10px; left: 10px; }
+.marquee-bolts i:nth-child(4) { bottom: 10px; right: 10px; }
+.marquee-bolts i:nth-child(5) { top: 10px; left: 50%; transform: translateX(-50%); }
+.marquee-bolts i:nth-child(6) { bottom: 10px; left: 50%; transform: translateX(-50%); }
+.marquee-bolts i:nth-child(7) { top: 50%; left: 10px; transform: translateY(-50%); }
+.marquee-bolts i:nth-child(8) { top: 50%; right: 10px; transform: translateY(-50%); }
+
+.marquee-headline {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.marquee-sub {
+  margin-top: 28px;
+  font-family: 'VT323', monospace;
+  font-size: 28px;
+  color: var(--arcade-yellow);
+  letter-spacing: 0.2em;
+}
+
+.marquee-credits {
+  position: absolute;
+  bottom: 28px;
+  left: 56px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 14px;
+  color: var(--arcade-green);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.credits-label { color: var(--bone-pixel); }
+.credits-blink {
+  animation: blink 1.2s steps(2, end) infinite;
+  color: var(--arcade-green);
+}
+@keyframes blink {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+.hero-joystick {
+  position: absolute;
+  top: 70px;
+  right: 56px;
+}
+
+/* ---------- Pixel-block letters ---------- */
+/* Each letter is a 5x7 grid of pixels. Spans inside .px-letter are positioned
+   absolutely via row/col classes. Color is set on the parent letter class. */
+.px-word {
+  display: flex;
+  gap: calc(var(--pixel) * 2);
+  flex-wrap: wrap;
+}
+.px-word-sm { gap: calc(var(--pixel-sm) * 2); }
+
+.px-letter {
+  position: relative;
+  width: calc(var(--pixel) * 5);
+  height: calc(var(--pixel) * 7);
+  flex-shrink: 0;
+}
+.px-word-sm .px-letter {
+  width: calc(var(--pixel-sm) * 5);
+  height: calc(var(--pixel-sm) * 7);
+}
+
+.px-letter > span {
+  position: absolute;
+  width: var(--pixel);
+  height: var(--pixel);
+  display: block;
+}
+.px-word-sm .px-letter > span {
+  width: var(--pixel-sm);
+  height: var(--pixel-sm);
+}
+
+/* Pixel-letter row/col positioning (5 cols, 7 rows) */
+.px-letter > .r0 { top: 0; }
+.px-letter > .r1 { top: var(--pixel); }
+.px-letter > .r2 { top: calc(var(--pixel) * 2); }
+.px-letter > .r3 { top: calc(var(--pixel) * 3); }
+.px-letter > .r4 { top: calc(var(--pixel) * 4); }
+.px-letter > .r5 { top: calc(var(--pixel) * 5); }
+.px-letter > .r6 { top: calc(var(--pixel) * 6); }
+.px-letter > .c0 { left: 0; }
+.px-letter > .c1 { left: var(--pixel); }
+.px-letter > .c2 { left: calc(var(--pixel) * 2); }
+.px-letter > .c3 { left: calc(var(--pixel) * 3); }
+.px-letter > .c4 { left: calc(var(--pixel) * 4); }
+
+.px-word-sm .px-letter > .r0 { top: 0; }
+.px-word-sm .px-letter > .r1 { top: var(--pixel-sm); }
+.px-word-sm .px-letter > .r2 { top: calc(var(--pixel-sm) * 2); }
+.px-word-sm .px-letter > .r3 { top: calc(var(--pixel-sm) * 3); }
+.px-word-sm .px-letter > .r4 { top: calc(var(--pixel-sm) * 4); }
+.px-word-sm .px-letter > .r5 { top: calc(var(--pixel-sm) * 5); }
+.px-word-sm .px-letter > .r6 { top: calc(var(--pixel-sm) * 6); }
+.px-word-sm .px-letter > .c0 { left: 0; }
+.px-word-sm .px-letter > .c1 { left: var(--pixel-sm); }
+.px-word-sm .px-letter > .c2 { left: calc(var(--pixel-sm) * 2); }
+.px-word-sm .px-letter > .c3 { left: calc(var(--pixel-sm) * 3); }
+.px-word-sm .px-letter > .c4 { left: calc(var(--pixel-sm) * 4); }
+
+/* Letter color variants */
+.px-cy > span { background: var(--arcade-cyan); }
+.px-mg > span { background: var(--arcade-magenta); }
+.px-yl > span { background: var(--arcade-yellow); }
+.px-rd > span { background: var(--arcade-red); }
+.px-gn > span { background: var(--arcade-green); }
+.px-bl > span { background: var(--arcade-blue); }
+
+/* ---------- Pixel art (sprite grids) ---------- */
+.px-art {
+  display: grid;
+  grid-template-columns: repeat(8, var(--pixel-art));
+  grid-template-rows: repeat(6, var(--pixel-art));
+  gap: 0;
+  width: calc(var(--pixel-art) * 8);
+}
+.px-art-joystick {
+  grid-template-rows: repeat(10, var(--pixel-art));
+}
+.px-art .p {
+  width: var(--pixel-art);
+  height: var(--pixel-art);
+}
+.px-art .r0 { grid-row: 1; }
+.px-art .r1 { grid-row: 2; }
+.px-art .r2 { grid-row: 3; }
+.px-art .r3 { grid-row: 4; }
+.px-art .r4 { grid-row: 5; }
+.px-art .r5 { grid-row: 6; }
+.px-art .r6 { grid-row: 7; }
+.px-art .r7 { grid-row: 8; }
+.px-art .r8 { grid-row: 9; }
+.px-art .r9 { grid-row: 10; }
+.px-art .c0 { grid-column: 1; }
+.px-art .c1 { grid-column: 2; }
+.px-art .c2 { grid-column: 3; }
+.px-art .c3 { grid-column: 4; }
+.px-art .c4 { grid-column: 5; }
+.px-art .c5 { grid-column: 6; }
+.px-art .c6 { grid-column: 7; }
+.px-art .c7 { grid-column: 8; }
+
+/* Pixel-art colors */
+.p-bk { background: var(--cabinet-black); }
+.p-rd { background: var(--arcade-red); }
+.p-yl { background: var(--arcade-yellow); }
+.p-cy { background: var(--arcade-cyan); }
+.p-mg { background: var(--arcade-magenta); }
+.p-gn { background: var(--arcade-green); }
+.p-bl { background: var(--arcade-blue); }
+.p-bn { background: var(--brown); }
+
+/* ---------- Sections / shared ---------- */
+.wrap {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+.section-head {
+  margin-bottom: 40px;
+  text-align: center;
+}
+.section-tag {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: var(--arcade-magenta);
+  letter-spacing: 0.18em;
+  margin-bottom: 16px;
+}
+.section-title {
+  font-family: 'Black Ops One', sans-serif;
+  font-size: clamp(38px, 6vw, 72px);
+  letter-spacing: 0.04em;
+  color: var(--bone-pixel);
+  line-height: 1;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+.section-sub {
+  font-size: 22px;
+  color: var(--bone-pixel);
+  opacity: 0.75;
+  max-width: 580px;
+  margin: 0 auto;
+}
+
+/* ---------- Cabinets ---------- */
+.cabinets {
+  padding: 80px 0;
+  background: var(--panel-black);
+  border-bottom: 4px solid var(--arcade-magenta);
+}
+
+.cab-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 22px;
+}
+
+.cab {
+  background: var(--cabinet-black);
+  border: 4px solid var(--bone-pixel);
+  padding: 22px 20px 16px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.cab-1 { border-color: var(--arcade-yellow); }
+.cab-2 { border-color: var(--arcade-cyan); }
+.cab-3 { border-color: var(--arcade-magenta); }
+.cab-4 { border-color: var(--arcade-green); }
+
+.cab-title {
+  margin-bottom: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 60px;
+}
+.cab-name {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+.cab-1 .cab-name { color: var(--arcade-yellow); }
+.cab-2 .cab-name { color: var(--arcade-cyan); }
+.cab-3 .cab-name { color: var(--arcade-magenta); }
+.cab-4 .cab-name { color: var(--arcade-green); }
+
+.cab-art {
+  background: var(--panel-black);
+  border: 2px dashed var(--bone-pixel);
+  padding: 18px;
+  margin-bottom: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 130px;
+}
+.cab-art .px-art { margin: 0 auto; }
+
+.cab-spec {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 12px;
+  margin-top: auto;
+  padding-top: 14px;
+  border-top: 2px dashed var(--bone-pixel);
+}
+.cab-spec dt {
+  color: var(--bone-pixel);
+  opacity: 0.6;
+  letter-spacing: 0.1em;
+}
+.cab-spec dd {
+  color: var(--bone-pixel);
+  text-align: right;
+  letter-spacing: 0.08em;
+}
+.cab-spec dd.ok { color: var(--arcade-green); }
+.cab-spec dd.hot { color: var(--arcade-red); }
+
+/* ---------- Repair bay ---------- */
+.bay {
+  padding: 80px 0;
+  background: var(--cabinet-black);
+  border-bottom: 4px solid var(--arcade-yellow);
+}
+
+.bay-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 28px;
+}
+
+.bay-card {
+  background: var(--panel-black);
+  padding: 32px 28px;
+  position: relative;
+  border: 4px solid var(--bone-pixel);
+  box-shadow: 8px 8px 0 var(--cabinet-black);
+}
+.bay-cy { border-color: var(--arcade-cyan); }
+.bay-mg { border-color: var(--arcade-magenta); }
+.bay-yl { border-color: var(--arcade-yellow); }
+
+.bay-num {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  color: var(--bone-pixel);
+  opacity: 0.5;
+  margin-bottom: 18px;
+  letter-spacing: 0.1em;
+}
+
+.bay-name {
+  font-family: 'Black Ops One', sans-serif;
+  font-size: 36px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+  line-height: 1;
+}
+.bay-cy .bay-name { color: var(--arcade-cyan); }
+.bay-mg .bay-name { color: var(--arcade-magenta); }
+.bay-yl .bay-name { color: var(--arcade-yellow); }
+
+.bay-desc {
+  font-size: 20px;
+  color: var(--bone-pixel);
+  opacity: 0.85;
+  margin-bottom: 18px;
+}
+
+.bay-bul {
+  list-style: none;
+  margin-bottom: 24px;
+}
+.bay-bul li {
+  font-family: 'VT323', monospace;
+  font-size: 19px;
+  color: var(--bone-pixel);
+  padding: 4px 0 4px 18px;
+  position: relative;
+}
+.bay-bul li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 12px;
+  width: 8px;
+  height: 8px;
+  background: currentColor;
+}
+.bay-cy .bay-bul li::before { background: var(--arcade-cyan); }
+.bay-mg .bay-bul li::before { background: var(--arcade-magenta); }
+.bay-yl .bay-bul li::before { background: var(--arcade-yellow); }
+
+.bay-price {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  border-top: 4px solid var(--bone-pixel);
+  padding-top: 16px;
+}
+.bay-cy .bay-price { border-top-color: var(--arcade-cyan); }
+.bay-mg .bay-price { border-top-color: var(--arcade-magenta); }
+.bay-yl .bay-price { border-top-color: var(--arcade-yellow); }
+
+.bay-tok {
+  font-family: 'Black Ops One', sans-serif;
+  font-size: 48px;
+  color: var(--coin-gold);
+  line-height: 1;
+}
+.bay-tlabel {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  color: var(--bone-pixel);
+  letter-spacing: 0.1em;
+}
+
+/* ---------- High Scores ---------- */
+.scores {
+  padding: 80px 0;
+  background: var(--panel-black);
+  border-bottom: 4px solid var(--arcade-green);
+}
+
+.hs-table {
+  max-width: 880px;
+  margin: 0 auto;
+  background: var(--cabinet-black);
+  border: 4px solid var(--arcade-yellow);
+  padding: 24px;
+}
+
+.hs-row {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  border-bottom: 2px dotted var(--bone-pixel);
+  color: var(--arcade-yellow);
+}
+.hs-row:last-child { border-bottom: none; }
+
+.hs-head {
+  font-size: 9px;
+  color: var(--arcade-cyan);
+  border-bottom: 4px solid var(--arcade-cyan);
+  margin-bottom: 6px;
+}
+
+.hs-rank  { flex: 0 0 60px; color: var(--arcade-red); }
+.hs-head .hs-rank { color: var(--arcade-cyan); }
+.hs-name  { flex: 1; color: var(--bone-pixel); }
+.hs-head .hs-name { color: var(--arcade-cyan); }
+.hs-score { flex: 0 0 140px; text-align: right; color: var(--arcade-yellow); }
+.hs-head .hs-score { color: var(--arcade-cyan); }
+.hs-game  { flex: 0 0 80px; text-align: center; color: var(--arcade-magenta); }
+.hs-head .hs-game { color: var(--arcade-cyan); }
+.hs-level { flex: 0 0 70px; text-align: center; color: var(--arcade-green); }
+.hs-head .hs-level { color: var(--arcade-cyan); }
+.hs-year  { flex: 0 0 70px; text-align: right; color: var(--bone-pixel); opacity: 0.6; }
+.hs-head .hs-year { color: var(--arcade-cyan); opacity: 1; }
+
+.hs-row a { color: inherit; border-bottom: none; }
+.hs-row a:hover { color: var(--arcade-yellow); }
+
+/* ---------- Hours strip ---------- */
+.hours {
+  padding: 60px 0;
+  background: var(--cabinet-black);
+  border-bottom: 6px solid var(--coin-gold);
+}
+.hours-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 28px;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.hours-block {
+  padding: 24px;
+  border: 3px solid var(--bone-pixel);
+  background: var(--panel-black);
+}
+.hours-block h4 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  color: var(--arcade-cyan);
+  letter-spacing: 0.12em;
+  margin-bottom: 14px;
+  padding-bottom: 10px;
+  border-bottom: 2px dashed var(--bone-pixel);
+}
+.hours-block p {
+  font-family: 'VT323', monospace;
+  font-size: 22px;
+  color: var(--bone-pixel);
+  letter-spacing: 0.05em;
+}
+
+/* ---------- Footer ---------- */
+.footer {
+  background: var(--cabinet-black);
+  color: var(--bone-pixel);
+  padding-bottom: 40px;
+}
+
+/* Scrolling marquee strip */
+.marq-strip {
+  background: var(--arcade-yellow);
+  color: var(--cabinet-black);
+  overflow: hidden;
+  border-top: 4px solid var(--cabinet-black);
+  border-bottom: 4px solid var(--cabinet-black);
+  padding: 10px 0;
+}
+.marq-track {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  white-space: nowrap;
+  animation: marq 22s linear infinite;
+}
+@keyframes marq {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+.marq-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--cabinet-black);
+}
+
+/* Coin bezel */
+.coin-bezel {
+  background: var(--panel-black);
+  padding: 28px 0;
+  border-bottom: 4px solid var(--coin-gold);
+}
+.coin-plate {
+  max-width: 280px;
+  margin: 0 auto;
+  background: var(--coin-gold);
+  border: 4px solid var(--cabinet-black);
+  padding: 18px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  position: relative;
+}
+.coin-slot {
+  display: block;
+  width: 80px;
+  height: 14px;
+  background: var(--cabinet-black);
+  border: 2px solid var(--brown);
+}
+.coin-label {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  color: var(--cabinet-black);
+  letter-spacing: 0.1em;
+}
+
+.footer-wrap {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 60px 28px 0;
+}
+
+.footer-headline {
+  display: flex;
+  gap: 36px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.footer-year {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  color: var(--arcade-yellow);
+  letter-spacing: 0.14em;
+  margin-bottom: 40px;
+  padding-bottom: 24px;
+  border-bottom: 3px solid var(--bone-pixel);
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 28px;
+  margin-bottom: 28px;
+}
+.footer-col h5 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  color: var(--arcade-magenta);
+  letter-spacing: 0.12em;
+  margin-bottom: 14px;
+}
+.footer-col a {
+  display: block;
+  font-family: 'VT323', monospace;
+  font-size: 20px;
+  color: var(--bone-pixel);
+  padding: 4px 0;
+  border-bottom: 1px dotted transparent;
+}
+.footer-col a:hover {
+  color: var(--arcade-yellow);
+  border-bottom-color: var(--arcade-yellow);
+}
+
+.footer-copy {
+  border-top: 2px dashed var(--bone-pixel);
+  padding-top: 18px;
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  letter-spacing: 0.1em;
+  color: var(--bone-pixel);
+  opacity: 0.6;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+/* ---------- Prose (page / 404 / section) ---------- */
+.prose {
+  max-width: 760px;
+  margin: 60px auto;
+  padding: 40px 36px;
+  background: var(--panel-black);
+  border: 4px solid var(--arcade-cyan);
+  color: var(--bone-pixel);
+}
+.prose h1 {
+  font-family: 'Black Ops One', sans-serif;
+  font-size: clamp(36px, 5vw, 56px);
+  color: var(--arcade-yellow);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 28px;
+  border-bottom: 4px solid var(--arcade-yellow);
+  padding-bottom: 16px;
+  line-height: 1;
+}
+.prose h2 {
+  font-family: 'Black Ops One', sans-serif;
+  font-size: 32px;
+  color: var(--arcade-magenta);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin: 36px 0 14px;
+  line-height: 1.1;
+}
+.prose h3 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 14px;
+  color: var(--arcade-cyan);
+  letter-spacing: 0.06em;
+  margin: 28px 0 12px;
+}
+.prose p {
+  font-size: 22px;
+  margin-bottom: 18px;
+  color: var(--bone-pixel);
+}
+.prose ul, .prose ol {
+  padding-left: 28px;
+  margin-bottom: 18px;
+}
+.prose li {
+  font-size: 21px;
+  padding: 4px 0;
+}
+.prose strong { color: var(--arcade-yellow); }
+.prose em { color: var(--arcade-magenta); font-style: normal; }
+.prose blockquote {
+  border-left: 6px solid var(--arcade-green);
+  padding: 12px 20px;
+  margin: 24px 0;
+  background: var(--cabinet-black);
+  font-size: 22px;
+  color: var(--arcade-green);
+}
+.prose a {
+  color: var(--arcade-cyan);
+  border-bottom: 2px solid var(--arcade-cyan);
+}
+.prose a:hover { color: var(--arcade-yellow); border-bottom-color: var(--arcade-yellow); }
+.prose code {
+  font-family: 'VT323', monospace;
+  background: var(--cabinet-black);
+  padding: 2px 8px;
+  color: var(--arcade-green);
+  font-size: 19px;
+  border: 1px solid var(--arcade-green);
+}
+.prose-back {
+  margin-top: 36px;
+  padding-top: 18px;
+  border-top: 2px dashed var(--bone-pixel);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+}
+
+.prose-404 {
+  text-align: center;
+}
+.prose-404 .px-word {
+  justify-content: center;
+  margin: 0 auto 28px;
+}
+
+.prose-section {
+  padding: 80px 0;
+  background: var(--panel-black);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 1024px) {
+  .cab-grid { grid-template-columns: repeat(2, 1fr); }
+  .bay-grid { grid-template-columns: 1fr; }
+  .footer-grid { grid-template-columns: repeat(2, 1fr); }
+  .hours-grid { grid-template-columns: 1fr; }
+  .hero-joystick { position: static; margin: 28px 0; }
+  :root { --pixel: 3px; }
+}
+
+@media (max-width: 720px) {
+  .strip-top { flex-wrap: wrap; gap: 10px; padding: 10px 14px; }
+  .strip-mid { display: none; }
+  .strip-nav { gap: 8px; }
+  .strip-nav a { font-size: 7px; padding: 3px 6px; }
+
+  .marquee { padding: 24px 12px 40px; }
+  .marquee-frame { padding: 36px 24px; min-height: 0; }
+  .marquee-credits { position: static; margin-top: 24px; }
+  :root { --pixel: 2px; --pixel-art: 10px; }
+
+  .cab-grid { grid-template-columns: 1fr; }
+  .footer-grid { grid-template-columns: 1fr; }
+  .hs-row { font-size: 10px; flex-wrap: wrap; }
+  .hs-rank { flex: 0 0 50px; }
+  .hs-score { flex: 0 0 110px; }
+  .hs-game, .hs-level, .hs-year { flex: 0 0 60px; font-size: 8px; }
+
+  .marq-track { font-size: 9px; gap: 16px; }
+}
+
+/* ---------- Print ---------- */
+@media print {
+  body { background: white; color: black; }
+  .strip-top, .footer, .marq-strip { display: none; }
+  .marquee, .cabinets, .bay, .scores, .hours { background: white; color: black; }
+}

--- a/examples/arcade-token/static/favicon.svg
+++ b/examples/arcade-token/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" shape-rendering="crispEdges">
+  <rect width="32" height="32" fill="#0a0a0a"/>
+  <rect x="4" y="4" width="24" height="24" fill="#d6a52a"/>
+  <rect x="6" y="6" width="20" height="20" fill="#1a1a1a"/>
+  <rect x="10" y="10" width="12" height="3" fill="#0a0a0a"/>
+  <rect x="9" y="13" width="14" height="2" fill="#00d0d4"/>
+  <rect x="10" y="15" width="12" height="2" fill="#ff2bb5"/>
+  <rect x="11" y="20" width="10" height="2" fill="#ffcb1f"/>
+  <rect x="13" y="22" width="6" height="1" fill="#f4ecd6"/>
+</svg>

--- a/examples/arcade-token/templates/404.html
+++ b/examples/arcade-token/templates/404.html
@@ -1,0 +1,39 @@
+{% include "header.html" %}
+<article class="prose prose-404">
+  <div class="px-word">
+    <!-- 4 -->
+    <div class="px-letter px-rd">
+      <span class="r0 c0"></span><span class="r0 c3"></span>
+      <span class="r1 c0"></span><span class="r1 c3"></span>
+      <span class="r2 c0"></span><span class="r2 c3"></span>
+      <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span><span class="r3 c4"></span>
+      <span class="r4 c3"></span>
+      <span class="r5 c3"></span>
+      <span class="r6 c3"></span>
+    </div>
+    <!-- 0 -->
+    <div class="px-letter px-yl">
+      <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+      <span class="r1 c0"></span><span class="r1 c4"></span>
+      <span class="r2 c0"></span><span class="r2 c3"></span><span class="r2 c4"></span>
+      <span class="r3 c0"></span><span class="r3 c2"></span><span class="r3 c4"></span>
+      <span class="r4 c0"></span><span class="r4 c1"></span><span class="r4 c4"></span>
+      <span class="r5 c0"></span><span class="r5 c4"></span>
+      <span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+    </div>
+    <!-- 4 -->
+    <div class="px-letter px-cy">
+      <span class="r0 c0"></span><span class="r0 c3"></span>
+      <span class="r1 c0"></span><span class="r1 c3"></span>
+      <span class="r2 c0"></span><span class="r2 c3"></span>
+      <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span><span class="r3 c4"></span>
+      <span class="r4 c3"></span>
+      <span class="r5 c3"></span>
+      <span class="r6 c3"></span>
+    </div>
+  </div>
+  <h1>GAME OVER // OUT OF ORDER</h1>
+  <p>This screen is dark. PCB's pulled, tube's drained, address is wrong. Pop another credit and head back to the marquee.</p>
+  <p class="prose-back"><a href="{{ base_url }}/">&laquo; INSERT COIN &middot; CONTINUE</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/arcade-token/templates/footer.html
+++ b/examples/arcade-token/templates/footer.html
@@ -1,0 +1,149 @@
+  <footer class="footer">
+    <div class="marq-strip" aria-hidden="true">
+      <div class="marq-track">
+        <span>TOKEN &amp; JOYSTICK</span><i class="marq-dot"></i>
+        <span>ARCADE REPAIR</span><i class="marq-dot"></i>
+        <span>LOT 7 &middot; EAST ALLEY</span><i class="marq-dot"></i>
+        <span>CRT &middot; PCB &middot; CABINET</span><i class="marq-dot"></i>
+        <span>TOKEN &amp; JOYSTICK</span><i class="marq-dot"></i>
+        <span>ARCADE REPAIR</span><i class="marq-dot"></i>
+        <span>LOT 7 &middot; EAST ALLEY</span><i class="marq-dot"></i>
+        <span>CRT &middot; PCB &middot; CABINET</span><i class="marq-dot"></i>
+      </div>
+    </div>
+
+    <div class="coin-bezel" aria-hidden="true">
+      <div class="coin-plate">
+        <span class="coin-slot"></span>
+        <span class="coin-label">INSERT COIN</span>
+      </div>
+    </div>
+
+    <div class="footer-wrap">
+      <div class="footer-headline">
+        <div class="px-word">
+          <!-- G -->
+          <div class="px-letter px-rd">
+            <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+            <span class="r1 c0"></span>
+            <span class="r2 c0"></span>
+            <span class="r3 c0"></span><span class="r3 c2"></span><span class="r3 c3"></span><span class="r3 c4"></span>
+            <span class="r4 c0"></span><span class="r4 c4"></span>
+            <span class="r5 c0"></span><span class="r5 c4"></span>
+            <span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+          </div>
+          <!-- A -->
+          <div class="px-letter px-rd">
+            <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+            <span class="r1 c0"></span><span class="r1 c4"></span>
+            <span class="r2 c0"></span><span class="r2 c4"></span>
+            <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span><span class="r3 c4"></span>
+            <span class="r4 c0"></span><span class="r4 c4"></span>
+            <span class="r5 c0"></span><span class="r5 c4"></span>
+            <span class="r6 c0"></span><span class="r6 c4"></span>
+          </div>
+          <!-- M -->
+          <div class="px-letter px-rd">
+            <span class="r0 c0"></span><span class="r0 c4"></span>
+            <span class="r1 c0"></span><span class="r1 c1"></span><span class="r1 c3"></span><span class="r1 c4"></span>
+            <span class="r2 c0"></span><span class="r2 c2"></span><span class="r2 c4"></span>
+            <span class="r3 c0"></span><span class="r3 c2"></span><span class="r3 c4"></span>
+            <span class="r4 c0"></span><span class="r4 c4"></span>
+            <span class="r5 c0"></span><span class="r5 c4"></span>
+            <span class="r6 c0"></span><span class="r6 c4"></span>
+          </div>
+          <!-- E -->
+          <div class="px-letter px-rd">
+            <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+            <span class="r1 c0"></span>
+            <span class="r2 c0"></span>
+            <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span>
+            <span class="r4 c0"></span>
+            <span class="r5 c0"></span>
+            <span class="r6 c0"></span><span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span><span class="r6 c4"></span>
+          </div>
+        </div>
+        <div class="px-word">
+          <!-- O -->
+          <div class="px-letter px-cy">
+            <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+            <span class="r1 c0"></span><span class="r1 c4"></span>
+            <span class="r2 c0"></span><span class="r2 c4"></span>
+            <span class="r3 c0"></span><span class="r3 c4"></span>
+            <span class="r4 c0"></span><span class="r4 c4"></span>
+            <span class="r5 c0"></span><span class="r5 c4"></span>
+            <span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+          </div>
+          <!-- V -->
+          <div class="px-letter px-cy">
+            <span class="r0 c0"></span><span class="r0 c4"></span>
+            <span class="r1 c0"></span><span class="r1 c4"></span>
+            <span class="r2 c0"></span><span class="r2 c4"></span>
+            <span class="r3 c0"></span><span class="r3 c4"></span>
+            <span class="r4 c1"></span><span class="r4 c3"></span>
+            <span class="r5 c1"></span><span class="r5 c3"></span>
+            <span class="r6 c2"></span>
+          </div>
+          <!-- E -->
+          <div class="px-letter px-cy">
+            <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+            <span class="r1 c0"></span>
+            <span class="r2 c0"></span>
+            <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span>
+            <span class="r4 c0"></span>
+            <span class="r5 c0"></span>
+            <span class="r6 c0"></span><span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span><span class="r6 c4"></span>
+          </div>
+          <!-- R -->
+          <div class="px-letter px-cy">
+            <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+            <span class="r1 c0"></span><span class="r1 c4"></span>
+            <span class="r2 c0"></span><span class="r2 c4"></span>
+            <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span>
+            <span class="r4 c0"></span><span class="r4 c2"></span>
+            <span class="r5 c0"></span><span class="r5 c3"></span>
+            <span class="r6 c0"></span><span class="r6 c4"></span>
+          </div>
+        </div>
+      </div>
+      <div class="footer-year">PRESS START &middot; {{ current_year }}</div>
+
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h5>SHOP</h5>
+          <a href="#cabinets">Cabinets</a>
+          <a href="#repair">Repair bay</a>
+          <a href="#scores">Parts &amp; consign</a>
+          <a href="{{ base_url }}/about/">Visit</a>
+        </div>
+        <div class="footer-col">
+          <h5>BENCH</h5>
+          <a href="#repair">CRT realign</a>
+          <a href="#repair">PCB swap</a>
+          <a href="#repair">Cabinet refit</a>
+          <a href="#repair">Custom builds</a>
+        </div>
+        <div class="footer-col">
+          <h5>CONTACT</h5>
+          <a href="#">bench@token-joystick</a>
+          <a href="#">parts@token-joystick</a>
+          <a href="#">No phone, ever</a>
+        </div>
+        <div class="footer-col">
+          <h5>VISIT</h5>
+          <a href="#">Lot 7 &middot; East Alley</a>
+          <a href="#">WED &mdash; SUN</a>
+          <a href="#">Ring the bell</a>
+        </div>
+      </div>
+
+      <div class="footer-copy">
+        <span>&copy; {{ current_year }} TOKEN &amp; JOYSTICK &middot; LOT 7</span>
+        <span>HWARO BUILD &middot; CABINET v{{ current_year }}.07</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/arcade-token/templates/header.html
+++ b/examples/arcade-token/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Black+Ops+One&family=Press+Start+2P&family=VT323&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <a class="strip-home" href="{{ base_url }}/">TOKEN &amp; JOYSTICK</a>
+    <span class="strip-mid">ARCADE REPAIR &middot; LOT 7 &middot; OPEN WED&ndash;SUN</span>
+    <nav class="strip-nav">
+      <a href="#cabinets">CABINETS</a>
+      <a href="#repair">SERVICE</a>
+      <a href="#scores">PARTS</a>
+      <a href="{{ base_url }}/about/">INSERT COIN</a>
+    </nav>
+  </header>

--- a/examples/arcade-token/templates/index.html
+++ b/examples/arcade-token/templates/index.html
@@ -1,0 +1,493 @@
+{% include "header.html" %}
+
+<section class="marquee">
+  <div class="marquee-frame">
+    <div class="marquee-bolts"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+
+    <div class="marquee-headline">
+      <!-- Pixel-block headline: each letter is a 5x7 pixel grid of colored spans -->
+      <div class="px-word">
+        <!-- T -->
+        <div class="px-letter px-cy">
+          <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+          <span class="r1 c2"></span>
+          <span class="r2 c2"></span>
+          <span class="r3 c2"></span>
+          <span class="r4 c2"></span>
+          <span class="r5 c2"></span>
+          <span class="r6 c2"></span>
+        </div>
+        <!-- O -->
+        <div class="px-letter px-mg">
+          <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+          <span class="r1 c0"></span><span class="r1 c4"></span>
+          <span class="r2 c0"></span><span class="r2 c4"></span>
+          <span class="r3 c0"></span><span class="r3 c4"></span>
+          <span class="r4 c0"></span><span class="r4 c4"></span>
+          <span class="r5 c0"></span><span class="r5 c4"></span>
+          <span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+        </div>
+        <!-- K -->
+        <div class="px-letter px-yl">
+          <span class="r0 c0"></span><span class="r0 c4"></span>
+          <span class="r1 c0"></span><span class="r1 c3"></span>
+          <span class="r2 c0"></span><span class="r2 c2"></span>
+          <span class="r3 c0"></span><span class="r3 c1"></span>
+          <span class="r4 c0"></span><span class="r4 c2"></span>
+          <span class="r5 c0"></span><span class="r5 c3"></span>
+          <span class="r6 c0"></span><span class="r6 c4"></span>
+        </div>
+        <!-- E -->
+        <div class="px-letter px-gn">
+          <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+          <span class="r1 c0"></span>
+          <span class="r2 c0"></span>
+          <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span>
+          <span class="r4 c0"></span>
+          <span class="r5 c0"></span>
+          <span class="r6 c0"></span><span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span><span class="r6 c4"></span>
+        </div>
+        <!-- N -->
+        <div class="px-letter px-rd">
+          <span class="r0 c0"></span><span class="r0 c4"></span>
+          <span class="r1 c0"></span><span class="r1 c1"></span><span class="r1 c4"></span>
+          <span class="r2 c0"></span><span class="r2 c2"></span><span class="r2 c4"></span>
+          <span class="r3 c0"></span><span class="r3 c2"></span><span class="r3 c4"></span>
+          <span class="r4 c0"></span><span class="r4 c3"></span><span class="r4 c4"></span>
+          <span class="r5 c0"></span><span class="r5 c3"></span><span class="r5 c4"></span>
+          <span class="r6 c0"></span><span class="r6 c4"></span>
+        </div>
+      </div>
+
+      <div class="px-word">
+        <!-- J -->
+        <div class="px-letter px-mg">
+          <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+          <span class="r1 c3"></span>
+          <span class="r2 c3"></span>
+          <span class="r3 c3"></span>
+          <span class="r4 c3"></span>
+          <span class="r5 c0"></span><span class="r5 c3"></span>
+          <span class="r6 c1"></span><span class="r6 c2"></span>
+        </div>
+        <!-- O -->
+        <div class="px-letter px-cy">
+          <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+          <span class="r1 c0"></span><span class="r1 c4"></span>
+          <span class="r2 c0"></span><span class="r2 c4"></span>
+          <span class="r3 c0"></span><span class="r3 c4"></span>
+          <span class="r4 c0"></span><span class="r4 c4"></span>
+          <span class="r5 c0"></span><span class="r5 c4"></span>
+          <span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+        </div>
+        <!-- Y -->
+        <div class="px-letter px-yl">
+          <span class="r0 c0"></span><span class="r0 c4"></span>
+          <span class="r1 c0"></span><span class="r1 c4"></span>
+          <span class="r2 c1"></span><span class="r2 c3"></span>
+          <span class="r3 c2"></span>
+          <span class="r4 c2"></span>
+          <span class="r5 c2"></span>
+          <span class="r6 c2"></span>
+        </div>
+        <!-- S -->
+        <div class="px-letter px-rd">
+          <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+          <span class="r1 c0"></span>
+          <span class="r2 c0"></span>
+          <span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span>
+          <span class="r4 c4"></span>
+          <span class="r5 c4"></span>
+          <span class="r6 c0"></span><span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+        </div>
+        <!-- T -->
+        <div class="px-letter px-gn">
+          <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+          <span class="r1 c2"></span>
+          <span class="r2 c2"></span>
+          <span class="r3 c2"></span>
+          <span class="r4 c2"></span>
+          <span class="r5 c2"></span>
+          <span class="r6 c2"></span>
+        </div>
+        <!-- I -->
+        <div class="px-letter px-cy">
+          <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+          <span class="r1 c2"></span>
+          <span class="r2 c2"></span>
+          <span class="r3 c2"></span>
+          <span class="r4 c2"></span>
+          <span class="r5 c2"></span>
+          <span class="r6 c0"></span><span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span><span class="r6 c4"></span>
+        </div>
+        <!-- C -->
+        <div class="px-letter px-yl">
+          <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+          <span class="r1 c0"></span>
+          <span class="r2 c0"></span>
+          <span class="r3 c0"></span>
+          <span class="r4 c0"></span>
+          <span class="r5 c0"></span>
+          <span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span><span class="r6 c4"></span>
+        </div>
+        <!-- K -->
+        <div class="px-letter px-mg">
+          <span class="r0 c0"></span><span class="r0 c4"></span>
+          <span class="r1 c0"></span><span class="r1 c3"></span>
+          <span class="r2 c0"></span><span class="r2 c2"></span>
+          <span class="r3 c0"></span><span class="r3 c1"></span>
+          <span class="r4 c0"></span><span class="r4 c2"></span>
+          <span class="r5 c0"></span><span class="r5 c3"></span>
+          <span class="r6 c0"></span><span class="r6 c4"></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="marquee-sub">INSERT COIN TO CONTINUE</div>
+
+    <!-- Side joystick + button cluster pixel art -->
+    <aside class="hero-joystick" aria-hidden="true">
+      <div class="px-art px-art-joystick">
+        <span class="p p-bk r0 c2"></span><span class="p p-bk r0 c3"></span><span class="p p-bk r0 c4"></span>
+        <span class="p p-rd r1 c2"></span><span class="p p-rd r1 c3"></span><span class="p p-rd r1 c4"></span>
+        <span class="p p-bk r2 c2"></span><span class="p p-bk r2 c3"></span><span class="p p-bk r2 c4"></span>
+        <span class="p p-bk r3 c3"></span>
+        <span class="p p-bk r4 c3"></span>
+        <span class="p p-yl r5 c2"></span><span class="p p-yl r5 c3"></span><span class="p p-yl r5 c4"></span>
+        <span class="p p-yl r6 c1"></span><span class="p p-yl r6 c2"></span><span class="p p-yl r6 c3"></span><span class="p p-yl r6 c4"></span><span class="p p-yl r6 c5"></span>
+        <span class="p p-yl r7 c1"></span><span class="p p-yl r7 c2"></span><span class="p p-yl r7 c3"></span><span class="p p-yl r7 c4"></span><span class="p p-yl r7 c5"></span>
+        <span class="p p-bk r8 c0"></span><span class="p p-bk r8 c1"></span><span class="p p-bk r8 c2"></span><span class="p p-bk r8 c3"></span><span class="p p-bk r8 c4"></span><span class="p p-bk r8 c5"></span><span class="p p-bk r8 c6"></span>
+        <span class="p p-cy r9 c0"></span><span class="p p-rd r9 c2"></span><span class="p p-gn r9 c4"></span><span class="p p-mg r9 c6"></span>
+      </div>
+    </aside>
+
+    <div class="marquee-credits">
+      <span class="credits-label">CREDITS</span>
+      <span class="credits-count">03</span>
+      <span class="credits-blink">_</span>
+    </div>
+  </div>
+</section>
+
+<section class="cabinets" id="cabinets">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="section-tag">// LOT 7 &middot; FLOOR</div>
+      <h2 class="section-title">CABINETS IN HOUSE</h2>
+      <p class="section-sub">Four machines on the floor this week. Two running, two in the shop. All originals.</p>
+    </div>
+
+    <div class="cab-grid">
+      <article class="cab cab-1">
+        <div class="cab-title px-yl">
+          <div class="px-word px-word-sm">
+            <!-- D -->
+            <div class="px-letter px-yl">
+              <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+              <span class="r1 c0"></span><span class="r1 c4"></span>
+              <span class="r2 c0"></span><span class="r2 c4"></span>
+              <span class="r3 c0"></span><span class="r3 c4"></span>
+              <span class="r4 c0"></span><span class="r4 c4"></span>
+              <span class="r5 c0"></span><span class="r5 c4"></span>
+              <span class="r6 c0"></span><span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+            </div>
+            <!-- K -->
+            <div class="px-letter px-yl">
+              <span class="r0 c0"></span><span class="r0 c4"></span>
+              <span class="r1 c0"></span><span class="r1 c3"></span>
+              <span class="r2 c0"></span><span class="r2 c2"></span>
+              <span class="r3 c0"></span><span class="r3 c1"></span>
+              <span class="r4 c0"></span><span class="r4 c2"></span>
+              <span class="r5 c0"></span><span class="r5 c3"></span>
+              <span class="r6 c0"></span><span class="r6 c4"></span>
+            </div>
+          </div>
+          <span class="cab-name">DONKEY KONG</span>
+        </div>
+        <div class="cab-art">
+          <!-- Brick wall pixel art -->
+          <div class="px-art px-art-brick">
+            <span class="p p-rd r0 c0"></span><span class="p p-rd r0 c1"></span><span class="p p-bk r0 c2"></span><span class="p p-rd r0 c3"></span><span class="p p-rd r0 c4"></span><span class="p p-rd r0 c5"></span><span class="p p-bk r0 c6"></span><span class="p p-rd r0 c7"></span>
+            <span class="p p-bk r1 c0"></span><span class="p p-bk r1 c1"></span><span class="p p-bk r1 c2"></span><span class="p p-bk r1 c3"></span><span class="p p-bk r1 c4"></span><span class="p p-bk r1 c5"></span><span class="p p-bk r1 c6"></span><span class="p p-bk r1 c7"></span>
+            <span class="p p-rd r2 c0"></span><span class="p p-bk r2 c1"></span><span class="p p-rd r2 c2"></span><span class="p p-rd r2 c3"></span><span class="p p-bk r2 c4"></span><span class="p p-rd r2 c5"></span><span class="p p-rd r2 c6"></span><span class="p p-rd r2 c7"></span>
+            <span class="p p-bk r3 c0"></span><span class="p p-bk r3 c1"></span><span class="p p-bk r3 c2"></span><span class="p p-bk r3 c3"></span><span class="p p-bk r3 c4"></span><span class="p p-bk r3 c5"></span><span class="p p-bk r3 c6"></span><span class="p p-bk r3 c7"></span>
+            <span class="p p-rd r4 c0"></span><span class="p p-rd r4 c1"></span><span class="p p-bk r4 c2"></span><span class="p p-rd r4 c3"></span><span class="p p-rd r4 c4"></span><span class="p p-rd r4 c5"></span><span class="p p-bk r4 c6"></span><span class="p p-rd r4 c7"></span>
+          </div>
+        </div>
+        <dl class="cab-spec">
+          <dt>YEAR</dt><dd>1981</dd>
+          <dt>CABINET</dt><dd>UPRIGHT</dd>
+          <dt>STATUS</dt><dd class="ok">RUNNING</dd>
+        </dl>
+      </article>
+
+      <article class="cab cab-2">
+        <div class="cab-title px-cy">
+          <div class="px-word px-word-sm">
+            <!-- P -->
+            <div class="px-letter px-cy">
+              <span class="r0 c0"></span><span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+              <span class="r1 c0"></span><span class="r1 c4"></span>
+              <span class="r2 c0"></span><span class="r2 c4"></span>
+              <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span>
+              <span class="r4 c0"></span>
+              <span class="r5 c0"></span>
+              <span class="r6 c0"></span>
+            </div>
+            <!-- C -->
+            <div class="px-letter px-cy">
+              <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+              <span class="r1 c0"></span>
+              <span class="r2 c0"></span>
+              <span class="r3 c0"></span>
+              <span class="r4 c0"></span>
+              <span class="r5 c0"></span>
+              <span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span><span class="r6 c4"></span>
+            </div>
+          </div>
+          <span class="cab-name">PAC-MAN</span>
+        </div>
+        <div class="cab-art">
+          <!-- Ghost pixel art -->
+          <div class="px-art px-art-ghost">
+            <span class="p p-mg r0 c2"></span><span class="p p-mg r0 c3"></span><span class="p p-mg r0 c4"></span><span class="p p-mg r0 c5"></span>
+            <span class="p p-mg r1 c1"></span><span class="p p-mg r1 c2"></span><span class="p p-mg r1 c3"></span><span class="p p-mg r1 c4"></span><span class="p p-mg r1 c5"></span><span class="p p-mg r1 c6"></span>
+            <span class="p p-mg r2 c0"></span><span class="p p-bn r2 c1"></span><span class="p p-bn r2 c2"></span><span class="p p-mg r2 c3"></span><span class="p p-bn r2 c4"></span><span class="p p-bn r2 c5"></span><span class="p p-mg r2 c6"></span><span class="p p-mg r2 c7"></span>
+            <span class="p p-mg r3 c0"></span><span class="p p-bn r3 c1"></span><span class="p p-cy r3 c2"></span><span class="p p-mg r3 c3"></span><span class="p p-bn r3 c4"></span><span class="p p-cy r3 c5"></span><span class="p p-mg r3 c6"></span><span class="p p-mg r3 c7"></span>
+            <span class="p p-mg r4 c0"></span><span class="p p-mg r4 c1"></span><span class="p p-mg r4 c2"></span><span class="p p-mg r4 c3"></span><span class="p p-mg r4 c4"></span><span class="p p-mg r4 c5"></span><span class="p p-mg r4 c6"></span><span class="p p-mg r4 c7"></span>
+            <span class="p p-mg r5 c0"></span><span class="p p-mg r5 c2"></span><span class="p p-mg r5 c4"></span><span class="p p-mg r5 c5"></span><span class="p p-mg r5 c7"></span>
+          </div>
+        </div>
+        <dl class="cab-spec">
+          <dt>YEAR</dt><dd>1980</dd>
+          <dt>CABINET</dt><dd>COCKTAIL</dd>
+          <dt>STATUS</dt><dd class="ok">RUNNING</dd>
+        </dl>
+      </article>
+
+      <article class="cab cab-3">
+        <div class="cab-title px-mg">
+          <div class="px-word px-word-sm">
+            <!-- G -->
+            <div class="px-letter px-mg">
+              <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+              <span class="r1 c0"></span>
+              <span class="r2 c0"></span>
+              <span class="r3 c0"></span><span class="r3 c2"></span><span class="r3 c3"></span><span class="r3 c4"></span>
+              <span class="r4 c0"></span><span class="r4 c4"></span>
+              <span class="r5 c0"></span><span class="r5 c4"></span>
+              <span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+            </div>
+            <!-- X -->
+            <div class="px-letter px-mg">
+              <span class="r0 c0"></span><span class="r0 c4"></span>
+              <span class="r1 c1"></span><span class="r1 c3"></span>
+              <span class="r2 c2"></span>
+              <span class="r3 c2"></span>
+              <span class="r4 c2"></span>
+              <span class="r5 c1"></span><span class="r5 c3"></span>
+              <span class="r6 c0"></span><span class="r6 c4"></span>
+            </div>
+          </div>
+          <span class="cab-name">GALAXIAN</span>
+        </div>
+        <div class="cab-art">
+          <!-- Saucer/UFO pixel art -->
+          <div class="px-art px-art-saucer">
+            <span class="p p-rd r0 c3"></span><span class="p p-rd r0 c4"></span>
+            <span class="p p-rd r1 c2"></span><span class="p p-yl r1 c3"></span><span class="p p-yl r1 c4"></span><span class="p p-rd r1 c5"></span>
+            <span class="p p-cy r2 c1"></span><span class="p p-cy r2 c2"></span><span class="p p-cy r2 c3"></span><span class="p p-cy r2 c4"></span><span class="p p-cy r2 c5"></span><span class="p p-cy r2 c6"></span>
+            <span class="p p-bk r3 c0"></span><span class="p p-bk r3 c1"></span><span class="p p-bk r3 c2"></span><span class="p p-bk r3 c3"></span><span class="p p-bk r3 c4"></span><span class="p p-bk r3 c5"></span><span class="p p-bk r3 c6"></span><span class="p p-bk r3 c7"></span>
+            <span class="p p-mg r4 c2"></span><span class="p p-mg r4 c5"></span>
+            <span class="p p-mg r5 c3"></span><span class="p p-mg r5 c4"></span>
+          </div>
+        </div>
+        <dl class="cab-spec">
+          <dt>YEAR</dt><dd>1979</dd>
+          <dt>CABINET</dt><dd>UPRIGHT</dd>
+          <dt>STATUS</dt><dd class="hot">IN SHOP</dd>
+        </dl>
+      </article>
+
+      <article class="cab cab-4">
+        <div class="cab-title px-gn">
+          <div class="px-word px-word-sm">
+            <!-- A -->
+            <div class="px-letter px-gn">
+              <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span>
+              <span class="r1 c0"></span><span class="r1 c4"></span>
+              <span class="r2 c0"></span><span class="r2 c4"></span>
+              <span class="r3 c0"></span><span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span><span class="r3 c4"></span>
+              <span class="r4 c0"></span><span class="r4 c4"></span>
+              <span class="r5 c0"></span><span class="r5 c4"></span>
+              <span class="r6 c0"></span><span class="r6 c4"></span>
+            </div>
+            <!-- S -->
+            <div class="px-letter px-gn">
+              <span class="r0 c1"></span><span class="r0 c2"></span><span class="r0 c3"></span><span class="r0 c4"></span>
+              <span class="r1 c0"></span>
+              <span class="r2 c0"></span>
+              <span class="r3 c1"></span><span class="r3 c2"></span><span class="r3 c3"></span>
+              <span class="r4 c4"></span>
+              <span class="r5 c4"></span>
+              <span class="r6 c0"></span><span class="r6 c1"></span><span class="r6 c2"></span><span class="r6 c3"></span>
+            </div>
+          </div>
+          <span class="cab-name">ASTEROIDS</span>
+        </div>
+        <div class="cab-art">
+          <!-- Asteroid rock pixel art -->
+          <div class="px-art px-art-rock">
+            <span class="p p-bn r0 c2"></span><span class="p p-bn r0 c3"></span><span class="p p-bn r0 c4"></span>
+            <span class="p p-bn r1 c1"></span><span class="p p-bn r1 c2"></span><span class="p p-bn r1 c3"></span><span class="p p-bn r1 c4"></span><span class="p p-bn r1 c5"></span><span class="p p-bn r1 c6"></span>
+            <span class="p p-bn r2 c0"></span><span class="p p-bn r2 c1"></span><span class="p p-bk r2 c2"></span><span class="p p-bn r2 c3"></span><span class="p p-bn r2 c4"></span><span class="p p-bk r2 c5"></span><span class="p p-bn r2 c6"></span><span class="p p-bn r2 c7"></span>
+            <span class="p p-bn r3 c0"></span><span class="p p-bn r3 c1"></span><span class="p p-bn r3 c2"></span><span class="p p-bn r3 c3"></span><span class="p p-bn r3 c4"></span><span class="p p-bn r3 c5"></span><span class="p p-bn r3 c6"></span><span class="p p-bn r3 c7"></span>
+            <span class="p p-bn r4 c1"></span><span class="p p-bn r4 c2"></span><span class="p p-bk r4 c3"></span><span class="p p-bn r4 c4"></span><span class="p p-bn r4 c5"></span><span class="p p-bn r4 c6"></span>
+            <span class="p p-bn r5 c2"></span><span class="p p-bn r5 c3"></span><span class="p p-bn r5 c4"></span>
+          </div>
+        </div>
+        <dl class="cab-spec">
+          <dt>YEAR</dt><dd>1979</dd>
+          <dt>CABINET</dt><dd>UPRIGHT</dd>
+          <dt>STATUS</dt><dd class="hot">IN SHOP</dd>
+        </dl>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="bay" id="repair">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="section-tag">// REPAIR BAY &middot; BOOKING REQUIRED</div>
+      <h2 class="section-title">SERVICE MENU</h2>
+      <p class="section-sub">Quotes are in tokens. One token equals one beer at the bar across the street; we'll convert.</p>
+    </div>
+
+    <div class="bay-grid">
+      <article class="bay-card bay-cy">
+        <div class="bay-num">01</div>
+        <h3 class="bay-name">CRT REALIGN</h3>
+        <p class="bay-desc">Convergence, purity, geometry. We open the chassis, discharge the tube, and dial in the yoke. Bring the cabinet; we don't ship CRTs.</p>
+        <ul class="bay-bul">
+          <li>Tri-color convergence pass</li>
+          <li>Pincushion &amp; barrel correction</li>
+          <li>HV recap if needed</li>
+        </ul>
+        <div class="bay-price"><span class="bay-tok">40</span><span class="bay-tlabel">TOKENS</span></div>
+      </article>
+
+      <article class="bay-card bay-mg">
+        <div class="bay-num">02</div>
+        <h3 class="bay-name">PCB SWAP</h3>
+        <p class="bay-desc">Original board down? We test in the bench harness, reflow joints, recap power rails, and swap socketed ROMs. We log every fix.</p>
+        <ul class="bay-bul">
+          <li>Logic probe + scope diagnosis</li>
+          <li>Socket &amp; reseat all ROMs</li>
+          <li>Cap kit &amp; battery replace</li>
+        </ul>
+        <div class="bay-price"><span class="bay-tok">90</span><span class="bay-tlabel">TOKENS</span></div>
+      </article>
+
+      <article class="bay-card bay-yl">
+        <div class="bay-num">03</div>
+        <h3 class="bay-name">CABINET REFIT</h3>
+        <p class="bay-desc">Side-art repaints, T-molding swap, control panel rewire, marquee reprint. Six-week turnaround. We do not paint over original art &mdash; we restore it.</p>
+        <ul class="bay-bul">
+          <li>New T-molding (any color)</li>
+          <li>CP rewire to Jamma std</li>
+          <li>Marquee reprint on acrylic</li>
+        </ul>
+        <div class="bay-price"><span class="bay-tok">220</span><span class="bay-tlabel">TOKENS</span></div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="scores" id="scores">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="section-tag">// ATTRACT MODE &middot; SHOP LEADERBOARD</div>
+      <h2 class="section-title">HIGH SCORES</h2>
+      <p class="section-sub">Rolling tally from the floor cabinets. Top score wins a free CRT realign next month.</p>
+    </div>
+
+    <div class="hs-table">
+      <div class="hs-row hs-head">
+        <span class="hs-rank">RNK</span>
+        <span class="hs-name">NAME</span>
+        <span class="hs-score">SCORE</span>
+        <span class="hs-game">GAME</span>
+        <span class="hs-level">LV</span>
+        <span class="hs-year">YR</span>
+      </div>
+      <div class="hs-row">
+        <span class="hs-rank">1ST</span>
+        <span class="hs-name">RR</span>
+        <span class="hs-score">214,300</span>
+        <span class="hs-game">DK</span>
+        <span class="hs-level">LV 22</span>
+        <span class="hs-year">1985</span>
+      </div>
+      <div class="hs-row">
+        <span class="hs-rank">2ND</span>
+        <span class="hs-name">JC</span>
+        <span class="hs-score">189,820</span>
+        <span class="hs-game">PAC</span>
+        <span class="hs-level">LV 17</span>
+        <span class="hs-year">1983</span>
+      </div>
+      <div class="hs-row">
+        <span class="hs-rank">3RD</span>
+        <span class="hs-name">MO</span>
+        <span class="hs-score">112,950</span>
+        <span class="hs-game">GAL</span>
+        <span class="hs-level">LV 14</span>
+        <span class="hs-year">1981</span>
+      </div>
+      <div class="hs-row">
+        <span class="hs-rank">4TH</span>
+        <span class="hs-name">DD</span>
+        <span class="hs-score">76,400</span>
+        <span class="hs-game">AST</span>
+        <span class="hs-level">LV 9</span>
+        <span class="hs-year">1980</span>
+      </div>
+      <div class="hs-row">
+        <span class="hs-rank">5TH</span>
+        <span class="hs-name">SH</span>
+        <span class="hs-score">42,180</span>
+        <span class="hs-game">DK</span>
+        <span class="hs-level">LV 6</span>
+        <span class="hs-year">1985</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="hours">
+  <div class="wrap">
+    <div class="hours-grid">
+      <div class="hours-block">
+        <h4>HOURS</h4>
+        <p>WED &mdash; FRI &middot; 14:00 / 21:00</p>
+        <p>SAT &mdash; SUN &middot; 12:00 / 22:00</p>
+        <p>MON / TUE &middot; CLOSED</p>
+      </div>
+      <div class="hours-block">
+        <h4>ADDRESS</h4>
+        <p>LOT 7, EAST ALLEY</p>
+        <p>OLD MARKET BLOCK</p>
+        <p>RING THE BELL</p>
+      </div>
+      <div class="hours-block">
+        <h4>BENCH</h4>
+        <p>bench@token-joystick</p>
+        <p>parts@token-joystick</p>
+        <p>(NO PHONE / EVER)</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/arcade-token/templates/page.html
+++ b/examples/arcade-token/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+  <p class="prose-back"><a href="{{ base_url }}/">&laquo; BACK TO THE MARQUEE</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/arcade-token/templates/section.html
+++ b/examples/arcade-token/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+<section class="prose-section">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="section-tag">// SHOP &middot; SECTION</div>
+      {% if page.title is present %}<h2 class="section-title">{{ page.title | e | upper }}</h2>{% endif %}
+    </div>
+    <div class="prose">{{ content | safe }}</div>
+    <div class="hs-table">
+      <div class="hs-row hs-head">
+        <span class="hs-rank">DATE</span>
+        <span class="hs-name" style="flex:2">TITLE</span>
+        <span class="hs-score">&gt;&gt;</span>
+      </div>
+      {% for post in section.pages %}
+      <div class="hs-row">
+        <span class="hs-rank">{{ post.date | date(format="%Y.%m") }}</span>
+        <span class="hs-name" style="flex:2"><a href="{{ post.url }}">{{ post.title | e | upper }}</a></span>
+        <span class="hs-score">GO</span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/arcade-token/templates/taxonomy.html
+++ b/examples/arcade-token/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Index of repair logs, parts categories, and shop bookmarks.</p>
+  {{ content | safe }}
+  <p class="prose-back"><a href="{{ base_url }}/">&laquo; BACK TO THE MARQUEE</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/arcade-token/templates/taxonomy_term.html
+++ b/examples/arcade-token/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Entries logged under this tag.</p>
+  {{ content | safe }}
+  <p class="prose-back"><a href="{{ base_url }}/">&laquo; BACK TO THE MARQUEE</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/balloon-mail/AGENTS.md
+++ b/examples/balloon-mail/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/balloon-mail/archetypes/default.md
+++ b/examples/balloon-mail/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/balloon-mail/config.toml
+++ b/examples/balloon-mail/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "AEROSTAT CLUB"
+description = "Aerostat Club — dawn ascents over the wine valley and a single postcard per flight, carried by hot-air balloon to the landing field."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/balloon-mail/content/about.md
+++ b/examples/balloon-mail/content/about.md
@@ -1,0 +1,38 @@
++++
+title = "About the Club"
+description = "Aerostat Club — the club, the pilots, the skymail programme, the weather, and how to book a seat."
++++
+
+## The Club
+
+The **Aerostat Club** is a private association of balloonists, founded in 1887 and headquartered at the Vossler Field, three miles into the wine valley. We fly **hot-air balloons** at dawn, weather permitting, between March and October. The Club operates under its own seal and under the supervision of the Postmaster.
+
+We are not a tourist operation. We are a flying club that carries the occasional paying passenger, and exactly one postcard per flight.
+
+## Pilot Training
+
+The Club trains pilots under a four-stage syllabus &mdash; *ground*, *tethered*, *free-flight*, and *passenger endorsement*. A pilot may not carry passengers until they have logged **400 hours aloft** and passed the Club's own oral examination, conducted at the field by two senior captains.
+
+We currently certify four active pilots. Their hours are recorded in the front of the logbook, and any one of them may, at their discretion, refuse to fly.
+
+## The Skymail Programme
+
+The **Sky-Mail** programme is a deliberately small thing. On every flight, a single postcard &mdash; **one and one only** &mdash; is carried in a tin tied to the basket. The card must be written by hand on Club stock, addressed in legible ink, and sealed at the pilot's table the evening before the ascent.
+
+After landing, the Postmaster stamps the card with the flight's number and date and delivers it by ordinary post. The journey is short. The romance is the point.
+
+## Weather Rules
+
+We fly under three hard rules, written into the Club's charter and never relaxed:
+
+- **Surface wind below eight knots**, measured at the field, in the half hour before lift.
+- **Cloud ceiling above three thousand feet**, observed by the duty pilot.
+- **No precipitation, no thunder within twenty miles**, by report and by ear.
+
+If any one of the three is missed, the flight is *postponed*, not cancelled. Postponed flights are re-scheduled to the following dawn, and the postcard, untouched in its tin, travels with us.
+
+## Booking
+
+To take a seat: write to the Postmaster at `post@aerostat.club`. Each ascent carries up to three passengers in addition to the pilot. Seats are **$240** per ascent, paid on confirmation. The Club does not accept credit cards, only bank transfer or, on rare occasions, a sealed envelope.
+
+Boarding is at **05:30** at the Vossler Field. Closed shoes, no scent, no glass. Bring a notebook if you mean to write a postcard.

--- a/examples/balloon-mail/content/index.md
+++ b/examples/balloon-mail/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Aerostat Club — dawn ascents over the wine valley and a single postcard per flight, carried by hot-air balloon to the landing field."
+template = "index"
++++

--- a/examples/balloon-mail/static/css/style.css
+++ b/examples/balloon-mail/static/css/style.css
@@ -1,0 +1,496 @@
+/* =============================================================================
+   AEROSTAT CLUB — A 19th-century aeronautics manual
+   No gradients. Pure stroke. Engraved-line aesthetic on broadsheet cream.
+   ============================================================================= */
+
+:root {
+  --sky-cream: #f1ead2;
+  --sky-cream-deep: #ddd0a8;
+  --balloon-coral: #c9543c;
+  --coral-deep: #8d3a26;
+  --altitude-blue: #2e5d8a;
+  --brass-burner: #b68a23;
+  --ink-engraving: #1f1a13;
+  --alt-red: #a02825;
+  --field-green: #3f614a;
+  --serif: "IM Fell DW Pica", "Cormorant Garamond", "Times New Roman", serif;
+  --serif-body: "Cormorant Garamond", Georgia, serif;
+  --mono: "IBM Plex Mono", ui-monospace, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--sky-cream);
+  color: var(--ink-engraving);
+  font-family: var(--serif-body);
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--balloon-coral);
+}
+
+.wrap {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 36px;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.mono {
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 13px;
+}
+
+/* Solid background only — no gradients of any kind */
+::selection {
+  background: var(--brass-burner);
+  color: var(--sky-cream);
+}
+
+main, header, section, footer, article {
+  position: relative;
+}
+
+/* --- Top strip ----------------------------------------------------------- */
+.strip-top {
+  background: var(--sky-cream);
+  border-bottom: 1px solid var(--ink-engraving);
+}
+
+.strip-top .wrap {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding-top: 14px;
+  padding-bottom: 12px;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.strip-top .brand {
+  font-family: var(--serif);
+  font-size: 18px;
+  letter-spacing: 0.08em;
+  color: var(--ink-engraving);
+}
+
+.strip-top .brand b {
+  letter-spacing: 0.14em;
+  font-weight: 700;
+}
+
+.strip-top .nav {
+  display: flex;
+  gap: 22px;
+  font-family: var(--serif);
+  font-size: 14px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.strip-top .nav a {
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+  transition: border-color 0.15s;
+}
+
+.strip-top .nav a:hover {
+  border-bottom-color: var(--balloon-coral);
+}
+
+.strip-top .rule {
+  height: 2px;
+  border-top: 1px solid var(--ink-engraving);
+  border-bottom: 1px solid var(--ink-engraving);
+  margin: 2px 0 0;
+}
+
+/* --- Hero ---------------------------------------------------------------- */
+.hero {
+  padding: 60px 0 80px;
+  background: var(--sky-cream);
+  position: relative;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 60px;
+  align-items: start;
+}
+
+.hero-text {
+  padding-top: 20px;
+}
+
+.kicker {
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.24em;
+  text-transform: uppercase; color: var(--coral-deep);
+  border-top: 1px solid var(--ink-engraving);
+  border-bottom: 1px solid var(--ink-engraving);
+  padding: 6px 0; display: inline-block; margin-bottom: 30px;
+}
+
+.head {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(56px, 8vw, 96px); line-height: 0.95; letter-spacing: 0.01em;
+  margin: 0; color: var(--ink-engraving);
+  display: flex; flex-direction: column;
+}
+.head span {
+  display: block;
+}
+
+.head span.rule {
+  height: 1px;
+  background: var(--ink-engraving);
+  width: 240px;
+  margin: 14px 0;
+}
+
+.head .italic {
+  font-style: italic;
+  font-size: clamp(34px, 5vw, 54px);
+  color: var(--coral-deep);
+  letter-spacing: 0;
+}
+
+.lede {
+  font-family: var(--serif-body); font-size: 19px; line-height: 1.6;
+  max-width: 480px; margin: 30px 0 36px; color: var(--ink-engraving);
+}
+.lede em {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--coral-deep);
+}
+
+.flight-no {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border-top: 2px solid var(--ink-engraving);
+  border-bottom: 1px solid var(--ink-engraving);
+  background: var(--sky-cream-deep); max-width: 540px;
+}
+.fno-block {
+  padding: 12px 14px;
+  border-right: 1px solid var(--ink-engraving);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fno-block:last-child {
+  border-right: 0;
+}
+
+.fno-block .lbl {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  color: var(--coral-deep);
+  text-transform: uppercase;
+}
+
+.fno-block .val {
+  font-family: var(--serif);
+  font-size: 24px;
+  color: var(--ink-engraving);
+}
+
+.hero-balloon {
+  background: var(--sky-cream-deep);
+  border: 1px solid var(--ink-engraving);
+  padding: 28px 24px 18px;
+  position: relative;
+}
+
+.balloon-card {
+  position: relative;
+}
+
+.card-corner {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--ink-engraving);
+}
+.card-corner.tl { top: -8px; left: -8px; border-right: 0; border-bottom: 0; }
+.card-corner.tr { top: -8px; right: -8px; border-left: 0; border-bottom: 0; }
+.card-corner.bl { bottom: -8px; left: -8px; border-right: 0; border-top: 0; }
+.card-corner.br { bottom: -8px; right: -8px; border-left: 0; border-top: 0; }
+.balloon-svg {
+  width: 100%;
+  max-width: 350px;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --- Section heads (shared) --------------------------------------------- */
+.sec-head {
+  display: grid; grid-template-columns: 80px 1fr; grid-template-rows: auto auto;
+  gap: 0 24px; align-items: end;
+  border-bottom: 1px solid var(--ink-engraving);
+  padding-bottom: 16px; margin-bottom: 36px;
+}
+.sec-num {
+  font-family: var(--serif); font-style: italic; font-size: 28px;
+  color: var(--coral-deep); grid-row: 1 / 3;
+  border-right: 1px solid var(--ink-engraving);
+  padding-right: 24px; align-self: stretch;
+  display: flex; align-items: center; justify-content: center;
+}
+.sec-head h2 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(40px, 5vw, 60px); line-height: 1;
+  margin: 0; letter-spacing: 0.01em;
+}
+.sec-note {
+  font-family: var(--serif-body); font-size: 15px;
+  color: var(--ink-engraving); opacity: 0.75;
+  max-width: 540px; margin-top: 8px;
+}
+
+/* --- Ascensions table (flight log) -------------------------------------- */
+.ascensions { padding: 70px 0; background: var(--sky-cream); border-top: 1px solid var(--ink-engraving); }
+.logbook {
+  width: 100%; border-collapse: collapse;
+  font-family: var(--serif-body); font-size: 16px;
+  border-top: 2px solid var(--ink-engraving);
+  border-bottom: 2px solid var(--ink-engraving);
+}
+.logbook thead th {
+  background: var(--brass-burner); color: var(--sky-cream);
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  text-align: left; padding: 12px 14px;
+  border-right: 1px solid var(--sky-cream); font-weight: 600;
+}
+.logbook thead th:last-child { border-right: 0; }
+.logbook thead th.c-no { width: 60px; text-align: center; }
+.logbook tbody td {
+  padding: 14px; border-top: 1px solid var(--ink-engraving);
+  border-right: 1px solid rgba(31, 26, 19, 0.18); vertical-align: middle;
+}
+.logbook tbody td:last-child { border-right: 0; }
+.logbook tbody tr:nth-child(even) td { background: var(--sky-cream-deep); }
+.logbook .c-no {
+  text-align: center; font-family: var(--serif); font-style: italic;
+  font-size: 17px; color: var(--coral-deep); width: 60px;
+}
+.logbook .apex { font-family: var(--mono); font-size: 13px; color: var(--altitude-blue); }
+.logbook .mail { font-family: var(--serif); font-style: italic; color: var(--field-green); }
+.logbook .mail.mailwet { color: var(--alt-red); }
+.logbook-foot {
+  display: flex; justify-content: space-between; font-size: 14px;
+  margin-top: 14px; color: var(--ink-engraving); opacity: 0.8;
+  flex-wrap: wrap; gap: 12px;
+}
+
+/* --- Skymail ------------------------------------------------------------- */
+.skymail {
+  padding: 70px 0; background: var(--sky-cream-deep);
+  border-top: 1px solid var(--ink-engraving);
+  border-bottom: 1px solid var(--ink-engraving);
+}
+.mail-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 28px; }
+.mail-step {
+  background: var(--sky-cream); border: 1px solid var(--ink-engraving);
+  padding: 26px 22px 22px; display: flex; flex-direction: column;
+  gap: 12px; position: relative;
+}
+.mail-step .step-num {
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em;
+  color: var(--coral-deep); text-transform: uppercase;
+  border-bottom: 1px solid var(--ink-engraving); padding-bottom: 6px;
+}
+.mail-step h3 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: 38px; margin: 0; letter-spacing: 0.04em;
+}
+.mail-step p { font-size: 15px; line-height: 1.55; color: var(--ink-engraving); margin: 0; max-width: 32ch; }
+.step-svg { width: 100%; height: auto; max-height: 200px; margin-top: 8px; }
+
+/* --- Crew & Bookings ---------------------------------------------------- */
+.crew-bookings { padding: 70px 0; background: var(--sky-cream); }
+.cb-grid { display: grid; grid-template-columns: 1.2fr 1fr; gap: 56px; align-items: start; }
+
+.pilot-list { list-style: none; padding: 0; margin: 0; }
+.pilot {
+  display: grid; grid-template-columns: 70px 1fr; gap: 18px;
+  padding: 18px 0; border-bottom: 1px solid rgba(31, 26, 19, 0.3);
+  align-items: start;
+}
+.pilot:first-child { border-top: 1px solid var(--ink-engraving); }
+.p-rank {
+  font-family: var(--mono); font-size: 13px; letter-spacing: 0.18em;
+  color: var(--brass-burner); border-right: 1px solid var(--ink-engraving);
+  padding-right: 18px; text-align: right;
+}
+.p-name { font-family: var(--serif); font-size: 26px; color: var(--ink-engraving); margin-bottom: 4px; }
+.p-meta { font-family: var(--serif-body); font-size: 15px; color: var(--ink-engraving); }
+.p-meta b { font-family: var(--mono); font-weight: 500; font-size: 14px; color: var(--altitude-blue); }
+.p-meta .seal { color: var(--brass-burner); font-size: 16px; margin-left: 2px; }
+.p-line { font-family: var(--serif); font-size: 15px; color: var(--coral-deep); margin-top: 6px; }
+
+.bookings { position: relative; }
+.b-card {
+  background: var(--sky-cream-deep); border: 2px solid var(--ink-engraving);
+  padding: 30px 28px; position: relative;
+}
+.b-ticket-corner {
+  position: absolute; width: 18px; height: 18px;
+  background: var(--sky-cream); border: 1px solid var(--ink-engraving); border-radius: 50%;
+}
+.b-ticket-corner.tl { top: -10px; left: -10px; }
+.b-ticket-corner.tr { top: -10px; right: -10px; }
+.b-ticket-corner.bl { bottom: -10px; left: -10px; }
+.b-ticket-corner.br { bottom: -10px; right: -10px; }
+.b-stamp {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  color: var(--alt-red); border: 1px solid var(--alt-red);
+  padding: 5px 10px; display: inline-block; margin-bottom: 14px; text-transform: uppercase;
+}
+.b-card h3 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: 32px; line-height: 1.05; margin: 0 0 18px; color: var(--ink-engraving);
+}
+.b-dates { list-style: none; padding: 0; margin: 0 0 18px; border-top: 1px solid var(--ink-engraving); }
+.b-dates li {
+  display: grid; grid-template-columns: 80px 14px 1fr; gap: 10px;
+  padding: 9px 0; border-bottom: 1px solid rgba(31, 26, 19, 0.25); align-items: baseline;
+}
+.b-d { font-family: var(--mono); font-size: 13px; color: var(--altitude-blue); letter-spacing: 0.08em; }
+.b-w { color: var(--coral-deep); text-align: center; }
+.b-t { font-family: var(--serif-body); font-style: italic; font-size: 15px; }
+.b-price {
+  display: flex; justify-content: space-between; align-items: baseline;
+  background: var(--brass-burner); color: var(--sky-cream);
+  padding: 12px 16px; margin: 0 -2px;
+}
+.b-price-l { font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; }
+.b-price-v { font-family: var(--serif); font-size: 26px; }
+.b-rule { height: 1px; background: var(--ink-engraving); margin: 18px -28px 16px; }
+.b-brief { font-size: 14px; line-height: 1.55; }
+.b-brief p { margin: 0 0 10px; }
+.b-brief b { font-family: var(--serif); font-style: normal; letter-spacing: 0.04em; color: var(--coral-deep); }
+
+/* --- Footer -------------------------------------------------------------- */
+.foot { background: var(--sky-cream); border-top: 2px solid var(--ink-engraving); padding: 50px 0 30px; }
+.balloon-sail { display: flex; justify-content: center; align-items: flex-end; gap: 64px; padding: 10px 0 30px; }
+.mini-balloon { width: 100px; height: auto; }
+.mini-balloon:nth-child(2) { transform: translateY(-12px); }
+.mini-balloon:nth-child(3) { transform: translateY(6px); }
+.foot-rule {
+  height: 3px; border-top: 1px solid var(--ink-engraving);
+  border-bottom: 1px solid var(--ink-engraving); margin: 0 0 36px;
+}
+.foot-grid { display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr; gap: 40px; margin-bottom: 30px; }
+.foot-colophon .brass {
+  font-family: var(--mono); font-size: 12px; letter-spacing: 0.22em;
+  color: var(--brass-burner); text-transform: uppercase; margin-bottom: 12px; line-height: 1.5;
+}
+.foot-colophon .cy { font-family: var(--serif); font-size: 22px; color: var(--ink-engraving); margin-bottom: 4px; }
+.foot-colophon .small { font-size: 14px; color: var(--ink-engraving); opacity: 0.75; }
+.foot-col h4 {
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--coral-deep);
+  margin: 0 0 10px; border-bottom: 1px solid var(--ink-engraving); padding-bottom: 5px;
+}
+.foot-col p { font-family: var(--serif-body); font-size: 15px; line-height: 1.55; margin: 0 0 8px; }
+.foot-col a { border-bottom: 1px dotted var(--ink-engraving); padding-bottom: 1px; }
+.foot-bot {
+  display: flex; justify-content: space-between;
+  border-top: 1px solid var(--ink-engraving); padding-top: 14px;
+  font-size: 13px; color: var(--ink-engraving); opacity: 0.8;
+  flex-wrap: wrap; gap: 10px;
+}
+
+/* --- Prose pages -------------------------------------------------------- */
+.prose {
+  max-width: 760px; margin: 60px auto 80px; padding: 0 36px;
+  font-family: var(--serif-body); font-size: 18px; line-height: 1.65;
+}
+.prose h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(44px, 6vw, 64px); line-height: 1;
+  margin: 0 0 36px; letter-spacing: 0.01em;
+  border-bottom: 2px solid var(--ink-engraving); padding-bottom: 16px;
+}
+.prose h2 {
+  font-family: var(--serif); font-weight: 400; font-style: italic;
+  font-size: 32px; color: var(--coral-deep);
+  margin: 44px 0 14px; letter-spacing: 0.01em;
+}
+.prose h3 { font-family: var(--serif); font-size: 22px; margin: 30px 0 10px; }
+.prose p { margin: 0 0 18px; }
+.prose strong { color: var(--coral-deep); font-weight: 600; }
+.prose em { font-family: var(--serif); font-style: italic; color: var(--altitude-blue); }
+.prose a { border-bottom: 1px solid var(--coral-deep); color: var(--coral-deep); }
+.prose ul, .prose ol { padding-left: 22px; margin: 0 0 22px; }
+.prose li { margin: 0 0 8px; }
+.prose blockquote {
+  border-left: 3px solid var(--brass-burner); background: var(--sky-cream-deep);
+  margin: 22px 0; padding: 16px 22px; font-style: italic;
+  font-family: var(--serif); font-size: 19px; color: var(--ink-engraving);
+}
+.prose code {
+  font-family: var(--mono); font-size: 14px;
+  background: var(--sky-cream-deep); padding: 2px 6px;
+  border: 1px solid rgba(31, 26, 19, 0.3);
+}
+
+/* --- Responsive --------------------------------------------------------- */
+@media (max-width: 1000px) {
+  .hero-grid { grid-template-columns: 1fr; gap: 36px; }
+  .head { font-size: clamp(52px, 11vw, 86px); }
+  .cb-grid { grid-template-columns: 1fr; gap: 40px; }
+  .foot-grid { grid-template-columns: 1fr 1fr; gap: 28px; }
+  .mail-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 700px) {
+  .wrap { padding: 0 22px; }
+  .strip-top .wrap { gap: 14px; }
+  .strip-top .nav { gap: 14px; font-size: 12px; }
+  .flight-no { grid-template-columns: 1fr 1fr; }
+  .fno-block:nth-child(2) { border-right: 0; }
+  .fno-block:nth-child(1), .fno-block:nth-child(2) { border-bottom: 1px solid var(--ink-engraving); }
+  .sec-head { grid-template-columns: 50px 1fr; gap: 0 16px; }
+  .sec-num { padding-right: 14px; font-size: 22px; }
+  .sec-head h2 { font-size: 38px; }
+  .logbook { font-size: 14px; }
+  .logbook thead th, .logbook tbody td { padding: 8px 8px; }
+  .balloon-sail { gap: 24px; }
+  .mini-balloon { width: 70px; }
+  .foot-grid { grid-template-columns: 1fr; gap: 22px; }
+  .pilot { grid-template-columns: 56px 1fr; gap: 12px; }
+  .p-rank { font-size: 11px; padding-right: 12px; }
+  .b-rule { margin: 18px -22px 14px; }
+}
+@media (max-width: 480px) {
+  .head { font-size: 48px; }
+  .head .italic { font-size: 28px; }
+  .head span.rule { width: 140px; }
+  .logbook thead th { font-size: 9px; }
+  .logbook .c-no { width: 36px; }
+}

--- a/examples/balloon-mail/static/favicon.svg
+++ b/examples/balloon-mail/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#f1ead2"/>
+  <g fill="none" stroke="#1f1a13" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M16 4c-5 0-8 4-8 9 0 4 2 7 4 9h8c2-2 4-5 4-9 0-5-3-9-8-9z"/>
+    <path d="M12 4.5c-1.5 3-1.5 14 0 17.5M16 4v18M20 4.5c1.5 3 1.5 14 0 17.5"/>
+    <path d="M12 22h8v2h-8z"/>
+    <path d="M13 24l-1 4M19 24l1 4"/>
+    <path d="M11 28h10v2h-10z"/>
+  </g>
+</svg>

--- a/examples/balloon-mail/templates/404.html
+++ b/examples/balloon-mail/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &middot; Off the Map</h1>
+  <p class="italic">No record of this ascent is held in the Club's logbook. The wind, it seems, carried this page elsewhere.</p>
+  <p>Return to <a href="{{ base_url }}/">the landing field</a> and consult the ascension calendar.</p>
+</article>
+{% include "footer.html" %}

--- a/examples/balloon-mail/templates/footer.html
+++ b/examples/balloon-mail/templates/footer.html
@@ -1,0 +1,121 @@
+  <footer class="foot">
+    <div class="wrap">
+      <div class="balloon-sail" aria-hidden="true">
+        <!-- Small coral balloon -->
+        <svg viewBox="0 0 120 170" class="mini-balloon">
+          <g fill="none" stroke="#c9543c" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M60 14 C 28 14, 14 44, 14 78 C 14 104, 28 124, 42 138 L 78 138 C 92 124, 106 104, 106 78 C 106 44, 92 14, 60 14 Z"/>
+            <ellipse cx="60" cy="16" rx="7" ry="2"/>
+            <path d="M60 14 C 48 50, 44 100, 42 138"/>
+            <path d="M60 14 C 34 44, 22 92, 18 122"/>
+            <path d="M60 14 C 60 60, 60 110, 60 138"/>
+            <path d="M60 14 C 72 50, 76 100, 78 138"/>
+            <path d="M60 14 C 86 44, 98 92, 102 122"/>
+            <line x1="20" y1="78" x2="100" y2="78"/>
+            <line x1="16" y1="92" x2="104" y2="92"/>
+            <g>
+              <path d="M34 85 l3 -4 l3 4 l-3 4 z"/>
+              <path d="M54 85 l3 -4 l3 4 l-3 4 z"/>
+              <path d="M74 85 l3 -4 l3 4 l-3 4 z"/>
+            </g>
+            <line x1="42" y1="138" x2="48" y2="152"/>
+            <line x1="54" y1="138" x2="54" y2="152"/>
+            <line x1="66" y1="138" x2="66" y2="152"/>
+            <line x1="78" y1="138" x2="72" y2="152"/>
+            <rect x="46" y="152" width="28" height="14"/>
+            <line x1="46" y1="158" x2="74" y2="158"/>
+            <line x1="56" y1="152" x2="56" y2="166"/>
+            <line x1="64" y1="152" x2="64" y2="166"/>
+          </g>
+        </svg>
+        <!-- Small blue balloon -->
+        <svg viewBox="0 0 120 170" class="mini-balloon">
+          <g fill="none" stroke="#2e5d8a" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M60 14 C 28 14, 14 44, 14 78 C 14 104, 28 124, 42 138 L 78 138 C 92 124, 106 104, 106 78 C 106 44, 92 14, 60 14 Z"/>
+            <ellipse cx="60" cy="16" rx="7" ry="2"/>
+            <path d="M60 14 C 48 50, 44 100, 42 138"/>
+            <path d="M60 14 C 34 44, 22 92, 18 122"/>
+            <path d="M60 14 C 60 60, 60 110, 60 138"/>
+            <path d="M60 14 C 72 50, 76 100, 78 138"/>
+            <path d="M60 14 C 86 44, 98 92, 102 122"/>
+            <line x1="20" y1="78" x2="100" y2="78"/>
+            <line x1="16" y1="92" x2="104" y2="92"/>
+            <g>
+              <circle cx="36" cy="89" r="3"/>
+              <circle cx="60" cy="89" r="3"/>
+              <circle cx="84" cy="89" r="3"/>
+            </g>
+            <line x1="42" y1="138" x2="48" y2="152"/>
+            <line x1="54" y1="138" x2="54" y2="152"/>
+            <line x1="66" y1="138" x2="66" y2="152"/>
+            <line x1="78" y1="138" x2="72" y2="152"/>
+            <rect x="46" y="152" width="28" height="14"/>
+            <line x1="46" y1="158" x2="74" y2="158"/>
+            <line x1="56" y1="152" x2="56" y2="166"/>
+            <line x1="64" y1="152" x2="64" y2="166"/>
+          </g>
+        </svg>
+        <!-- Small ink balloon on cream -->
+        <svg viewBox="0 0 120 170" class="mini-balloon">
+          <g fill="none" stroke="#1f1a13" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M60 14 C 28 14, 14 44, 14 78 C 14 104, 28 124, 42 138 L 78 138 C 92 124, 106 104, 106 78 C 106 44, 92 14, 60 14 Z"/>
+            <ellipse cx="60" cy="16" rx="7" ry="2"/>
+            <path d="M60 14 C 48 50, 44 100, 42 138"/>
+            <path d="M60 14 C 34 44, 22 92, 18 122"/>
+            <path d="M60 14 C 60 60, 60 110, 60 138"/>
+            <path d="M60 14 C 72 50, 76 100, 78 138"/>
+            <path d="M60 14 C 86 44, 98 92, 102 122"/>
+            <line x1="20" y1="78" x2="100" y2="78"/>
+            <line x1="16" y1="92" x2="104" y2="92"/>
+            <g>
+              <path d="M30 85 l5 7 M40 85 l5 7 M50 85 l5 7 M60 85 l5 7 M70 85 l5 7 M80 85 l5 7"/>
+            </g>
+            <line x1="42" y1="138" x2="48" y2="152"/>
+            <line x1="54" y1="138" x2="54" y2="152"/>
+            <line x1="66" y1="138" x2="66" y2="152"/>
+            <line x1="78" y1="138" x2="72" y2="152"/>
+            <rect x="46" y="152" width="28" height="14"/>
+            <line x1="46" y1="158" x2="74" y2="158"/>
+            <line x1="56" y1="152" x2="56" y2="166"/>
+            <line x1="64" y1="152" x2="64" y2="166"/>
+          </g>
+        </svg>
+      </div>
+
+      <div class="foot-rule"></div>
+
+      <div class="foot-grid">
+        <div class="foot-colophon">
+          <div class="brass">FLOWN BY HAND &middot; MAILED FROM ABOVE</div>
+          <div class="cy">&copy; {{ current_year }} Aerostat Club</div>
+          <div class="italic small">Founded 1887. Pressed by the Postmaster.</div>
+        </div>
+        <div class="foot-col">
+          <h4>The Field</h4>
+          <p>The Vossler Field<br>3 Vineyard Road<br>Valley Mile XII</p>
+          <p class="mono">38&deg; 14&prime; 22&Prime; N<br>122&deg; 51&prime; 04&Prime; W</p>
+        </div>
+        <div class="foot-col">
+          <h4>The Post</h4>
+          <p><a href="#">post@aerostat.club</a></p>
+          <p><a href="#">bookings@aerostat.club</a></p>
+          <p><a href="#">postmaster@aerostat.club</a></p>
+        </div>
+        <div class="foot-col">
+          <h4>The Ledgers</h4>
+          <p><a href="{{ base_url }}/about/">About the Club</a></p>
+          <p><a href="#ascensions">Ascent Records</a></p>
+          <p><a href="#skymail">Skymail Programme</a></p>
+        </div>
+      </div>
+
+      <div class="foot-bot">
+        <span>Hwaro press &middot; Vol. IV / Fascicle 2 / {{ current_year }}</span>
+        <span class="italic">Weather permitting. The wind has the final word.</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/balloon-mail/templates/header.html
+++ b/examples/balloon-mail/templates/header.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IM+Fell+DW+Pica:ital@0;1&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <div class="wrap">
+      <a class="brand" href="{{ base_url }}/"><b>AEROSTAT CLUB</b> &middot; ASCENSIONS &middot; N&deg; 14</a>
+      <nav class="nav">
+        <a href="#ascensions">Ascents</a>
+        <a href="#skymail">Skymail</a>
+        <a href="#crew">Crew</a>
+        <a href="#bookings">Bookings</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+    <div class="rule"></div>
+  </header>

--- a/examples/balloon-mail/templates/index.html
+++ b/examples/balloon-mail/templates/index.html
@@ -1,0 +1,434 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="wrap">
+    <div class="hero-grid">
+      <div class="hero-text">
+        <div class="kicker">An Aeronautical Manual &middot; Vol. IV &middot; Fascicle 2</div>
+        <h1 class="head">
+          <span>ASCEND</span>
+          <span>OVER</span>
+          <span>THE VALLEY</span>
+          <span class="rule"></span>
+          <span class="italic">at first light.</span>
+        </h1>
+        <p class="lede">The <em>Aerostat Club</em> flies dawn ascents above the wine valley by hot-air balloon, and carries a single postcard per flight &mdash; sealed, numbered, and delivered to the landing field below.</p>
+        <div class="flight-no">
+          <div class="fno-block">
+            <span class="lbl">FLIGHT</span>
+            <span class="val">14</span>
+          </div>
+          <div class="fno-block">
+            <span class="lbl">LIFT</span>
+            <span class="val">06:12</span>
+          </div>
+          <div class="fno-block">
+            <span class="lbl">LAND</span>
+            <span class="val">09:47</span>
+          </div>
+          <div class="fno-block">
+            <span class="lbl">APEX</span>
+            <span class="val">1,840&thinsp;ft</span>
+          </div>
+        </div>
+      </div>
+      <div class="hero-balloon">
+        <div class="balloon-card">
+          <div class="card-corner tl"></div>
+          <div class="card-corner tr"></div>
+          <div class="card-corner bl"></div>
+          <div class="card-corner br"></div>
+          <svg viewBox="0 0 350 460" class="balloon-svg" aria-hidden="true">
+            <!-- Sky dotted lines (altitude marks) -->
+            <g stroke="#1f1a13" stroke-width="0.5" stroke-dasharray="2 3" fill="none" opacity="0.5">
+              <line x1="20" y1="40" x2="330" y2="40"/>
+              <line x1="20" y1="90" x2="330" y2="90"/>
+              <line x1="20" y1="140" x2="330" y2="140"/>
+              <line x1="20" y1="200" x2="330" y2="200"/>
+            </g>
+            <!-- Altitude tick labels -->
+            <g font-family="IBM Plex Mono, monospace" font-size="8" fill="#1f1a13">
+              <text x="332" y="42">2000</text>
+              <text x="332" y="92">1500</text>
+              <text x="332" y="142">1000</text>
+              <text x="332" y="202">500</text>
+            </g>
+            <!-- Balloon envelope (pure stroke) -->
+            <g fill="none" stroke="#1f1a13" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+              <!-- Envelope outline -->
+              <path d="M175 30
+                       C 95 30, 50 95, 50 175
+                       C 50 235, 75 280, 110 310
+                       L 240 310
+                       C 275 280, 300 235, 300 175
+                       C 300 95, 255 30, 175 30 Z"/>
+              <!-- Top crown ring -->
+              <ellipse cx="175" cy="32" rx="14" ry="4"/>
+              <line x1="161" y1="32" x2="161" y2="22"/>
+              <line x1="189" y1="32" x2="189" y2="22"/>
+              <line x1="175" y1="18" x2="175" y2="28"/>
+              <!-- 12 vertical gore lines -->
+              <path d="M175 30 C 162 95, 155 220, 138 310"/>
+              <path d="M175 30 C 150 95, 138 220, 110 310"/>
+              <path d="M175 30 C 130 80, 105 200, 80 285"/>
+              <path d="M175 30 C 110 70, 70 180, 55 240"/>
+              <path d="M175 30 C 95 60, 55 150, 50 195"/>
+              <path d="M175 30 C 175 95, 175 220, 175 310"/>
+              <path d="M175 30 C 188 95, 195 220, 212 310"/>
+              <path d="M175 30 C 200 95, 212 220, 240 310"/>
+              <path d="M175 30 C 220 80, 245 200, 270 285"/>
+              <path d="M175 30 C 240 70, 280 180, 295 240"/>
+              <path d="M175 30 C 255 60, 295 150, 300 195"/>
+              <!-- Horizontal bands -->
+              <path d="M65 130 C 100 122, 250 122, 285 130"/>
+              <path d="M55 195 C 95 187, 255 187, 295 195"/>
+              <path d="M75 260 C 110 252, 240 252, 275 260"/>
+              <!-- Decoration band with motif (between bands) -->
+              <g stroke-width="1">
+                <line x1="60" y1="160" x2="290" y2="160"/>
+                <line x1="60" y1="180" x2="290" y2="180"/>
+                <!-- Diamond motifs in decoration band -->
+                <g>
+                  <path d="M85 170 l5 -7 l5 7 l-5 7 z"/>
+                  <path d="M115 170 l5 -7 l5 7 l-5 7 z"/>
+                  <path d="M145 170 l5 -7 l5 7 l-5 7 z"/>
+                  <path d="M175 170 l5 -7 l5 7 l-5 7 z"/>
+                  <path d="M205 170 l5 -7 l5 7 l-5 7 z"/>
+                  <path d="M235 170 l5 -7 l5 7 l-5 7 z"/>
+                  <path d="M265 170 l5 -7 l5 7 l-5 7 z"/>
+                </g>
+              </g>
+              <!-- Rope cradle (crossed lines from envelope to basket) -->
+              <line x1="110" y1="310" x2="125" y2="370"/>
+              <line x1="135" y1="310" x2="135" y2="370"/>
+              <line x1="160" y1="310" x2="148" y2="370"/>
+              <line x1="190" y1="310" x2="202" y2="370"/>
+              <line x1="215" y1="310" x2="215" y2="370"/>
+              <line x1="240" y1="310" x2="225" y2="370"/>
+              <!-- Cross-rope diagonals -->
+              <line x1="110" y1="320" x2="240" y2="335"/>
+              <line x1="240" y1="320" x2="110" y2="335"/>
+              <!-- Burner ring + flame frame above basket -->
+              <rect x="155" y="358" width="40" height="6"/>
+              <!-- Burner flame (stylized) -->
+              <path d="M165 358 c -2 -6 6 -8 4 -14 c 4 4 8 -2 6 -8 c 6 6 14 4 12 12 c 4 -4 8 4 4 10" stroke="#b68a23" stroke-width="1.2"/>
+              <line x1="160" y1="354" x2="190" y2="354" stroke="#b68a23"/>
+              <!-- Basket -->
+              <rect x="125" y="370" width="100" height="50"/>
+              <!-- Basket woven hatching -->
+              <g stroke-width="0.7">
+                <line x1="125" y1="380" x2="225" y2="380"/>
+                <line x1="125" y1="390" x2="225" y2="390"/>
+                <line x1="125" y1="400" x2="225" y2="400"/>
+                <line x1="125" y1="410" x2="225" y2="410"/>
+                <line x1="140" y1="370" x2="140" y2="420"/>
+                <line x1="155" y1="370" x2="155" y2="420"/>
+                <line x1="170" y1="370" x2="170" y2="420"/>
+                <line x1="185" y1="370" x2="185" y2="420"/>
+                <line x1="200" y1="370" x2="200" y2="420"/>
+                <line x1="215" y1="370" x2="215" y2="420"/>
+              </g>
+              <!-- Postcard tied to basket -->
+              <g stroke="#c9543c" stroke-width="1.1">
+                <rect x="232" y="382" width="22" height="14"/>
+                <line x1="232" y1="389" x2="254" y2="389"/>
+                <line x1="225" y1="385" x2="232" y2="385"/>
+              </g>
+              <!-- Altitude trail dashed lines below basket -->
+              <g stroke-dasharray="4 4" opacity="0.7">
+                <line x1="175" y1="425" x2="175" y2="455"/>
+                <line x1="150" y1="430" x2="150" y2="450"/>
+                <line x1="200" y1="430" x2="200" y2="450"/>
+              </g>
+              <!-- Compass rose in corner (small) -->
+              <g transform="translate(40,415)" stroke-width="0.8">
+                <circle cx="0" cy="0" r="16"/>
+                <circle cx="0" cy="0" r="10"/>
+                <line x1="0" y1="-16" x2="0" y2="16"/>
+                <line x1="-16" y1="0" x2="16" y2="0"/>
+                <path d="M0 -16 L4 0 L0 16 L-4 0 Z"/>
+              </g>
+            </g>
+            <!-- Compass labels -->
+            <g font-family="IM Fell DW Pica, serif" font-size="7" fill="#1f1a13" text-anchor="middle">
+              <text x="40" y="396">N</text>
+              <text x="40" y="438">S</text>
+              <text x="22" y="418">W</text>
+              <text x="58" y="418">E</text>
+            </g>
+            <!-- Plate caption -->
+            <text x="175" y="455" font-family="IM Fell DW Pica, serif" font-size="10" fill="#1f1a13" text-anchor="middle" font-style="italic">Plate I. &mdash; The Aerostat at lift.</text>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="ascensions" id="ascensions">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="sec-num">&sect; I</div>
+      <h2>Ascensions Logged</h2>
+      <div class="sec-note italic">Recorded by the burner's hand. Apex in feet, drift in compass points.</div>
+    </div>
+    <table class="logbook">
+      <thead>
+        <tr>
+          <th class="c-no">N&deg;</th>
+          <th>Date</th>
+          <th>Pilot</th>
+          <th>Lift</th>
+          <th>Land</th>
+          <th>Apex</th>
+          <th>Drift</th>
+          <th>Skymail</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="c-no">XIV</td>
+          <td>23 May 2026</td>
+          <td>Capt. R. Vossler</td>
+          <td>06:12</td>
+          <td>09:47</td>
+          <td class="apex">1,840&thinsp;ft</td>
+          <td>NNE &middot; 6&deg;</td>
+          <td class="mail">delivered</td>
+        </tr>
+        <tr>
+          <td class="c-no">XIII</td>
+          <td>09 May 2026</td>
+          <td>Capt. I. Marchetti</td>
+          <td>05:48</td>
+          <td>09:02</td>
+          <td class="apex">2,110&thinsp;ft</td>
+          <td>NE &middot; 11&deg;</td>
+          <td class="mail">delivered</td>
+        </tr>
+        <tr>
+          <td class="c-no">XII</td>
+          <td>25 Apr 2026</td>
+          <td>Capt. H. Berenson</td>
+          <td>06:04</td>
+          <td>08:51</td>
+          <td class="apex">1,620&thinsp;ft</td>
+          <td>N &middot; 2&deg;</td>
+          <td class="mail">delivered</td>
+        </tr>
+        <tr>
+          <td class="c-no">XI</td>
+          <td>11 Apr 2026</td>
+          <td>Capt. L. Achterberg</td>
+          <td>06:31</td>
+          <td>09:14</td>
+          <td class="apex">1,975&thinsp;ft</td>
+          <td>ENE &middot; 8&deg;</td>
+          <td class="mail mailwet">postponed &mdash; wet</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="logbook-foot italic">
+      <span>Recorded under the seal of the Aerostat Club &mdash; Founded 1887.</span>
+      <span>Next entry: Flight N&deg;&thinsp;XV &mdash; 06 Jun 2026</span>
+    </div>
+  </div>
+</section>
+
+<section class="skymail" id="skymail">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="sec-num">&sect; II</div>
+      <h2>Sky-Mail</h2>
+      <div class="sec-note italic">One postcard, one balloon, one landing field. The amateur postal service for those who write at dawn.</div>
+    </div>
+    <div class="mail-grid">
+      <article class="mail-step">
+        <div class="step-num">No.&thinsp;01</div>
+        <h3>WRITE</h3>
+        <p class="italic">A single postcard, by hand &mdash; cream stock, no envelope. Sealed at the pilot's table.</p>
+        <svg viewBox="0 0 200 140" class="step-svg" aria-hidden="true">
+          <g fill="none" stroke="#1f1a13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
+            <!-- Postcard -->
+            <rect x="20" y="20" width="160" height="100" fill="#f1ead2"/>
+            <!-- Stamp box -->
+            <rect x="150" y="28" width="22" height="18"/>
+            <path d="M152 30 l18 14 M170 30 l-18 14" stroke-width="0.6"/>
+            <text x="161" y="42" font-family="IM Fell DW Pica" font-size="6" fill="#a02825" text-anchor="middle">14&cent;</text>
+            <!-- Divider -->
+            <line x1="98" y1="28" x2="98" y2="112" stroke-dasharray="2 2"/>
+            <!-- Handwritten lines (italic faux script) -->
+            <g stroke-width="0.9" stroke="#2e5d8a">
+              <path d="M28 60 C 40 56, 60 64, 88 58"/>
+              <path d="M28 72 C 45 68, 65 76, 90 70"/>
+              <path d="M28 84 C 38 80, 62 88, 88 82"/>
+              <path d="M28 96 C 42 92, 55 100, 80 95"/>
+            </g>
+            <!-- Address lines -->
+            <g stroke-width="0.7">
+              <line x1="106" y1="60" x2="170" y2="60"/>
+              <line x1="106" y1="72" x2="170" y2="72"/>
+              <line x1="106" y1="84" x2="170" y2="84"/>
+              <line x1="106" y1="96" x2="160" y2="96"/>
+            </g>
+            <!-- Wax seal -->
+            <circle cx="60" cy="110" r="6" stroke="#a02825" fill="none"/>
+            <path d="M57 108 l6 4 M63 108 l-6 4" stroke="#a02825"/>
+          </g>
+        </svg>
+      </article>
+
+      <article class="mail-step">
+        <div class="step-num">No.&thinsp;02</div>
+        <h3>CARRY</h3>
+        <p class="italic">Tied to the basket by twine. Lofted with the dawn flight, witnessed by the pilot.</p>
+        <svg viewBox="0 0 200 180" class="step-svg" aria-hidden="true">
+          <g fill="none" stroke="#1f1a13" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+            <!-- Small balloon -->
+            <path d="M100 20 C 65 20, 45 50, 45 85 C 45 110, 60 130, 75 142 L 125 142 C 140 130, 155 110, 155 85 C 155 50, 135 20, 100 20 Z"/>
+            <ellipse cx="100" cy="22" rx="8" ry="2"/>
+            <!-- Gore lines -->
+            <path d="M100 20 C 88 60, 85 110, 75 142"/>
+            <path d="M100 20 C 75 50, 60 100, 55 130"/>
+            <path d="M100 20 C 100 65, 100 110, 100 142"/>
+            <path d="M100 20 C 112 60, 115 110, 125 142"/>
+            <path d="M100 20 C 125 50, 140 100, 145 130"/>
+            <!-- Band -->
+            <line x1="55" y1="85" x2="145" y2="85"/>
+            <line x1="50" y1="95" x2="150" y2="95"/>
+            <g>
+              <path d="M72 90 l3 -4 l3 4 l-3 4 z"/>
+              <path d="M92 90 l3 -4 l3 4 l-3 4 z"/>
+              <path d="M112 90 l3 -4 l3 4 l-3 4 z"/>
+              <path d="M132 90 l3 -4 l3 4 l-3 4 z"/>
+            </g>
+            <!-- Ropes -->
+            <line x1="75" y1="142" x2="82" y2="160"/>
+            <line x1="92" y1="142" x2="92" y2="160"/>
+            <line x1="108" y1="142" x2="108" y2="160"/>
+            <line x1="125" y1="142" x2="118" y2="160"/>
+            <!-- Basket -->
+            <rect x="80" y="160" width="40" height="14"/>
+            <line x1="80" y1="166" x2="120" y2="166"/>
+            <line x1="90" y1="160" x2="90" y2="174"/>
+            <line x1="100" y1="160" x2="100" y2="174"/>
+            <line x1="110" y1="160" x2="110" y2="174"/>
+            <!-- Postcard tied to basket -->
+            <g stroke="#c9543c">
+              <rect x="125" y="162" width="14" height="9"/>
+              <line x1="125" y1="166" x2="139" y2="166"/>
+              <line x1="120" y1="164" x2="125" y2="164"/>
+            </g>
+          </g>
+        </svg>
+      </article>
+
+      <article class="mail-step">
+        <div class="step-num">No.&thinsp;03</div>
+        <h3>DELIVER</h3>
+        <p class="italic">Stamped at the field, dated by the postmaster, mailed by hand to the addressee.</p>
+        <svg viewBox="0 0 200 140" class="step-svg" aria-hidden="true">
+          <g fill="none" stroke="#1f1a13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
+            <!-- Envelope -->
+            <rect x="20" y="34" width="160" height="86"/>
+            <path d="M20 34 L100 88 L180 34"/>
+            <!-- Stamp -->
+            <rect x="138" y="44" width="28" height="22"/>
+            <g stroke="#a02825" stroke-width="0.9">
+              <circle cx="152" cy="55" r="5"/>
+              <path d="M148 51 l8 8 M156 51 l-8 8"/>
+            </g>
+            <!-- Postmark circle -->
+            <g stroke="#a02825" stroke-width="1.1">
+              <circle cx="62" cy="98" r="18"/>
+              <circle cx="62" cy="98" r="13"/>
+              <text x="62" y="96" font-family="IBM Plex Mono" font-size="6" fill="#a02825" text-anchor="middle">FLT 14</text>
+              <text x="62" y="105" font-family="IBM Plex Mono" font-size="5" fill="#a02825" text-anchor="middle">23.V.26</text>
+            </g>
+            <!-- Field grass -->
+            <g stroke="#3f614a" stroke-width="0.9">
+              <path d="M0 132 l4 -8 l4 8 M14 132 l4 -8 l4 8 M28 132 l4 -8 l4 8 M42 132 l4 -8 l4 8 M56 132 l4 -8 l4 8 M70 132 l4 -8 l4 8 M84 132 l4 -8 l4 8 M98 132 l4 -8 l4 8 M112 132 l4 -8 l4 8 M126 132 l4 -8 l4 8 M140 132 l4 -8 l4 8 M154 132 l4 -8 l4 8 M168 132 l4 -8 l4 8 M182 132 l4 -8 l4 8"/>
+            </g>
+          </g>
+        </svg>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="crew-bookings">
+  <div class="wrap">
+    <div class="cb-grid">
+      <div class="crew" id="crew">
+        <div class="sec-head">
+          <div class="sec-num">&sect; III</div>
+          <h2>The Crew</h2>
+          <div class="sec-note italic">Pilots of record, endorsed for commercial passenger operations under the Club seal.</div>
+        </div>
+        <ul class="pilot-list">
+          <li class="pilot">
+            <div class="p-rank">CPT.</div>
+            <div class="p-body">
+              <div class="p-name">R.&thinsp;Vossler</div>
+              <div class="p-meta">Senior pilot &middot; <b>2,140&thinsp;hrs</b> aloft &middot; commercial endorsement <span class="seal">&#10026;</span></div>
+              <div class="p-line italic">"The valley has a tide. You ride it."</div>
+            </div>
+          </li>
+          <li class="pilot">
+            <div class="p-rank">CPT.</div>
+            <div class="p-body">
+              <div class="p-name">I.&thinsp;Marchetti</div>
+              <div class="p-meta">Pilot &middot; <b>1,460&thinsp;hrs</b> aloft &middot; commercial endorsement <span class="seal">&#10026;</span></div>
+              <div class="p-line italic">"Dawn flights only. The afternoon belongs to the wind."</div>
+            </div>
+          </li>
+          <li class="pilot">
+            <div class="p-rank">CPT.</div>
+            <div class="p-body">
+              <div class="p-name">H.&thinsp;Berenson</div>
+              <div class="p-meta">Pilot &middot; <b>980&thinsp;hrs</b> aloft &middot; commercial endorsement <span class="seal">&#10026;</span></div>
+              <div class="p-line italic">"I have flown over three vineyards and one war memorial."</div>
+            </div>
+          </li>
+          <li class="pilot">
+            <div class="p-rank">LT.</div>
+            <div class="p-body">
+              <div class="p-name">L.&thinsp;Achterberg</div>
+              <div class="p-meta">Junior pilot &middot; <b>610&thinsp;hrs</b> aloft &middot; instrument-rated</div>
+              <div class="p-line italic">"The postcards are heavier than they look."</div>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <aside class="bookings" id="bookings">
+        <div class="b-card">
+          <div class="b-ticket-corner tl"></div>
+          <div class="b-ticket-corner tr"></div>
+          <div class="b-ticket-corner bl"></div>
+          <div class="b-ticket-corner br"></div>
+          <div class="b-stamp">FLIGHT &middot; NOTICE</div>
+          <h3>Spring &amp; Summer<br>Ascent Calendar</h3>
+          <ul class="b-dates">
+            <li><span class="b-d">06 Jun</span><span class="b-w">&middot;</span><span class="b-t">Flight XV &middot; Dawn ascent</span></li>
+            <li><span class="b-d">20 Jun</span><span class="b-w">&middot;</span><span class="b-t">Flight XVI &middot; Solstice flight</span></li>
+            <li><span class="b-d">04 Jul</span><span class="b-w">&middot;</span><span class="b-t">Flight XVII &middot; Vineyard charter</span></li>
+            <li><span class="b-d">18 Jul</span><span class="b-w">&middot;</span><span class="b-t">Flight XVIII &middot; Skymail special</span></li>
+            <li><span class="b-d">15 Aug</span><span class="b-w">&middot;</span><span class="b-t">Flight XIX &middot; Harvest dawn</span></li>
+          </ul>
+          <div class="b-price">
+            <span class="b-price-l">Seat, per ascent</span>
+            <span class="b-price-v">$ 240</span>
+          </div>
+          <div class="b-rule"></div>
+          <div class="b-brief italic">
+            <p><b>Safety brief.</b> Boarding at 05:30 sharp. Closed shoes, no scent. Flights require clear ceiling above 3,000&thinsp;ft and surface wind below 8&thinsp;knots. Cancellations are refunded; postponements are flown next dawn.</p>
+            <p>To book: write to the Postmaster &mdash; <span class="mono">post@aerostat.club</span>. Confirmed by return post.</p>
+          </div>
+        </div>
+      </aside>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/balloon-mail/templates/page.html
+++ b/examples/balloon-mail/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/balloon-mail/templates/section.html
+++ b/examples/balloon-mail/templates/section.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+<section class="ascensions">
+  <div class="wrap">
+    <div class="sec-head">
+      {% if page.title is present %}<h2>{{ page.title | e }}</h2>{% endif %}
+    </div>
+    {{ content | safe }}
+    <table class="logbook">
+      <thead>
+        <tr>
+          <th class="c-no">N&deg;</th>
+          <th>Date</th>
+          <th>Entry</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for post in section.pages %}
+        <tr>
+          <td class="c-no">{{ loop.index }}</td>
+          <td>{{ post.date | date(format="%d %b %Y") }}</td>
+          <td><a href="{{ post.url }}">{{ post.title | e }}</a></td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/balloon-mail/templates/shortcodes/alert.html
+++ b/examples/balloon-mail/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd0a8; background-color: #f1ead2; border-left: 5px solid #c9543c; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/balloon-mail/templates/taxonomy.html
+++ b/examples/balloon-mail/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p class="italic">Index of subjects from the Club ledgers.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/balloon-mail/templates/taxonomy_term.html
+++ b/examples/balloon-mail/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p class="italic">Entries filed under this heading in the Club's records.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/carbon-press/AGENTS.md
+++ b/examples/carbon-press/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/carbon-press/archetypes/default.md
+++ b/examples/carbon-press/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/carbon-press/config.toml
+++ b/examples/carbon-press/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Carbon Press"
+description = "A co-operative of legal scribes drafting small-claims forms, NDAs, and rental contracts — in triplicate, by hand."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/carbon-press/content/about.md
+++ b/examples/carbon-press/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "About the Co-operative"
+description = "Carbon Press — how the desk takes intake, drafts the instrument, witnesses the signing, files the white copy, and sets the fee."
++++
+
+## Intake
+
+A matter begins at the desk. You bring the paperwork you already have — a lease on a napkin, a screenshot of an invoice, a torn receipt — and the date the trouble started. A scribe records the matter in the day-book, in pencil, and assigns it a number. We do not take matters by phone, by message, or by email. The desk is open from nine to five, six days a week.
+
+## Drafting
+
+The scribe types the instrument on an IBM Selectric, on a stack of NCR paper — pink, yellow, white, in that order. We read the draft aloud once together. You correct it in red pencil on the white copy. The scribe re-types the page if more than three corrections are needed. **Nothing leaves the desk without a clean white copy.**
+
+## Witnessing
+
+Every instrument is witnessed by two members of the co-operative. Witnesses sign in blue ink on the white copy; the carbon impression carries the signature to the yellow and pink. The rubber stamp goes last — once, hard, on the bottom right of all three sheets. The desk does not witness instruments it has not drafted.
+
+## Filing
+
+The white copy is filed with the court, the registry, or the counter-party, as the instrument requires. The yellow copy is yours; we put it in a manila folder, with the tab cut, ready for your shelf. The pink copy stays in the bottom drawer of the co-operative for seven years, organised by matter number and never by name.
+
+## Fees
+
+Fees are flat, and posted in the tariff schedule on the front of the building. Witnessing is included when the matter is filed before 16:00 the same day. A rush surcharge applies to anything filed within the same hour as intake. The co-operative does not bill by the hour; it bills by the page, and it does not bill twice.

--- a/examples/carbon-press/content/index.md
+++ b/examples/carbon-press/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Carbon Press — a co-operative of legal scribes drafting small-claims forms, NDAs, and rental contracts in triplicate, by hand."
+template = "index"
++++

--- a/examples/carbon-press/static/css/style.css
+++ b/examples/carbon-press/static/css/style.css
@@ -1,0 +1,901 @@
+/* CARBON PRESS — NCR triplicate-form aesthetic */
+
+:root {
+  --carbon-pink: #f4c5cf;
+  --carbon-yellow: #f4e2a3;
+  --carbon-white: #f6f4ee;
+  --ink: #131313;
+  --ink-soft: #2a2a2a;
+  --stamp-red: #c01a1a;
+  --stamp-red-soft: rgba(192, 26, 26, 0.78);
+  --rule-blue: #3a5b8a;
+  --pencil-red: #b8362f;
+  --serif: "Cormorant Garamond", "Times New Roman", Georgia, serif;
+  --mono: "Courier Prime", "JetBrains Mono", ui-monospace, "Courier New", monospace;
+  --hand: "Special Elite", "Courier Prime", "Courier New", monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--carbon-white);
+  color: var(--ink);
+  overflow-x: hidden;
+}
+
+body {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='280' height='29'><line x1='0' y1='28.5' x2='280' y2='28.5' stroke='rgba(58,91,138,0.18)' stroke-width='1'/><line x1='0.5' y1='0' x2='0.5' y2='29' stroke='rgba(58,91,138,0.14)' stroke-width='1'/></svg>");
+  background-size: 280px 29px;
+}
+
+a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--stamp-red);
+  font-weight: 600;
+}
+a:hover { color: var(--stamp-red); border-bottom-style: solid; }
+
+::selection { background: var(--carbon-yellow); color: var(--ink); }
+
+/* TOP STRIP */
+.strip-top {
+  background: var(--ink);
+  color: var(--carbon-white);
+  padding: 10px 22px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border-bottom: 3px double var(--carbon-white);
+}
+.strip-left { display: flex; align-items: center; gap: 10px; }
+.strip-left .dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1.5px solid var(--carbon-white);
+}
+.dot-pink { background: var(--carbon-pink); }
+.dot-yellow { background: var(--carbon-yellow); }
+.dot-white { background: var(--carbon-white); }
+.strip-form { margin-left: 6px; }
+.strip-mid { display: flex; align-items: center; justify-content: center; gap: 12px; }
+.strip-mid .op { font-weight: 700; }
+.strip-mid .sep { opacity: 0.5; }
+.strip-nav { display: flex; gap: 22px; justify-content: flex-end; }
+.strip-nav a {
+  color: var(--carbon-white);
+  border: none;
+  font-weight: 400;
+}
+.strip-nav a:hover { color: var(--carbon-yellow); border: none; }
+
+/* RUBBER STAMPS — scattered absolute */
+.stamp {
+  position: absolute;
+  font-family: var(--mono);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--stamp-red-soft);
+  border: 3px double var(--stamp-red-soft);
+  padding: 8px 14px;
+  font-size: 18px;
+  z-index: 12;
+  pointer-events: none;
+  background: transparent;
+  opacity: 0.82;
+}
+.stamp-received { top: 80px; right: 38px; transform: rotate(11deg); }
+.stamp-filed { top: 240px; left: 30px; transform: rotate(-7deg); font-size: 15px; }
+.stamp-certified { bottom: 140px; right: 60px; transform: rotate(-14deg); border-radius: 200px; padding: 10px 22px; }
+.stamp-original { top: 420px; right: 220px; transform: rotate(4deg); font-size: 14px; }
+.stamp-void {
+  bottom: 60px;
+  left: 220px;
+  transform: rotate(-19deg);
+  font-size: 28px;
+  letter-spacing: 0.22em;
+  border-width: 4px;
+  padding: 6px 18px;
+}
+
+/* HERO — triplicate stack */
+.hero {
+  position: relative;
+  padding: 44px 24px 80px;
+  overflow: hidden;
+  border-bottom: 1px dotted var(--ink);
+}
+.hero-inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  position: relative;
+}
+.triplicate {
+  position: relative;
+  margin: 0 auto;
+}
+.copy {
+  position: relative;
+  border: 1.5px solid var(--ink);
+  padding: 26px 32px 36px;
+  box-shadow: 6px 6px 0 var(--ink);
+  font-family: var(--mono);
+}
+.copy-pink {
+  background: var(--carbon-pink);
+  transform: rotate(-1.6deg);
+  margin: 0 60px 0 0;
+  height: 120px;
+}
+.copy-yellow {
+  background: var(--carbon-yellow);
+  transform: rotate(1.4deg);
+  margin: -82px 30px 0 40px;
+  height: 140px;
+  position: relative;
+  z-index: 2;
+}
+.copy-white {
+  background: var(--carbon-white);
+  transform: rotate(-0.6deg);
+  margin: -100px 0 0 0;
+  position: relative;
+  z-index: 3;
+}
+/* Carbon-paper smudges as ::before solid color blotches */
+.copy-white::before {
+  content: "";
+  position: absolute;
+  top: -18px;
+  right: 70px;
+  width: 90px;
+  height: 36px;
+  background: var(--ink-soft);
+  opacity: 0.18;
+  transform: rotate(8deg);
+  z-index: 0;
+}
+.copy-white::after {
+  content: "";
+  position: absolute;
+  bottom: 30px;
+  left: -22px;
+  width: 60px;
+  height: 80px;
+  background: var(--carbon-pink);
+  opacity: 0.35;
+  transform: rotate(-12deg);
+  z-index: 0;
+}
+.copy-yellow::before {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: -10px;
+  width: 44px;
+  height: 90px;
+  background: var(--ink);
+  opacity: 0.08;
+  transform: rotate(6deg);
+}
+
+.copy-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  padding-bottom: 10px;
+  border-bottom: 1px dotted var(--ink);
+  position: relative;
+  z-index: 1;
+}
+.copy-head span:nth-child(2) { font-weight: 700; }
+.copy-head span:nth-child(3) { color: var(--stamp-red); font-weight: 700; }
+
+.copy-meta {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px 18px;
+  margin: 22px 0 28px;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding: 14px 0;
+  font-size: 12px;
+  position: relative;
+  z-index: 1;
+}
+.copy-meta label {
+  display: block;
+  color: var(--rule-blue);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-size: 10px;
+  margin-bottom: 3px;
+}
+.copy-meta b {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.headline {
+  font-family: var(--hand);
+  font-weight: 400;
+  font-size: clamp(64px, 11vw, 152px);
+  line-height: 0.92;
+  letter-spacing: -0.01em;
+  margin: 12px 0 22px;
+  color: var(--ink);
+  position: relative;
+  z-index: 1;
+}
+.headline .line { display: block; }
+.headline .dash {
+  display: block;
+  color: var(--stamp-red);
+  font-size: 0.4em;
+  letter-spacing: 0.4em;
+  margin: 4px 0;
+}
+
+.hero-lede {
+  font-family: var(--serif);
+  font-size: 21px;
+  line-height: 1.45;
+  max-width: 640px;
+  margin: 0 0 28px;
+  color: var(--ink);
+  position: relative;
+  z-index: 1;
+}
+.hero-lede em {
+  font-style: italic;
+  background: var(--carbon-yellow);
+  padding: 0 4px;
+}
+
+.hero-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px 28px;
+  margin-bottom: 32px;
+  position: relative;
+  z-index: 1;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.field label {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 10px;
+  color: var(--rule-blue);
+  white-space: nowrap;
+}
+.field .rule {
+  flex: 1;
+  border-bottom: 1px solid var(--rule-blue);
+  height: 18px;
+}
+.field .rule.short { flex: 0 0 90px; }
+.field label.curr { font-size: 10px; color: var(--ink); }
+
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  position: relative;
+  z-index: 1;
+}
+.cta-pin {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 12px 18px;
+  border: 1.5px solid var(--ink);
+  background: var(--carbon-white);
+  color: var(--ink);
+  font-weight: 700;
+  box-shadow: 3px 3px 0 var(--ink);
+}
+.cta-pin:hover {
+  background: var(--ink);
+  color: var(--carbon-yellow);
+  border-color: var(--ink);
+}
+.cta-pin.alt { background: var(--carbon-yellow); }
+.cta-pin.out { background: var(--carbon-pink); }
+
+.hero-perf {
+  position: absolute;
+  bottom: 24px;
+  left: 0;
+  right: 0;
+  height: 14px;
+  border-top: 2px dotted var(--ink);
+  border-bottom: 2px dotted var(--ink);
+}
+
+/* TARIFF SECTION */
+.tariff {
+  position: relative;
+  background: var(--carbon-yellow);
+  padding: 64px 24px;
+  border-bottom: 1px dotted var(--ink);
+}
+.tariff .wrap { max-width: 1080px; margin: 0 auto; position: relative; }
+.tariff-head { border-bottom: 3px double var(--ink); padding-bottom: 24px; margin-bottom: 28px; }
+.tariff-meta {
+  display: flex;
+  gap: 22px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+  color: var(--ink-soft);
+}
+.tariff h2 {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: clamp(38px, 5vw, 56px);
+  line-height: 1.0;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+.tariff h2 .hand {
+  font-family: var(--hand);
+  font-weight: 400;
+  color: var(--stamp-red);
+}
+.tariff-note {
+  font-family: var(--mono);
+  font-size: 13px;
+  max-width: 640px;
+  margin: 14px 0 0;
+  line-height: 1.5;
+}
+.tariff-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 13px;
+  background: var(--carbon-white);
+  border: 1.5px solid var(--ink);
+}
+.tariff-table thead th {
+  text-align: left;
+  padding: 12px 14px;
+  background: var(--ink);
+  color: var(--carbon-white);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border-right: 1px dotted var(--carbon-white);
+}
+.tariff-table thead th:last-child { border-right: none; }
+.tariff-table th.num, .tariff-table td.num { text-align: right; width: 1%; white-space: nowrap; }
+.tariff-table tbody td {
+  padding: 12px 14px;
+  border-bottom: 1px dotted var(--rule-blue);
+  border-right: 1px dotted var(--rule-blue);
+  vertical-align: middle;
+}
+.tariff-table tbody td:last-child { border-right: none; }
+.tariff-table tbody tr:last-child td { border-bottom: none; }
+.tariff-table tbody tr:nth-child(even) { background: rgba(58, 91, 138, 0.04); }
+.tariff-table .stamp-col { width: 90px; text-align: center; }
+
+.mini-stamp {
+  display: inline-block;
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--stamp-red);
+  border: 2px solid var(--stamp-red);
+  padding: 3px 8px;
+  transform: rotate(-6deg);
+  opacity: 0.86;
+}
+.mini-stamp.ok { color: var(--rule-blue); border-color: var(--rule-blue); transform: rotate(4deg); }
+.mini-stamp.warn { color: var(--ink); border-color: var(--ink); background: var(--carbon-pink); transform: rotate(-9deg); }
+
+.tariff-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 22px;
+  font-family: var(--mono);
+  font-size: 12px;
+  border-top: 1px dotted var(--ink);
+  padding-top: 16px;
+}
+.tariff-foot .hand {
+  font-family: var(--hand);
+  font-size: 16px;
+  color: var(--stamp-red);
+}
+.tariff-foot .sigline {
+  font-family: var(--hand);
+  font-size: 14px;
+  border-top: 1px solid var(--ink);
+  padding-top: 6px;
+  min-width: 280px;
+  text-align: right;
+}
+
+/* TESTIMONY */
+.testimony {
+  position: relative;
+  background: var(--carbon-pink);
+  padding: 64px 24px;
+  border-bottom: 1px dotted var(--ink);
+}
+.testimony .wrap { max-width: 1080px; margin: 0 auto; }
+.testimony-head { margin-bottom: 36px; }
+.testimony-head h2 {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: clamp(38px, 5vw, 56px);
+  line-height: 1.0;
+  margin: 0 0 8px;
+}
+.testimony-head h2 .hand {
+  font-family: var(--hand);
+  font-weight: 400;
+  color: var(--stamp-red);
+}
+.testimony-head p {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+}
+.witnesses {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.witness {
+  position: relative;
+  background: var(--carbon-white);
+  border: 1.5px solid var(--ink);
+  padding: 22px 24px 26px;
+  box-shadow: 4px 4px 0 var(--ink);
+}
+.witness:nth-child(1) { transform: rotate(-0.8deg); }
+.witness:nth-child(2) { transform: rotate(0.6deg); }
+.witness:nth-child(3) { transform: rotate(-0.4deg); }
+.witness-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding-bottom: 10px;
+  border-bottom: 1px dotted var(--ink);
+  margin-bottom: 16px;
+}
+.date-stamp {
+  font-family: var(--mono);
+  background: var(--carbon-yellow);
+  padding: 2px 6px;
+  border: 1px dashed var(--ink);
+}
+.witness-body {
+  font-family: var(--hand);
+  font-size: 18px;
+  line-height: 1.45;
+  margin: 0 0 26px;
+  color: var(--ink);
+}
+.witness-sig { margin-top: 16px; }
+.sig-line {
+  display: block;
+  height: 18px;
+  border-bottom: 1.5px solid var(--ink);
+  margin-bottom: 4px;
+}
+.sig-name {
+  font-family: var(--hand);
+  font-size: 14px;
+  color: var(--ink-soft);
+}
+.testimony-stamp {
+  position: absolute;
+  top: 14px;
+  right: -10px;
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  color: var(--stamp-red-soft);
+  border: 2.5px double var(--stamp-red-soft);
+  padding: 4px 10px;
+  transform: rotate(12deg);
+  opacity: 0.82;
+}
+.testimony-stamp.red { color: var(--ink); border-color: var(--ink); background: var(--carbon-yellow); opacity: 1; transform: rotate(-6deg); }
+
+/* PROCESS */
+.process {
+  position: relative;
+  background: var(--carbon-white);
+  padding: 64px 24px;
+  border-bottom: 1px dotted var(--ink);
+}
+.process .wrap { max-width: 1080px; margin: 0 auto; }
+.process-head { margin-bottom: 36px; }
+.proc-meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+  color: var(--ink-soft);
+}
+.process-head h2 {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: clamp(38px, 5vw, 56px);
+  line-height: 1.0;
+  margin: 0;
+}
+.process-head h2 .hand {
+  font-family: var(--hand);
+  font-weight: 400;
+  color: var(--stamp-red);
+}
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr) auto;
+  gap: 0;
+  align-items: stretch;
+  border: 1.5px solid var(--ink);
+  background: var(--carbon-white);
+}
+.step {
+  position: relative;
+  padding: 22px 18px 26px;
+  border-right: 1px dotted var(--ink);
+  display: flex;
+  flex-direction: column;
+  background: var(--carbon-white);
+}
+.step:nth-child(odd) { background: rgba(244, 226, 163, 0.32); }
+.step.last { border-right: none; }
+.step-num {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  background: var(--ink);
+  color: var(--carbon-white);
+  display: inline-block;
+  padding: 4px 10px;
+  margin-bottom: 14px;
+  align-self: flex-start;
+}
+.step-body h3 {
+  font-family: var(--hand);
+  font-weight: 400;
+  font-size: 28px;
+  margin: 0 0 10px;
+  color: var(--stamp-red);
+}
+.step-body p {
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0;
+}
+.step-arrow {
+  display: none;
+}
+
+/* MANILA FOLDER FOOTER */
+.foot {
+  background: var(--carbon-white);
+  padding: 60px 24px 40px;
+  position: relative;
+}
+.folder-tab {
+  display: inline-block;
+  background: #c9a566;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  padding: 10px 26px 12px;
+  margin-left: 40px;
+  border: 1.5px solid var(--ink);
+  border-bottom: none;
+  border-radius: 6px 18px 0 0;
+  text-transform: uppercase;
+}
+.folder-body {
+  background: #d8b87a;
+  border: 1.5px solid var(--ink);
+  padding: 32px 36px 28px;
+  max-width: 1080px;
+  margin: 0 auto;
+  position: relative;
+}
+.folder-body::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 1px dotted rgba(19, 19, 19, 0.4);
+  pointer-events: none;
+}
+.folder-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 28px;
+  position: relative;
+  z-index: 1;
+}
+.folder-grid .col h4 {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  margin: 0 0 12px;
+  color: var(--ink);
+  border-bottom: 1px dotted var(--ink);
+  padding-bottom: 6px;
+}
+.folder-grid .col p {
+  font-family: var(--mono);
+  font-size: 13px;
+  margin: 0;
+  line-height: 1.6;
+}
+.folder-grid .col a {
+  display: block;
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 3px 0;
+  color: var(--ink);
+  border-bottom: none;
+}
+.folder-grid .col a:hover { color: var(--stamp-red); }
+.folder-stamp {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px dotted var(--ink);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  position: relative;
+  z-index: 1;
+}
+
+/* PROSE PAGES */
+.prose {
+  max-width: 740px;
+  margin: 64px auto 80px;
+  padding: 0 24px;
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.65;
+}
+.prose h1 {
+  font-family: var(--hand);
+  font-weight: 400;
+  font-size: clamp(44px, 6vw, 72px);
+  line-height: 1.0;
+  margin: 0 0 30px;
+  color: var(--ink);
+  border-bottom: 3px double var(--ink);
+  padding-bottom: 18px;
+}
+.prose h2 {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 30px;
+  margin: 44px 0 14px;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+.prose h2::before {
+  content: "§ ";
+  color: var(--stamp-red);
+  font-family: var(--mono);
+  font-size: 0.7em;
+}
+.prose h3 {
+  font-family: var(--mono);
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin: 30px 0 10px;
+  color: var(--rule-blue);
+}
+.prose p { margin: 0 0 16px; }
+.prose p strong { background: var(--carbon-yellow); padding: 0 3px; font-weight: 700; }
+.prose ul {
+  padding-left: 0;
+  list-style: none;
+}
+.prose li {
+  font-family: var(--mono);
+  font-size: 15px;
+  padding: 6px 0 6px 22px;
+  border-bottom: 1px dotted var(--rule-blue);
+  position: relative;
+}
+.prose li::before {
+  content: "□";
+  position: absolute;
+  left: 0;
+  top: 6px;
+  color: var(--stamp-red);
+}
+.prose blockquote {
+  margin: 24px 0;
+  padding: 18px 22px;
+  background: var(--carbon-pink);
+  border-left: 4px solid var(--stamp-red);
+  font-family: var(--hand);
+  font-size: 20px;
+  font-style: normal;
+}
+.prose blockquote p { margin: 0; }
+.prose code {
+  font-family: var(--mono);
+  background: var(--carbon-yellow);
+  padding: 1px 5px;
+  font-size: 0.92em;
+}
+
+/* SECTION / FILING LIST */
+.filing-list {
+  padding: 56px 24px 80px;
+}
+.filing-list .wrap { max-width: 1080px; margin: 0 auto; }
+.filing-head {
+  border-bottom: 3px double var(--ink);
+  padding-bottom: 20px;
+  margin-bottom: 24px;
+}
+.filing-meta {
+  display: flex;
+  gap: 22px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 14px;
+}
+.filing-head h1 {
+  font-family: var(--hand);
+  font-weight: 400;
+  font-size: clamp(40px, 6vw, 72px);
+  line-height: 1.0;
+  margin: 0;
+}
+.filing-head .hand {
+  font-family: var(--mono);
+  font-size: 14px;
+  display: block;
+  margin-top: 10px;
+  color: var(--rule-blue);
+}
+.filing-body { margin-bottom: 24px; }
+.filing-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 13px;
+  background: var(--carbon-white);
+  border: 1.5px solid var(--ink);
+}
+.filing-table thead th {
+  text-align: left;
+  padding: 12px 14px;
+  background: var(--ink);
+  color: var(--carbon-white);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.filing-table tbody td {
+  padding: 12px 14px;
+  border-bottom: 1px dotted var(--rule-blue);
+}
+.filing-table tbody tr:last-child td { border-bottom: none; }
+.filing-table tbody tr:nth-child(even) { background: rgba(58, 91, 138, 0.04); }
+
+/* CARD INDEX */
+.card-index .index-meta {
+  display: flex;
+  gap: 22px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 12px;
+}
+.card-drawer {
+  margin-top: 24px;
+  padding: 20px 22px;
+  background: var(--carbon-yellow);
+  border: 1.5px solid var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+  font-family: var(--mono);
+  font-size: 14px;
+}
+.card-drawer a {
+  display: inline-block;
+  margin: 4px 8px 4px 0;
+  padding: 4px 10px;
+  background: var(--carbon-white);
+  border: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+
+/* RESPONSIVE */
+@media (max-width: 900px) {
+  .strip-top {
+    grid-template-columns: 1fr;
+    text-align: center;
+    gap: 8px;
+  }
+  .strip-nav { justify-content: center; }
+  .strip-mid { justify-content: center; }
+  .copy-meta { grid-template-columns: repeat(2, 1fr); }
+  .hero-fields { grid-template-columns: 1fr; }
+  .witnesses { grid-template-columns: 1fr; }
+  .steps {
+    grid-template-columns: 1fr;
+  }
+  .step { border-right: none; border-bottom: 1px dotted var(--ink); }
+  .step.last { border-bottom: none; }
+  .folder-grid { grid-template-columns: 1fr 1fr; }
+  .headline { font-size: clamp(48px, 14vw, 96px); }
+  .stamp-void, .stamp-original, .stamp-certified { display: none; }
+}
+
+@media (max-width: 560px) {
+  body { font-size: 16px; }
+  .copy-pink { margin-right: 20px; }
+  .copy-yellow { margin: -70px 10px 0 20px; }
+  .folder-grid { grid-template-columns: 1fr; }
+  .tariff-table { font-size: 11px; }
+  .tariff-table thead th, .tariff-table tbody td { padding: 8px 6px; }
+  .stamp { display: none; }
+  .stamp-received { display: block; }
+}

--- a/examples/carbon-press/static/favicon.svg
+++ b/examples/carbon-press/static/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="3" y="11" width="22" height="18" fill="#f4c5cf" stroke="#131313" stroke-width="1.2"/>
+  <rect x="6" y="7" width="22" height="18" fill="#f4e2a3" stroke="#131313" stroke-width="1.2"/>
+  <rect x="9" y="3" width="22" height="18" fill="#f6f4ee" stroke="#131313" stroke-width="1.2"/>
+  <line x1="13" y1="8" x2="27" y2="8" stroke="#3a5b8a" stroke-width="0.8"/>
+  <line x1="13" y1="12" x2="27" y2="12" stroke="#3a5b8a" stroke-width="0.8"/>
+  <line x1="13" y1="16" x2="23" y2="16" stroke="#3a5b8a" stroke-width="0.8"/>
+  <circle cx="25" cy="18" r="3" fill="none" stroke="#c01a1a" stroke-width="1.2"/>
+</svg>

--- a/examples/carbon-press/templates/404.html
+++ b/examples/carbon-press/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="filing-meta">
+    <span>FORM&nbsp;NOT&nbsp;ON&nbsp;FILE</span>
+    <span>404</span>
+    <span>VOID</span>
+  </div>
+  <h1>Form not on file.</h1>
+  <p>The matter you asked for is not in the drawer. It may have been re-filed under another heading, returned to the petitioner, or never opened at all. The desk apologises for the inconvenience.</p>
+  <p>Try the <a href="{{ base_url }}/">front desk</a> or consult the <a href="{{ base_url }}/tags/">card index</a>.</p>
+</article>
+{% include "footer.html" %}

--- a/examples/carbon-press/templates/footer.html
+++ b/examples/carbon-press/templates/footer.html
@@ -1,0 +1,37 @@
+  <footer class="foot">
+    <div class="folder-tab">MANILA / 24-B / {{ current_year }}</div>
+    <div class="folder-body">
+      <div class="folder-grid">
+        <div class="col">
+          <h4>// the desk</h4>
+          <p>Carbon Press Co-operative<br>Room 4, Second Floor<br>14 Filing Lane<br>Office Hours: 09:00&ndash;17:00</p>
+        </div>
+        <div class="col">
+          <h4>// drafting</h4>
+          <a href="#tariff">Tariff schedule</a>
+          <a href="{{ base_url }}/about/">Intake process</a>
+          <a href="#process">Filing workflow</a>
+        </div>
+        <div class="col">
+          <h4>// records</h4>
+          <a href="{{ base_url }}/tags/">Brief archive</a>
+          <a href="#testimony">Witness book</a>
+          <a href="#">Standing orders</a>
+        </div>
+        <div class="col">
+          <h4>// reach</h4>
+          <a href="#">desk@carbon.press</a>
+          <a href="#">By post, preferred</a>
+          <a href="#">No fax after 16:00</a>
+        </div>
+      </div>
+      <div class="folder-stamp">
+        <span class="left">&copy; {{ current_year }} Carbon Press &middot; drafted by hand, filed in triplicate</span>
+        <span class="right">FILE COPY &middot; DO NOT REMOVE FROM DRAWER</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/carbon-press/templates/header.html
+++ b/examples/carbon-press/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Special+Elite&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <div class="strip-left">
+      <span class="dot dot-pink"></span>
+      <span class="dot dot-yellow"></span>
+      <span class="dot dot-white"></span>
+      <span class="strip-form">FORM&nbsp;24-B&nbsp;//&nbsp;{{ current_year }}</span>
+    </div>
+    <div class="strip-mid">
+      <span class="op">FILE</span>
+      <span class="sep">/</span>
+      <span class="op">DRAFT</span>
+      <span class="sep">/</span>
+      <span class="op">FILE&nbsp;AGAIN</span>
+    </div>
+    <nav class="strip-nav">
+      <a href="{{ base_url }}/">Index</a>
+      <a href="{{ base_url }}/about/">About</a>
+      <a href="{{ base_url }}/tags/">Briefs</a>
+      <a href="#tariff">Forms</a>
+    </nav>
+  </header>

--- a/examples/carbon-press/templates/index.html
+++ b/examples/carbon-press/templates/index.html
@@ -1,0 +1,254 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <span class="stamp stamp-received">RECEIVED</span>
+  <span class="stamp stamp-filed">FILED&nbsp;04/{{ current_year }}</span>
+  <span class="stamp stamp-certified">CERTIFIED</span>
+  <span class="stamp stamp-original">ORIGINAL</span>
+  <span class="stamp stamp-void">VOID</span>
+
+  <div class="hero-inner">
+    <div class="triplicate">
+      <div class="copy copy-pink">
+        <div class="copy-head">
+          <span>TRIPLICATE</span>
+          <span>PINK&nbsp;COPY</span>
+          <span>FILE</span>
+        </div>
+      </div>
+      <div class="copy copy-yellow">
+        <div class="copy-head">
+          <span>DUPLICATE</span>
+          <span>YELLOW&nbsp;COPY</span>
+          <span>CLIENT</span>
+        </div>
+      </div>
+      <div class="copy copy-white">
+        <div class="copy-head">
+          <span>ORIGINAL</span>
+          <span>WHITE&nbsp;COPY</span>
+          <span>COURT</span>
+        </div>
+        <div class="copy-meta">
+          <div><label>FORM</label><b>24-B</b></div>
+          <div><label>MATTER</label><b>SMALL&nbsp;CLAIMS</b></div>
+          <div><label>BUREAU</label><b>CO-OPERATIVE</b></div>
+          <div><label>DATE</label><b>04 / {{ current_year }}</b></div>
+        </div>
+        <h1 class="headline">
+          <span class="line">WE&nbsp;DRAFT</span>
+          <span class="dash">/</span>
+          <span class="line">IN&nbsp;TRIPLICATE.</span>
+        </h1>
+        <p class="hero-lede">A co-operative of legal scribes preparing small-claims forms, non-disclosure agreements, and rental contracts <em>by hand</em>, on no-carbon-required paper, with witnesses present.</p>
+        <div class="hero-fields">
+          <div class="field"><label>Petitioner</label><span class="rule"></span></div>
+          <div class="field"><label>Respondent</label><span class="rule"></span></div>
+          <div class="field"><label>Amount in dispute</label><span class="rule short"></span><label class="curr">KRW</label></div>
+          <div class="field"><label>Signature of scribe</label><span class="rule"></span></div>
+        </div>
+        <div class="hero-cta">
+          <a class="cta-pin" href="#tariff">SEE&nbsp;TARIFF&nbsp;&raquo;</a>
+          <a class="cta-pin alt" href="#process">FILING&nbsp;PROCESS&nbsp;&raquo;</a>
+          <a class="cta-pin out" href="{{ base_url }}/about/">ABOUT&nbsp;THE&nbsp;CO-OP&nbsp;&raquo;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="hero-perf"></div>
+</section>
+
+<section class="tariff" id="tariff">
+  <div class="wrap">
+    <header class="tariff-head">
+      <div class="tariff-meta">
+        <span>SCHEDULE&nbsp;C</span>
+        <span>EFFECTIVE&nbsp;04 / {{ current_year }}</span>
+        <span>RATES&nbsp;IN&nbsp;KRW</span>
+      </div>
+      <h2>Tariff Schedule &mdash; <span class="hand">drafting&nbsp;fees</span></h2>
+      <p class="tariff-note">Fees are flat. Witnessing included for forms filed before 16:00. The desk reserves the right to refuse matters it finds unfilable.</p>
+    </header>
+    <table class="tariff-table">
+      <thead>
+        <tr>
+          <th class="num">No.</th>
+          <th>Instrument</th>
+          <th>Length</th>
+          <th>Witnessed</th>
+          <th class="num">Fee</th>
+          <th class="stamp-col">Mark</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="num">01</td>
+          <td>Demand Letter &mdash; standard, single party</td>
+          <td>1 page</td>
+          <td>No</td>
+          <td class="num">28,000</td>
+          <td class="stamp-col"><span class="mini-stamp">PAID</span></td>
+        </tr>
+        <tr>
+          <td class="num">02</td>
+          <td>Non-Disclosure Agreement &mdash; mutual</td>
+          <td>3 pages</td>
+          <td>Yes</td>
+          <td class="num">62,000</td>
+          <td class="stamp-col"><span class="mini-stamp">NDA</span></td>
+        </tr>
+        <tr>
+          <td class="num">03</td>
+          <td>Residential Rental Contract &mdash; twelve-month</td>
+          <td>6 pages</td>
+          <td>Yes</td>
+          <td class="num">94,000</td>
+          <td class="stamp-col"><span class="mini-stamp ok">FILED</span></td>
+        </tr>
+        <tr>
+          <td class="num">04</td>
+          <td>Small Claims Petition &mdash; under 3,000,000 KRW</td>
+          <td>2 pages</td>
+          <td>Yes</td>
+          <td class="num">48,000</td>
+          <td class="stamp-col"><span class="mini-stamp">SC</span></td>
+        </tr>
+        <tr>
+          <td class="num">05</td>
+          <td>Cease &amp; Desist &mdash; with affidavit</td>
+          <td>2 pages</td>
+          <td>Yes</td>
+          <td class="num">55,000</td>
+          <td class="stamp-col"><span class="mini-stamp">CD</span></td>
+        </tr>
+        <tr>
+          <td class="num">06</td>
+          <td>Promissory Note &mdash; private loan</td>
+          <td>1 page</td>
+          <td>Yes</td>
+          <td class="num">22,000</td>
+          <td class="stamp-col"><span class="mini-stamp">PN</span></td>
+        </tr>
+        <tr>
+          <td class="num">07</td>
+          <td>Power of Attorney &mdash; limited scope</td>
+          <td>2 pages</td>
+          <td>Yes</td>
+          <td class="num">40,000</td>
+          <td class="stamp-col"><span class="mini-stamp ok">FILED</span></td>
+        </tr>
+        <tr>
+          <td class="num">08</td>
+          <td>Affidavit of Service &mdash; postal proof attached</td>
+          <td>1 page</td>
+          <td>Yes</td>
+          <td class="num">18,000</td>
+          <td class="stamp-col"><span class="mini-stamp">AOS</span></td>
+        </tr>
+        <tr>
+          <td class="num">09</td>
+          <td>Rush draft &mdash; same-day filing surcharge</td>
+          <td>&mdash;</td>
+          <td>&mdash;</td>
+          <td class="num">+12,000</td>
+          <td class="stamp-col"><span class="mini-stamp warn">RUSH</span></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="tariff-foot">
+      <span class="hand">All rates witnessed and entered into the ledger.</span>
+      <span class="sigline">desk &mdash; M. Han / scribe-in-charge</span>
+    </div>
+  </div>
+</section>
+
+<section class="testimony" id="testimony">
+  <div class="wrap">
+    <header class="testimony-head">
+      <h2>From the <span class="hand">witness book</span>.</h2>
+      <p>Statements taken at the desk, in the presence of two scribes, copied to the file.</p>
+    </header>
+    <div class="witnesses">
+      <article class="witness">
+        <div class="witness-meta">
+          <span>STATEMENT&nbsp;N&deg;&nbsp;108</span>
+          <span class="date-stamp">17 MAR {{ current_year }}</span>
+        </div>
+        <p class="witness-body">&ldquo;The landlord said our lease was on a napkin. The desk gave us six pages by morning. The court accepted it the same week.&rdquo;</p>
+        <div class="witness-sig">
+          <span class="sig-line"></span>
+          <span class="sig-name">J. Park &middot; tenant, Mapo</span>
+        </div>
+        <span class="testimony-stamp">SWORN</span>
+      </article>
+      <article class="witness">
+        <div class="witness-meta">
+          <span>STATEMENT&nbsp;N&deg;&nbsp;114</span>
+          <span class="date-stamp">02 APR {{ current_year }}</span>
+        </div>
+        <p class="witness-body">&ldquo;I was owed two months of invoices and a chair. I sent the demand letter on a Tuesday. The chair arrived on a Friday.&rdquo;</p>
+        <div class="witness-sig">
+          <span class="sig-line"></span>
+          <span class="sig-name">S. Ahn &middot; freelance, Yongsan</span>
+        </div>
+        <span class="testimony-stamp red">CERT.</span>
+      </article>
+      <article class="witness">
+        <div class="witness-meta">
+          <span>STATEMENT&nbsp;N&deg;&nbsp;121</span>
+          <span class="date-stamp">28 APR {{ current_year }}</span>
+        </div>
+        <p class="witness-body">&ldquo;They typed the NDA in front of me. They asked me what I actually meant by &lsquo;confidential.&rsquo; Nobody had ever asked me that.&rdquo;</p>
+        <div class="witness-sig">
+          <span class="sig-line"></span>
+          <span class="sig-name">R. Choe &middot; founder, Seongsu</span>
+        </div>
+        <span class="testimony-stamp">SWORN</span>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="process" id="process">
+  <div class="wrap">
+    <header class="process-head">
+      <div class="proc-meta">FORM 24-B / SECTION IV / FILING WORKFLOW</div>
+      <h2>How a matter <span class="hand">moves through the desk</span>.</h2>
+    </header>
+    <ol class="steps">
+      <li class="step">
+        <div class="step-num">01</div>
+        <div class="step-body">
+          <h3>Intake</h3>
+          <p>Bring the paperwork, the disputed amount, the date the trouble started. The desk records the matter in the day-book, in pencil.</p>
+        </div>
+        <div class="step-arrow">&rarr;</div>
+      </li>
+      <li class="step">
+        <div class="step-num">02</div>
+        <div class="step-body">
+          <h3>Drafting</h3>
+          <p>A scribe types the instrument on a Selectric. You read it aloud once. We correct it twice, in red pencil, on the white copy.</p>
+        </div>
+        <div class="step-arrow">&rarr;</div>
+      </li>
+      <li class="step">
+        <div class="step-num">03</div>
+        <div class="step-body">
+          <h3>Witnessing</h3>
+          <p>Two co-op members sign as witnesses. The stamp goes on all three sheets &mdash; pink, yellow, white &mdash; through carbon impression.</p>
+        </div>
+        <div class="step-arrow">&rarr;</div>
+      </li>
+      <li class="step last">
+        <div class="step-num">04</div>
+        <div class="step-body">
+          <h3>Filing</h3>
+          <p>The white copy is filed with the court or registry. You keep the yellow. We keep the pink in the bottom drawer for seven years.</p>
+        </div>
+      </li>
+    </ol>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/carbon-press/templates/page.html
+++ b/examples/carbon-press/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/carbon-press/templates/section.html
+++ b/examples/carbon-press/templates/section.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+<section class="filing-list">
+  <div class="wrap">
+    <header class="filing-head">
+      <div class="filing-meta">
+        <span>SECTION&nbsp;FILE</span>
+        <span>{{ current_year }}</span>
+        <span>PINK&nbsp;COPY</span>
+      </div>
+      {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+      <p class="hand">All matters logged below were drafted, witnessed, and filed by the co-operative.</p>
+    </header>
+    <div class="filing-body">{{ content | safe }}</div>
+    <table class="filing-table">
+      <thead>
+        <tr>
+          <th class="num">No.</th>
+          <th>Date</th>
+          <th>Matter</th>
+          <th class="stamp-col">Mark</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for post in section.pages %}
+        <tr>
+          <td class="num">{{ loop.index }}</td>
+          <td>{{ post.date | date(format="%d %b %Y") }}</td>
+          <td><a href="{{ post.url }}">{{ post.title | e }}</a></td>
+          <td class="stamp-col"><span class="mini-stamp ok">FILED</span></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/carbon-press/templates/taxonomy.html
+++ b/examples/carbon-press/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<article class="prose card-index">
+  <div class="index-meta">
+    <span>CARD&nbsp;INDEX</span>
+    <span>DRAWER&nbsp;{{ current_year }}-A</span>
+    <span>SUBJECT&nbsp;HEADINGS</span>
+  </div>
+  <h1>{{ page.title | e }}</h1>
+  <p>// Subjects under which the desk has drafted, witnessed, and filed.</p>
+  <div class="card-drawer">
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/carbon-press/templates/taxonomy_term.html
+++ b/examples/carbon-press/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<article class="prose filing-term">
+  <div class="filing-meta">
+    <span>FILE&nbsp;UNDER</span>
+    <span>{{ page.title | e | upper }}</span>
+    <span>YELLOW&nbsp;COPY</span>
+  </div>
+  <h1>{{ page.title | e }}</h1>
+  <p>// Matters drafted, stamped, and filed under this heading.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/diner-counter/AGENTS.md
+++ b/examples/diner-counter/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/diner-counter/archetypes/default.md
+++ b/examples/diner-counter/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/diner-counter/config.toml
+++ b/examples/diner-counter/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "COUNTER 12"
+description = "Counter 12 — a 24-hour American diner open since 1967. Burgers, fries, milkshakes, blue-plate specials, and all-day breakfast at the counter."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/diner-counter/content/about.md
+++ b/examples/diner-counter/content/about.md
@@ -1,0 +1,29 @@
++++
+title = "About the Counter"
+description = "Counter 12 — a 24-hour American diner open since 1967. The history, the counter, the cooks, the booths, and how to find us."
++++
+
+## Since 1967
+
+We opened on a Tuesday in March 1967, at the corner of Lot 4 and the truck route. The first cook flipped the OPEN sign on at 5:43 in the morning and nobody has flipped it off since. The grill has been on for fifty-nine years. The coffee pot has been on for fifty-nine years. The fryer was new in 1982.
+
+## The counter
+
+Twelve stools in a row, formica top, chrome edge, cracked vinyl on stool seven. The stool is older than most of the cooks. We refuse to replace it. The counter runs the length of the kitchen and you can watch every plate come up — eggs over easy, hash brown crispy, toast dark on the right side because that's the side closest to the heat.
+
+## The cooks
+
+Three cooks rotate the grill. Mae has been here since 1979, opens five mornings a week, eggs in under two minutes. Junior took the night shift in 2004 and hasn't slept on a Saturday since. Pete works the swing — noon to midnight, weekends. None of them measure. All of them remember your order.
+
+## The booths
+
+Six red-vinyl booths along the window. They seat four. They have seated more. We do not take reservations. We never have. If the booth is empty when you walk in, it's yours; if it's not, the counter has a stool, and the stool comes with the same plate and the same coffee.
+
+## Contact
+
+> No reservations. No app. No email list. You either come in or you don't.
+
+- **Phone** — 555&middot;0167 (rotary dial behind the register)
+- **Address** — Lot 4, off the old truck route
+- **Hours** — 24 / 7 / 365, since 1967
+- **Best time** — 3 AM, when the booths are empty and the chili is at its best

--- a/examples/diner-counter/content/index.md
+++ b/examples/diner-counter/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Counter 12 — a 24-hour American diner open since 1967. Burgers, fries, milkshakes, blue-plate specials, all-day breakfast at the counter."
+template = "index"
++++

--- a/examples/diner-counter/static/css/style.css
+++ b/examples/diner-counter/static/css/style.css
@@ -1,0 +1,562 @@
+/* =============================================================================
+   COUNTER 12 — 24-hour diner stylesheet
+   Solid colors only. No gradients. No emoji.
+   ========================================================================== */
+
+:root {
+  --chalkboard: #1a1a1a;
+  --chalk-white: #f1eedf;
+  --diner-cream: #f6ecca;
+  --booth-red: #b3252b;
+  --mustard: #d6a52a;
+  --neon-pink: #ff3a8f;
+  --formica-teal: #1f7775;
+  --floor-black: #18130f;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  background: var(--diner-cream);
+  color: var(--chalkboard);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* ---------- top strip ---------- */
+.strip-top {
+  background: var(--diner-cream);
+  border-bottom: 4px solid var(--chalkboard);
+  padding: 14px 28px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.logo {
+  font-family: 'Alfa Slab One', serif;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.logo-red { color: var(--booth-red); }
+.logo-black { color: var(--chalkboard); }
+.logo-dot { color: var(--booth-red); font-weight: 900; }
+
+.topnav { display: flex; gap: 24px; }
+.topnav a {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.05rem;
+  color: var(--chalkboard);
+  padding: 4px 2px;
+  position: relative;
+}
+.topnav a::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -2px;
+  height: 3px;
+  background: var(--neon-pink);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.18s ease;
+}
+.topnav a:hover::after { transform: scaleX(1); }
+
+/* ---------- hero ---------- */
+.hero {
+  background: var(--diner-cream);
+  padding: 56px 28px 64px;
+  display: grid;
+  grid-template-columns: 1fr 1.6fr;
+  gap: 48px;
+  align-items: start;
+  border-bottom: 6px solid var(--chalkboard);
+}
+
+.hero-headline { position: relative; padding-top: 40px; }
+.hero-headline h1 {
+  font-family: 'Alfa Slab One', serif;
+  font-size: clamp(2.4rem, 5vw, 4.2rem);
+  line-height: 0.95;
+  color: var(--chalkboard);
+  letter-spacing: -0.01em;
+}
+.hero-headline .hl { display: block; }
+.hero-headline .hl.pink { color: var(--booth-red); }
+
+.stamp {
+  position: absolute;
+  top: -6px;
+  left: -6px;
+  background: var(--booth-red);
+  color: var(--diner-cream);
+  font-family: 'Permanent Marker', cursive;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  padding: 8px 16px;
+  border: 3px solid var(--chalkboard);
+  transform: rotate(-7deg);
+}
+
+.chalkboard {
+  background: var(--chalkboard);
+  color: var(--chalk-white);
+  padding: 32px 36px 36px;
+  border: 8px solid var(--mustard);
+  outline: 4px solid var(--chalkboard);
+  outline-offset: 4px;
+  min-height: 520px;
+  position: relative;
+  box-shadow: 0 14px 0 var(--floor-black);
+}
+
+.board-top, .board-bottom {
+  text-align: center;
+  font-family: 'Caveat Brush', cursive;
+  color: var(--chalk-white);
+  opacity: 0.85;
+}
+
+.board-label {
+  font-size: 1.4rem;
+  letter-spacing: 0.06em;
+  display: inline-block;
+  padding-bottom: 12px;
+  border-bottom: 2px dashed var(--chalk-white);
+}
+
+.board-foot {
+  margin-top: 18px;
+  display: inline-block;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+}
+
+.chalk-menu {
+  list-style: none;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px 56px;
+  margin: 28px 0 18px;
+}
+
+.chalk-menu li {
+  display: flex;
+  align-items: baseline;
+  font-family: 'Caveat Brush', cursive;
+  font-size: 1.7rem;
+  color: var(--chalk-white);
+  gap: 8px;
+}
+
+.chalk-menu .dish { white-space: nowrap; }
+.chalk-menu .dots {
+  flex: 1;
+  border-bottom: 2px dotted var(--chalk-white);
+  margin: 0 6px 6px;
+  opacity: 0.6;
+}
+.chalk-menu .price {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--mustard);
+  letter-spacing: 0.04em;
+}
+
+.chalk-menu li:nth-child(2n) .price { color: var(--neon-pink); }
+
+/* ---------- sections shared ---------- */
+section .wrap { max-width: 1180px; margin: 0 auto; padding: 0 28px; }
+
+.sec-head { margin-bottom: 32px; padding-top: 56px; }
+.sec-head h2 {
+  font-family: 'Alfa Slab One', serif;
+  font-size: clamp(2rem, 4vw, 3rem);
+  color: var(--chalkboard);
+  letter-spacing: -0.01em;
+}
+.sec-sub {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.1rem;
+  color: var(--booth-red);
+  margin-top: 6px;
+}
+
+/* ---------- specials ---------- */
+.specials {
+  background: var(--diner-cream);
+  padding-bottom: 64px;
+  border-bottom: 6px solid var(--chalkboard);
+  position: relative;
+}
+
+.plate-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.plate {
+  background: var(--chalk-white);
+  border: 3px solid var(--chalkboard);
+  padding: 18px 18px 20px;
+  position: relative;
+  box-shadow: 6px 6px 0 var(--chalkboard);
+}
+
+.plate .day {
+  font-family: 'Alfa Slab One', serif;
+  font-size: 1.6rem;
+  color: var(--booth-red);
+  letter-spacing: 0.04em;
+  border-bottom: 3px solid var(--chalkboard);
+  padding-bottom: 8px;
+  margin-bottom: 14px;
+}
+
+.plate .ast {
+  color: var(--mustard);
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.4rem;
+}
+
+.plate .dish-name {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  margin-bottom: 6px;
+  color: var(--chalkboard);
+}
+
+.plate .dish-side {
+  font-size: 0.85rem;
+  color: var(--formica-teal);
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.plate .plate-price {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: var(--chalkboard);
+  background: var(--mustard);
+  display: inline-block;
+  padding: 4px 10px;
+  border: 2px solid var(--chalkboard);
+}
+
+.plate.pick { background: var(--mustard); }
+.plate.pick .plate-price { background: var(--booth-red); color: var(--diner-cream); }
+
+.legend {
+  margin-top: 18px;
+  font-family: 'Permanent Marker', cursive;
+  color: var(--formica-teal);
+}
+.legend .ast { color: var(--booth-red); font-size: 1.2rem; }
+
+/* ---------- stools ---------- */
+.stools-section {
+  background: var(--booth-red);
+  color: var(--diner-cream);
+  padding-bottom: 72px;
+  border-bottom: 6px solid var(--chalkboard);
+}
+
+.stools-section .sec-head h2 { color: var(--diner-cream); }
+.stools-section .sec-sub { color: var(--mustard); }
+
+.counter-block {
+  background: var(--formica-teal);
+  border: 5px solid var(--chalkboard);
+  padding: 28px 28px 24px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: center;
+  box-shadow: 10px 10px 0 var(--floor-black);
+}
+
+.counter-strip {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.stool {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 4px solid var(--chalkboard);
+  display: inline-block;
+}
+
+.stool.taken { background: var(--booth-red); }
+.stool.free { background: var(--diner-cream); }
+
+.counter-shelf {
+  grid-column: 1 / -1;
+  height: 10px;
+  background: var(--chalk-white);
+  border: 3px solid var(--chalkboard);
+  margin-top: -4px;
+}
+
+.seat-readout {
+  background: var(--chalkboard);
+  color: var(--diner-cream);
+  padding: 18px 22px;
+  border: 4px solid var(--mustard);
+  text-align: center;
+  min-width: 160px;
+}
+
+.big-count {
+  display: block;
+  font-family: 'Alfa Slab One', serif;
+  font-size: 2.6rem;
+  color: var(--neon-pink);
+  line-height: 1;
+}
+
+.readout-label {
+  display: block;
+  font-family: 'Permanent Marker', cursive;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  margin-top: 6px;
+  color: var(--diner-cream);
+}
+
+/* ---------- hours / phone / booths ---------- */
+.hours-section {
+  background: var(--diner-cream);
+  padding-bottom: 80px;
+}
+
+.card-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 22px;
+}
+
+.card {
+  background: var(--chalk-white);
+  border: 4px solid var(--chalkboard);
+  padding: 26px 24px 28px;
+  box-shadow: 8px 8px 0 var(--chalkboard);
+  position: relative;
+}
+
+.card-kicker {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--booth-red);
+  margin-bottom: 8px;
+}
+
+.card-big {
+  font-family: 'Alfa Slab One', serif;
+  font-size: 2.8rem;
+  line-height: 1;
+  color: var(--chalkboard);
+  margin-bottom: 14px;
+  letter-spacing: 0.02em;
+}
+
+.card-body {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--chalkboard);
+}
+
+.hours-card { background: var(--mustard); }
+.hours-card .card-big { color: var(--chalkboard); }
+.hours-card .card-kicker { color: var(--chalkboard); }
+
+.phone-card .card-big { color: var(--formica-teal); }
+
+.booths-card { background: var(--booth-red); color: var(--diner-cream); }
+.booths-card .card-kicker { color: var(--mustard); }
+.booths-card .card-big { color: var(--diner-cream); }
+.booths-card .card-body { color: var(--diner-cream); }
+
+/* ---------- footer ---------- */
+.foot { background: var(--floor-black); color: var(--diner-cream); }
+
+.check-strip {
+  height: 56px;
+  background-color: var(--diner-cream);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='56' height='56' viewBox='0 0 56 56'><rect width='28' height='28' x='0' y='0' fill='%2318130f'/><rect width='28' height='28' x='28' y='28' fill='%2318130f'/><rect width='28' height='28' x='28' y='0' fill='%23f6ecca'/><rect width='28' height='28' x='0' y='28' fill='%23f6ecca'/></svg>");
+  background-repeat: repeat;
+  background-size: 56px 56px;
+  border-top: 4px solid var(--chalkboard);
+  border-bottom: 4px solid var(--chalkboard);
+}
+
+.foot-body {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 28px;
+  align-items: center;
+  padding: 40px 28px;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.open-sign {
+  background: var(--chalkboard);
+  border: 4px solid var(--neon-pink);
+  padding: 14px 26px;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.open-bulb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--neon-pink);
+  animation: blink 1.6s steps(2, end) infinite;
+}
+
+.open-word {
+  font-family: 'Alfa Slab One', serif;
+  font-size: 1.8rem;
+  letter-spacing: 0.12em;
+  color: var(--neon-pink);
+  animation: blink 1.6s steps(2, end) infinite;
+}
+
+@keyframes blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0.35; }
+}
+
+.colophon {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+  color: var(--diner-cream);
+  text-align: center;
+}
+
+.foot-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  color: var(--mustard);
+  text-align: right;
+}
+
+/* ---------- prose (about page) ---------- */
+.prose {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 64px 28px 96px;
+  font-size: 1.02rem;
+  line-height: 1.75;
+  color: var(--chalkboard);
+}
+
+.prose h1 {
+  font-family: 'Alfa Slab One', serif;
+  font-size: clamp(2.4rem, 5vw, 3.6rem);
+  line-height: 1;
+  margin-bottom: 32px;
+  color: var(--booth-red);
+  border-bottom: 6px solid var(--chalkboard);
+  padding-bottom: 16px;
+}
+
+.prose h2 {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.7rem;
+  margin: 36px 0 14px;
+  color: var(--chalkboard);
+}
+
+.prose h3 {
+  font-family: 'Alfa Slab One', serif;
+  font-size: 1.2rem;
+  margin: 22px 0 10px;
+  color: var(--formica-teal);
+}
+
+.prose p { margin-bottom: 14px; }
+.prose strong { color: var(--booth-red); }
+.prose em { color: var(--formica-teal); font-style: italic; }
+
+.prose a {
+  color: var(--booth-red);
+  border-bottom: 2px solid var(--mustard);
+}
+.prose a:hover { background: var(--mustard); color: var(--chalkboard); }
+
+.prose blockquote {
+  border-left: 6px solid var(--booth-red);
+  background: var(--mustard);
+  padding: 14px 20px;
+  margin: 20px 0;
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.1rem;
+}
+
+.prose ul, .prose ol { margin: 14px 0 14px 22px; }
+.prose li { margin-bottom: 6px; }
+
+.prose code {
+  background: var(--chalkboard);
+  color: var(--chalk-white);
+  padding: 2px 6px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.92em;
+}
+
+/* ---------- responsive ---------- */
+@media (max-width: 900px) {
+  .hero { grid-template-columns: 1fr; gap: 32px; padding: 32px 22px 44px; }
+  .chalkboard { min-height: 0; padding: 24px 22px; }
+  .chalk-menu { grid-template-columns: 1fr; gap: 6px; }
+  .chalk-menu li { font-size: 1.45rem; }
+  .strip-top { flex-direction: column; align-items: flex-start; padding: 12px 18px; }
+  .topnav { gap: 18px; }
+  .counter-block { grid-template-columns: 1fr; }
+  .seat-readout { justify-self: stretch; }
+  .foot-body { grid-template-columns: 1fr; text-align: center; }
+  .foot-meta { text-align: center; align-items: center; }
+  section .wrap { padding: 0 22px; }
+  .sec-head { padding-top: 40px; }
+}
+
+@media (max-width: 540px) {
+  .stool { width: 36px; height: 36px; border-width: 3px; }
+  .counter-strip { gap: 10px; }
+  .card-big { font-size: 2.2rem; }
+  .hero-headline h1 { font-size: 2rem; }
+  .stamp { font-size: 0.8rem; padding: 6px 12px; }
+}

--- a/examples/diner-counter/static/favicon.svg
+++ b/examples/diner-counter/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#1a1a1a"/>
+  <text x="16" y="22" text-anchor="middle" font-family="Georgia, serif" font-weight="900" font-size="18" fill="#f1eedf">12</text>
+  <rect x="3" y="26" width="26" height="2" fill="#ff3a8f"/>
+</svg>

--- a/examples/diner-counter/templates/404.html
+++ b/examples/diner-counter/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 / 86'D.</h1>
+  <p>That dish isn't on the board tonight. Cook is out of it &mdash; or it never made the menu. Try a different plate.</p>
+  <p><a href="{{ base_url }}/">&laquo; back to the counter</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/diner-counter/templates/footer.html
+++ b/examples/diner-counter/templates/footer.html
@@ -1,0 +1,21 @@
+  <footer class="foot">
+    <div class="check-strip" aria-hidden="true"></div>
+    <div class="foot-body">
+      <div class="open-sign">
+        <span class="open-bulb"></span>
+        <span class="open-word">OPEN</span>
+      </div>
+      <div class="colophon">
+        COUNTER 12 &middot; LOT 4 &middot; {{ current_year }}
+      </div>
+      <div class="foot-meta">
+        <span>24 / 7 / 365</span>
+        <span>SINCE 1967</span>
+        <span>NO RESERVATIONS</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/diner-counter/templates/header.html
+++ b/examples/diner-counter/templates/header.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Caveat+Brush&family=Permanent+Marker&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <a class="logo" href="{{ base_url }}/">
+      <span class="logo-red">COUNTER 12</span>
+      <span class="logo-dot">&middot;</span>
+      <span class="logo-black">OPEN 24 HOURS</span>
+      <span class="logo-dot">&middot;</span>
+      <span class="logo-black">EST. 1967</span>
+    </a>
+    <nav class="topnav">
+      <a href="#menu">Menu</a>
+      <a href="#specials">Specials</a>
+      <a href="#booths">Booths</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </header>

--- a/examples/diner-counter/templates/index.html
+++ b/examples/diner-counter/templates/index.html
@@ -1,0 +1,151 @@
+{% include "header.html" %}
+
+<section class="hero" id="menu">
+  <div class="hero-headline">
+    <h1>
+      <span class="hl">STILL OPEN.</span>
+      <span class="hl">STILL CHEAP.</span>
+      <span class="hl pink">STILL FRYING.</span>
+    </h1>
+    <div class="stamp">TODAY'S SPECIAL</div>
+  </div>
+
+  <div class="chalkboard">
+    <div class="board-top">
+      <span class="board-label">&mdash; AT THE COUNTER &mdash;</span>
+    </div>
+    <ul class="chalk-menu">
+      <li><span class="dish">Denver Omelette</span><span class="dots"></span><span class="price">$9.50</span></li>
+      <li><span class="dish">BLT</span><span class="dots"></span><span class="price">$7.25</span></li>
+      <li><span class="dish">Tuna Melt</span><span class="dots"></span><span class="price">$8.75</span></li>
+      <li><span class="dish">Country Steak</span><span class="dots"></span><span class="price">$14.00</span></li>
+      <li><span class="dish">Chili Bowl</span><span class="dots"></span><span class="price">$6.00</span></li>
+      <li><span class="dish">Meatloaf</span><span class="dots"></span><span class="price">$11.00</span></li>
+      <li><span class="dish">Patty Melt</span><span class="dots"></span><span class="price">$9.00</span></li>
+      <li><span class="dish">Milkshake</span><span class="dots"></span><span class="price">$5.00</span></li>
+    </ul>
+    <div class="board-bottom">
+      <span class="board-foot">all served with hash &amp; toast &middot; coffee bottomless</span>
+    </div>
+  </div>
+</section>
+
+<section class="specials" id="specials">
+  <div class="wrap">
+    <div class="sec-head">
+      <h2>Blue-Plate Specials</h2>
+      <p class="sec-sub">One dish a day. Cook picks. Until it runs out.</p>
+    </div>
+    <div class="plate-grid">
+      <article class="plate">
+        <div class="day">MON</div>
+        <div class="dish-name">Hot Turkey Sandwich</div>
+        <div class="dish-side">mashed &middot; gravy</div>
+        <div class="plate-price">$10.50</div>
+      </article>
+      <article class="plate">
+        <div class="day">TUE</div>
+        <div class="dish-name">Liver &amp; Onions</div>
+        <div class="dish-side">bacon &middot; rice</div>
+        <div class="plate-price">$11.00</div>
+      </article>
+      <article class="plate pick">
+        <div class="day">WED <span class="ast">*</span></div>
+        <div class="dish-name">Meatloaf Plate</div>
+        <div class="dish-side">corn &middot; biscuits</div>
+        <div class="plate-price">$11.00</div>
+      </article>
+      <article class="plate">
+        <div class="day">THU</div>
+        <div class="dish-name">Pot Roast</div>
+        <div class="dish-side">carrots &middot; roll</div>
+        <div class="plate-price">$12.50</div>
+      </article>
+      <article class="plate pick">
+        <div class="day">FRI <span class="ast">*</span></div>
+        <div class="dish-name">Fried Catfish</div>
+        <div class="dish-side">slaw &middot; hush-puppy</div>
+        <div class="plate-price">$13.00</div>
+      </article>
+      <article class="plate">
+        <div class="day">SAT</div>
+        <div class="dish-name">Open-Face Roast Beef</div>
+        <div class="dish-side">mashed &middot; gravy</div>
+        <div class="plate-price">$12.00</div>
+      </article>
+      <article class="plate">
+        <div class="day">SUN</div>
+        <div class="dish-name">Chicken &amp; Waffles</div>
+        <div class="dish-side">butter &middot; syrup</div>
+        <div class="plate-price">$11.50</div>
+      </article>
+    </div>
+    <p class="legend"><span class="ast">*</span> chef's pick &middot; ask the cook for tonight's pie</p>
+  </div>
+</section>
+
+<section class="stools-section">
+  <div class="wrap">
+    <div class="sec-head">
+      <h2>Counter Stools</h2>
+      <p class="sec-sub">Twelve at the formica. First come, first served.</p>
+    </div>
+    <div class="counter-block">
+      <div class="counter-strip">
+        <span class="stool taken" title="taken"></span>
+        <span class="stool taken" title="taken"></span>
+        <span class="stool free" title="free"></span>
+        <span class="stool taken" title="taken"></span>
+        <span class="stool taken" title="taken"></span>
+        <span class="stool taken" title="taken"></span>
+        <span class="stool free" title="free"></span>
+        <span class="stool taken" title="taken"></span>
+        <span class="stool free" title="free"></span>
+        <span class="stool taken" title="taken"></span>
+        <span class="stool taken" title="taken"></span>
+        <span class="stool free" title="free"></span>
+      </div>
+      <div class="counter-shelf"></div>
+      <div class="seat-readout">
+        <span class="big-count">8/12</span>
+        <span class="readout-label">SEATS TAKEN</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="hours-section" id="booths">
+  <div class="wrap">
+    <div class="sec-head">
+      <h2>Hours &amp; Booths</h2>
+    </div>
+    <div class="card-row">
+      <article class="card hours-card">
+        <div class="card-kicker">HOURS</div>
+        <div class="card-big">24 / 7</div>
+        <div class="card-body">
+          The grill has been on since 1967. The lights have been on since 1967.
+          Nobody flips the OPEN sign &mdash; it stays.
+        </div>
+      </article>
+      <article class="card phone-card">
+        <div class="card-kicker">PHONE</div>
+        <div class="card-big">555&middot;0167</div>
+        <div class="card-body">
+          Rotary dial behind the register. We answer in two rings or not at all.
+          Pickup orders only after 11 PM.
+        </div>
+      </article>
+      <article class="card booths-card">
+        <div class="card-kicker">BOOTHS</div>
+        <div class="card-big">6 ONLY</div>
+        <div class="card-body">
+          No reservations. Six red-vinyl booths along the window, twelve stools at the counter.
+          Coffee comes when you sit down.
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/diner-counter/templates/page.html
+++ b/examples/diner-counter/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/diner-counter/templates/section.html
+++ b/examples/diner-counter/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<section class="specials">
+  <div class="wrap">
+    <div class="sec-head">
+      {% if page.title is present %}<h2>{{ page.title | e }}</h2>{% endif %}
+    </div>
+    <article class="prose">
+      {{ content | safe }}
+    </article>
+    <div class="plate-grid">
+      {% for post in section.pages %}
+      <article class="plate">
+        <div class="day">{{ post.date | date(format="%b") | upper }}</div>
+        <div class="dish-name"><a href="{{ post.url }}">{{ post.title | e }}</a></div>
+        <div class="dish-side">{{ post.date | date(format="%Y &middot; %m / %d") }}</div>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/diner-counter/templates/shortcodes/alert.html
+++ b/examples/diner-counter/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 2px solid #1a1a1a; background-color: #f6ecca; border-left: 8px solid #b3252b; margin: 1rem 0; font-family: 'IBM Plex Mono', monospace;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/diner-counter/templates/taxonomy.html
+++ b/examples/diner-counter/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p>// Index of dishes &amp; stories from the counter.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/diner-counter/templates/taxonomy_term.html
+++ b/examples/diner-counter/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p>// Plated under this label.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/gridfield-mfg/AGENTS.md
+++ b/examples/gridfield-mfg/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/gridfield-mfg/archetypes/default.md
+++ b/examples/gridfield-mfg/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/gridfield-mfg/config.toml
+++ b/examples/gridfield-mfg/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "GRIDFIELD MFG"
+description = "Gridfield Manufacturing Co. — an industrial parts catalog for precision-machined fasteners, jigs, and brackets. Built for engineers who order in singles."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/gridfield-mfg/content/about.md
+++ b/examples/gridfield-mfg/content/about.md
@@ -1,0 +1,50 @@
++++
+title = "About the Shop"
+description = "Gridfield Mfg — the shop, the materials, the tolerance classes, ordering, and returns."
++++
+
+## The shop
+
+Gridfield Mfg Co. is a two-floor shop in Lot 14 of the Cheonan industrial belt. We run **four CNC mills, three lathes, one wire-EDM**, and one very old Swiss-type that refuses to die. The catalog you see here is what we make every week, in singles or thousands, with the same paperwork either way.
+
+We are engineers who got tired of MOQ-of-500. So we print the drawing, machine the part, stamp the lot, and ship it. No reseller markup, no rebrand, no chrome-plated nonsense.
+
+## Materials we stock
+
+- **C1018 cold-rolled steel** — the everyday bracket stock.
+- **304 / 316 stainless** — for anything that gets wet or salty.
+- **6061-T6 aluminum** — light, machinable, anodizes evenly.
+- **Brass 360** — for fasteners that need to look like they belong.
+- **A2 / D2 tool steel** — for jigs, punches, and parts under shock load.
+
+Every lot ships with a **certificate of conformance** referencing the material heat number and the inspection sheet.
+
+## Tolerance classes we cut to
+
+We hold to **ISO 286** shaft and hole tolerances. Most catalog parts are cut to **h6** (general) or **k6** (transition). Press-fit pins are **p6**. If you need tighter than h5, mail us — we'll quote it as a custom job and we will be honest about whether the machine can hold it.
+
+| Class | Use | Typical range |
+| :---- | :-- | :------------ |
+| h6 | General sliding fit | 0 / -8 µm |
+| k6 | Transition fit | +2 / +13 µm |
+| p6 | Press fit | +15 / +28 µm |
+| H7 | Reamed hole | +0 / +21 µm |
+| H8 | Standard bored hole | +0 / +33 µm |
+
+## How to order
+
+1. **Pick a part number from the catalog.** Every part has a sheet on file — drawing, material, finish, tolerance class.
+2. **Quantity is yours.** One piece, ten, ten thousand. The price per piece on the catalog card is the price per piece, full stop. No setup fee for catalog parts.
+3. **Pay by wire or card.** We invoice the same day we ship.
+4. **Lead time is on the card.** "REV C / 5 days" means the part is at revision C and we will hand it to the courier inside five working days. We've missed twice in nine years; both times we wrote you a paper apology.
+
+## Returns
+
+If the part doesn't match the drawing, send it back. We pay the freight, we cut you a new one, and we eat the scrap. We do not accept returns on parts that meet the drawing but don't fit your assembly — that's a redesign, not a return, and we'll happily quote the redesign.
+
+## How to reach us
+
+- **Order desk** — `desk@gridfield.mfg`
+- **Engineering** — `eng@gridfield.mfg`
+- **Phone** — 041-555-0140, 09:00 to 17:00 KST, weekdays
+- **Walk-in** — Lot 14, Cheonan. Coffee on the bench.

--- a/examples/gridfield-mfg/content/index.md
+++ b/examples/gridfield-mfg/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Gridfield Mfg Co. — precision fasteners, jigs, and brackets. Singles welcome."
+template = "index"
++++

--- a/examples/gridfield-mfg/static/css/style.css
+++ b/examples/gridfield-mfg/static/css/style.css
@@ -1,0 +1,658 @@
+/* =============================================================================
+   GRIDFIELD MFG CO. — blueprint annotation aesthetic
+   Solid palette only. No gradients. No emojis. No glassy cards.
+   ============================================================================= */
+
+:root {
+  --blueprint:       #0e3a66;
+  --blueprint-deep:  #06223f;
+  --white-line:      #f0f5fb;
+  --chalk-50:        rgba(240, 245, 251, 0.5);
+  --chalk-30:        rgba(240, 245, 251, 0.3);
+  --chalk-15:        rgba(240, 245, 251, 0.15);
+  --alert-orange:    #ff8c1a;
+  --alert-orange-deep: #c66400;
+  --spec-cream:      #f4ecd2;
+
+  --font-display: "Inter Tight", system-ui, sans-serif;
+  --font-mono:    "IBM Plex Mono", ui-monospace, monospace;
+  --font-stencil: "Major Mono Display", "IBM Plex Mono", monospace;
+
+  --grid-step: 40px;
+  --max: 1320px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--blueprint);
+  color: var(--white-line);
+  font-family: var(--font-display);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* SVG-tile grid background — NOT a CSS gradient. A 40px square tile with
+   one 1px stroke at top and one at left, painted in chalk-50 white. */
+body {
+  background-color: var(--blueprint);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'><path d='M0 0 L40 0 M0 0 L0 40' stroke='%23f0f5fb' stroke-opacity='0.18' stroke-width='1'/><path d='M20 0 L20 40 M0 20 L40 20' stroke='%23f0f5fb' stroke-opacity='0.07' stroke-width='1'/></svg>");
+  background-repeat: repeat;
+}
+
+a { color: var(--white-line); text-decoration: none; }
+a:hover { color: var(--alert-orange); }
+
+/* =============================================================================
+   STRIP TOP
+   ============================================================================= */
+.strip-top {
+  border-bottom: 1px solid var(--white-line);
+  background-color: var(--blueprint-deep);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.strip-inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 14px 28px;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 28px;
+}
+
+.brand {
+  color: var(--white-line);
+}
+.brand-mark {
+  font-family: var(--font-stencil);
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  margin-right: 4px;
+}
+.strip-sep { color: var(--chalk-50); margin: 0 4px; }
+
+.strip-nav { display: flex; gap: 22px; }
+.strip-nav a { color: var(--white-line); }
+.strip-nav a:hover { color: var(--alert-orange); }
+
+.rev-stamp {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--alert-orange);
+  color: var(--alert-orange);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+}
+.rev-label { color: var(--alert-orange); }
+.rev-value {
+  font-family: var(--font-stencil);
+  font-size: 15px;
+  color: var(--alert-orange);
+}
+.rev-date { color: var(--alert-orange-deep); font-size: 10px; }
+
+/* =============================================================================
+   HERO
+   ============================================================================= */
+.hero {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 64px 28px 96px;
+  border-bottom: 1px solid var(--chalk-30);
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 64px;
+  align-items: start;
+}
+
+.hero-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--chalk-50);
+  margin-bottom: 28px;
+}
+.tag-dot {
+  width: 8px;
+  height: 8px;
+  background-color: var(--alert-orange);
+  display: inline-block;
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-stretch: 75%;
+  font-size: clamp(56px, 9vw, 132px);
+  line-height: 0.92;
+  letter-spacing: -0.02em;
+  margin: 0 0 36px;
+  text-transform: uppercase;
+}
+.hero-title .line { display: block; }
+.hero-title .slash {
+  color: var(--alert-orange);
+  font-weight: 500;
+  font-size: 0.9em;
+  line-height: 0.5;
+  margin: 0;
+  letter-spacing: 0;
+}
+
+.hero-lede {
+  max-width: 440px;
+  font-family: var(--font-display);
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--white-line);
+  margin: 0 0 36px;
+}
+
+.legend {
+  border: 1px solid var(--white-line);
+  background-color: var(--blueprint-deep);
+  margin-bottom: 36px;
+  max-width: 460px;
+}
+.legend-row {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  border-bottom: 1px solid var(--chalk-30);
+}
+.legend-row:last-child { border-bottom: 0; }
+.legend-key {
+  padding: 10px 14px;
+  border-right: 1px solid var(--chalk-30);
+  color: var(--chalk-50);
+  text-transform: uppercase;
+}
+.legend-val {
+  padding: 10px 14px;
+  color: var(--white-line);
+  text-transform: uppercase;
+}
+
+.hero-ctas {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.ctlink {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 14px 18px;
+  border: 1px solid var(--alert-orange);
+  color: var(--alert-orange);
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  background-color: transparent;
+}
+.ctlink:hover {
+  background-color: var(--alert-orange);
+  color: var(--blueprint-deep);
+}
+.ctlink.alt {
+  border-color: var(--white-line);
+  color: var(--white-line);
+}
+.ctlink.alt:hover {
+  background-color: var(--white-line);
+  color: var(--blueprint-deep);
+}
+.ctlink .arr { font-family: var(--font-mono); font-size: 12px; }
+
+.hero-drawing {
+  color: var(--white-line);
+  border: 1px solid var(--chalk-30);
+  background-color: var(--blueprint-deep);
+  padding: 8px;
+}
+.iso-bolt { display: block; width: 100%; height: auto; color: var(--white-line); }
+.dim-cream { fill: var(--spec-cream); }
+
+/* =============================================================================
+   SECTION HEADS
+   ============================================================================= */
+.section-head {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 64px 28px 32px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: 28px;
+  border-top: 1px solid var(--chalk-30);
+}
+.sh-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--alert-orange);
+  margin-bottom: 14px;
+}
+.sh-title {
+  font-family: var(--font-display);
+  font-size: clamp(36px, 5vw, 64px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  margin: 0;
+}
+.sh-right {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--chalk-50);
+}
+
+/* =============================================================================
+   CATALOG CARDS
+   ============================================================================= */
+.catalog {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 28px 96px;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+}
+
+.card {
+  border: 1px solid var(--white-line);
+  background-color: var(--blueprint-deep);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  color: var(--white-line);
+}
+.card-drawing {
+  border-bottom: 1px solid var(--chalk-30);
+  padding: 16px;
+  color: var(--white-line);
+}
+.card-drawing svg { display: block; width: 100%; height: auto; color: var(--white-line); }
+
+.card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.part-no {
+  font-family: var(--font-stencil);
+  font-size: 14px;
+  color: var(--white-line);
+  letter-spacing: 0.16em;
+}
+.card-rev {
+  color: var(--alert-orange);
+  border: 1px solid var(--alert-orange);
+  padding: 2px 8px;
+  font-size: 10px;
+}
+
+.card-name {
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 4px 16px 14px;
+  line-height: 1.2;
+}
+
+.card-specs {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--chalk-30);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+.card-specs > div {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 14px;
+  border-right: 1px solid var(--chalk-30);
+  border-bottom: 1px solid var(--chalk-30);
+}
+.card-specs > div:nth-child(2n) { border-right: 0; }
+.card-specs > div:nth-last-child(-n+2) { border-bottom: 0; }
+.card-specs dt {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--chalk-50);
+  text-transform: uppercase;
+  margin: 0 0 4px;
+}
+.card-specs dd {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--white-line);
+}
+
+/* =============================================================================
+   TOLERANCE & FINISH
+   ============================================================================= */
+.tol {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 28px 96px;
+}
+
+.tol-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+  align-items: stretch;
+}
+.tol-diagram {
+  border: 1px solid var(--white-line);
+  background-color: var(--blueprint-deep);
+  padding: 16px;
+  color: var(--white-line);
+}
+.tol-diagram svg { display: block; width: 100%; height: auto; color: var(--white-line); }
+
+.tol-table-wrap {
+  border: 1px solid var(--white-line);
+  background-color: var(--blueprint-deep);
+  padding: 0;
+}
+.tol-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+.tol-table thead th {
+  text-align: left;
+  padding: 14px 16px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--alert-orange);
+  border-bottom: 1px solid var(--white-line);
+  background-color: var(--blueprint);
+}
+.tol-table tbody td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--chalk-30);
+  color: var(--white-line);
+}
+.tol-table tr:last-child td { border-bottom: 0; }
+.tol-table .cls {
+  font-family: var(--font-stencil);
+  letter-spacing: 0.18em;
+  color: var(--white-line);
+}
+.tol-table tr.hot td {
+  background-color: var(--spec-cream);
+  color: var(--blueprint-deep);
+}
+.tol-table tr.hot .cls { color: var(--alert-orange-deep); }
+.tol-note {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--chalk-50);
+  padding: 14px 16px;
+  border-top: 1px solid var(--chalk-30);
+  margin: 0;
+}
+
+/* =============================================================================
+   DRAWING INDEX
+   ============================================================================= */
+.drawings {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 28px 96px;
+}
+
+.dwg-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--white-line);
+  background-color: var(--blueprint-deep);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+.dwg-table thead th {
+  text-align: left;
+  padding: 14px 18px;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--alert-orange);
+  border-bottom: 1px solid var(--white-line);
+}
+.dwg-table tbody td {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--chalk-30);
+  color: var(--white-line);
+}
+.dwg-table tr:last-child td { border-bottom: 0; }
+.dwg-table .pn {
+  font-family: var(--font-stencil);
+  letter-spacing: 0.16em;
+  color: var(--white-line);
+}
+.dwg-table tbody tr:hover td { background-color: var(--blueprint); }
+.dwg-table a { color: var(--alert-orange); }
+
+/* =============================================================================
+   TITLE BLOCK (FOOTER)
+   ============================================================================= */
+.title-block {
+  max-width: var(--max);
+  margin: 0 auto 48px;
+  padding: 0 28px;
+}
+.tb-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr 1fr 0.6fr;
+  border: 1px solid var(--white-line);
+  background-color: var(--blueprint-deep);
+}
+.tb-cell {
+  padding: 14px 16px;
+  border-right: 1px solid var(--white-line);
+}
+.tb-cell:last-child { border-right: 0; }
+.tb-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--chalk-50);
+  margin-bottom: 6px;
+}
+.tb-value {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--white-line);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.tb-name .tb-value {
+  font-family: var(--font-stencil);
+  letter-spacing: 0.16em;
+}
+.tb-rev .tb-value {
+  font-family: var(--font-stencil);
+  font-size: 22px;
+  color: var(--alert-orange);
+  letter-spacing: 0.18em;
+}
+.tb-bottom {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--chalk-50);
+}
+
+/* =============================================================================
+   PROSE (about, taxonomy, 404)
+   ============================================================================= */
+.prose {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 64px 28px 96px;
+  color: var(--white-line);
+}
+.prose-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--alert-orange);
+  margin-bottom: 14px;
+}
+.prose h1 {
+  font-family: var(--font-display);
+  font-size: clamp(40px, 5vw, 64px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.04;
+  margin: 0 0 32px;
+}
+.prose h2 {
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 56px 0 18px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--chalk-30);
+}
+.prose h3 {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin: 32px 0 12px;
+  color: var(--alert-orange);
+}
+.prose p {
+  font-size: 16px;
+  line-height: 1.65;
+  margin: 0 0 18px;
+}
+.prose strong { color: var(--alert-orange); font-weight: 600; }
+.prose em { font-style: normal; color: var(--spec-cream); }
+.prose a { color: var(--alert-orange); border-bottom: 1px solid var(--alert-orange); }
+.prose a:hover { color: var(--white-line); border-color: var(--white-line); }
+.prose ul, .prose ol { padding-left: 22px; margin: 0 0 22px; }
+.prose li { margin-bottom: 8px; line-height: 1.55; }
+.prose blockquote {
+  border-left: 2px solid var(--alert-orange);
+  background-color: var(--spec-cream);
+  color: var(--blueprint-deep);
+  padding: 16px 20px;
+  margin: 24px 0;
+  font-family: var(--font-mono);
+  font-size: 14px;
+}
+.prose blockquote p { margin: 0; }
+.prose code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background-color: var(--blueprint-deep);
+  padding: 2px 6px;
+  border: 1px solid var(--chalk-30);
+  color: var(--spec-cream);
+}
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 24px 0;
+  border: 1px solid var(--white-line);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+.prose th, .prose td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--chalk-30);
+  border-right: 1px solid var(--chalk-30);
+  text-align: left;
+}
+.prose th {
+  color: var(--alert-orange);
+  background-color: var(--blueprint-deep);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 11px;
+}
+.prose tr:last-child td { border-bottom: 0; }
+.prose th:last-child, .prose td:last-child { border-right: 0; }
+
+/* =============================================================================
+   RESPONSIVE
+   ============================================================================= */
+@media (max-width: 1024px) {
+  .hero-grid { grid-template-columns: 1fr; gap: 40px; }
+  .cards { grid-template-columns: repeat(2, 1fr); }
+  .tol-grid { grid-template-columns: 1fr; }
+  .tb-grid { grid-template-columns: 1fr 1fr 1fr; }
+  .tb-cell { border-bottom: 1px solid var(--white-line); }
+  .tb-cell:nth-child(3n) { border-right: 0; }
+}
+
+@media (max-width: 640px) {
+  .strip-inner {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    text-align: center;
+  }
+  .strip-nav { justify-content: center; flex-wrap: wrap; gap: 14px; }
+  .rev-stamp { justify-self: center; }
+  .hero { padding: 40px 18px 64px; }
+  .hero-title { font-size: 56px; }
+  .section-head { padding: 48px 18px 24px; }
+  .catalog, .tol, .drawings { padding: 0 18px 64px; }
+  .cards { grid-template-columns: 1fr; }
+  .tb-grid { grid-template-columns: 1fr 1fr; }
+  .tb-cell:nth-child(3n) { border-right: 1px solid var(--white-line); }
+  .tb-cell:nth-child(2n) { border-right: 0; }
+  .prose { padding: 40px 18px 64px; }
+  .tb-bottom { flex-direction: column; gap: 8px; }
+}

--- a/examples/gridfield-mfg/static/favicon.svg
+++ b/examples/gridfield-mfg/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0e3a66"/>
+  <g fill="none" stroke="#f0f5fb" stroke-width="1.2">
+    <rect x="4.5" y="4.5" width="23" height="23"/>
+    <line x1="4.5" y1="16" x2="27.5" y2="16"/>
+    <line x1="16" y1="4.5" x2="16" y2="27.5"/>
+    <circle cx="16" cy="16" r="4"/>
+  </g>
+  <rect x="14" y="14" width="4" height="4" fill="#ff8c1a"/>
+</svg>

--- a/examples/gridfield-mfg/templates/404.html
+++ b/examples/gridfield-mfg/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-eyebrow">SHEET 404 / NOT ON FILE</div>
+  <h1>404 &mdash; drawing not on file.</h1>
+  <p>This sheet isn't in the archive. It may have been superseded by a later revision, scrapped on the floor, or it simply never existed. Walk back to the catalog and try the part number again.</p>
+  <p><a href="{{ base_url }}/">&laquo; back to the catalog</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/gridfield-mfg/templates/footer.html
+++ b/examples/gridfield-mfg/templates/footer.html
@@ -1,0 +1,36 @@
+  <footer class="title-block">
+    <div class="tb-grid">
+      <div class="tb-cell tb-name">
+        <div class="tb-label">DRAWING</div>
+        <div class="tb-value">GRIDFIELD MFG CO. &mdash; CATALOG INDEX</div>
+      </div>
+      <div class="tb-cell">
+        <div class="tb-label">DRAWN BY</div>
+        <div class="tb-value">M. HEO</div>
+      </div>
+      <div class="tb-cell">
+        <div class="tb-label">DATE</div>
+        <div class="tb-value">{{ current_year }}.04.14</div>
+      </div>
+      <div class="tb-cell">
+        <div class="tb-label">SCALE</div>
+        <div class="tb-value">1 : 1</div>
+      </div>
+      <div class="tb-cell">
+        <div class="tb-label">SHEET</div>
+        <div class="tb-value">1 OF 1</div>
+      </div>
+      <div class="tb-cell tb-rev">
+        <div class="tb-label">REV</div>
+        <div class="tb-value">C</div>
+      </div>
+    </div>
+    <div class="tb-bottom">
+      <span>GRIDFIELD MFG. &copy; {{ current_year }} &mdash; DIMENSIONS IN MM</span>
+      <span class="tb-meta">LOT 14 &middot; CHEONAN &middot; KR &mdash; desk@gridfield.mfg</span>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/gridfield-mfg/templates/header.html
+++ b/examples/gridfield-mfg/templates/header.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&family=Major+Mono+Display&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <div class="strip-inner">
+      <a class="brand" href="{{ base_url }}/"><span class="brand-mark">GRIDFIELD MFG CO.</span> <span class="strip-sep">&middot;</span> PRECISION FASTENERS <span class="strip-sep">&middot;</span> LOT 14</a>
+      <nav class="strip-nav">
+        <a href="{{ base_url }}/">Catalog</a>
+        <a href="#drawings">Drawings</a>
+        <a href="#specs">Specs</a>
+        <a href="{{ base_url }}/about/">Order Desk</a>
+      </nav>
+      <div class="rev-stamp">
+        <span class="rev-label">REV</span>
+        <span class="rev-value">C</span>
+        <span class="rev-date">{{ current_year }}.04</span>
+      </div>
+    </div>
+  </header>

--- a/examples/gridfield-mfg/templates/index.html
+++ b/examples/gridfield-mfg/templates/index.html
@@ -1,0 +1,506 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="hero-grid">
+    <div class="hero-text">
+      <div class="hero-tag">
+        <span class="tag-dot"></span>
+        <span>SHEET 01 / FASTENER FAMILY / HEX-CAP SERIES</span>
+      </div>
+      <h1 class="hero-title">
+        <span class="line">FASTEN</span>
+        <span class="line slash">/</span>
+        <span class="line">WHAT MATTERS.</span>
+      </h1>
+      <p class="hero-lede">Catalog parts for engineers who order in singles. Every piece comes with the drawing, the cert, and the inspection sheet. No reseller markup, no MOQ.</p>
+
+      <div class="legend">
+        <div class="legend-row"><span class="legend-key">MATERIAL</span><span class="legend-val">A2-70 / 304SS</span></div>
+        <div class="legend-row"><span class="legend-key">THREAD</span><span class="legend-val">M10 &times; 1.5 &mdash; 6g</span></div>
+        <div class="legend-row"><span class="legend-key">FINISH</span><span class="legend-val">PASSIVATED &middot; MATTE</span></div>
+        <div class="legend-row"><span class="legend-key">TOLERANCE</span><span class="legend-val">h6 / ISO 286</span></div>
+        <div class="legend-row"><span class="legend-key">STANDARD</span><span class="legend-val">DIN 933 / ISO 4017</span></div>
+      </div>
+
+      <div class="hero-ctas">
+        <a class="ctlink" href="#catalog">VIEW CATALOG <span class="arr">&rarr;</span></a>
+        <a class="ctlink alt" href="{{ base_url }}/about/">ORDER DESK <span class="arr">&rarr;</span></a>
+      </div>
+    </div>
+
+    <div class="hero-drawing">
+      <svg class="iso-bolt" viewBox="0 0 560 520" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+          <!-- isometric hex bolt head -->
+          <!-- top hex face -->
+          <polygon points="240,80 320,80 360,140 320,200 240,200 200,140"/>
+          <line x1="200" y1="140" x2="360" y2="140"/>
+          <line x1="240" y1="80"  x2="320" y2="200"/>
+          <line x1="320" y1="80"  x2="240" y2="200"/>
+          <!-- head side (depth) -->
+          <line x1="240" y1="200" x2="240" y2="232"/>
+          <line x1="320" y1="200" x2="320" y2="232"/>
+          <line x1="200" y1="140" x2="200" y2="172"/>
+          <line x1="360" y1="140" x2="360" y2="172"/>
+          <path d="M200,172 L240,232 L320,232 L360,172"/>
+          <!-- flange under head -->
+          <ellipse cx="280" cy="248" rx="110" ry="22"/>
+          <line x1="170" y1="248" x2="170" y2="260"/>
+          <line x1="390" y1="248" x2="390" y2="260"/>
+          <path d="M170,260 Q280,290 390,260"/>
+          <!-- shank -->
+          <line x1="240" y1="270" x2="240" y2="430"/>
+          <line x1="320" y1="270" x2="320" y2="430"/>
+          <!-- thread lines -->
+          <line x1="240" y1="296" x2="320" y2="304"/>
+          <line x1="240" y1="312" x2="320" y2="320"/>
+          <line x1="240" y1="328" x2="320" y2="336"/>
+          <line x1="240" y1="344" x2="320" y2="352"/>
+          <line x1="240" y1="360" x2="320" y2="368"/>
+          <line x1="240" y1="376" x2="320" y2="384"/>
+          <line x1="240" y1="392" x2="320" y2="400"/>
+          <line x1="240" y1="408" x2="320" y2="416"/>
+          <!-- chamfered tip -->
+          <path d="M240,430 L260,452 L300,452 L320,430"/>
+
+          <!-- dimension lines -->
+          <!-- length on right -->
+          <line x1="400" y1="80"  x2="440" y2="80"/>
+          <line x1="400" y1="452" x2="440" y2="452"/>
+          <line x1="420" y1="80"  x2="420" y2="452"/>
+          <polygon points="420,80 416,92 424,92" fill="currentColor"/>
+          <polygon points="420,452 416,440 424,440" fill="currentColor"/>
+          <!-- head dia on top -->
+          <line x1="200" y1="60" x2="200" y2="30"/>
+          <line x1="360" y1="60" x2="360" y2="30"/>
+          <line x1="200" y1="42" x2="360" y2="42"/>
+          <polygon points="200,42 212,38 212,46" fill="currentColor"/>
+          <polygon points="360,42 348,38 348,46" fill="currentColor"/>
+          <!-- thread pitch leader -->
+          <line x1="320" y1="340" x2="480" y2="340"/>
+          <line x1="480" y1="340" x2="500" y2="320"/>
+          <circle cx="320" cy="340" r="3" fill="currentColor"/>
+        </g>
+
+        <!-- callouts -->
+        <g font-family="IBM Plex Mono, monospace" font-size="13" fill="currentColor">
+          <text x="446" y="270" letter-spacing="1">L = 65.0</text>
+          <text x="446" y="288" letter-spacing="1">+0 / -0.30</text>
+          <text x="232" y="22" letter-spacing="1">&#216; D = 16.0</text>
+          <text x="490" y="316" letter-spacing="1">M10 &times; 1.5 &mdash; 6g</text>
+          <text x="60"  y="156" letter-spacing="1" class="dim-cream">REF / SHEET 01</text>
+        </g>
+
+        <!-- part stamp -->
+        <g font-family="Major Mono Display, monospace" font-size="22" fill="currentColor">
+          <text x="60" y="464" letter-spacing="2">gf-2014-a</text>
+        </g>
+        <g font-family="IBM Plex Mono, monospace" font-size="11" fill="currentColor">
+          <text x="60" y="484" letter-spacing="2">HEX-CAP / FLANGE / SS304</text>
+          <text x="60" y="500" letter-spacing="2">DRAWN 04.14 &middot; REV C</text>
+        </g>
+      </svg>
+    </div>
+  </div>
+</section>
+
+<section class="catalog" id="catalog">
+  <div class="section-head">
+    <div class="sh-left">
+      <div class="sh-eyebrow">SHEET 02 / CATALOG</div>
+      <h2 class="sh-title">Catalog &mdash; current stock.</h2>
+    </div>
+    <div class="sh-right">
+      <span>04 ITEMS &middot; SHIPS FROM LOT 14</span>
+    </div>
+  </div>
+
+  <div class="cards">
+    <article class="card">
+      <div class="card-drawing">
+        <svg viewBox="0 0 320 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <!-- L-bracket isometric -->
+            <polygon points="60,150 180,150 220,120 100,120"/>
+            <polygon points="180,150 220,120 220,170 180,200"/>
+            <polygon points="60,150 180,150 180,200 60,200"/>
+            <!-- vertical leg -->
+            <polygon points="100,120 140,120 140,40 100,40"/>
+            <polygon points="140,40 180,20 180,100 140,120"/>
+            <polygon points="100,40 140,40 180,20 140,20"/>
+            <!-- mounting holes -->
+            <ellipse cx="90"  cy="175" rx="6" ry="3"/>
+            <ellipse cx="150" cy="175" rx="6" ry="3"/>
+            <ellipse cx="120" cy="80" rx="4" ry="8"/>
+            <!-- dim lines -->
+            <line x1="60" y1="215" x2="180" y2="215"/>
+            <polygon points="60,215 70,211 70,219" fill="currentColor"/>
+            <polygon points="180,215 170,211 170,219" fill="currentColor"/>
+            <line x1="60" y1="200" x2="60" y2="220"/>
+            <line x1="180" y1="200" x2="180" y2="220"/>
+            <!-- accent on critical hole -->
+          </g>
+          <g class="critical">
+            <circle cx="120" cy="80" r="14" fill="none" stroke="#ff8c1a" stroke-width="1.8"/>
+            <line x1="134" y1="80" x2="250" y2="40" stroke="#ff8c1a" stroke-width="1.4"/>
+            <polygon points="134,80 142,76 142,84" fill="#ff8c1a"/>
+          </g>
+          <g font-family="IBM Plex Mono, monospace" font-size="10" fill="currentColor">
+            <text x="105" y="232">L = 60.0 mm</text>
+            <text x="252" y="44" fill="#ff8c1a">SLOT &#216; 4 &times; 10</text>
+          </g>
+        </svg>
+      </div>
+      <div class="card-meta">
+        <span class="part-no">GF-2014-A</span>
+        <span class="card-rev">REV C</span>
+      </div>
+      <h3 class="card-name">90&deg; mount bracket</h3>
+      <dl class="card-specs">
+        <div><dt>MATL</dt><dd>304SS</dd></div>
+        <div><dt>TOL</dt><dd>h6</dd></div>
+        <div><dt>LEAD</dt><dd>5 days</dd></div>
+        <div><dt>PRICE</dt><dd>14.20 / pc</dd></div>
+      </dl>
+    </article>
+
+    <article class="card">
+      <div class="card-drawing">
+        <svg viewBox="0 0 320 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <!-- dowel pin -->
+            <ellipse cx="60" cy="110" rx="8" ry="20"/>
+            <line x1="60" y1="90" x2="260" y2="90"/>
+            <line x1="60" y1="130" x2="260" y2="130"/>
+            <ellipse cx="260" cy="110" rx="8" ry="20"/>
+            <ellipse cx="260" cy="110" rx="4" ry="10"/>
+            <!-- chamfers -->
+            <line x1="60" y1="95" x2="74" y2="90"/>
+            <line x1="60" y1="125" x2="74" y2="130"/>
+            <line x1="260" y1="95" x2="246" y2="90"/>
+            <line x1="260" y1="125" x2="246" y2="130"/>
+            <!-- dim length -->
+            <line x1="60" y1="160" x2="260" y2="160"/>
+            <polygon points="60,160 72,156 72,164" fill="currentColor"/>
+            <polygon points="260,160 248,156 248,164" fill="currentColor"/>
+            <line x1="60" y1="135" x2="60" y2="170"/>
+            <line x1="260" y1="135" x2="260" y2="170"/>
+            <!-- dia call -->
+            <line x1="160" y1="90" x2="160" y2="40"/>
+            <line x1="160" y1="40" x2="240" y2="40"/>
+          </g>
+          <g class="critical">
+            <line x1="60" y1="90" x2="60" y2="60" stroke="#ff8c1a" stroke-width="1.4"/>
+            <line x1="60" y1="60" x2="20" y2="60" stroke="#ff8c1a" stroke-width="1.4"/>
+            <polygon points="60,90 56,80 64,80" fill="#ff8c1a"/>
+          </g>
+          <g font-family="IBM Plex Mono, monospace" font-size="10" fill="currentColor">
+            <text x="120" y="182">L = 80.0</text>
+            <text x="180" y="32">&#216; 8.000 h6</text>
+            <text x="2" y="52" fill="#ff8c1a">CHAMFER 0.5&times;45&deg;</text>
+          </g>
+        </svg>
+      </div>
+      <div class="card-meta">
+        <span class="part-no">GF-2014-B</span>
+        <span class="card-rev">REV A</span>
+      </div>
+      <h3 class="card-name">Dowel pin &#216;8 &times; 80</h3>
+      <dl class="card-specs">
+        <div><dt>MATL</dt><dd>D2 tool</dd></div>
+        <div><dt>TOL</dt><dd>h6</dd></div>
+        <div><dt>LEAD</dt><dd>3 days</dd></div>
+        <div><dt>PRICE</dt><dd>4.80 / pc</dd></div>
+      </dl>
+    </article>
+
+    <article class="card">
+      <div class="card-drawing">
+        <svg viewBox="0 0 320 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <!-- knurled thumbscrew -->
+            <ellipse cx="100" cy="60" rx="40" ry="14"/>
+            <line x1="60" y1="60" x2="60" y2="90"/>
+            <line x1="140" y1="60" x2="140" y2="90"/>
+            <path d="M60,90 Q100,104 140,90"/>
+            <!-- knurl strokes -->
+            <line x1="70" y1="64" x2="70" y2="86"/>
+            <line x1="82" y1="62" x2="82" y2="88"/>
+            <line x1="94" y1="60" x2="94" y2="90"/>
+            <line x1="106" y1="60" x2="106" y2="90"/>
+            <line x1="118" y1="62" x2="118" y2="88"/>
+            <line x1="130" y1="64" x2="130" y2="86"/>
+            <!-- shank with thread -->
+            <line x1="88" y1="100" x2="88" y2="190"/>
+            <line x1="112" y1="100" x2="112" y2="190"/>
+            <line x1="88" y1="116" x2="112" y2="118"/>
+            <line x1="88" y1="130" x2="112" y2="132"/>
+            <line x1="88" y1="144" x2="112" y2="146"/>
+            <line x1="88" y1="158" x2="112" y2="160"/>
+            <line x1="88" y1="172" x2="112" y2="174"/>
+            <path d="M88,190 L96,200 L104,200 L112,190"/>
+            <!-- dim -->
+            <line x1="180" y1="60" x2="180" y2="200"/>
+            <polygon points="180,60 176,72 184,72" fill="currentColor"/>
+            <polygon points="180,200 176,188 184,188" fill="currentColor"/>
+            <line x1="140" y1="60" x2="190" y2="60"/>
+            <line x1="112" y1="200" x2="190" y2="200"/>
+          </g>
+          <g class="critical">
+            <rect x="56" y="46" width="88" height="28" fill="none" stroke="#ff8c1a" stroke-width="1.6"/>
+            <line x1="144" y1="46" x2="240" y2="20" stroke="#ff8c1a" stroke-width="1.4"/>
+          </g>
+          <g font-family="IBM Plex Mono, monospace" font-size="10" fill="currentColor">
+            <text x="200" y="134">L = 32.0</text>
+            <text x="200" y="148">M6 &times; 1.0</text>
+            <text x="200" y="24" fill="#ff8c1a">KNURL 0.8 / DIAMOND</text>
+          </g>
+        </svg>
+      </div>
+      <div class="card-meta">
+        <span class="part-no">GF-2014-C</span>
+        <span class="card-rev">REV B</span>
+      </div>
+      <h3 class="card-name">Knurled thumbscrew M6</h3>
+      <dl class="card-specs">
+        <div><dt>MATL</dt><dd>Brass 360</dd></div>
+        <div><dt>TOL</dt><dd>6g</dd></div>
+        <div><dt>LEAD</dt><dd>7 days</dd></div>
+        <div><dt>PRICE</dt><dd>9.60 / pc</dd></div>
+      </dl>
+    </article>
+
+    <article class="card">
+      <div class="card-drawing">
+        <svg viewBox="0 0 320 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <!-- jig plate -->
+            <polygon points="40,140 220,140 260,110 80,110"/>
+            <polygon points="220,140 260,110 260,170 220,200"/>
+            <polygon points="40,140 220,140 220,200 40,200"/>
+            <!-- bushing holes -->
+            <ellipse cx="80" cy="170" rx="10" ry="5"/>
+            <ellipse cx="120" cy="170" rx="10" ry="5"/>
+            <ellipse cx="160" cy="170" rx="10" ry="5"/>
+            <ellipse cx="200" cy="170" rx="10" ry="5"/>
+            <ellipse cx="80" cy="170" rx="5" ry="2.5"/>
+            <ellipse cx="120" cy="170" rx="5" ry="2.5"/>
+            <ellipse cx="160" cy="170" rx="5" ry="2.5"/>
+            <ellipse cx="200" cy="170" rx="5" ry="2.5"/>
+            <!-- centerline -->
+            <line x1="40" y1="170" x2="220" y2="170" stroke-dasharray="4 4"/>
+            <!-- dim -->
+            <line x1="40" y1="215" x2="220" y2="215"/>
+            <polygon points="40,215 52,211 52,219" fill="currentColor"/>
+            <polygon points="220,215 208,211 208,219" fill="currentColor"/>
+            <line x1="40" y1="200" x2="40" y2="220"/>
+            <line x1="220" y1="200" x2="220" y2="220"/>
+          </g>
+          <g class="critical">
+            <circle cx="160" cy="170" r="14" fill="none" stroke="#ff8c1a" stroke-width="1.6"/>
+            <line x1="174" y1="170" x2="280" y2="200" stroke="#ff8c1a" stroke-width="1.4"/>
+          </g>
+          <g font-family="IBM Plex Mono, monospace" font-size="10" fill="currentColor">
+            <text x="80" y="232">L = 180.0</text>
+            <text x="84" y="106">P = 40.0 &middot; 4&times;</text>
+            <text x="216" y="216" fill="#ff8c1a">BUSH H7 PRESS-FIT</text>
+          </g>
+        </svg>
+      </div>
+      <div class="card-meta">
+        <span class="part-no">GF-2014-D</span>
+        <span class="card-rev">REV C</span>
+      </div>
+      <h3 class="card-name">Drill jig &mdash; 4-bush</h3>
+      <dl class="card-specs">
+        <div><dt>MATL</dt><dd>A2 tool</dd></div>
+        <div><dt>TOL</dt><dd>H7 / p6</dd></div>
+        <div><dt>LEAD</dt><dd>10 days</dd></div>
+        <div><dt>PRICE</dt><dd>180.00 / pc</dd></div>
+      </dl>
+    </article>
+  </div>
+</section>
+
+<section class="tol" id="specs">
+  <div class="section-head">
+    <div class="sh-left">
+      <div class="sh-eyebrow">SHEET 03 / TOLERANCE &amp; FINISH</div>
+      <h2 class="sh-title">Tolerance &amp; finish.</h2>
+    </div>
+    <div class="sh-right">
+      <span>ISO 286 &middot; SHAFT / HOLE</span>
+    </div>
+  </div>
+
+  <div class="tol-grid">
+    <div class="tol-diagram">
+      <svg viewBox="0 0 540 360" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+          <!-- nominal shaft -->
+          <line x1="40" y1="200" x2="500" y2="200" stroke-dasharray="6 6"/>
+          <!-- shaft profile -->
+          <line x1="80" y1="160" x2="460" y2="160"/>
+          <line x1="80" y1="240" x2="460" y2="240"/>
+          <line x1="80" y1="160" x2="80" y2="240"/>
+          <line x1="460" y1="160" x2="460" y2="240"/>
+          <!-- chamfers -->
+          <line x1="80" y1="160" x2="92" y2="170"/>
+          <line x1="80" y1="240" x2="92" y2="230"/>
+          <line x1="460" y1="160" x2="448" y2="170"/>
+          <line x1="460" y1="240" x2="448" y2="230"/>
+          <!-- tolerance zone -->
+          <line x1="80" y1="154" x2="460" y2="154" stroke-dasharray="3 3"/>
+          <line x1="80" y1="246" x2="460" y2="246" stroke-dasharray="3 3"/>
+          <!-- length dim -->
+          <line x1="80" y1="290" x2="460" y2="290"/>
+          <polygon points="80,290 94,284 94,296" fill="currentColor"/>
+          <polygon points="460,290 446,284 446,296" fill="currentColor"/>
+          <line x1="80" y1="240" x2="80" y2="300"/>
+          <line x1="460" y1="240" x2="460" y2="300"/>
+          <!-- dia dim -->
+          <line x1="500" y1="160" x2="520" y2="160"/>
+          <line x1="500" y1="240" x2="520" y2="240"/>
+          <line x1="510" y1="160" x2="510" y2="240"/>
+          <polygon points="510,160 506,172 514,172" fill="currentColor"/>
+          <polygon points="510,240 506,228 514,228" fill="currentColor"/>
+          <!-- centerline marks -->
+          <circle cx="270" cy="200" r="3" fill="currentColor"/>
+          <line x1="266" y1="200" x2="274" y2="200"/>
+          <line x1="270" y1="196" x2="270" y2="204"/>
+        </g>
+        <g class="critical">
+          <line x1="80" y1="154" x2="40" y2="120" stroke="#ff8c1a" stroke-width="1.4"/>
+          <line x1="460" y1="246" x2="500" y2="320" stroke="#ff8c1a" stroke-width="1.4"/>
+        </g>
+        <g font-family="IBM Plex Mono, monospace" font-size="13" fill="currentColor">
+          <text x="160" y="310" letter-spacing="1">L = 120.00 &plusmn; 0.05</text>
+          <text x="524" y="204" letter-spacing="1">&#216; 25</text>
+          <text x="200" y="148" letter-spacing="1">TOL ZONE / 0.013 mm</text>
+        </g>
+        <g font-family="IBM Plex Mono, monospace" font-size="11" fill="#ff8c1a">
+          <text x="6" y="116">UPPER LIMIT</text>
+          <text x="430" y="338">LOWER LIMIT</text>
+        </g>
+        <g font-family="Major Mono Display, monospace" font-size="14" fill="currentColor">
+          <text x="40" y="40" letter-spacing="2">tol-25h6</text>
+        </g>
+      </svg>
+    </div>
+
+    <div class="tol-table-wrap">
+      <table class="tol-table">
+        <thead>
+          <tr>
+            <th>Class</th>
+            <th>Use</th>
+            <th>Upper &micro;m</th>
+            <th>Lower &micro;m</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="cls">h5</td>
+            <td>Sliding fit, light load</td>
+            <td>0</td>
+            <td>&minus;6</td>
+          </tr>
+          <tr>
+            <td class="cls">h6</td>
+            <td>General sliding fit</td>
+            <td>0</td>
+            <td>&minus;13</td>
+          </tr>
+          <tr>
+            <td class="cls">k6</td>
+            <td>Transition fit</td>
+            <td>+2</td>
+            <td>+15</td>
+          </tr>
+          <tr class="hot">
+            <td class="cls">p6</td>
+            <td>Press fit &mdash; dowel pins</td>
+            <td>+22</td>
+            <td>+35</td>
+          </tr>
+          <tr>
+            <td class="cls">H7</td>
+            <td>Reamed hole, mating</td>
+            <td>+21</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td class="cls">H8</td>
+            <td>Bored hole, standard</td>
+            <td>+33</td>
+            <td>0</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="tol-note">Values shown for nominal &#216; 18 &mdash; 30. Other ranges quoted on request. Hold tighter than h5? Call engineering.</p>
+    </div>
+  </div>
+</section>
+
+<section class="drawings" id="drawings">
+  <div class="section-head">
+    <div class="sh-left">
+      <div class="sh-eyebrow">SHEET 04 / DRAWING INDEX</div>
+      <h2 class="sh-title">Drawing index.</h2>
+    </div>
+    <div class="sh-right">
+      <span>FILED &middot; LOT 14 &middot; ARCHIVE</span>
+    </div>
+  </div>
+
+  <table class="dwg-table">
+    <thead>
+      <tr>
+        <th>Part no.</th>
+        <th>Name</th>
+        <th>Sheet</th>
+        <th>Last rev.</th>
+        <th>Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="pn">GF-2014-A</td>
+        <td>90&deg; mount bracket</td>
+        <td>01 / 04</td>
+        <td>REV C</td>
+        <td>{{ current_year }}.04.14</td>
+      </tr>
+      <tr>
+        <td class="pn">GF-2014-B</td>
+        <td>Dowel pin &#216;8 &times; 80</td>
+        <td>02 / 04</td>
+        <td>REV A</td>
+        <td>{{ current_year }}.02.02</td>
+      </tr>
+      <tr>
+        <td class="pn">GF-2014-C</td>
+        <td>Knurled thumbscrew M6</td>
+        <td>03 / 04</td>
+        <td>REV B</td>
+        <td>{{ current_year }}.03.18</td>
+      </tr>
+      <tr>
+        <td class="pn">GF-2014-D</td>
+        <td>Drill jig &mdash; 4-bush</td>
+        <td>04 / 04</td>
+        <td>REV C</td>
+        <td>{{ current_year }}.04.06</td>
+      </tr>
+      <tr>
+        <td class="pn">GF-2013-Z</td>
+        <td>Flanged sleeve, retired</td>
+        <td>&mdash;</td>
+        <td>REV F (final)</td>
+        <td>2024.12.21</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+{% include "footer.html" %}

--- a/examples/gridfield-mfg/templates/page.html
+++ b/examples/gridfield-mfg/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}
+    <div class="prose-eyebrow">SHEET / {{ page.section | default("page") | upper }} / GRIDFIELD MFG</div>
+    <h1>{{ page.title | e }}</h1>
+  {% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/gridfield-mfg/templates/section.html
+++ b/examples/gridfield-mfg/templates/section.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+<section class="drawings">
+  <div class="section-head">
+    <div class="sh-left">
+      {% if page.title is present %}
+        <div class="sh-eyebrow">SHEET / {{ page.title | e | upper }}</div>
+        <h2 class="sh-title">{{ page.title | e }}</h2>
+      {% endif %}
+    </div>
+    <div class="sh-right">
+      <span>FILED &middot; LOT 14</span>
+    </div>
+  </div>
+  {{ content | safe }}
+  {% if section.pages %}
+  <table class="dwg-table">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Title</th>
+        <th>Link</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for post in section.pages %}
+      <tr>
+        <td class="pn">{{ post.date | date(format="%Y.%m.%d") }}</td>
+        <td>{{ post.title | e }}</td>
+        <td><a href="{{ post.url }}">open &rarr;</a></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/gridfield-mfg/templates/shortcodes/alert.html
+++ b/examples/gridfield-mfg/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/gridfield-mfg/templates/taxonomy.html
+++ b/examples/gridfield-mfg/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-eyebrow">SHEET / INDEX</div>
+  <h1>{{ page.title | e }}</h1>
+  <p>// Index of subjects across the drawing archive.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/gridfield-mfg/templates/taxonomy_term.html
+++ b/examples/gridfield-mfg/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-eyebrow">SHEET / FILED UNDER</div>
+  <h1>{{ page.title | e }}</h1>
+  <p>// Entries filed under this stamp.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/gymnasium-bell/AGENTS.md
+++ b/examples/gymnasium-bell/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/gymnasium-bell/archetypes/default.md
+++ b/examples/gymnasium-bell/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/gymnasium-bell/config.toml
+++ b/examples/gymnasium-bell/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "HALL ATHLETIC CO."
+description = "An indoor climbing gym and old-school physical culture club — bouldering, gymnastics rings, kettlebells, hand-balancing. Est. 1924."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/gymnasium-bell/content/about.md
+++ b/examples/gymnasium-bell/content/about.md
@@ -1,0 +1,55 @@
++++
+title = "About the Hall"
+description = "Hall Athletic Co. — the hall, the disciplines, the instructor lineage, hours, and membership policy."
++++
+
+## The Hall
+
+A converted print-works floor in Seoul's Hapjeong district. Tall sash windows, a wooden vault, hooks for rings drilled into the original 1924 beams. The chalk on the floor is real. The bell on the wall is brass.
+
+We don't pipe in music. The pulley creaks, the chalk hisses, the ropes hum. That is the soundtrack.
+
+## The Disciplines
+
+We teach four. We teach them in order, and we teach them slowly.
+
+- **Bouldering** — V0 through V8. Two 4.5m walls, one slab, one cave. Routes reset on the first Monday of every month, never on a weekend.
+- **Gymnastics Rings** — wooden, 32mm, hung at 2.8m. Support holds, pulls, dips, levers. We do not teach kipping here.
+- **Kettlebells** — Russian girya weights, 8kg through 48kg. Swings, cleans, presses, snatches. One-arm work is the point.
+- **Hand-Balancing** — frog, tuck, straddle, full. Wooden parallettes built by the carpenter on the floor below.
+
+## The Instructor Lineage
+
+The hall has had three head instructors since opening.
+
+1. **Pyo Min-su** (1924 – 1957) — built the original ring frame. The carpentry survives him.
+2. **Cho Han-sol** (1957 – 1998) — codified the Hall progression. Coached the 1972 Olympic gymnastics reserve.
+3. **Im Jun-ho** (1998 – present) — kept the discipline. Added the climbing wall in 2011 and not a thing since.
+
+Every coach on staff has been here at least six years. None of them post.
+
+## Hours
+
+| Day      | Open   | Close  |
+|----------|--------|--------|
+| Mon–Fri  | 06:30  | 22:00  |
+| Sat      | 08:00  | 20:00  |
+| Sun      | 09:00  | 18:00  |
+
+The bell rings at the top of every hour. Class begins on the next chime.
+
+## Membership Policy
+
+> The first session is on us. Walk in, sign the slate, lift the eight. Bring shoes that grip.
+
+- **Drop-In** — single session, all disciplines, no booking. Pay at the desk.
+- **Monthly** — unlimited classes, one guest pass, locker included.
+- **Founding** — annual seat at the long table. Includes the lineage handbook, key to the side door, and a name on the back wall.
+
+Cancellation is in person, with the head instructor, over tea. No forms.
+
+## How to Reach Us
+
+- **Desk** — `desk@hallathletic.co`
+- **Coaching** — `jun-ho@hallathletic.co`
+- **Address** — 14 Yanghwa-ro 6-gil, Mapo-gu, Seoul. The brass bell is on the door.

--- a/examples/gymnasium-bell/content/index.md
+++ b/examples/gymnasium-bell/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Hall Athletic Co. — an indoor climbing gym and old-school physical culture club. Bouldering, rings, kettlebells, hand-balancing. Seoul, since 1924."
+template = "index"
++++

--- a/examples/gymnasium-bell/static/css/style.css
+++ b/examples/gymnasium-bell/static/css/style.css
@@ -1,0 +1,361 @@
+/* =============================================================================
+   HALL ATHLETIC CO. — 1920s Bauhaus gymnasium broadsheet
+   Solid color only. No gradients. No emoji. Hairline rules and heavy blocks.
+   ============================================================================= */
+
+:root {
+  --cream: #efe5cf;
+  --cream-deep: #d8c8a0;
+  --brass: #b97f1d;
+  --plinth: #161210;
+  --ribbon: #c33329;
+  --chalk: #2a4781;
+  --clay: #c45d3a;
+  --shadow: #8a6a3a;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--cream);
+  color: var(--plinth);
+  font-family: "DM Serif Display", "Georgia", serif;
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+a { color: var(--plinth); text-decoration: none; }
+a:hover { color: var(--ribbon); }
+
+/* ------------- top strip ------------- */
+.strip-top {
+  background: var(--plinth);
+  color: var(--cream);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 28px;
+  font-family: "Oswald", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.strip-mark { display: flex; align-items: center; gap: 10px; }
+.strip-mark b { color: var(--cream); font-weight: 600; letter-spacing: 0.18em; }
+.strip-mark .dot { width: 12px; height: 12px; background: var(--brass); border-radius: 50%; }
+.strip-mark .sep { color: var(--brass); }
+.strip-mark .sub { color: var(--cream-deep); }
+.strip-nav { display: flex; gap: 22px; }
+.strip-nav a {
+  color: var(--cream);
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+}
+.strip-nav a:hover { color: var(--cream); border-bottom-color: var(--brass); }
+.brass-rule { height: 3px; background: var(--brass); border-bottom: 1px solid var(--plinth); }
+
+/* ------------- hero ------------- */
+.hero {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr 1fr;
+  border-bottom: 4px solid var(--plinth);
+  min-height: 540px;
+}
+.band { position: relative; padding: 38px 32px; border-right: 2px solid var(--plinth); overflow: hidden; }
+.band:last-child { border-right: 0; }
+.band-left { background: var(--chalk); color: var(--cream); display: flex; align-items: flex-end; justify-content: center; }
+.band-mid { background: var(--cream); }
+.band-right { background: var(--clay); color: var(--cream); display: flex; align-items: flex-end; justify-content: center; }
+.figure, .bell { width: 100%; max-width: 280px; height: auto; display: block; }
+.band-tag {
+  position: absolute; top: 18px; left: 22px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px; letter-spacing: 0.18em;
+  background: var(--plinth); color: var(--cream);
+  padding: 6px 10px;
+}
+.band-tag.right { left: auto; right: 22px; }
+.hero-mark {
+  display: flex; align-items: center; gap: 10px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--plinth);
+  padding-bottom: 10px;
+  border-bottom: 2px solid var(--plinth);
+  margin-bottom: 22px;
+}
+.hero-bullet { width: 14px; height: 14px; background: var(--ribbon); }
+.hero-headline {
+  font-family: "Oswald", sans-serif;
+  font-weight: 700;
+  font-size: clamp(64px, 9vw, 128px);
+  line-height: 0.88;
+  letter-spacing: -0.02em;
+  margin: 0;
+  text-transform: uppercase;
+  color: var(--plinth);
+}
+.hl-line { display: block; }
+.hl-rule { display: block; width: 92%; height: 6px; background: var(--plinth); margin: 8px 0; }
+.hl-form { color: var(--ribbon); font-style: normal; }
+.hero-lede {
+  margin: 26px 0 22px;
+  font-family: "DM Serif Display", serif;
+  font-size: 19px; line-height: 1.45;
+  color: var(--plinth); max-width: 560px;
+}
+.hero-meta {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+  border-top: 2px solid var(--plinth);
+  border-bottom: 2px solid var(--plinth);
+  font-family: "IBM Plex Mono", monospace;
+}
+.hero-meta > div { padding: 10px 12px; border-right: 1px solid var(--plinth); display: flex; flex-direction: column; gap: 4px; }
+.hero-meta > div:last-child { border-right: 0; }
+.hero-meta span { font-size: 10px; letter-spacing: 0.22em; color: var(--shadow); }
+.hero-meta b { font-size: 16px; letter-spacing: 0.08em; color: var(--plinth); }
+
+/* ------------- strip meta ------------- */
+.strip-meta {
+  background: var(--brass); color: var(--plinth);
+  border-top: 2px solid var(--plinth);
+  border-bottom: 2px solid var(--plinth);
+  font-family: "Oswald", sans-serif;
+  letter-spacing: 0.32em; font-size: 14px;
+  text-transform: uppercase; text-align: center;
+  padding: 14px 12px; font-weight: 500;
+}
+
+/* ------------- section heads ------------- */
+.section-head {
+  padding: 60px 28px 28px;
+  max-width: 1280px; margin: 0 auto;
+  border-bottom: 2px solid var(--plinth);
+}
+.head-num { font-family: "IBM Plex Mono", monospace; font-size: 12px; letter-spacing: 0.32em; color: var(--brass); margin-bottom: 14px; }
+.head-title {
+  font-family: "Oswald", sans-serif; font-weight: 700;
+  text-transform: uppercase;
+  font-size: clamp(40px, 5.5vw, 72px);
+  line-height: 0.95; margin: 0 0 10px; letter-spacing: -0.01em;
+}
+.head-title em { font-family: "DM Serif Display", serif; font-style: italic; font-weight: 400; color: var(--ribbon); text-transform: lowercase; }
+.head-sub { font-family: "DM Serif Display", serif; font-size: 18px; margin: 0; color: var(--shadow); font-style: italic; }
+
+/* ------------- disciplines ------------- */
+.disciplines { background: var(--cream); }
+.discipline-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border-top: 2px solid var(--plinth);
+  border-bottom: 4px solid var(--plinth);
+}
+.disc { padding: 28px 22px 32px; border-right: 2px solid var(--plinth); display: flex; flex-direction: column; gap: 14px; min-height: 460px; }
+.disc:last-child { border-right: 0; }
+.disc-climb  { background: var(--cream-deep); }
+.disc-rings  { background: var(--chalk); color: var(--cream); }
+.disc-kettle { background: var(--ribbon); color: var(--cream); }
+.disc-hand   { background: var(--brass); color: var(--plinth); }
+.disc-rings .disc-num, .disc-kettle .disc-num { color: var(--cream); }
+.disc-rings h3, .disc-kettle h3 { color: var(--cream); }
+.disc-fig { width: 100%; max-width: 180px; height: auto; align-self: center; }
+.disc-num { font-family: "IBM Plex Mono", monospace; font-size: 12px; letter-spacing: 0.32em; color: var(--plinth); }
+.disc h3 { font-family: "Oswald", sans-serif; font-weight: 600; text-transform: uppercase; font-size: 32px; letter-spacing: 0.02em; margin: 0; }
+.disc p { font-family: "DM Serif Display", serif; font-size: 15px; line-height: 1.45; margin: 0; }
+.disc-times {
+  margin: auto 0 0;
+  display: grid; grid-template-columns: max-content 1fr;
+  gap: 4px 14px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px; letter-spacing: 0.08em;
+  border-top: 1px solid currentColor; padding-top: 12px;
+}
+.disc-times dt { font-weight: 600; text-transform: uppercase; }
+.disc-times dd { margin: 0; }
+
+/* ------------- schedule ------------- */
+.schedule { background: var(--cream); padding-bottom: 60px; }
+.schedule-table-wrap { max-width: 1280px; margin: 32px auto 0; padding: 0 28px; }
+.schedule-table { width: 100%; border-collapse: collapse; border: 2px solid var(--plinth); background: var(--cream); }
+.schedule-table th, .schedule-table td {
+  border: 1px solid var(--plinth);
+  padding: 14px 16px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 14px; letter-spacing: 0.08em; text-align: left;
+}
+.schedule-table thead th {
+  background: var(--plinth); color: var(--cream);
+  font-family: "Oswald", sans-serif; font-size: 13px;
+  letter-spacing: 0.24em; text-transform: uppercase; font-weight: 600;
+}
+.schedule-table tbody th {
+  background: var(--brass); color: var(--plinth);
+  font-family: "Oswald", sans-serif; font-size: 14px;
+  letter-spacing: 0.2em; text-transform: uppercase; width: 90px;
+}
+.schedule-table tbody tr:nth-child(even) td { background: var(--cream-deep); }
+.th-day { width: 90px; }
+
+/* ------------- manifesto ------------- */
+.manifesto {
+  background: var(--plinth); color: var(--cream);
+  border-top: 4px solid var(--plinth);
+  border-bottom: 4px solid var(--brass);
+  padding: 64px 28px;
+}
+.manifesto-band {
+  max-width: 1180px; margin: 0 auto;
+  border-top: 2px solid var(--brass);
+  border-bottom: 2px solid var(--brass);
+  padding: 36px 0;
+}
+.manifesto-tag { font-family: "IBM Plex Mono", monospace; font-size: 12px; letter-spacing: 0.32em; color: var(--brass); margin-bottom: 18px; }
+.manifesto-text {
+  font-family: "Oswald", sans-serif; font-weight: 700; text-transform: uppercase;
+  font-size: clamp(38px, 6vw, 86px); line-height: 1.02; margin: 0; letter-spacing: -0.005em;
+}
+.m-red { color: var(--ribbon); }
+.m-blue { color: var(--cream-deep); border-bottom: 6px solid var(--brass); }
+.manifesto-sign { font-family: "DM Serif Display", serif; font-style: italic; font-size: 16px; margin-top: 24px; color: var(--cream-deep); }
+
+/* ------------- membership ------------- */
+.membership { background: var(--cream); padding-bottom: 64px; }
+.tier-grid {
+  max-width: 1280px; margin: 36px auto 0; padding: 0 28px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px;
+}
+.tier { border: 4px solid var(--plinth); background: var(--cream); padding: 26px 26px 30px; display: flex; flex-direction: column; gap: 14px; position: relative; }
+.tier-drop  { background: var(--cream-deep); }
+.tier-month { background: var(--chalk); color: var(--cream); }
+.tier-found { background: var(--brass); color: var(--plinth); }
+.tier-head { display: flex; align-items: baseline; gap: 14px; border-bottom: 2px solid currentColor; padding-bottom: 12px; }
+.tier-num { font-family: "DM Serif Display", serif; font-style: italic; font-size: 36px; line-height: 1; }
+.tier-label { font-family: "Oswald", sans-serif; text-transform: uppercase; letter-spacing: 0.24em; font-size: 20px; font-weight: 600; }
+.tier-price { font-family: "Oswald", sans-serif; font-weight: 700; font-size: 60px; line-height: 0.9; letter-spacing: -0.01em; }
+.tier-price .krw { font-family: "DM Serif Display", serif; font-weight: 400; font-size: 38px; margin-right: 6px; }
+.tier-unit { font-family: "IBM Plex Mono", monospace; letter-spacing: 0.2em; font-size: 12px; text-transform: uppercase; opacity: 0.85; }
+.tier-list { margin: 10px 0 0; padding: 0; list-style: none; font-family: "DM Serif Display", serif; font-size: 16px; }
+.tier-list li { padding: 8px 0; border-top: 1px solid currentColor; }
+
+/* ------------- ticker row ------------- */
+.ticker-row {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border-top: 4px solid var(--plinth);
+  border-bottom: 4px solid var(--plinth);
+  background: var(--plinth); color: var(--cream);
+}
+.ticker-cell { padding: 30px 22px; border-right: 2px solid var(--brass); display: flex; flex-direction: column; gap: 8px; }
+.ticker-cell:last-child { border-right: 0; }
+.ticker-num { font-family: "Oswald", sans-serif; font-weight: 700; font-size: 68px; line-height: 1; color: var(--brass); }
+.ticker-num .kg { font-family: "IBM Plex Mono", monospace; font-size: 22px; color: var(--cream); margin-left: 4px; }
+.ticker-label { font-family: "IBM Plex Mono", monospace; letter-spacing: 0.22em; font-size: 12px; text-transform: uppercase; color: var(--cream-deep); }
+
+/* ------------- prose / inner pages ------------- */
+.prose { max-width: 820px; margin: 0 auto; padding: 64px 28px 96px; background: var(--cream); }
+.prose-plate { font-family: "IBM Plex Mono", monospace; font-size: 12px; letter-spacing: 0.32em; color: var(--brass); margin-bottom: 14px; }
+.prose-title {
+  font-family: "Oswald", sans-serif; font-weight: 700; text-transform: uppercase;
+  font-size: clamp(40px, 6vw, 80px); line-height: 0.95;
+  margin: 0 0 18px; letter-spacing: -0.01em; color: var(--plinth);
+}
+.prose-rule { height: 3px; background: var(--plinth); margin: 0 0 32px; }
+.prose-body { font-family: "DM Serif Display", serif; font-size: 18px; line-height: 1.65; }
+.prose-body h2 {
+  font-family: "Oswald", sans-serif; font-weight: 700; text-transform: uppercase;
+  font-size: 30px; letter-spacing: 0.02em; margin: 48px 0 12px; color: var(--plinth);
+  border-bottom: 2px solid var(--plinth); padding-bottom: 8px;
+}
+.prose-body h3 { font-family: "Oswald", sans-serif; text-transform: uppercase; letter-spacing: 0.04em; font-size: 22px; margin: 32px 0 8px; }
+.prose-body p { margin: 0 0 18px; }
+.prose-body a { color: var(--chalk); border-bottom: 2px solid var(--brass); }
+.prose-body a:hover { color: var(--ribbon); border-bottom-color: var(--ribbon); }
+.prose-body ul, .prose-body ol { margin: 0 0 22px 22px; padding: 0; }
+.prose-body li { margin-bottom: 6px; }
+.prose-body strong { color: var(--ribbon); font-weight: 700; }
+.prose-body em { color: var(--chalk); font-style: italic; }
+.prose-body blockquote {
+  margin: 24px 0; padding: 18px 22px;
+  background: var(--cream-deep); border-left: 6px solid var(--brass);
+  font-style: italic; color: var(--plinth);
+}
+.prose-body table { width: 100%; border-collapse: collapse; margin: 24px 0; font-family: "IBM Plex Mono", monospace; font-size: 14px; }
+.prose-body th, .prose-body td { border: 1px solid var(--plinth); padding: 10px 14px; text-align: left; }
+.prose-body th { background: var(--plinth); color: var(--cream); letter-spacing: 0.16em; text-transform: uppercase; font-size: 12px; }
+.prose-body code { font-family: "IBM Plex Mono", monospace; background: var(--cream-deep); padding: 1px 6px; font-size: 0.92em; color: var(--plinth); }
+
+/* ------------- section listing ------------- */
+.section-listing { max-width: 1100px; margin: 0 auto; padding-bottom: 64px; }
+.section-list { list-style: none; margin: 12px 28px 0; padding: 0; border-top: 2px solid var(--plinth); }
+.section-row {
+  display: grid; grid-template-columns: 130px 1fr 40px;
+  align-items: center; gap: 18px;
+  padding: 14px 0; border-bottom: 1px solid var(--plinth);
+}
+.row-date { font-family: "IBM Plex Mono", monospace; letter-spacing: 0.2em; font-size: 12px; color: var(--shadow); text-transform: uppercase; }
+.row-title { font-family: "Oswald", sans-serif; text-transform: uppercase; letter-spacing: 0.06em; font-size: 20px; font-weight: 500; }
+.row-arrow { font-family: "IBM Plex Mono", monospace; text-align: right; color: var(--brass); }
+
+/* ------------- alert shortcode ------------- */
+.alert { display: flex; gap: 14px; margin: 22px 0; padding: 14px 18px; background: var(--cream-deep); border: 2px solid var(--plinth); border-left: 10px solid var(--brass); }
+.alert-tag { font-family: "IBM Plex Mono", monospace; letter-spacing: 0.24em; font-size: 12px; color: var(--ribbon); font-weight: 600; }
+.alert-body { font-family: "DM Serif Display", serif; font-size: 16px; }
+
+/* ------------- footer ------------- */
+.foot { background: var(--plinth); color: var(--cream); padding: 48px 28px 32px; }
+.foot-ornaments { max-width: 1280px; margin: 0 auto 22px; display: flex; gap: 20px; align-items: center; }
+.orn { display: inline-block; }
+.orn.c1 { width: 36px; height: 36px; border-radius: 50%; background: var(--ribbon); }
+.orn.c2 { width: 36px; height: 36px; border-radius: 50%; background: var(--brass); }
+.orn.c3 { width: 36px; height: 36px; border-radius: 50%; background: var(--chalk); }
+.orn.sq { width: 36px; height: 36px; background: var(--cream); }
+.orn.tri { width: 0; height: 0; border-left: 22px solid transparent; border-right: 22px solid transparent; border-bottom: 36px solid var(--clay); background: transparent; }
+.foot-rule { max-width: 1280px; margin: 0 auto 28px; height: 3px; background: var(--brass); }
+.foot-grid {
+  max-width: 1280px; margin: 0 auto;
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 28px;
+  border-bottom: 2px solid var(--brass); padding-bottom: 28px;
+}
+.foot-cell h4 { font-family: "Oswald", sans-serif; text-transform: uppercase; letter-spacing: 0.2em; font-size: 14px; color: var(--brass); margin: 0 0 12px; }
+.foot-cell p { margin: 4px 0; font-family: "DM Serif Display", serif; font-size: 15px; }
+.foot-cell a { color: var(--cream); border-bottom: 1px solid var(--shadow); }
+.foot-cell a:hover { color: var(--brass); border-bottom-color: var(--brass); }
+.foot-colophon {
+  max-width: 1280px; margin: 22px auto 0;
+  display: flex; justify-content: space-between; gap: 22px; flex-wrap: wrap;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--cream-deep);
+}
+
+/* ------------- responsive ------------- */
+@media (max-width: 1024px) {
+  .hero { grid-template-columns: 1fr; }
+  .band { border-right: 0; border-bottom: 2px solid var(--plinth); }
+  .band:last-child { border-bottom: 0; }
+  .discipline-grid { grid-template-columns: repeat(2, 1fr); }
+  .disc { border-bottom: 2px solid var(--plinth); }
+  .disc:nth-child(odd) { border-right: 2px solid var(--plinth); }
+  .disc:nth-child(even) { border-right: 0; }
+  .tier-grid { grid-template-columns: 1fr; }
+  .ticker-row { grid-template-columns: repeat(2, 1fr); }
+  .ticker-cell:nth-child(2) { border-right: 0; }
+  .ticker-cell:nth-child(1), .ticker-cell:nth-child(2) { border-bottom: 2px solid var(--brass); }
+  .foot-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .strip-top { flex-direction: column; gap: 10px; align-items: flex-start; }
+  .strip-nav { flex-wrap: wrap; gap: 14px; }
+  .hero-meta { grid-template-columns: repeat(2, 1fr); }
+  .hero-meta > div:nth-child(2) { border-right: 0; }
+  .hero-meta > div:nth-child(1), .hero-meta > div:nth-child(2) { border-bottom: 1px solid var(--plinth); }
+  .discipline-grid { grid-template-columns: 1fr; }
+  .disc { border-right: 0 !important; border-bottom: 2px solid var(--plinth); }
+  .schedule-table th, .schedule-table td { padding: 10px 8px; font-size: 12px; }
+  .ticker-row { grid-template-columns: 1fr; }
+  .ticker-cell { border-right: 0; border-bottom: 2px solid var(--brass); }
+  .foot-grid { grid-template-columns: 1fr; }
+  .section-row { grid-template-columns: 1fr; gap: 4px; }
+  .row-arrow { display: none; }
+}

--- a/examples/gymnasium-bell/static/favicon.svg
+++ b/examples/gymnasium-bell/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#161210"/>
+  <circle cx="16" cy="14" r="7" fill="#b97f1d"/>
+  <rect x="14" y="4" width="4" height="5" fill="#b97f1d"/>
+  <rect x="3" y="22" width="26" height="3" fill="#c33329"/>
+</svg>

--- a/examples/gymnasium-bell/templates/404.html
+++ b/examples/gymnasium-bell/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-plate">PLATE &middot; 404</div>
+  <h1 class="prose-title">404 &middot; OFF THE TIMETABLE.</h1>
+  <div class="prose-rule" aria-hidden="true"></div>
+  <div class="prose-body">
+    <p>This page is not on this week's roster. Perhaps it was retired, perhaps the bell never rang for it. Step back into the hall and try a different door.</p>
+    <p><a href="{{ base_url }}/">&laquo; back to the hall</a></p>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/gymnasium-bell/templates/footer.html
+++ b/examples/gymnasium-bell/templates/footer.html
@@ -1,0 +1,42 @@
+  <footer class="foot">
+    <div class="foot-ornaments" aria-hidden="true">
+      <span class="orn c1"></span>
+      <span class="orn c2"></span>
+      <span class="orn c3"></span>
+      <span class="orn sq"></span>
+      <span class="orn tri"></span>
+    </div>
+    <div class="foot-rule" aria-hidden="true"></div>
+    <div class="foot-grid">
+      <div class="foot-cell">
+        <h4>The Hall</h4>
+        <p>14 Yanghwa-ro 6-gil<br>Mapo-gu, Seoul</p>
+        <p>Open daily &middot; bell on the door</p>
+      </div>
+      <div class="foot-cell">
+        <h4>Desk</h4>
+        <p><a href="mailto:desk@hallathletic.co">desk@hallathletic.co</a></p>
+        <p><a href="mailto:jun-ho@hallathletic.co">coaching@hallathletic.co</a></p>
+      </div>
+      <div class="foot-cell">
+        <h4>Hours</h4>
+        <p>Mon&ndash;Fri &middot; 06:30 &ndash; 22:00</p>
+        <p>Sat &middot; 08:00 &ndash; 20:00</p>
+        <p>Sun &middot; 09:00 &ndash; 18:00</p>
+      </div>
+      <div class="foot-cell">
+        <h4>Disciplines</h4>
+        <p><a href="{{ base_url }}/#climb">Climbing</a></p>
+        <p><a href="{{ base_url }}/#rings">Rings</a></p>
+        <p><a href="{{ base_url }}/#programs">Kettlebells &amp; Balance</a></p>
+      </div>
+    </div>
+    <div class="foot-colophon">
+      <span>INSTRUCTED &middot; LIFTED &middot; BELLED &middot; {{ current_year }}</span>
+      <span class="colophon-end">HALL ATHLETIC CO. &middot; Hwaro press, vol. {{ current_year }}</span>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/gymnasium-bell/templates/header.html
+++ b/examples/gymnasium-bell/templates/header.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=DM+Serif+Display:ital@0;1&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <div class="strip-mark">
+      <span class="dot"></span>
+      <b>HALL ATHLETIC CO.</b>
+      <span class="sep">&middot;</span>
+      <span class="sub">INDOOR CULTURE</span>
+      <span class="sep">&middot;</span>
+      <span class="sub">EST. 1924</span>
+    </div>
+    <nav class="strip-nav">
+      <a href="{{ base_url }}/#climb">Climb</a>
+      <a href="{{ base_url }}/#rings">Rings</a>
+      <a href="{{ base_url }}/#programs">Programs</a>
+      <a href="{{ base_url }}/about/">Members</a>
+    </nav>
+  </header>
+  <div class="brass-rule" aria-hidden="true"></div>

--- a/examples/gymnasium-bell/templates/index.html
+++ b/examples/gymnasium-bell/templates/index.html
@@ -1,0 +1,262 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="band band-left" aria-hidden="true">
+    <svg class="figure climber" viewBox="0 0 240 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bauhaus climber silhouette">
+      <rect width="240" height="480" fill="#2a4781"/>
+      <circle cx="120" cy="84" r="44" fill="#c33329"/>
+      <rect x="92" y="124" width="56" height="14" fill="#161210"/>
+      <rect x="80" y="138" width="80" height="120" fill="#efe5cf"/>
+      <polygon points="80,258 160,258 132,400 108,400" fill="#161210"/>
+      <rect x="108" y="400" width="24" height="40" fill="#b97f1d"/>
+      <rect x="40" y="180" width="80" height="14" fill="#161210" transform="rotate(-22 80 187)"/>
+      <rect x="120" y="180" width="80" height="14" fill="#161210" transform="rotate(22 160 187)"/>
+      <circle cx="34" cy="158" r="14" fill="#c33329"/>
+      <circle cx="206" cy="158" r="14" fill="#c33329"/>
+    </svg>
+    <div class="band-tag">NO. 1 &middot; CLIMB</div>
+  </div>
+  <div class="band band-mid">
+    <div class="hero-mark">
+      <span class="hero-bullet"></span>
+      <span class="hero-bullet-text">VOL. CI &middot; SPRING SEASON</span>
+    </div>
+    <h1 class="hero-headline">
+      <span class="hl-line">STRENGTH</span>
+      <span class="hl-rule"></span>
+      <span class="hl-line hl-form">FORM</span>
+      <span class="hl-rule"></span>
+      <span class="hl-line">TIME.</span>
+    </h1>
+    <p class="hero-lede">A working hall for indoor athletics &mdash; climbing, rings, kettlebells, hand-balance. Founded 1924. Still bell-rung, still chalk-floored.</p>
+    <div class="hero-meta">
+      <div><span>HALL</span><b>HAPJEONG</b></div>
+      <div><span>SINCE</span><b>1924</b></div>
+      <div><span>COACHES</span><b>04</b></div>
+      <div><span>BELL</span><b>BRASS</b></div>
+    </div>
+  </div>
+  <div class="band band-right" aria-hidden="true">
+    <svg class="bell" viewBox="0 0 240 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Brass bell on rope">
+      <rect width="240" height="480" fill="#c45d3a"/>
+      <rect x="118" y="0" width="4" height="120" fill="#161210"/>
+      <rect x="78" y="118" width="84" height="10" fill="#161210"/>
+      <path d="M70 128 Q70 230 90 270 L150 270 Q170 230 170 128 Z" fill="#b97f1d"/>
+      <rect x="70" y="270" width="100" height="14" fill="#161210"/>
+      <circle cx="120" cy="298" r="12" fill="#b97f1d"/>
+      <rect x="60" y="320" width="120" height="6" fill="#161210"/>
+      <text x="120" y="370" text-anchor="middle" font-family="DM Serif Display, serif" font-size="38" fill="#efe5cf">BELL</text>
+      <text x="120" y="408" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="14" fill="#efe5cf">RUNG ON THE HOUR</text>
+    </svg>
+    <div class="band-tag right">NO. 2 &middot; BELL</div>
+  </div>
+</section>
+
+<section class="strip-meta" aria-label="hall notice">
+  <div class="strip-meta-line">FIRST SESSION ON THE HOUSE &middot; SIGN THE SLATE &middot; LIFT THE EIGHT &middot; CHALK PROVIDED</div>
+</section>
+
+<section class="disciplines" id="climb">
+  <div class="section-head">
+    <div class="head-num">PLATE I</div>
+    <h2 class="head-title">The <em>Four</em> Disciplines.</h2>
+    <p class="head-sub">Taught in sequence, in the order the body learns them.</p>
+  </div>
+  <div class="discipline-grid">
+
+    <article class="disc disc-climb">
+      <svg class="disc-fig" viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <circle cx="100" cy="42" r="22" fill="#161210"/>
+        <rect x="80" y="64" width="40" height="60" fill="#c33329"/>
+        <polygon points="80,124 120,124 110,200 90,200" fill="#161210"/>
+        <rect x="30" y="80" width="56" height="10" fill="#161210" transform="rotate(-30 58 85)"/>
+        <rect x="114" y="80" width="56" height="10" fill="#161210" transform="rotate(30 142 85)"/>
+        <circle cx="16" cy="56" r="8" fill="#b97f1d"/>
+        <circle cx="184" cy="56" r="8" fill="#b97f1d"/>
+      </svg>
+      <div class="disc-num">01</div>
+      <h3>Climbing</h3>
+      <p>Two walls, one slab, one cave. Routes set monthly, never on a weekend.</p>
+      <dl class="disc-times">
+        <dt>Mon</dt><dd>07:00 &middot; 19:30</dd>
+        <dt>Wed</dt><dd>07:00 &middot; 20:00</dd>
+        <dt>Sat</dt><dd>09:00 &middot; 14:00</dd>
+      </dl>
+    </article>
+
+    <article class="disc disc-rings" id="rings">
+      <svg class="disc-fig" viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <rect x="20" y="0" width="6" height="48" fill="#161210"/>
+        <rect x="174" y="0" width="6" height="48" fill="#161210"/>
+        <circle cx="23" cy="60" r="14" fill="none" stroke="#161210" stroke-width="6"/>
+        <circle cx="177" cy="60" r="14" fill="none" stroke="#161210" stroke-width="6"/>
+        <rect x="60" y="58" width="80" height="10" fill="#161210"/>
+        <circle cx="100" cy="92" r="20" fill="#c33329"/>
+        <rect x="84" y="112" width="32" height="60" fill="#161210"/>
+        <polygon points="84,172 116,172 108,210 92,210" fill="#b97f1d"/>
+      </svg>
+      <div class="disc-num">02</div>
+      <h3>Rings</h3>
+      <p>Wooden, 32mm, 2.8m off the deck. Holds before swings. We do not kip.</p>
+      <dl class="disc-times">
+        <dt>Tue</dt><dd>06:30 &middot; 18:30</dd>
+        <dt>Thu</dt><dd>06:30 &middot; 18:30</dd>
+        <dt>Sun</dt><dd>10:00</dd>
+      </dl>
+    </article>
+
+    <article class="disc disc-kettle">
+      <svg class="disc-fig" viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <circle cx="100" cy="30" r="18" fill="#161210"/>
+        <rect x="86" y="48" width="28" height="42" fill="#c33329"/>
+        <rect x="56" y="62" width="32" height="10" fill="#161210"/>
+        <rect x="112" y="62" width="32" height="10" fill="#161210"/>
+        <rect x="36" y="40" width="22" height="38" fill="#161210"/>
+        <rect x="142" y="40" width="22" height="38" fill="#161210"/>
+        <rect x="86" y="90" width="28" height="50" fill="#161210"/>
+        <rect x="74" y="140" width="52" height="10" fill="#161210"/>
+        <rect x="76" y="150" width="14" height="50" fill="#b97f1d"/>
+        <rect x="110" y="150" width="14" height="50" fill="#b97f1d"/>
+        <rect x="86" y="200" width="28" height="10" fill="#161210"/>
+      </svg>
+      <div class="disc-num">03</div>
+      <h3>Kettlebells</h3>
+      <p>Russian girya, 8 to 48kg. Swings, cleans, presses, snatches. One arm at a time.</p>
+      <dl class="disc-times">
+        <dt>Mon</dt><dd>12:00 &middot; 19:00</dd>
+        <dt>Fri</dt><dd>07:30 &middot; 18:00</dd>
+        <dt>Sat</dt><dd>10:30</dd>
+      </dl>
+    </article>
+
+    <article class="disc disc-hand">
+      <svg class="disc-fig" viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <rect x="20" y="200" width="160" height="10" fill="#161210"/>
+        <rect x="40" y="170" width="14" height="30" fill="#b97f1d"/>
+        <rect x="146" y="170" width="14" height="30" fill="#b97f1d"/>
+        <rect x="32" y="160" width="30" height="10" fill="#161210"/>
+        <rect x="138" y="160" width="30" height="10" fill="#161210"/>
+        <rect x="44" y="120" width="10" height="40" fill="#161210"/>
+        <rect x="146" y="120" width="10" height="40" fill="#161210"/>
+        <rect x="44" y="116" width="112" height="10" fill="#161210"/>
+        <rect x="92" y="60" width="16" height="56" fill="#161210"/>
+        <circle cx="100" cy="44" r="20" fill="#c33329"/>
+        <rect x="60" y="80" width="36" height="10" fill="#161210" transform="rotate(20 78 85)"/>
+        <rect x="104" y="80" width="36" height="10" fill="#161210" transform="rotate(-20 122 85)"/>
+      </svg>
+      <div class="disc-num">04</div>
+      <h3>Hand-Balance</h3>
+      <p>Frog, tuck, straddle, full. Wooden parallettes from the carpenter downstairs.</p>
+      <dl class="disc-times">
+        <dt>Wed</dt><dd>18:00</dd>
+        <dt>Fri</dt><dd>19:30</dd>
+        <dt>Sun</dt><dd>11:30</dd>
+      </dl>
+    </article>
+
+  </div>
+</section>
+
+<section class="schedule" id="programs">
+  <div class="section-head">
+    <div class="head-num">PLATE II</div>
+    <h2 class="head-title">Class <em>Schedule</em>.</h2>
+    <p class="head-sub">Weekly grid. The bell on the wall opens each session.</p>
+  </div>
+  <div class="schedule-table-wrap">
+    <table class="schedule-table">
+      <thead>
+        <tr>
+          <th class="th-day">Day</th>
+          <th>Climb</th>
+          <th>Rings</th>
+          <th>Kettle</th>
+          <th>Balance</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><th>Mon</th><td>07:00 &middot; 19:30</td><td>&mdash;</td><td>12:00 &middot; 19:00</td><td>&mdash;</td></tr>
+        <tr><th>Tue</th><td>&mdash;</td><td>06:30 &middot; 18:30</td><td>&mdash;</td><td>20:00</td></tr>
+        <tr><th>Wed</th><td>07:00 &middot; 20:00</td><td>&mdash;</td><td>&mdash;</td><td>18:00</td></tr>
+        <tr><th>Thu</th><td>&mdash;</td><td>06:30 &middot; 18:30</td><td>13:00</td><td>&mdash;</td></tr>
+        <tr><th>Fri</th><td>06:30</td><td>&mdash;</td><td>07:30 &middot; 18:00</td><td>19:30</td></tr>
+        <tr><th>Sat</th><td>09:00 &middot; 14:00</td><td>11:00</td><td>10:30</td><td>&mdash;</td></tr>
+        <tr><th>Sun</th><td>&mdash;</td><td>10:00</td><td>&mdash;</td><td>11:30</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section class="manifesto">
+  <div class="manifesto-band">
+    <div class="manifesto-tag">SIDE A &middot; THE HALL CODE</div>
+    <h2 class="manifesto-text">
+      WE <span class="m-red">LIFT</span> SLOWLY.<br>
+      WE <span class="m-blue">CLIMB</span> CLEAN.<br>
+      WE DO NOT <span class="m-red">RUSH</span> THE BELL.<br>
+      WE DO NOT <span class="m-blue">SKIP</span> THE WORK.
+    </h2>
+    <div class="manifesto-sign">&mdash; Im Jun-ho, head instructor &middot; {{ current_year }}</div>
+  </div>
+</section>
+
+<section class="membership">
+  <div class="section-head">
+    <div class="head-num">PLATE III</div>
+    <h2 class="head-title">Member<em>ship</em>.</h2>
+    <p class="head-sub">Three tiers. No contracts. Cancel in person, over tea.</p>
+  </div>
+  <div class="tier-grid">
+    <article class="tier tier-drop">
+      <div class="tier-head">
+        <span class="tier-num">I</span>
+        <span class="tier-label">Drop-In</span>
+      </div>
+      <div class="tier-price"><span class="krw">&#8361;</span>22,000</div>
+      <div class="tier-unit">per session</div>
+      <ul class="tier-list">
+        <li>All four disciplines</li>
+        <li>Walk in, no booking</li>
+        <li>Chalk &amp; shoes loaner</li>
+        <li>Pay at the desk</li>
+      </ul>
+    </article>
+    <article class="tier tier-month">
+      <div class="tier-head">
+        <span class="tier-num">II</span>
+        <span class="tier-label">Monthly</span>
+      </div>
+      <div class="tier-price"><span class="krw">&#8361;</span>180,000</div>
+      <div class="tier-unit">per month</div>
+      <ul class="tier-list">
+        <li>Unlimited classes</li>
+        <li>One guest pass / month</li>
+        <li>Locker, hook, hand towel</li>
+        <li>Quarterly lineage talk</li>
+      </ul>
+    </article>
+    <article class="tier tier-found">
+      <div class="tier-head">
+        <span class="tier-num">III</span>
+        <span class="tier-label">Founding</span>
+      </div>
+      <div class="tier-price"><span class="krw">&#8361;</span>1,920,000</div>
+      <div class="tier-unit">per year</div>
+      <ul class="tier-list">
+        <li>Seat at the long table</li>
+        <li>Lineage handbook, hand-bound</li>
+        <li>Side-door key</li>
+        <li>Name on the back wall</li>
+      </ul>
+    </article>
+  </div>
+</section>
+
+<section class="ticker-row">
+  <div class="ticker-cell"><div class="ticker-num">1924</div><div class="ticker-label">FIRST BELL RUNG</div></div>
+  <div class="ticker-cell"><div class="ticker-num">04</div><div class="ticker-label">DISCIPLINES TAUGHT</div></div>
+  <div class="ticker-cell"><div class="ticker-num">48<span class="kg">kg</span></div><div class="ticker-label">HEAVIEST GIRYA</div></div>
+  <div class="ticker-cell"><div class="ticker-num">00</div><div class="ticker-label">MIRRORS ON THE WALL</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/gymnasium-bell/templates/page.html
+++ b/examples/gymnasium-bell/templates/page.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}
+    <div class="prose-plate">PLATE &middot; {{ page.title | e | upper }}</div>
+    <h1 class="prose-title">{{ page.title | e }}</h1>
+  {% endif %}
+  <div class="prose-rule" aria-hidden="true"></div>
+  <div class="prose-body">
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/gymnasium-bell/templates/section.html
+++ b/examples/gymnasium-bell/templates/section.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<section class="section-listing">
+  <div class="section-head">
+    {% if page.title is present %}
+      <div class="head-num">SECTION</div>
+      <h2 class="head-title">{{ page.title | e }}</h2>
+    {% endif %}
+  </div>
+  <div class="prose-body">
+    {{ content | safe }}
+  </div>
+  <ul class="section-list">
+    {% for post in section.pages %}
+      <li class="section-row">
+        <span class="row-date">{{ post.date | date(format="%Y / %m") }}</span>
+        <a class="row-title" href="{{ post.url }}">{{ post.title | e | upper }}</a>
+        <span class="row-arrow">&rarr;</span>
+      </li>
+    {% endfor %}
+  </ul>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/gymnasium-bell/templates/shortcodes/alert.html
+++ b/examples/gymnasium-bell/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert" role="note">
+  <span class="alert-tag">{{ type | upper }}</span>
+  <span class="alert-body">{{ body }}</span>
+</div>

--- a/examples/gymnasium-bell/templates/taxonomy.html
+++ b/examples/gymnasium-bell/templates/taxonomy.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-plate">INDEX</div>
+  <h1 class="prose-title">{{ page.title | e }}</h1>
+  <div class="prose-rule" aria-hidden="true"></div>
+  <div class="prose-body">
+    <p>Index of subjects taught and written in the hall.</p>
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/gymnasium-bell/templates/taxonomy_term.html
+++ b/examples/gymnasium-bell/templates/taxonomy_term.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-plate">STAMP</div>
+  <h1 class="prose-title">{{ page.title | e }}</h1>
+  <div class="prose-rule" aria-hidden="true"></div>
+  <div class="prose-body">
+    <p>Entries logged under this stamp.</p>
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/knit-pattern/AGENTS.md
+++ b/examples/knit-pattern/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/knit-pattern/archetypes/default.md
+++ b/examples/knit-pattern/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/knit-pattern/config.toml
+++ b/examples/knit-pattern/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Skein & Chart"
+description = "A small studio publishing hand-knitting patterns as PDF and printed booklets — stitch charts, schematics, and yarn substitution guides for sweaters, mittens, and socks."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/knit-pattern/content/about.md
+++ b/examples/knit-pattern/content/about.md
@@ -1,0 +1,37 @@
++++
+title = "About the Studio"
+description = "Skein & Chart — who we are, how we test, and how to order a printed booklet."
++++
+
+## The studio
+
+Skein & Chart is a two-person pattern studio working out of a converted shoe shop in Gangwon. We publish small, careful pattern booklets for hand-knitters who would rather follow a chart than a paragraph. Every pattern ships as a PDF and, for those who ask, a hand-bound booklet printed on 90gsm cartridge.
+
+We started in 2017 with a single sock pattern photocopied at a stationer's. Issue 14 is the eighty-ninth pattern we have set in lead.
+
+## The test-knitters
+
+Each pattern is knit, in full, by three test-knitters before we sign off. Our test-knitters live across four time zones and work in different yarns, gauges, and handednesses. They are paid in patterns, mailed yarn, and tea. Their names appear at the back of every booklet they shape.
+
+Test-knitters this issue:
+
+- **Joon** — Seoul, double-pointed needles, Continental
+- **Iben** — Ribe, magic loop, English
+- **Marit** — Tromso, two circulars, lefty-knit
+
+## How we test
+
+> A pattern is not finished until three strangers have knit it without a single email.
+
+A draft pattern enters our test pool with a stitch chart, a schematic, and a yarn note. The test-knitter knits to gauge, then to size, then to the finished garment. They mark up the booklet in pencil — anywhere the chart misled them, anywhere the math drifted, anywhere a row count felt wrong. Their marked-up copies come back to the studio, where we recut every chart that two or more test-knitters questioned.
+
+## Yarn substitution philosophy
+
+We name a yarn, a weight, and a meterage. We do not name a single mill as the only true source. If you have a yarn that matches the weight and meterage and you can hit the gauge, the pattern will work. Every booklet ends with a substitution table giving three alternatives — one luxe, one workhorse, one budget — for the named yarn.
+
+## Ordering
+
+- **PDF** — `desk@skeinandchart.studio`. Pay-what-you-want above the floor price; we will not ask.
+- **Printed booklet** — `+82-33-440-1814` between Tuesday and Friday, 10:00 to 16:00 KST.
+- **Errata** — `errata@skeinandchart.studio`. We answer within seven days, in writing.
+- **Stockists** — six independent yarn shops carry the booklets in person. Ask at your local; we are happy to introduce them.

--- a/examples/knit-pattern/content/index.md
+++ b/examples/knit-pattern/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Skein & Chart — hand-knitting patterns published as PDF and printed booklets. Stitch charts, schematics, and yarn substitution guides for sweaters, mittens, and socks."
+template = "index"
++++

--- a/examples/knit-pattern/static/css/style.css
+++ b/examples/knit-pattern/static/css/style.css
@@ -1,0 +1,509 @@
+/* =========================================================================
+   Skein & Chart — Issue 14
+   Pattern-booklet design. Solid colors only, no gradients.
+   Palette: cream / cream-deep / heather / sage / rust / ink / pencil / needle
+   ========================================================================= */
+
+:root {
+  --cream: #f4ecd6;
+  --cream-deep: #e3d9b8;
+  --heather: #6f8ba6;
+  --sage: #6c8a5a;
+  --rust: #b2562b;
+  --ink: #2a2620;
+  --pencil: #6e6855;
+  --needle: #2a4a7d;
+  --hair: rgba(42, 38, 32, 0.35);
+  --rule: rgba(42, 38, 32, 0.55);
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+body {
+  background: var(--cream);
+  color: var(--ink);
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+  font-feature-settings: "kern" 1, "liga" 1;
+}
+
+a { color: var(--needle); text-decoration: underline; text-underline-offset: 2px; }
+a:hover { color: var(--rust); }
+
+/* ----- Top strip ----- */
+.strip { padding: 14px 28px 0; }
+.strip-inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: baseline;
+  gap: 18px;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.strip-mark {
+  font-family: "DM Serif Display", serif;
+  font-style: italic;
+  font-size: 18px;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: var(--ink);
+  text-decoration: none;
+}
+.strip-mid { text-align: center; color: var(--pencil); font-weight: 500; }
+.strip-nav { justify-self: end; display: flex; gap: 18px; }
+.strip-nav a { color: var(--ink); text-decoration: none; font-weight: 600; }
+.strip-nav a:hover { color: var(--rust); }
+.strip-rule { height: 1px; background: var(--rule); margin-top: 12px; }
+
+/* ----- Masthead / hero ----- */
+.masthead { padding: 48px 28px 56px; border-bottom: 1px solid var(--hair); }
+.masthead-grid {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 56px;
+  align-items: start;
+  max-width: 1240px;
+  margin: 0 auto;
+}
+
+/* Stitch chart */
+.chart-wrap {
+  border: 1px solid var(--ink);
+  padding: 22px 22px 18px;
+}
+.chart-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pencil);
+  margin-bottom: 14px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--hair);
+}
+.chart-row { display: flex; gap: 8px; }
+.chart {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  aspect-ratio: 1 / 1;
+  border: 1px solid var(--ink);
+}
+.cell {
+  background: var(--cream);
+  border-right: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cell:nth-child(12n) { border-right: none; }
+.cell:nth-child(n+133) { border-bottom: none; }
+.stitch { width: 70%; height: 70%; display: block; }
+.row-numbers {
+  display: grid;
+  grid-template-rows: repeat(12, 1fr);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  color: var(--pencil);
+  align-items: center;
+  width: 16px;
+}
+.stitch-numbers {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  color: var(--pencil);
+  text-align: center;
+  padding-top: 6px;
+  padding-right: 24px;
+}
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--hair);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  color: var(--pencil);
+}
+.lg {
+  display: inline-block;
+  width: 14px; height: 14px;
+  vertical-align: -3px;
+  margin-right: 4px;
+  border: 1px solid var(--ink);
+  background: var(--cream);
+  position: relative;
+}
+.lg.knit::after { content: ""; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background: var(--ink); border-radius: 50%; width: 4px; height: 4px; }
+.lg.purl::after { content: ""; position: absolute; left: 2px; right: 2px; top: 50%; height: 1px; background: var(--ink); }
+.lg.k2tog::after { content: ""; position: absolute; left: 2px; top: 11px; width: 13px; height: 1px; background: var(--ink); transform: rotate(-45deg); transform-origin: 0 50%; }
+.lg.ssk::after { content: ""; position: absolute; left: 2px; top: 2px; width: 13px; height: 1px; background: var(--ink); transform: rotate(45deg); transform-origin: 0 50%; }
+.lg.yo::after { content: ""; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 7px; height: 7px; border: 1px solid var(--ink); border-radius: 50%; }
+
+/* Masthead text */
+.kicker {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--rust);
+  margin: 0 0 14px;
+}
+.headline {
+  font-family: "DM Serif Display", serif;
+  font-weight: 400;
+  font-size: clamp(46px, 6vw, 84px);
+  line-height: 0.98;
+  letter-spacing: -0.01em;
+  margin: 0 0 28px;
+}
+.headline em { font-style: italic; color: var(--needle); }
+.subtitle {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 19px;
+  line-height: 1.5;
+  max-width: 38em;
+  margin: 0 0 28px;
+}
+.masthead-meta {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px 24px;
+  border-top: 1px solid var(--hair);
+  padding-top: 18px;
+}
+.masthead-meta > div { display: flex; flex-direction: column; gap: 2px; }
+.m-key {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--pencil);
+}
+.m-val {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 17px;
+}
+
+/* ----- Section headers ----- */
+.section-head {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 48px 28px 12px;
+  display: grid;
+  grid-template-columns: 48px auto 1fr;
+  align-items: baseline;
+  gap: 14px;
+}
+.section-num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--rust);
+}
+.section-title {
+  font-family: "DM Serif Display", serif;
+  font-weight: 400;
+  font-size: clamp(28px, 3.4vw, 40px);
+  line-height: 1.05;
+  margin: 0;
+}
+.section-rule { height: 1px; background: var(--rule); align-self: center; margin-top: 6px; }
+.section-note {
+  grid-column: 2 / -1;
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 17px;
+  color: var(--pencil);
+  margin: 6px 0 0;
+  max-width: 56em;
+}
+
+/* ----- Pattern cards ----- */
+.patterns { padding-bottom: 56px; }
+.pattern-grid {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 28px 28px 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 28px;
+}
+.pattern {
+  border: 1px solid var(--ink);
+  padding: 22px 22px 18px;
+  display: grid;
+  gap: 12px;
+}
+.pattern-head { display: flex; align-items: center; justify-content: space-between; }
+.pattern-no {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--pencil);
+}
+.pattern-swatch {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--ink);
+  display: inline-block;
+}
+.swatch-heather { background: var(--heather); }
+.swatch-sage { background: var(--sage); }
+.swatch-rust { background: var(--rust); }
+.swatch-needle { background: var(--needle); }
+.pattern-name {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 30px;
+  line-height: 1.05;
+  margin: 4px 0 0;
+}
+.pattern-name em { font-style: italic; color: var(--needle); }
+.pattern-sub { font-size: 13px; color: var(--pencil); margin: 0; }
+.schematic {
+  border: 1px solid var(--hair);
+  background: var(--cream-deep);
+  padding: 8px;
+}
+.schematic svg { display: block; width: 100%; height: auto; }
+.spec { width: 100%; border-collapse: collapse; font-family: "IBM Plex Mono", monospace; font-size: 12px; }
+.spec th, .spec td {
+  text-align: left;
+  padding: 6px 0;
+  border-top: 1px dotted var(--hair);
+  vertical-align: top;
+}
+.spec th {
+  width: 90px;
+  color: var(--pencil);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 10px;
+  padding-right: 12px;
+}
+.spec tr:first-child th, .spec tr:first-child td { border-top: none; padding-top: 10px; }
+
+/* ----- Yarn library ----- */
+.yarns { padding-bottom: 56px; border-top: 1px solid var(--hair); }
+.yarn-grid {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 28px 28px 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 28px;
+}
+.yarn { border: 1px solid var(--ink); padding: 22px; }
+.yarn-name {
+  font-family: "DM Serif Display", serif;
+  font-weight: 400;
+  font-size: 24px;
+  margin: 0 0 4px;
+}
+.yarn-meta {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--pencil);
+  margin: 0 0 16px;
+}
+.dots {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 6px;
+  margin-bottom: 18px;
+}
+.dots span {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  border: 1px solid var(--ink);
+  display: block;
+}
+.fibre { width: 100%; border-collapse: collapse; font-family: "IBM Plex Mono", monospace; font-size: 12px; }
+.fibre th, .fibre td { padding: 5px 0; border-top: 1px dotted var(--hair); }
+.fibre th { text-align: left; font-weight: 400; }
+.fibre td { text-align: right; color: var(--rust); font-weight: 500; }
+.fibre tr:first-child th, .fibre tr:first-child td { border-top: none; }
+
+/* ----- Errata ----- */
+.errata { padding-bottom: 64px; border-top: 1px solid var(--hair); }
+.errata-list {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px 28px 0;
+  list-style: none;
+}
+.errata-list li {
+  display: grid;
+  grid-template-columns: 200px 1fr 140px;
+  gap: 20px;
+  align-items: start;
+  padding: 18px 0;
+  border-top: 1px solid var(--hair);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 13px;
+  line-height: 1.55;
+}
+.errata-list li:last-child { border-bottom: 1px solid var(--hair); }
+.err-tag {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--rust);
+  padding-top: 2px;
+}
+.errata-list p { margin: 0; }
+.err-date {
+  text-align: right;
+  font-size: 11px;
+  color: var(--pencil);
+  letter-spacing: 0.06em;
+}
+
+/* ----- Colophon / footer ----- */
+.colophon { background: var(--cream-deep); padding: 36px 28px 28px; margin-top: 24px; }
+.colophon-rule { height: 1px; background: var(--rule); margin-bottom: 28px; }
+.colophon-inner {
+  max-width: 1240px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 28px;
+}
+.colophon-col h4 {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin: 0 0 10px;
+  color: var(--rust);
+  font-weight: 500;
+}
+.colophon-col p {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 16px;
+  line-height: 1.45;
+  margin: 0 0 10px;
+}
+.colophon-foot {
+  max-width: 1240px;
+  margin: 28px auto 0;
+  padding-top: 18px;
+  border-top: 1px solid var(--hair);
+  display: flex;
+  justify-content: space-between;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--pencil);
+}
+
+/* ----- Prose pages ----- */
+.prose { max-width: 720px; margin: 0 auto; padding: 56px 28px 64px; }
+.prose h1 {
+  font-family: "DM Serif Display", serif;
+  font-weight: 400;
+  font-size: clamp(36px, 4.4vw, 56px);
+  line-height: 1.05;
+  margin: 0 0 28px;
+}
+.prose h2 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 28px;
+  margin: 40px 0 12px;
+  color: var(--needle);
+}
+.prose h3 {
+  font-size: 14px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin: 28px 0 10px;
+  color: var(--rust);
+}
+.prose p, .prose ul, .prose ol {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 19px;
+  line-height: 1.55;
+  margin: 0 0 18px;
+}
+.prose ul, .prose ol { padding-left: 22px; }
+.prose ul li { list-style: square; }
+.prose code {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 14px;
+  background: var(--cream-deep);
+  padding: 1px 5px;
+  border: 1px solid var(--hair);
+}
+.prose blockquote {
+  border-left: 2px solid var(--rust);
+  margin: 22px 0;
+  padding: 4px 0 4px 18px;
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 22px;
+}
+.prose hr { border: none; border-top: 1px solid var(--hair); margin: 32px 0; }
+
+.post-list { list-style: none; padding: 0; margin: 24px 0 0; }
+.post-list li {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 16px;
+  padding: 12px 0;
+  border-top: 1px solid var(--hair);
+  align-items: baseline;
+}
+.post-list li:last-child { border-bottom: 1px solid var(--hair); }
+.post-date {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px;
+  color: var(--pencil);
+  letter-spacing: 0.06em;
+}
+.post-list a {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink);
+  text-decoration: none;
+}
+.post-list a:hover { color: var(--rust); }
+
+/* ----- Responsive ----- */
+@media (max-width: 980px) {
+  .masthead-grid { grid-template-columns: 1fr; gap: 36px; }
+  .pattern-grid, .yarn-grid { grid-template-columns: 1fr; }
+  .colophon-inner { grid-template-columns: repeat(2, 1fr); }
+  .errata-list li { grid-template-columns: 1fr; gap: 6px; }
+  .err-date { text-align: left; }
+}
+@media (max-width: 640px) {
+  .strip-inner { grid-template-columns: 1fr; gap: 8px; }
+  .strip-mid { text-align: left; }
+  .strip-nav { justify-self: start; flex-wrap: wrap; gap: 12px; }
+  .masthead { padding: 28px 18px 36px; }
+  .section-head { padding: 32px 18px 8px; grid-template-columns: 32px 1fr; }
+  .section-rule { display: none; }
+  .pattern-grid, .yarn-grid { padding: 20px 18px 0; }
+  .errata-list { padding: 16px 18px 0; }
+  .colophon { padding: 28px 18px; }
+  .colophon-inner { grid-template-columns: 1fr; }
+  .colophon-foot { flex-direction: column; gap: 8px; }
+  .prose { padding: 36px 18px 48px; }
+}

--- a/examples/knit-pattern/static/favicon.svg
+++ b/examples/knit-pattern/static/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f4ecd6"/>
+  <g fill="none" stroke="#2a2620" stroke-width="1.5" stroke-linecap="round">
+    <line x1="6" y1="8" x2="26" y2="8"/>
+    <line x1="6" y1="14" x2="26" y2="14"/>
+    <line x1="6" y1="20" x2="26" y2="20"/>
+    <line x1="6" y1="26" x2="26" y2="26"/>
+  </g>
+  <g fill="#b2562b">
+    <circle cx="10" cy="11" r="1.2"/>
+    <circle cx="16" cy="11" r="1.2"/>
+    <circle cx="22" cy="11" r="1.2"/>
+    <circle cx="10" cy="23" r="1.2"/>
+    <circle cx="16" cy="23" r="1.2"/>
+    <circle cx="22" cy="23" r="1.2"/>
+  </g>
+</svg>

--- a/examples/knit-pattern/templates/404.html
+++ b/examples/knit-pattern/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &middot; A dropped stitch.</h1>
+  <p>This page is not in the index. It may have been an early draft, a working title, or a chart that never made it past test-knitting. Try the front page or the back issues.</p>
+  <p><a href="{{ base_url }}/">&laquo; back to the front</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/knit-pattern/templates/footer.html
+++ b/examples/knit-pattern/templates/footer.html
@@ -1,0 +1,32 @@
+  <footer class="colophon">
+    <div class="colophon-rule"></div>
+    <div class="colophon-inner">
+      <div class="colophon-col">
+        <h4>The Studio</h4>
+        <p>Skein &amp; Chart<br>Pattern Booklets &middot; est. 2017<br>Issue 14 &middot; October {{ current_year }}</p>
+        <p>Printed on 90gsm cartridge.<br>Bound by hand in Gangwon.</p>
+      </div>
+      <div class="colophon-col">
+        <h4>Return Address</h4>
+        <p>Skein &amp; Chart Studio<br>14 Mulgun-ro, Gangwon-do<br>South Korea, 25430</p>
+        <p>Open Tue&ndash;Fri, 10:00&ndash;16:00 KST</p>
+      </div>
+      <div class="colophon-col">
+        <h4>Desk</h4>
+        <p><a href="mailto:desk@skeinandchart.studio">desk@skeinandchart.studio</a><br><a href="mailto:errata@skeinandchart.studio">errata@skeinandchart.studio</a><br>+82-33-440-1814</p>
+      </div>
+      <div class="colophon-col">
+        <h4>Press</h4>
+        <p>Set in Cormorant Garamond,<br>Inter, and IBM Plex Mono.</p>
+        <p>Hwaro build &middot; press {{ current_year }}.10</p>
+      </div>
+    </div>
+    <div class="colophon-foot">
+      <span>&copy; {{ current_year }} Skein &amp; Chart &middot; All charts and schematics drawn in-studio.</span>
+      <span>Issue 14 &middot; 1 of 500 numbered.</span>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/knit-pattern/templates/header.html
+++ b/examples/knit-pattern/templates/header.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Serif+Display:ital@0;1&family=IBM+Plex+Mono:wght@400;500&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip">
+    <div class="strip-inner">
+      <a class="strip-mark" href="{{ base_url }}/">SKEIN &amp; CHART</a>
+      <span class="strip-mid">PATTERN COLLECTION &middot; ISSUE 14 &middot; OCTOBER {{ current_year }}</span>
+      <nav class="strip-nav">
+        <a href="#patterns">Patterns</a>
+        <a href="#yarns">Yarns</a>
+        <a href="#errata">Errata</a>
+        <a href="{{ base_url }}/about/">Workshop</a>
+      </nav>
+    </div>
+    <div class="strip-rule"></div>
+  </header>

--- a/examples/knit-pattern/templates/index.html
+++ b/examples/knit-pattern/templates/index.html
@@ -1,0 +1,332 @@
+{% include "header.html" %}
+
+{# ----- Stitch symbol SVGs (reused across chart cells) ----- #}
+{% set knit_svg %}<svg class="stitch" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="2" fill="#2a2620"/></svg>{% endset %}
+{% set purl_svg %}<svg class="stitch" viewBox="0 0 20 20" aria-hidden="true"><line x1="4" y1="10" x2="16" y2="10" stroke="#2a2620" stroke-width="1.6" stroke-linecap="round"/></svg>{% endset %}
+{% set k2tog_svg %}<svg class="stitch" viewBox="0 0 20 20" aria-hidden="true"><line x1="4" y1="16" x2="16" y2="4" stroke="#2a2620" stroke-width="1.6" stroke-linecap="round"/></svg>{% endset %}
+{% set ssk_svg %}<svg class="stitch" viewBox="0 0 20 20" aria-hidden="true"><line x1="4" y1="4" x2="16" y2="16" stroke="#2a2620" stroke-width="1.6" stroke-linecap="round"/></svg>{% endset %}
+{% set yo_svg %}<svg class="stitch" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="4.2" fill="none" stroke="#2a2620" stroke-width="1.4"/></svg>{% endset %}
+
+{# Encode the 12-row chart as strings (k/p/t/s/o = 5 symbols). 12x12 = 144 cells. #}
+{% set chart_rows = [
+  "kkkpkkpookkk",
+  "kpkkooktkkpk",
+  "pkpokksskkpk",
+  "kkookkpkookk",
+  "ktkpkooopkts",
+  "kkkpookkpkkk",
+  "kpkooksskkpk",
+  "kkpokkookpkk",
+  "ktkpookkptks",
+  "kkookkppookk",
+  "kpkkooktkkpk",
+  "kkkpkkpookkk"
+] %}
+
+<section class="masthead">
+  <div class="masthead-grid">
+    <div class="chart-wrap">
+      <div class="chart-label">FIG. A &middot; CHART 14-A &middot; CABLE YOKE PANEL</div>
+      <div class="chart-row">
+        <div class="chart">
+          {% for row in chart_rows %}
+            {% for ch in row | split(pat="") %}
+              {% if ch %}
+              <div class="cell">
+                {% if ch == "k" %}{{ knit_svg }}
+                {% elif ch == "p" %}{{ purl_svg }}
+                {% elif ch == "t" %}{{ k2tog_svg }}
+                {% elif ch == "s" %}{{ ssk_svg }}
+                {% elif ch == "o" %}{{ yo_svg }}
+                {% endif %}
+              </div>
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        </div>
+        <div class="row-numbers">
+          {% for n in [12,11,10,9,8,7,6,5,4,3,2,1] %}<span>{{ n }}</span>{% endfor %}
+        </div>
+      </div>
+      <div class="stitch-numbers">
+        {% for n in [1,2,3,4,5,6,7,8,9,10,11,12] %}<span>{{ n }}</span>{% endfor %}
+      </div>
+      <div class="chart-legend">
+        <span><i class="lg knit"></i> knit</span>
+        <span><i class="lg purl"></i> purl</span>
+        <span><i class="lg k2tog"></i> k2tog</span>
+        <span><i class="lg ssk"></i> ssk</span>
+        <span><i class="lg yo"></i> yarn over</span>
+      </div>
+    </div>
+
+    <div class="masthead-text">
+      <p class="kicker">ISSUE 14 &middot; OCTOBER &middot; {{ current_year }}</p>
+      <h1 class="headline">One pattern<br><em>for every</em><br>forgotten stitch.</h1>
+      <p class="subtitle">Four hand-knitting patterns &mdash; sweater, mittens, socks, and a yoked pullover &mdash; set in lead, photocopied, then bound by hand. Each booklet ships with a stitch chart, a measured schematic, and a three-yarn substitution guide.</p>
+      <div class="masthead-meta">
+        <div><span class="m-key">Booklets</span><span class="m-val">04 patterns</span></div>
+        <div><span class="m-key">Edition</span><span class="m-val">500 numbered</span></div>
+        <div><span class="m-key">Paper</span><span class="m-val">90gsm cartridge</span></div>
+        <div><span class="m-key">Binding</span><span class="m-val">Saddle, by hand</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# ============== PATTERNS ============== #}
+<section class="patterns" id="patterns">
+  <div class="section-head">
+    <div class="section-num">II.</div>
+    <h2 class="section-title">This Issue's Patterns</h2>
+    <div class="section-rule"></div>
+    <p class="section-note">Four patterns. Three test-knitters per draft. Forty-one corrections folded back in before press.</p>
+  </div>
+
+  <div class="pattern-grid">
+
+    <article class="pattern">
+      <header class="pattern-head">
+        <span class="pattern-no">No. 14-A</span>
+        <span class="pattern-swatch swatch-heather" aria-label="Heather blue swatch"></span>
+      </header>
+      <h3 class="pattern-name">The <em>Mulgun</em> Yoke</h3>
+      <p class="pattern-sub">A round-yoke pullover with a chart-only colourwork band.</p>
+      <div class="schematic">
+        <svg viewBox="0 0 220 180" aria-hidden="true">
+          <g fill="none" stroke="#2a2620" stroke-width="1.2" stroke-linejoin="round">
+            <path d="M40 30 L40 70 L20 70 L20 150 L60 150 L60 100 L160 100 L160 150 L200 150 L200 70 L180 70 L180 30 Z"/>
+            <path d="M80 30 Q110 18 140 30"/>
+            <line x1="40" y1="30" x2="80" y2="30" stroke-dasharray="2 2"/>
+            <line x1="140" y1="30" x2="180" y2="30" stroke-dasharray="2 2"/>
+            <line x1="20" y1="100" x2="60" y2="100"/>
+            <line x1="160" y1="100" x2="200" y2="100"/>
+          </g>
+          <g font-family="IBM Plex Mono" font-size="8" fill="#6e6855">
+            <text x="110" y="14" text-anchor="middle">42 cm</text>
+            <text x="10" y="112" text-anchor="middle" transform="rotate(-90 10 112)">64 cm</text>
+            <text x="110" y="168" text-anchor="middle">54 cm bust</text>
+            <text x="210" y="90" text-anchor="middle" transform="rotate(-90 210 90)">36 cm</text>
+          </g>
+        </svg>
+      </div>
+      <table class="spec">
+        <tr><th>Needle</th><td>4.0 mm circular, 80 cm</td></tr>
+        <tr><th>Yarn</th><td>DK weight &middot; 1,200 m</td></tr>
+        <tr><th>Bust</th><td>S 88 / M 96 / L 108 / XL 120 cm</td></tr>
+        <tr><th>Length</th><td>62 &ndash; 68 cm</td></tr>
+        <tr><th>Gauge</th><td>22 sts &times; 30 r / 10 cm</td></tr>
+      </table>
+    </article>
+
+    <article class="pattern">
+      <header class="pattern-head">
+        <span class="pattern-no">No. 14-B</span>
+        <span class="pattern-swatch swatch-sage" aria-label="Sage swatch"></span>
+      </header>
+      <h3 class="pattern-name">Two-End <em>Tvebands</em> Mittens</h3>
+      <p class="pattern-sub">Twined-knit mittens with a charted thumbgore.</p>
+      <div class="schematic">
+        <svg viewBox="0 0 220 180" aria-hidden="true">
+          <g fill="none" stroke="#2a2620" stroke-width="1.2" stroke-linejoin="round">
+            <path d="M70 150 L70 90 Q70 50 110 50 Q150 50 150 90 L150 150 Z"/>
+            <path d="M150 100 Q175 95 175 78 Q175 62 158 62 Q150 62 150 70"/>
+            <path d="M70 150 L150 150"/>
+            <line x1="70" y1="138" x2="150" y2="138" stroke-dasharray="2 2"/>
+          </g>
+          <g font-family="IBM Plex Mono" font-size="8" fill="#6e6855">
+            <text x="110" y="44" text-anchor="middle">cuff edge</text>
+            <text x="60" y="120" text-anchor="end">22 cm</text>
+            <text x="110" y="168" text-anchor="middle">9 cm palm</text>
+            <text x="190" y="80" text-anchor="middle">thumb 6 cm</text>
+          </g>
+        </svg>
+      </div>
+      <table class="spec">
+        <tr><th>Needle</th><td>2.5 mm DPN, set of 5</td></tr>
+        <tr><th>Yarn</th><td>Fingering &middot; 320 m</td></tr>
+        <tr><th>Sizes</th><td>W S / W M / W L &middot; M S / M M</td></tr>
+        <tr><th>Length</th><td>26 cm cuff to tip</td></tr>
+        <tr><th>Gauge</th><td>28 sts &times; 36 r / 10 cm</td></tr>
+      </table>
+    </article>
+
+    <article class="pattern">
+      <header class="pattern-head">
+        <span class="pattern-no">No. 14-C</span>
+        <span class="pattern-swatch swatch-rust" aria-label="Rust swatch"></span>
+      </header>
+      <h3 class="pattern-name">The <em>Pencil-Mark</em> Sock</h3>
+      <p class="pattern-sub">A cuff-down sock with a lifted-heel and a 12-row repeat.</p>
+      <div class="schematic">
+        <svg viewBox="0 0 220 180" aria-hidden="true">
+          <g fill="none" stroke="#2a2620" stroke-width="1.2" stroke-linejoin="round">
+            <path d="M70 25 L70 100 Q70 110 80 110 L80 145 L150 145 L150 110 Q200 105 200 80 L180 80 L180 25 Z"/>
+            <line x1="70" y1="35" x2="180" y2="35" stroke-dasharray="2 2"/>
+            <line x1="80" y1="120" x2="150" y2="120" stroke-dasharray="2 2"/>
+          </g>
+          <g font-family="IBM Plex Mono" font-size="8" fill="#6e6855">
+            <text x="125" y="20" text-anchor="middle">cuff 18 cm</text>
+            <text x="60" y="72" text-anchor="end">leg 17 cm</text>
+            <text x="115" y="160" text-anchor="middle">foot 24 cm</text>
+            <text x="210" y="78" text-anchor="middle">heel</text>
+          </g>
+        </svg>
+      </div>
+      <table class="spec">
+        <tr><th>Needle</th><td>2.25 mm DPN or magic loop</td></tr>
+        <tr><th>Yarn</th><td>4-ply sock &middot; 380 m</td></tr>
+        <tr><th>Sizes</th><td>EU 36 / 38 / 40 / 42 / 44</td></tr>
+        <tr><th>Length</th><td>To wearer</td></tr>
+        <tr><th>Gauge</th><td>32 sts &times; 44 r / 10 cm</td></tr>
+      </table>
+    </article>
+
+    <article class="pattern">
+      <header class="pattern-head">
+        <span class="pattern-no">No. 14-D</span>
+        <span class="pattern-swatch swatch-needle" aria-label="Needlework blue swatch"></span>
+      </header>
+      <h3 class="pattern-name">The <em>Cartridge</em> Cardigan</h3>
+      <p class="pattern-sub">A seamed cardigan with hand-finished facings and pocket bags.</p>
+      <div class="schematic">
+        <svg viewBox="0 0 220 180" aria-hidden="true">
+          <g fill="none" stroke="#2a2620" stroke-width="1.2" stroke-linejoin="round">
+            <path d="M50 28 L50 70 L25 70 L25 158 L75 158 L75 105 L145 105 L145 158 L195 158 L195 70 L170 70 L170 28 Z"/>
+            <line x1="110" y1="28" x2="110" y2="158"/>
+            <path d="M85 28 Q110 18 135 28"/>
+            <circle cx="110" cy="60" r="1.4" fill="#2a2620"/>
+            <circle cx="110" cy="80" r="1.4" fill="#2a2620"/>
+            <circle cx="110" cy="100" r="1.4" fill="#2a2620"/>
+            <circle cx="110" cy="120" r="1.4" fill="#2a2620"/>
+            <circle cx="110" cy="140" r="1.4" fill="#2a2620"/>
+          </g>
+          <g font-family="IBM Plex Mono" font-size="8" fill="#6e6855">
+            <text x="110" y="14" text-anchor="middle">48 cm</text>
+            <text x="14" y="115" text-anchor="middle" transform="rotate(-90 14 115)">68 cm</text>
+            <text x="110" y="174" text-anchor="middle">5 buttons</text>
+            <text x="208" y="92" text-anchor="middle" transform="rotate(-90 208 92)">38 cm</text>
+          </g>
+        </svg>
+      </div>
+      <table class="spec">
+        <tr><th>Needle</th><td>3.5 mm straight &middot; 4.0 mm finishing</td></tr>
+        <tr><th>Yarn</th><td>Aran &middot; 1,460 m</td></tr>
+        <tr><th>Bust</th><td>S 92 / M 100 / L 112 / XL 124 cm</td></tr>
+        <tr><th>Length</th><td>66 &ndash; 72 cm</td></tr>
+        <tr><th>Gauge</th><td>18 sts &times; 26 r / 10 cm</td></tr>
+      </table>
+    </article>
+
+  </div>
+</section>
+
+{# ============== YARN LIBRARY ============== #}
+<section class="yarns" id="yarns">
+  <div class="section-head">
+    <div class="section-num">III.</div>
+    <h2 class="section-title">Yarn Library</h2>
+    <div class="section-rule"></div>
+    <p class="section-note">Three mills we keep on the shelf this season &mdash; with their fibre breakdown and stocked colour ranges.</p>
+  </div>
+
+  <div class="yarn-grid">
+
+    <article class="yarn">
+      <h3 class="yarn-name">Halfdan Mill</h3>
+      <p class="yarn-meta">Roskilde, Denmark &middot; est. 1948 &middot; DK / fingering</p>
+      <div class="dots">
+        <span style="background:#f4ecd6"></span>
+        <span style="background:#e3d9b8"></span>
+        <span style="background:#6f8ba6"></span>
+        <span style="background:#6c8a5a"></span>
+        <span style="background:#b2562b"></span>
+        <span style="background:#2a4a7d"></span>
+        <span style="background:#6e6855"></span>
+        <span style="background:#2a2620"></span>
+      </div>
+      <table class="fibre">
+        <tr><th>Wool, Gotland</th><td>72%</td></tr>
+        <tr><th>Wool, Romney</th><td>22%</td></tr>
+        <tr><th>Mohair</th><td>06%</td></tr>
+        <tr><th>Twist</th><td>2-ply, S</td></tr>
+        <tr><th>Meterage</th><td>240 m / 100 g</td></tr>
+      </table>
+    </article>
+
+    <article class="yarn">
+      <h3 class="yarn-name">Yang Spinnery</h3>
+      <p class="yarn-meta">Jeju, Korea &middot; est. 1981 &middot; aran / worsted</p>
+      <div class="dots">
+        <span style="background:#e3d9b8"></span>
+        <span style="background:#b2562b"></span>
+        <span style="background:#6c8a5a"></span>
+        <span style="background:#2a4a7d"></span>
+        <span style="background:#6f8ba6"></span>
+        <span style="background:#6e6855"></span>
+        <span style="background:#f4ecd6"></span>
+        <span style="background:#2a2620"></span>
+      </div>
+      <table class="fibre">
+        <tr><th>Wool, Merino</th><td>80%</td></tr>
+        <tr><th>Alpaca, Suri</th><td>15%</td></tr>
+        <tr><th>Silk</th><td>05%</td></tr>
+        <tr><th>Twist</th><td>3-ply, Z</td></tr>
+        <tr><th>Meterage</th><td>160 m / 100 g</td></tr>
+      </table>
+    </article>
+
+    <article class="yarn">
+      <h3 class="yarn-name">Borre &amp; Brun</h3>
+      <p class="yarn-meta">Tromso, Norway &middot; est. 1962 &middot; sock / fingering</p>
+      <div class="dots">
+        <span style="background:#2a4a7d"></span>
+        <span style="background:#6f8ba6"></span>
+        <span style="background:#6c8a5a"></span>
+        <span style="background:#b2562b"></span>
+        <span style="background:#e3d9b8"></span>
+        <span style="background:#f4ecd6"></span>
+        <span style="background:#6e6855"></span>
+        <span style="background:#2a2620"></span>
+      </div>
+      <table class="fibre">
+        <tr><th>Wool, Bluefaced</th><td>75%</td></tr>
+        <tr><th>Nylon</th><td>20%</td></tr>
+        <tr><th>Silk noil</th><td>05%</td></tr>
+        <tr><th>Twist</th><td>4-ply, S</td></tr>
+        <tr><th>Meterage</th><td>425 m / 100 g</td></tr>
+      </table>
+    </article>
+
+  </div>
+</section>
+
+{# ============== ERRATA ============== #}
+<section class="errata" id="errata">
+  <div class="section-head">
+    <div class="section-num">IV.</div>
+    <h2 class="section-title">Errata</h2>
+    <div class="section-rule"></div>
+    <p class="section-note">Corrections to past issues, typed up by the desk. If you are knitting from an earlier print, please write these in by hand.</p>
+  </div>
+
+  <ul class="errata-list">
+    <li>
+      <span class="err-tag">Issue 13 &middot; p. 18</span>
+      <p>Row 24 of the yoke chart should read &ldquo;k2, yo, ssk, k2, k2tog, yo, k2&rdquo; &mdash; not &ldquo;k2, yo, k2tog, k2, ssk, yo, k2&rdquo;. The chart on p. 19 is correct; the written line is the typo.</p>
+      <span class="err-date">Filed {{ current_year }}.06</span>
+    </li>
+    <li>
+      <span class="err-tag">Issue 12 &middot; p. 7</span>
+      <p>Finished bust for size L should be 108 cm, not 106 cm. The schematic was drawn to 108; the table on p. 7 was set from an earlier draft.</p>
+      <span class="err-date">Filed {{ current_year }}.03</span>
+    </li>
+    <li>
+      <span class="err-tag">Issue 11 &middot; p. 24</span>
+      <p>The thumb gusset on the right-hand mitten should mirror the left. The chart printed on p. 24 has the increases on the wrong side of the thumbgore. A corrected single-page insert is available on request.</p>
+      <span class="err-date">Filed 2024.11</span>
+    </li>
+  </ul>
+</section>
+
+{% include "footer.html" %}

--- a/examples/knit-pattern/templates/page.html
+++ b/examples/knit-pattern/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/knit-pattern/templates/section.html
+++ b/examples/knit-pattern/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+<section class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+  <ul class="post-list">
+    {% for post in section.pages %}
+    <li>
+      <span class="post-date">{{ post.date | date(format="%Y / %m") }}</span>
+      <a href="{{ post.url }}">{{ post.title | e }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/knit-pattern/templates/shortcodes/alert.html
+++ b/examples/knit-pattern/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/knit-pattern/templates/taxonomy.html
+++ b/examples/knit-pattern/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p>Subjects catalogued across the pattern booklets.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/knit-pattern/templates/taxonomy_term.html
+++ b/examples/knit-pattern/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p>Patterns and notes filed under this term.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/late-broadcast/AGENTS.md
+++ b/examples/late-broadcast/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/late-broadcast/archetypes/default.md
+++ b/examples/late-broadcast/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/late-broadcast/config.toml
+++ b/examples/late-broadcast/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "LATE BROADCAST LAB"
+description = "A VHS, Super-8 and cassette digitization studio. We transfer your tapes in one pass and return them with a hand-typed broadcast log."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/late-broadcast/content/about.md
+++ b/examples/late-broadcast/content/about.md
@@ -1,0 +1,49 @@
++++
+title = "About the Lab"
+description = "LATE BROADCAST LAB — the studio, the gear, the turnaround, and the broadcast log."
++++
+
+## The lab
+
+Late Broadcast Lab is a two-room digitization studio on the fourth floor of a quiet building in Seoul. We transfer one tape at a time, in real time, the way broadcasters did when these decks were new. No batch carts, no parallel rigs, no "we'll fix it in post."
+
+The front room is the desk. The back room has the decks. The decks do not leave the back room.
+
+## The gear
+
+We keep a small, working bench of period-correct hardware. Everything is serviced in-house and aligned on schedule.
+
+- **VHS / VHS-C** — two service-grade decks, PAL and NTSC, time-base corrected
+- **Hi8 / Video8** — one Sony EV-S9000 with a fresh head
+- **MiniDV** — a single DSR-11 over FireWire, the only way that still works
+- **U-matic** — one BVU-950, used sparingly, with parts on hand
+- **Super-8 / Regular-8** — Retroscan Mini for 2K frame-by-frame scanning
+- **Reel-to-Reel** — Studer A810, Revox B77, both calibrated for 7.5 and 15 IPS
+- **Cassette** — Nakamichi Dragon, manually azimuth-aligned per tape
+- **Microcassette** — one Pearlcorder, because someone has to
+
+## Turnaround
+
+We do not promise hours. We promise that every transfer is real-time and logged.
+
+| Format | Typical turnaround |
+| --- | --- |
+| Cassette, microcassette | 5&ndash;7 days |
+| VHS, Hi8, MiniDV | 7&ndash;10 days |
+| Reel-to-reel, U-matic | 10&ndash;14 days |
+| Super-8, Regular-8 film | 14&ndash;21 days |
+
+If a tape arrives damaged we call before we start. We will not run a tape we do not trust.
+
+## The broadcast log
+
+Every transfer leaves the lab with a typed broadcast log: timecodes, drop-outs, head cleanings, deck assignments, engineer initials, and a short note in plain language. The log is printed on a Brother typewriter, scanned at 600 DPI, and stapled to the cassette case it came with.
+
+We do this because the tape is a record of a moment. The log is a record of how we handled that moment.
+
+## Contact the desk
+
+- **Desk** &mdash; `desk@late-broadcast.lab`
+- **Drop-off** &mdash; walk-in Friday 14:00 to 20:00
+- **Mail-in** &mdash; insured only, return postage included in the quote
+- **Phone** &mdash; the line is open during transfer hours; leave a number and we will call back between deck runs

--- a/examples/late-broadcast/content/index.md
+++ b/examples/late-broadcast/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "LATE BROADCAST LAB — a VHS, Super-8 and cassette digitization studio that returns your tapes with a hand-typed broadcast log."
+template = "index"
++++

--- a/examples/late-broadcast/static/css/style.css
+++ b/examples/late-broadcast/static/css/style.css
@@ -1,0 +1,662 @@
+/* LATE BROADCAST LAB — VHS / SMPTE / late-night signoff */
+
+:root {
+  --bar-white: #c1c1c1;
+  --bar-yellow: #c1c100;
+  --bar-cyan: #00c1c1;
+  --bar-green: #00c100;
+  --bar-magenta: #c100c1;
+  --bar-red: #c10000;
+  --bar-blue: #0000c1;
+  --black: #050505;
+  --ink: #0d0d0d;
+  --paper: #e6e3da;
+  --amber: #ffb84a;
+  --rule: #1a1a1a;
+  --display: "Anton", "Oswald", "Arial Narrow", sans-serif;
+  --bc: "VT323", "Courier New", monospace;
+  --mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--black);
+  color: var(--paper);
+  overflow-x: hidden;
+}
+
+body {
+  font-family: var(--mono);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  /* Scanline texture (NOT a gradient) — 1px dark stripe on a 3px tile */
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='3' height='3'><rect width='3' height='1' fill='%23000000' fill-opacity='0.35'/></svg>");
+  background-size: 3px 3px;
+}
+
+a { color: var(--amber); text-decoration: none; }
+a:hover { color: var(--bar-yellow); }
+
+::selection { background: var(--amber); color: var(--black); }
+
+/* ===== TOP STRIP ===== */
+.strip-top {
+  background: var(--black);
+  color: var(--amber);
+  padding: 10px 24px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border-bottom: 2px solid var(--amber);
+  gap: 24px;
+}
+.strip-top .onair {
+  color: var(--amber);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+}
+.strip-top .onair .dot {
+  width: 10px; height: 10px;
+  background: var(--bar-red);
+  border-radius: 50%;
+  animation: onair-blink 1.4s infinite;
+  box-shadow: 0 0 0 1px var(--amber);
+}
+.strip-top .tc {
+  font-family: var(--mono);
+  color: var(--bar-white);
+  letter-spacing: 0.22em;
+  justify-self: end;
+}
+.strip-top nav {
+  display: flex;
+  gap: 18px;
+}
+.strip-top nav a {
+  color: var(--paper);
+  border-bottom: 1px dotted var(--paper);
+  padding-bottom: 1px;
+}
+.strip-top nav a:hover { color: var(--amber); border-bottom-color: var(--amber); }
+
+@keyframes onair-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0.15; }
+}
+
+/* ===== HERO ===== */
+.hero {
+  background: var(--black);
+  border-bottom: 2px solid var(--amber);
+  padding: 0;
+}
+.hero-wrap {
+  display: grid;
+  grid-template-columns: 60% 40%;
+  min-height: 78vh;
+}
+.hero .left {
+  padding: 48px 56px 56px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 22px;
+  border-right: 2px solid var(--amber);
+}
+.hero .slug {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--bar-cyan);
+}
+.hero h1 {
+  font-family: var(--bc);
+  font-weight: normal;
+  font-size: clamp(70px, 9vw, 132px);
+  line-height: 0.92;
+  margin: 0;
+  letter-spacing: 0.01em;
+  color: var(--paper);
+  text-transform: uppercase;
+}
+.hero h1 .l { display: block; }
+.hero h1 .hi { color: var(--amber); }
+.hero .log {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bar-white);
+  margin: 0;
+  padding: 10px 14px;
+  border: 1px solid var(--amber);
+  border-left: 6px solid var(--amber);
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  align-self: flex-start;
+}
+.hero .log .tc { color: var(--amber); }
+.hero .log .bar { color: var(--rule); }
+.hero .lede {
+  font-family: var(--mono);
+  font-size: 14px;
+  max-width: 56ch;
+  color: var(--paper);
+  margin: 0;
+}
+.hero .cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.btn {
+  font-family: var(--display);
+  font-size: 15px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 11px 18px;
+  border: 2px solid var(--paper);
+  background: var(--black);
+  color: var(--paper);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.btn:hover { background: var(--paper); color: var(--black); }
+.btn .ar { font-family: var(--mono); font-size: 12px; }
+.btn.red { background: var(--bar-red); border-color: var(--bar-red); color: var(--paper); }
+.btn.red:hover { background: var(--paper); color: var(--bar-red); border-color: var(--paper); }
+.btn.cy { background: var(--bar-cyan); border-color: var(--bar-cyan); color: var(--black); }
+.btn.cy:hover { background: var(--paper); color: var(--black); border-color: var(--paper); }
+
+/* hero right — SMPTE bars panel */
+.hero .right {
+  position: relative;
+  background: var(--black);
+  display: flex;
+  flex-direction: column;
+}
+.bars-main {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  height: 75%;
+}
+.bars-main span { display: block; }
+.bars-main .b-w { background: var(--bar-white); }
+.bars-main .b-y { background: var(--bar-yellow); }
+.bars-main .b-c { background: var(--bar-cyan); }
+.bars-main .b-g { background: var(--bar-green); }
+.bars-main .b-m { background: var(--bar-magenta); }
+.bars-main .b-r { background: var(--bar-red); }
+.bars-main .b-b { background: var(--bar-blue); }
+.bars-sub {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  height: 25%;
+}
+.bars-sub span { display: block; }
+.bars-sub .s1 { background: var(--bar-blue); }
+.bars-sub .s2 { background: var(--black); }
+.bars-sub .s3 { background: var(--bar-magenta); }
+.bars-sub .s4 { background: var(--black); }
+.bars-sub .s5 { background: var(--bar-cyan); }
+.bars-sub .s6 { background: var(--black); }
+.bars-sub .s7 { background: var(--bar-white); }
+.hero-tc {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  background: var(--black);
+  color: var(--amber);
+  padding: 6px 10px;
+  border: 1px solid var(--amber);
+}
+
+/* ===== FORMATS ===== */
+.formats {
+  background: var(--black);
+  padding: 64px 0;
+  border-bottom: 2px solid var(--amber);
+}
+.wrap { max-width: 1240px; margin: 0 auto; padding: 0 40px; }
+
+.hd {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--amber);
+  padding-bottom: 12px;
+  margin-bottom: 28px;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+.hd h2 {
+  font-family: var(--display);
+  font-size: clamp(34px, 4.4vw, 56px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--paper);
+  margin: 0;
+}
+.hd .sub {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--amber);
+}
+
+.formats .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border: 1px solid var(--amber);
+}
+.fmt {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  align-items: center;
+  gap: 14px;
+  padding: 18px 18px;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: var(--black);
+  font-family: var(--bc);
+  font-size: 26px;
+  text-transform: uppercase;
+}
+.fmt b { color: var(--paper); font-weight: normal; }
+.fmt .mono {
+  grid-column: 2;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: var(--bar-cyan);
+  text-transform: uppercase;
+}
+.fmt .sw {
+  grid-row: 1 / span 2;
+  width: 28px;
+  height: 44px;
+  display: block;
+}
+.fmt .sw.w { background: var(--bar-white); }
+.fmt .sw.y { background: var(--bar-yellow); }
+.fmt .sw.c { background: var(--bar-cyan); }
+.fmt .sw.g { background: var(--bar-green); }
+.fmt .sw.m { background: var(--bar-magenta); }
+.fmt .sw.r { background: var(--bar-red); }
+.fmt .sw.bl { background: var(--bar-blue); }
+.formats .note {
+  margin-top: 22px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  color: var(--bar-white);
+  border-left: 4px solid var(--amber);
+  padding: 6px 14px;
+}
+
+/* ===== LOG SECTION ===== */
+.log-section {
+  background: var(--black);
+  padding: 64px 0;
+  border-bottom: 2px solid var(--amber);
+}
+.entry {
+  border: 1px solid var(--amber);
+  padding: 22px 26px 24px;
+  margin-bottom: 18px;
+  background: var(--black);
+}
+.entry .head {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--amber);
+  border-bottom: 1px dotted var(--amber);
+  padding-bottom: 8px;
+  margin-bottom: 14px;
+}
+.entry .head .ch { color: var(--bar-cyan); }
+.entry h3 {
+  font-family: var(--display);
+  font-size: clamp(22px, 2.4vw, 30px);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--paper);
+  margin: 0 0 6px;
+  line-height: 1.05;
+}
+.entry h3 a { color: var(--paper); }
+.entry h3 a:hover { color: var(--amber); }
+.entry .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--bar-white);
+  margin-bottom: 12px;
+}
+.entry .hand {
+  font-family: var(--bc);
+  font-size: 22px;
+  line-height: 1.35;
+  color: var(--paper);
+  margin: 0 0 12px;
+}
+.entry .sign {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  color: var(--bar-yellow);
+  text-transform: uppercase;
+}
+
+/* ===== TEST PATTERN ===== */
+.test-pattern {
+  background: var(--black);
+  padding: 72px 0 0;
+  text-align: center;
+  border-bottom: 2px solid var(--amber);
+}
+.test-pattern .card {
+  max-width: 720px;
+  margin: 0 auto 48px;
+  padding: 36px 24px 28px;
+  border: 2px solid var(--amber);
+  background: var(--black);
+}
+.test-pattern .halo {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.45em;
+  color: var(--amber);
+  text-transform: uppercase;
+  margin-bottom: 18px;
+}
+.test-pattern .big-mark {
+  font-family: var(--display);
+  font-size: clamp(64px, 9vw, 108px);
+  line-height: 0.95;
+  letter-spacing: 0.04em;
+  color: var(--paper);
+}
+.test-pattern .big-mark span {
+  display: block;
+  font-family: var(--bc);
+  font-size: clamp(22px, 2.4vw, 32px);
+  letter-spacing: 0.3em;
+  margin-top: 8px;
+  color: var(--amber);
+}
+.test-pattern .freq {
+  margin-top: 18px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  color: var(--bar-cyan);
+  text-transform: uppercase;
+}
+.test-pattern .meta {
+  margin-top: 8px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  color: var(--bar-white);
+  text-transform: uppercase;
+}
+.pattern-bars {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  height: 70px;
+}
+.pattern-bars span { display: block; }
+.pattern-bars .b-w { background: var(--bar-white); }
+.pattern-bars .b-y { background: var(--bar-yellow); }
+.pattern-bars .b-c { background: var(--bar-cyan); }
+.pattern-bars .b-g { background: var(--bar-green); }
+.pattern-bars .b-m { background: var(--bar-magenta); }
+.pattern-bars .b-r { background: var(--bar-red); }
+.pattern-bars .b-b { background: var(--bar-blue); }
+
+/* ===== TICKER ===== */
+.ticker {
+  background: var(--black);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 2px solid var(--amber);
+}
+.ticker > div {
+  padding: 36px 24px;
+  border-right: 1px solid var(--amber);
+  text-align: center;
+}
+.ticker > div:last-child { border-right: none; }
+.ticker .n {
+  font-family: var(--bc);
+  font-size: clamp(54px, 7vw, 88px);
+  color: var(--amber);
+  line-height: 1;
+}
+.ticker .l {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  color: var(--bar-white);
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* ===== FOOTER / SIGNOFF ===== */
+.signoff {
+  background: var(--black);
+  padding: 64px 0 28px;
+  color: var(--paper);
+}
+.signoff .card {
+  max-width: 640px;
+  margin: 0 auto 28px;
+  text-align: center;
+  padding: 32px 18px;
+  border: 2px solid var(--amber);
+}
+.signoff .mark {
+  font-family: var(--display);
+  font-size: 64px;
+  color: var(--amber);
+  letter-spacing: 0.06em;
+  line-height: 0.95;
+}
+.signoff .title {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--paper);
+  margin-top: 14px;
+}
+.signoff .stand {
+  font-family: var(--bc);
+  font-size: 32px;
+  color: var(--amber);
+  letter-spacing: 0.22em;
+  margin-top: 8px;
+}
+.signoff .bars {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  height: 36px;
+  margin-bottom: 36px;
+}
+.signoff .bars span { display: block; }
+.signoff .bars .b-w { background: var(--bar-white); }
+.signoff .bars .b-y { background: var(--bar-yellow); }
+.signoff .bars .b-c { background: var(--bar-cyan); }
+.signoff .bars .b-g { background: var(--bar-green); }
+.signoff .bars .b-m { background: var(--bar-magenta); }
+.signoff .bars .b-r { background: var(--bar-red); }
+.signoff .bars .b-b { background: var(--bar-blue); }
+
+.signoff .grid {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 40px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 28px;
+}
+.signoff .grid h4 {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin: 0 0 10px;
+  border-bottom: 1px solid var(--amber);
+  padding-bottom: 6px;
+}
+.signoff .grid a {
+  display: block;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--paper);
+  margin-bottom: 4px;
+  letter-spacing: 0.04em;
+}
+.signoff .grid a:hover { color: var(--amber); }
+.signoff .copy {
+  grid-column: 1 / -1;
+  border-top: 1px dotted var(--amber);
+  padding-top: 14px;
+  margin-top: 8px;
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--bar-white);
+}
+
+/* ===== PROSE / page.html ===== */
+.prose {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 56px 40px 80px;
+  font-family: var(--mono);
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--paper);
+}
+.prose h1 {
+  font-family: var(--display);
+  font-size: clamp(40px, 5.6vw, 72px);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--paper);
+  border-bottom: 2px solid var(--amber);
+  padding-bottom: 14px;
+  margin: 0 0 28px;
+}
+.prose h2 {
+  font-family: var(--display);
+  font-size: clamp(26px, 3vw, 38px);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin: 36px 0 14px;
+}
+.prose h3 {
+  font-family: var(--mono);
+  font-size: 14px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--bar-cyan);
+  margin: 24px 0 8px;
+}
+.prose p { margin: 0 0 16px; }
+.prose a { color: var(--amber); border-bottom: 1px dotted var(--amber); }
+.prose a:hover { color: var(--bar-yellow); border-bottom-color: var(--bar-yellow); }
+.prose ul, .prose ol { padding-left: 22px; margin: 0 0 20px; }
+.prose li { margin-bottom: 6px; }
+.prose strong { color: var(--bar-yellow); }
+.prose blockquote {
+  border-left: 4px solid var(--bar-red);
+  padding: 8px 16px;
+  margin: 18px 0;
+  font-family: var(--bc);
+  font-size: 22px;
+  color: var(--paper);
+  background: var(--black);
+}
+.prose code {
+  font-family: var(--mono);
+  background: var(--rule);
+  color: var(--amber);
+  padding: 1px 6px;
+  font-size: 13px;
+}
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  font-size: 13px;
+}
+.prose th, .prose td {
+  border: 1px solid var(--amber);
+  padding: 8px 12px;
+  text-align: left;
+}
+.prose th {
+  background: var(--rule);
+  color: var(--amber);
+  font-family: var(--mono);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+
+/* ===== RESPONSIVE ===== */
+@media (max-width: 900px) {
+  .hero-wrap { grid-template-columns: 1fr; }
+  .hero .left { border-right: none; border-bottom: 2px solid var(--amber); padding: 36px 28px 40px; }
+  .hero .right { min-height: 280px; }
+  .formats .grid { grid-template-columns: repeat(2, 1fr); }
+  .ticker { grid-template-columns: repeat(2, 1fr); }
+  .ticker > div:nth-child(2) { border-right: none; }
+  .signoff .grid { grid-template-columns: repeat(2, 1fr); }
+  .signoff .copy { flex-direction: column; gap: 6px; }
+  .strip-top { grid-template-columns: 1fr; text-align: center; gap: 8px; }
+  .strip-top .tc { justify-self: center; }
+  .strip-top nav { justify-content: center; }
+}
+@media (max-width: 560px) {
+  .formats .grid { grid-template-columns: 1fr; }
+  .ticker { grid-template-columns: 1fr; }
+  .ticker > div { border-right: none; border-bottom: 1px solid var(--amber); }
+  .signoff .grid { grid-template-columns: 1fr; }
+  .hero .left { padding: 28px 20px 32px; }
+  .wrap { padding: 0 20px; }
+}

--- a/examples/late-broadcast/static/favicon.svg
+++ b/examples/late-broadcast/static/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#050505"/>
+  <rect x="2" y="4" width="4" height="20" fill="#c1c1c1"/>
+  <rect x="6" y="4" width="4" height="20" fill="#c1c100"/>
+  <rect x="10" y="4" width="4" height="20" fill="#00c1c1"/>
+  <rect x="14" y="4" width="4" height="20" fill="#00c100"/>
+  <rect x="18" y="4" width="4" height="20" fill="#c100c1"/>
+  <rect x="22" y="4" width="4" height="20" fill="#c10000"/>
+  <rect x="26" y="4" width="4" height="20" fill="#0000c1"/>
+  <circle cx="16" cy="28" r="2" fill="#ffb84a"/>
+</svg>

--- a/examples/late-broadcast/templates/404.html
+++ b/examples/late-broadcast/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 // SIGNAL LOST.</h1>
+  <p>The carrier dropped. This page is between channels &mdash; static, snow, and the faint hum of a deck still running. Try the front again.</p>
+  <p><a href="{{ base_url }}/">&laquo; return to broadcast</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/late-broadcast/templates/footer.html
+++ b/examples/late-broadcast/templates/footer.html
@@ -1,0 +1,46 @@
+  <footer class="signoff" id="desk">
+    <div class="wrap">
+      <div class="card">
+        <div class="mark">LBL</div>
+        <div class="title">TRANSMISSION ENDS &middot; {{ current_year }}</div>
+        <div class="stand">PLEASE STAND BY</div>
+      </div>
+      <div class="bars">
+        <span class="b-w"></span><span class="b-y"></span><span class="b-c"></span><span class="b-g"></span><span class="b-m"></span><span class="b-r"></span><span class="b-b"></span>
+      </div>
+      <div class="grid">
+        <div>
+          <h4>DESK</h4>
+          <a href="#">desk@late-broadcast.lab</a>
+          <a href="#">+82-2-04-1958</a>
+          <a href="#">Walk-in &middot; Fri 14:00&ndash;20:00</a>
+        </div>
+        <div>
+          <h4>FORMATS</h4>
+          <a href="{{ base_url }}/about/">Tape index</a>
+          <a href="#">Drop-off slip</a>
+          <a href="#">Master copies</a>
+        </div>
+        <div>
+          <h4>ARCHIVE</h4>
+          <a href="{{ base_url }}/tags/">Restoration log</a>
+          <a href="#">Engineer notes</a>
+          <a href="#">Lost reels found</a>
+        </div>
+        <div>
+          <h4>LAB</h4>
+          <a href="#">About the gear</a>
+          <a href="#">Turnaround times</a>
+          <a href="#">Press inquiries</a>
+        </div>
+        <div class="copy">
+          <span>&copy; {{ current_year }} LATE BROADCAST LAB &middot; CH 04 &middot; SE-04</span>
+          <span>Hwaro build &middot; tape {{ current_year }}.04</span>
+        </div>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/late-broadcast/templates/header.html
+++ b/examples/late-broadcast/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=VT323&family=Anton&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <a href="{{ base_url }}/" class="onair"><span class="dot"></span> ON AIR &middot; CHANNEL 04 &middot; LATE BROADCAST LAB</a>
+    <span class="tc">TC 02:47:13:22</span>
+    <nav>
+      <a href="{{ base_url }}/about/">Services</a>
+      <a href="{{ base_url }}/tags/">Archive</a>
+      <a href="#desk">Desk</a>
+    </nav>
+  </header>

--- a/examples/late-broadcast/templates/index.html
+++ b/examples/late-broadcast/templates/index.html
@@ -1,0 +1,116 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="hero-wrap">
+    <div class="left">
+      <div class="slug">CH 04 &middot; LATE BROADCAST LAB &middot; SE-04</div>
+      <h1>
+        <span class="l">WE TRANSFER</span>
+        <span class="l">YOUR TAPES</span>
+        <span class="l hi">IN ONE PASS.</span>
+      </h1>
+      <p class="log">
+        <span class="tc">TC 02:47:13:22</span>
+        <span class="bar">|</span>
+        VHS-C &middot; HOUSEHOLD &middot; 64 MIN RUNTIME &middot; CAPTURED IN ONE TAKE
+      </p>
+      <p class="lede">
+        We are a small digitization studio in Seoul. Bring us a tape, a reel, or a box of unmarked cassettes. We run them once, in real time, through the same decks the broadcasters used. You get a clean digital master and a typed broadcast log of every minute we touched.
+      </p>
+      <div class="cta">
+        <a class="btn red" href="{{ base_url }}/about/">BOOK A TRANSFER <span class="ar">&gt;&gt;</span></a>
+        <a class="btn cy" href="#formats">SUPPORTED FORMATS <span class="ar">&gt;&gt;</span></a>
+        <a class="btn" href="#log">RECENT LOG <span class="ar">&gt;&gt;</span></a>
+      </div>
+    </div>
+    <div class="right" aria-hidden="true">
+      <div class="bars-main">
+        <span class="b-w"></span><span class="b-y"></span><span class="b-c"></span><span class="b-g"></span><span class="b-m"></span><span class="b-r"></span><span class="b-b"></span>
+      </div>
+      <div class="bars-sub">
+        <span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span><span class="s7"></span>
+      </div>
+      <div class="hero-tc">02:47:13:22</div>
+    </div>
+  </div>
+</section>
+
+<section class="formats" id="formats">
+  <div class="wrap">
+    <div class="hd">
+      <h2>FORMAT LIST</h2>
+      <div class="sub">SUPPORTED INTAKE &middot; 04 / {{ current_year }}</div>
+    </div>
+    <div class="grid">
+      <div class="fmt"><span class="sw w"></span><b>VHS</b><span class="mono">PAL/NTSC &middot; 240 LINES</span></div>
+      <div class="fmt"><span class="sw y"></span><b>Hi8</b><span class="mono">8MM &middot; 400 LINES</span></div>
+      <div class="fmt"><span class="sw c"></span><b>SUPER-8</b><span class="mono">FILM &middot; 18 FPS</span></div>
+      <div class="fmt"><span class="sw g"></span><b>MiniDV</b><span class="mono">DV-25 &middot; 1394</span></div>
+      <div class="fmt"><span class="sw m"></span><b>U-MATIC</b><span class="mono">3/4" &middot; LO/HI BAND</span></div>
+      <div class="fmt"><span class="sw r"></span><b>REEL-TO-REEL</b><span class="mono">1/4" &middot; 7.5/15 IPS</span></div>
+      <div class="fmt"><span class="sw bl"></span><b>CASSETTE</b><span class="mono">TYPE I &middot; II &middot; IV</span></div>
+      <div class="fmt"><span class="sw w"></span><b>MICROCASSETTE</b><span class="mono">DICTAPHONE</span></div>
+    </div>
+    <p class="note">If your tape is not on this list, bring it anyway. We have a back room of orphan decks and we like a challenge.</p>
+  </div>
+</section>
+
+<section class="log-section" id="log">
+  <div class="wrap">
+    <div class="hd">
+      <h2>RECENT RESTORATIONS</h2>
+      <div class="sub">BROADCAST LOG &middot; LATEST ENTRIES</div>
+    </div>
+    <article class="entry">
+      <div class="head">
+        <span class="tc">TC 00:00:00:00 &rarr; 01:14:08:11</span>
+        <span class="ch">CH 04</span>
+      </div>
+      <h3>HOUSEHOLD TAPES &middot; CASSETTE 14 &middot; RESTORED 04:{{ current_year }}</h3>
+      <div class="meta">RUNNING TIME 74:08 &middot; TYPE II &middot; DOLBY B OFF</div>
+      <p class="hand">Two children, one birthday, a dog that barks for the entire B-side. Tape arrived with a stretched leader; we transferred from the second pass to keep the wow under threshold. Master returned on USB and on a fresh Type II copy.</p>
+      <div class="sign">&mdash; HARU, ENGINEER &middot; DECK 02</div>
+    </article>
+    <article class="entry">
+      <div class="head">
+        <span class="tc">TC 00:00:00:00 &rarr; 00:42:30:00</span>
+        <span class="ch">CH 04</span>
+      </div>
+      <h3>WEDDING REEL 1978 &middot; SUPER-8 &middot; RESTORED 04:{{ current_year }}</h3>
+      <div class="meta">RUNNING TIME 42:30 &middot; SILENT &middot; 18 FPS</div>
+      <p class="hand">Eight rolls, three of them spliced badly. Cleaned and scanned at 2K with the Retroscan. The grandmother in the third reel is the same age the bride is now. We left the cigarette burns alone &mdash; the client asked.</p>
+      <div class="sign">&mdash; MIN, ENGINEER &middot; SCAN ROOM</div>
+    </article>
+    <article class="entry">
+      <div class="head">
+        <span class="tc">TC 00:00:00:00 &rarr; 02:11:54:08</span>
+        <span class="ch">CH 04</span>
+      </div>
+      <h3>PIRATE BROADCAST &middot; VHS-C &middot; RESTORED 03:{{ current_year }}</h3>
+      <div class="meta">RUNNING TIME 131:54 &middot; SP/EP &middot; ARTIFACTS LIGHT</div>
+      <p class="hand">Recorded off-air from a basement transmitter in 1994. The tape head was caked in pollen &mdash; we paused at 00:23:11 for a full clean. Result is mostly intact; the colour burst goes out under heavy magenta around the second hour. We logged every drop-out.</p>
+      <div class="sign">&mdash; JIN, ENGINEER &middot; DECK 01</div>
+    </article>
+  </div>
+</section>
+
+<section class="test-pattern">
+  <div class="card">
+    <div class="halo">&mdash; TEST PATTERN &mdash;</div>
+    <div class="big-mark">LBL<br><span>LATE BROADCAST LAB</span></div>
+    <div class="freq">1 KHz TONE &middot; -20 dBFS</div>
+    <div class="meta">CH 04 &middot; SE-04 &middot; LICENSED CARRIER &middot; OFF-AIR 03:00&ndash;05:00</div>
+  </div>
+  <div class="pattern-bars">
+    <span class="b-w"></span><span class="b-y"></span><span class="b-c"></span><span class="b-g"></span><span class="b-m"></span><span class="b-r"></span><span class="b-b"></span>
+  </div>
+</section>
+
+<section class="ticker">
+  <div><div class="n">14</div><div class="l">TAPES / WEEK</div></div>
+  <div><div class="n">04</div><div class="l">DECKS / ONLINE</div></div>
+  <div><div class="n">2K</div><div class="l">FILM / SCAN</div></div>
+  <div><div class="n">{{ current_year }}</div><div class="l">YEAR / CH 04</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/late-broadcast/templates/page.html
+++ b/examples/late-broadcast/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/late-broadcast/templates/section.html
+++ b/examples/late-broadcast/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<section class="log-section">
+  <div class="wrap">
+    <div class="hd">
+      {% if page.title is present %}<h2>{{ page.title | e | upper }}</h2>{% endif %}
+      <div class="sub">BROADCAST LOG INDEX</div>
+    </div>
+    {{ content | safe }}
+    {% for post in section.pages %}
+    <article class="entry">
+      <div class="head">
+        <span class="tc">TC {{ post.date | date(format="%Y:%m:%d") }}</span>
+        <span class="ch">CH 04</span>
+      </div>
+      <h3><a href="{{ post.url }}">{{ post.title | e | upper }}</a></h3>
+      {% if post.description is present %}<p class="hand">{{ post.description | e }}</p>{% endif %}
+    </article>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/late-broadcast/templates/shortcodes/alert.html
+++ b/examples/late-broadcast/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #c10000; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/late-broadcast/templates/taxonomy.html
+++ b/examples/late-broadcast/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Index of subjects across the broadcast log.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/late-broadcast/templates/taxonomy_term.html
+++ b/examples/late-broadcast/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Tapes logged under this stamp.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/library-card/AGENTS.md
+++ b/examples/library-card/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/library-card/archetypes/default.md
+++ b/examples/library-card/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/library-card/config.toml
+++ b/examples/library-card/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Heongdang Lending Library"
+description = "A small independent neighborhood lending library run from a converted shopfront — members borrow physical books and pay an annual subscription."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/library-card/content/about.md
+++ b/examples/library-card/content/about.md
@@ -1,0 +1,29 @@
++++
+title = "Membership & House Rules"
+description = "How the Heongdang Lending Library was founded, what's on the shelves, how membership works, what we ask of borrowers, and how to reach the desk."
++++
+
+## How it began
+
+The library opened in **April 2014** in a former dry-goods shop on Saemunan Alley. Two retired schoolteachers and a graphic designer pooled their personal collections, built six oak shelves over a long weekend, and printed the first borrower cards on a tabletop letterpress. We have been lending continuously since.
+
+## The collection
+
+Roughly **four thousand titles**, cataloged by hand using a modified Dewey decimal system. The collection skews toward twentieth-century fiction, Korean poetry, design history, food writing, and slow nature writing. We accept donations on Saturday afternoons only, and we say no kindly when the shelves are full.
+
+## Membership
+
+A flat **annual subscription** of ₩ 30,000. One card per reader. Cards are kept at the desk in the original card drawer — you sign yours out when you visit, and we slip a date-due stamp into the back when you borrow. There is no app and no online catalog by design.
+
+## Lending policy
+
+> Three books at a time. Three weeks at a time. No late fees, ever.
+
+If a book is late we will send a postcard, not an invoice. If a book is lost we ask members to replace it with another book they love. If a book is damaged we mend it together at the desk.
+
+## How to reach us
+
+- **Desk** — `desk@heongdang.kr`
+- **Mail** — Heongdang Lending Library, 14 Saemunan Alley, Seochon, Jongno-gu, Seoul 03044
+- **Phone** — we don't keep one; please stop by during open hours
+- **Donations** — Saturday 11:00–14:00, by appointment only

--- a/examples/library-card/content/index.md
+++ b/examples/library-card/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Heongdang Lending Library — a small independent neighborhood lending library run from a converted shopfront in Seochon, Seoul."
+template = "index"
++++

--- a/examples/library-card/static/css/style.css
+++ b/examples/library-card/static/css/style.css
@@ -1,0 +1,480 @@
+/* =============================================================================
+   Heongdang Lending Library — card-catalog aesthetic
+   Solid colors only. No gradients. No emoji.
+   Palette: card-cream #efe6cc, card-cream-deep #d8c89e, drawer-walnut #6c4423,
+            walnut-shadow #3d2614, stamp-purple #4a1f6e, ink-blue #1a3766,
+            pencil-graphite #4c463a, ribbon-red #a02825, brass-bar #b58727
+============================================================================= */
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0;
+  background: #3d2614; color: #4c463a;
+  font-family: "Cormorant Garamond", "Times New Roman", Georgia, serif;
+  font-size: 17px; line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+a { color: #1a3766; text-decoration: none; }
+a:hover { color: #a02825; }
+::selection { background: #4a1f6e; color: #efe6cc; }
+
+/* -- Top strip ---------------------------------------------------------- */
+.drawer-strip { background: #6c4423; color: #efe6cc; position: relative; }
+.strip-inner {
+  max-width: 1240px; margin: 0 auto; padding: 18px 36px;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 32px; flex-wrap: wrap;
+}
+.drawer-strip .mark {
+  color: #efe6cc; font-family: "Cormorant Garamond", serif;
+  font-weight: 700; font-size: 1.05rem;
+  letter-spacing: 0.18em; text-transform: uppercase;
+}
+.drawer-strip .mark .dot { color: #b58727; padding: 0 6px; }
+.drawer-nav {
+  display: flex; gap: 24px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem; letter-spacing: 0.14em; text-transform: uppercase;
+}
+.drawer-nav a {
+  color: #efe6cc; border-bottom: 1px dotted #b58727; padding-bottom: 2px;
+}
+.drawer-nav a:hover { color: #b58727; border-bottom-color: #efe6cc; }
+.brass-bar {
+  height: 3px; background: #b58727; width: 100%;
+  box-shadow: inset 0 1px 0 #d8c89e, inset 0 -1px 0 #8a6420;
+}
+
+/* -- Hero drawer -------------------------------------------------------- */
+.hero-drawer { background: #6c4423; padding: 64px 24px 80px; }
+.drawer-inside {
+  max-width: 1280px; margin: 0 auto;
+  background: #efe6cc; border: 1px solid #3d2614;
+  padding: 56px 48px 64px; position: relative;
+  box-shadow: inset 0 0 0 6px #d8c89e, 0 0 0 1px #3d2614;
+}
+.drawer-inside::before {
+  content: ""; position: absolute; top: 36px; left: 32px; right: 32px;
+  height: 3px; background: #b58727;
+  box-shadow: inset 0 1px 0 #d8c89e, inset 0 -1px 0 #8a6420; z-index: 5;
+}
+.hero-row {
+  display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 56px; align-items: start; margin-top: 24px;
+}
+@media (max-width: 960px) { .hero-row { grid-template-columns: 1fr; gap: 40px; } }
+
+/* -- Catalog cards ------------------------------------------------------ */
+.catalog-stack {
+  position: relative; display: flex; flex-direction: column;
+  gap: 22px; padding: 12px 0;
+}
+.cat-card {
+  background: #efe6cc; border: 1px solid #4c463a;
+  padding: 18px 22px 22px 56px;
+  font-family: "IBM Plex Mono", monospace; position: relative;
+  box-shadow: 2px 3px 0 #d8c89e, 4px 6px 0 rgba(61,38,20,0.18);
+}
+.cat-card.tilt-a { transform: rotate(-1.5deg); }
+.cat-card.tilt-b { transform: rotate(1deg); margin-left: 24px; }
+.cat-card.tilt-c { transform: rotate(-0.5deg); margin-left: -10px; }
+.cat-card.tilt-d { transform: rotate(2deg); margin-left: 14px; }
+.cat-card::before {
+  content: ""; position: absolute; left: 18px; top: 50%;
+  width: 18px; height: 18px;
+  border: 1.5px solid #4c463a; border-radius: 50%;
+  background: #d8c89e; transform: translateY(-50%);
+}
+.cat-card .punch { display: none; }
+.card-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-size: 0.72rem; letter-spacing: 0.12em; text-transform: uppercase;
+  border-bottom: 1px dashed #4c463a; padding-bottom: 8px; margin-bottom: 10px;
+}
+.dewey { color: #1a3766; font-weight: 600; }
+.card-no { color: #a02825; font-weight: 600; }
+.card-body .author {
+  font-family: "Special Elite", "IBM Plex Mono", monospace;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: #4c463a; font-size: 0.95rem; margin-bottom: 4px;
+}
+.card-body .title {
+  font-family: "Special Elite", "IBM Plex Mono", monospace;
+  font-size: 1.15rem; color: #3d2614; margin-bottom: 4px;
+}
+.card-body .title em { font-style: italic; }
+.card-body .pub { font-size: 0.78rem; color: #4c463a; margin-bottom: 10px; }
+.card-body .meta {
+  font-size: 0.7rem; letter-spacing: 0.1em; color: #4c463a;
+  text-transform: uppercase; padding-top: 8px;
+  border-top: 1px dashed #4c463a;
+}
+.card-body .pencil {
+  margin-top: 10px; font-family: "Cormorant Garamond", serif;
+  font-style: italic; color: #4c463a; font-size: 0.92rem; opacity: 0.85;
+}
+
+/* date-due stamp on top card */
+.due-stamp { position: absolute; top: -18px; right: 26px; z-index: 6; }
+.due-stamp.stamp-a { transform: rotate(-12deg); }
+.stamp-ring {
+  width: 96px; height: 96px;
+  border: 2.5px solid #4a1f6e; border-radius: 50%; padding: 4px;
+}
+.stamp-inner {
+  width: 100%; height: 100%;
+  border: 1.5px solid #4a1f6e; border-radius: 50%;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  color: #4a1f6e; font-family: "Special Elite", monospace;
+}
+.stamp-word { font-size: 0.7rem; letter-spacing: 0.2em; text-transform: uppercase; }
+.stamp-date {
+  font-size: 0.78rem; text-align: center; line-height: 1.05;
+  margin-top: 4px; letter-spacing: 0.05em;
+}
+
+/* -- Hero side ---------------------------------------------------------- */
+.hero-side { padding-top: 8px; }
+.filing-tag {
+  display: inline-block; font-family: "IBM Plex Mono", monospace;
+  font-size: 0.74rem; letter-spacing: 0.22em; text-transform: uppercase;
+  color: #a02825;
+  border-top: 1px solid #a02825; border-bottom: 1px solid #a02825;
+  padding: 4px 10px; margin-bottom: 22px;
+}
+.hero-head {
+  font-family: "Special Elite", "IBM Plex Mono", monospace;
+  font-size: clamp(2.1rem, 4.6vw, 3.4rem);
+  line-height: 1.05; color: #3d2614;
+  margin: 0 0 20px; letter-spacing: 0.01em;
+}
+.hero-head .hl { color: #a02825; }
+.hero-manifest {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 1.18rem; color: #4c463a;
+  margin: 0 0 22px; max-width: 38ch;
+  border-left: 2px solid #b58727; padding-left: 14px;
+}
+.hero-actions { display: flex; flex-wrap: wrap; gap: 22px; }
+.link-tag {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem; letter-spacing: 0.16em; text-transform: uppercase;
+  color: #1a3766; border-bottom: 1px solid #1a3766; padding-bottom: 2px;
+}
+.link-tag.plain { color: #4c463a; border-bottom-color: #4c463a; }
+.link-tag:hover { color: #a02825; border-bottom-color: #a02825; }
+
+/* -- Section scaffolding ------------------------------------------------ */
+.returns-section, .visit-section, .prose-section { background: #6c4423; padding: 64px 24px; }
+.member-section { background: #3d2614; padding: 64px 24px; }
+.prose-section { padding: 56px 24px 80px; }
+.section-wrap {
+  max-width: 1180px; margin: 0 auto;
+  background: #efe6cc; border: 1px solid #3d2614;
+  padding: 48px 44px 56px; position: relative;
+  box-shadow: inset 0 0 0 5px #d8c89e;
+}
+.section-head { position: relative; margin-bottom: 32px; padding-top: 22px; }
+.rule-bar {
+  position: absolute; top: 0; left: -20px; right: -20px;
+  height: 3px; background: #b58727;
+  box-shadow: inset 0 1px 0 #d8c89e, inset 0 -1px 0 #8a6420;
+}
+.section-head h2 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic; font-weight: 600;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  color: #3d2614; margin: 0 0 6px;
+}
+.section-sub {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem; letter-spacing: 0.14em;
+  text-transform: uppercase; color: #4c463a;
+}
+
+/* -- Returns table ------------------------------------------------------ */
+.returns-table { border-top: 1px solid #4c463a; border-bottom: 1px solid #4c463a; }
+.ret-row {
+  display: grid; grid-template-columns: 140px 1.1fr 2fr 110px;
+  gap: 18px; align-items: baseline; padding: 14px 8px;
+  border-bottom: 1px dashed #4c463a;
+  font-family: "IBM Plex Mono", monospace; font-size: 0.86rem;
+}
+.ret-row:last-child { border-bottom: 0; }
+.ret-row.ret-head {
+  text-transform: uppercase; letter-spacing: 0.16em;
+  font-size: 0.7rem; color: #4c463a; background: #d8c89e;
+  border-bottom: 1px solid #4c463a;
+}
+.ret-row .col-call { color: #1a3766; font-weight: 600; }
+.ret-row .col-author {
+  font-family: "Special Elite", monospace;
+  letter-spacing: 0.05em; color: #3d2614;
+}
+.ret-row .col-title { font-family: "Special Elite", monospace; color: #3d2614; }
+.ret-row .col-title em { font-style: italic; }
+.ret-row .col-title a { color: #3d2614; }
+.ret-row .col-title a:hover { color: #a02825; }
+.ret-row .col-date {
+  color: #4a1f6e; font-weight: 600;
+  letter-spacing: 0.06em; text-align: right;
+}
+@media (max-width: 720px) {
+  .ret-row { grid-template-columns: 1fr; gap: 4px; }
+  .ret-row.ret-head { display: none; }
+  .ret-row .col-date { text-align: left; }
+}
+
+/* -- Member card -------------------------------------------------------- */
+.member-row {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 36px; margin-top: 12px;
+}
+@media (max-width: 820px) { .member-row { grid-template-columns: 1fr; } }
+.member-card {
+  background: #efe6cc; padding: 24px 26px; position: relative;
+  min-height: 260px; font-family: "IBM Plex Mono", monospace;
+  border: 1px solid #4c463a;
+}
+.member-card.front { border: 3px solid #a02825; padding: 22px 24px; }
+.member-card.front::before {
+  content: ""; position: absolute; inset: 6px;
+  border: 1px solid #a02825; pointer-events: none;
+}
+.mc-top {
+  display: flex; justify-content: space-between;
+  font-size: 0.7rem; letter-spacing: 0.18em;
+  text-transform: uppercase; color: #a02825;
+  font-weight: 600; margin-bottom: 12px;
+}
+.mc-rib {
+  font-family: "Special Elite", monospace;
+  font-size: 0.82rem; letter-spacing: 0.32em;
+  color: #efe6cc; background: #a02825;
+  display: inline-block; padding: 4px 12px; margin-bottom: 14px;
+}
+.mc-no {
+  font-family: "Special Elite", monospace;
+  color: #a02825; font-size: 1.4rem;
+  letter-spacing: 0.04em; margin-bottom: 18px;
+}
+.mc-no .mc-digits { letter-spacing: 0.4em; }
+.mc-field { margin-bottom: 14px; }
+.mc-field .mc-label {
+  display: block; font-size: 0.62rem;
+  letter-spacing: 0.2em; text-transform: uppercase;
+  color: #4c463a; margin-bottom: 4px;
+}
+.mc-line { display: block; height: 1px; background: #4c463a; width: 100%; }
+.mc-line.short { width: 75%; }
+.mc-field.half {
+  display: grid; grid-template-columns: 1.4fr 1fr;
+  gap: 22px; align-items: end;
+}
+.mc-year-stamp { display: flex; justify-content: flex-end; transform: rotate(-6deg); }
+.ys-ring {
+  width: 78px; height: 78px;
+  border: 2.5px solid #4a1f6e; border-radius: 50%;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  color: #4a1f6e; font-family: "Special Elite", monospace;
+  position: relative;
+}
+.ys-ring::after {
+  content: ""; position: absolute; inset: 4px;
+  border: 1px solid #4a1f6e; border-radius: 50%;
+}
+.ys-word { font-size: 0.62rem; letter-spacing: 0.2em; }
+.ys-year { font-size: 1.05rem; letter-spacing: 0.08em; }
+.mc-foot {
+  margin-top: 14px; padding-top: 10px;
+  border-top: 1px dashed #4c463a;
+  font-size: 0.66rem; letter-spacing: 0.18em;
+  text-transform: uppercase; color: #4c463a;
+}
+
+/* member card back */
+.member-card.back { border: 1.5px solid #4c463a; }
+.mc-back-head {
+  display: grid; grid-template-columns: 1fr 1fr 1fr;
+  font-size: 0.62rem; letter-spacing: 0.2em;
+  text-transform: uppercase; color: #4c463a;
+  border-bottom: 1px solid #4c463a;
+  padding-bottom: 6px; margin-bottom: 14px;
+}
+.mc-back-head span:nth-child(2) { text-align: center; }
+.mc-back-head span:nth-child(3) { text-align: right; }
+.mc-back-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px 16px;
+}
+.back-stamp {
+  font-family: "Special Elite", monospace; text-align: center;
+  font-size: 0.78rem; line-height: 1.15;
+  color: #4a1f6e; border: 1px dashed #4a1f6e;
+  padding: 6px 4px; letter-spacing: 0.04em;
+}
+.back-stamp:nth-child(1) { transform: rotate(-3deg); }
+.back-stamp:nth-child(3) { transform: rotate(2deg); }
+.back-stamp:nth-child(5) { transform: rotate(-1.5deg); }
+.back-stamp:nth-child(7) { transform: rotate(1deg); }
+.back-stamp:nth-child(9) { transform: rotate(-2deg); }
+.back-stamp:nth-child(11) { transform: rotate(2.5deg); }
+.mc-back-foot {
+  margin-top: 14px; padding-top: 8px;
+  border-top: 1px solid #4c463a;
+  font-size: 0.64rem; letter-spacing: 0.18em;
+  text-transform: uppercase; color: #4c463a; text-align: center;
+}
+
+/* -- Visit paste-up ----------------------------------------------------- */
+.visit-paste {
+  max-width: 640px; margin: 0 auto;
+  background: #efe6cc; border: 1px solid #4c463a;
+  padding: 36px 36px 32px; position: relative;
+  box-shadow: 2px 4px 0 #d8c89e, 6px 10px 0 rgba(61,38,20,0.2);
+  transform: rotate(-0.5deg);
+}
+.paste-tape {
+  position: absolute; width: 96px; height: 22px;
+  background: #d8c89e; border: 1px solid #b58727; opacity: 0.85;
+}
+.paste-tape.tape-l { top: -10px; left: -16px; transform: rotate(-12deg); }
+.paste-tape.tape-r { top: -10px; right: -16px; transform: rotate(10deg); }
+.paste-head {
+  font-family: "Special Elite", monospace;
+  font-size: 0.9rem; letter-spacing: 0.2em;
+  text-transform: uppercase; text-align: center;
+  border-bottom: 1px solid #4c463a;
+  padding-bottom: 10px; margin-bottom: 18px; color: #3d2614;
+}
+table.hours {
+  width: 100%; border-collapse: collapse;
+  font-family: "IBM Plex Mono", monospace; font-size: 0.92rem;
+}
+table.hours td { padding: 8px 4px; border-bottom: 1px dashed #4c463a; }
+table.hours td:first-child { letter-spacing: 0.16em; color: #4c463a; }
+table.hours td:last-child { text-align: right; color: #1a3766; font-weight: 600; }
+table.hours td.closed { color: #a02825; font-style: italic; letter-spacing: 0.08em; }
+.paste-foot {
+  margin-top: 16px; font-family: "Cormorant Garamond", serif;
+  font-size: 1rem; font-style: italic; color: #4c463a;
+}
+.paste-foot p { margin: 0; }
+.paste-stamp {
+  position: absolute; bottom: -22px; right: 24px; transform: rotate(8deg);
+}
+.ps-ring {
+  width: 86px; height: 86px;
+  border: 2.5px solid #4a1f6e; border-radius: 50%;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  color: #4a1f6e; font-family: "Special Elite", monospace;
+  background: #efe6cc; position: relative;
+}
+.ps-ring::after {
+  content: ""; position: absolute; inset: 5px;
+  border: 1px solid #4a1f6e; border-radius: 50%;
+}
+.ps-word { font-size: 0.66rem; letter-spacing: 0.22em; }
+.ps-date { font-size: 0.88rem; letter-spacing: 0.05em; margin-top: 2px; }
+
+/* -- Footer ------------------------------------------------------------- */
+.drawer-foot { background: #6c4423; color: #efe6cc; padding: 0 0 36px; }
+.foot-wrap { max-width: 1240px; margin: 0 auto; padding: 36px 36px 0; }
+.colophon {
+  font-family: "Special Elite", monospace;
+  font-size: 0.92rem; letter-spacing: 0.22em;
+  text-transform: uppercase; color: #efe6cc;
+  border-bottom: 1px dashed #b58727;
+  padding-bottom: 18px; margin-bottom: 28px;
+}
+.colophon .sep { color: #b58727; padding: 0 8px; }
+.foot-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 32px; margin-bottom: 28px;
+}
+@media (max-width: 820px) { .foot-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 520px) { .foot-grid { grid-template-columns: 1fr; } }
+.foot-block h4 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic; font-weight: 600;
+  font-size: 1.1rem; color: #b58727;
+  margin: 0 0 10px; letter-spacing: 0.05em;
+}
+.foot-block p {
+  margin: 0 0 4px; font-family: "IBM Plex Mono", monospace;
+  font-size: 0.82rem; color: #efe6cc; letter-spacing: 0.04em;
+}
+.foot-block a { color: #efe6cc; border-bottom: 1px dotted #b58727; }
+.foot-block a:hover { color: #b58727; }
+.foot-stamp {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.7rem; letter-spacing: 0.22em;
+  text-transform: uppercase; color: #b58727;
+  padding-top: 18px; border-top: 1px dashed #b58727;
+}
+.foot-stamp .num { color: #efe6cc; }
+
+/* -- Prose page --------------------------------------------------------- */
+.prose-card {
+  background: #efe6cc; border: 1px solid #4c463a;
+  padding: 38px 44px 44px 60px; position: relative;
+  font-family: "Cormorant Garamond", serif;
+  box-shadow: 2px 3px 0 #d8c89e, 4px 6px 0 rgba(61,38,20,0.18);
+}
+.prose-card::before {
+  content: ""; position: absolute; left: 22px; top: 50%;
+  width: 18px; height: 18px;
+  border: 1.5px solid #4c463a; border-radius: 50%;
+  background: #d8c89e; transform: translateY(-50%);
+}
+.prose-head {
+  display: flex; justify-content: space-between;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.74rem; letter-spacing: 0.16em; text-transform: uppercase;
+  border-bottom: 1px dashed #4c463a;
+  padding-bottom: 10px; margin-bottom: 22px;
+}
+.prose-head .prose-call { color: #1a3766; font-weight: 600; }
+.prose-head .prose-no { color: #a02825; font-weight: 600; }
+.prose h1 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic; font-weight: 700;
+  font-size: clamp(1.9rem, 3.6vw, 2.6rem);
+  color: #3d2614; margin: 0 0 18px;
+}
+.prose h2 {
+  font-family: "Special Elite", monospace;
+  font-size: 1.15rem; color: #3d2614;
+  margin: 28px 0 10px; letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-top: 1px solid #b58727; padding-top: 14px;
+}
+.prose h3 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic; font-weight: 600;
+  color: #3d2614; font-size: 1.25rem; margin: 22px 0 8px;
+}
+.prose p {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 1.15rem; color: #3d2614; margin: 0 0 14px;
+}
+.prose strong { color: #a02825; }
+.prose em { color: #3d2614; }
+.prose a { color: #1a3766; border-bottom: 1px solid #1a3766; }
+.prose a:hover { color: #a02825; border-bottom-color: #a02825; }
+.prose blockquote {
+  border-left: 3px solid #4a1f6e; margin: 18px 0;
+  padding: 6px 0 6px 18px;
+  font-family: "Special Elite", monospace;
+  font-size: 1.02rem; color: #4a1f6e; letter-spacing: 0.02em;
+}
+.prose ul { margin: 0 0 18px; padding-left: 22px; }
+.prose ul li {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 1.1rem; color: #3d2614; margin-bottom: 6px;
+}
+.prose code {
+  font-family: "IBM Plex Mono", monospace;
+  background: #d8c89e; color: #4a1f6e;
+  padding: 1px 5px; font-size: 0.88rem;
+}

--- a/examples/library-card/static/favicon.svg
+++ b/examples/library-card/static/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#6c4423"/>
+  <rect x="4" y="6" width="24" height="20" rx="1" fill="#efe6cc"/>
+  <rect x="4" y="14" width="24" height="1.4" fill="#b58727"/>
+  <rect x="7" y="9" width="10" height="1.4" fill="#1a3766"/>
+  <rect x="7" y="18" width="14" height="1" fill="#4c463a"/>
+  <rect x="7" y="21" width="10" height="1" fill="#4c463a"/>
+  <circle cx="22" cy="22" r="3" fill="none" stroke="#4a1f6e" stroke-width="1"/>
+</svg>

--- a/examples/library-card/templates/404.html
+++ b/examples/library-card/templates/404.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<section class="prose-section">
+  <div class="section-wrap">
+    <div class="prose-card">
+      <div class="prose-head">
+        <span class="prose-call">404 / MIS&middot;FILED</span>
+        <span class="prose-no">HD&middot;0404</span>
+      </div>
+      <article class="prose">
+        <h1>This card isn&rsquo;t in the drawer.</h1>
+        <p>Either the page was never cataloged or someone slipped the card behind the wrong divider. Try the front of the drawer.</p>
+        <p><a href="{{ base_url }}/">&laquo; Back to the catalog</a></p>
+      </article>
+      <div class="punch" aria-hidden="true"></div>
+    </div>
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/library-card/templates/footer.html
+++ b/examples/library-card/templates/footer.html
@@ -1,0 +1,37 @@
+  <footer class="drawer-foot" id="visit">
+    <div class="brass-bar" aria-hidden="true"></div>
+    <div class="foot-wrap">
+      <div class="colophon">LENDING SINCE 2014 <span class="sep">&middot;</span> NO LATE FEES <span class="sep">&middot;</span> SOLELY MEMBER-FUNDED</div>
+      <div class="foot-grid">
+        <div class="foot-block">
+          <h4>The Library</h4>
+          <p>14 Saemunan Alley</p>
+          <p>Seochon, Jongno-gu</p>
+          <p>Seoul, 03044</p>
+        </div>
+        <div class="foot-block">
+          <h4>Open</h4>
+          <p>Tue&ndash;Fri &middot; 14:00&ndash;21:00</p>
+          <p>Sat &middot; 11:00&ndash;19:00</p>
+          <p>Closed Sun &amp; Mon</p>
+        </div>
+        <div class="foot-block">
+          <h4>Write</h4>
+          <p>desk@heongdang.kr</p>
+          <p>Membership renewals by mail</p>
+          <p>or in person at the desk.</p>
+        </div>
+        <div class="foot-block">
+          <h4>Pages</h4>
+          <p><a href="{{ base_url }}/">Catalog &amp; index</a></p>
+          <p><a href="{{ base_url }}/about/">Membership terms</a></p>
+          <p><a href="{{ base_url }}/tags/">Subject headings</a></p>
+        </div>
+      </div>
+      <div class="foot-stamp">FILED <span class="num">{{ current_year }}</span> &middot; DRAWER 04 OF 12 &middot; BUILT WITH HWARO</div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/library-card/templates/header.html
+++ b/examples/library-card/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=IBM+Plex+Mono:wght@400;500;600&family=Special+Elite&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="drawer-strip">
+    <div class="strip-inner">
+      <a class="mark" href="{{ base_url }}/">HEONGDANG LENDING LIBRARY <span class="dot">&middot;</span> DRAWER 04</a>
+      <nav class="drawer-nav">
+        <a href="{{ base_url }}/">Catalog</a>
+        <a href="{{ base_url }}/about/">Membership</a>
+        <a href="#returns">Returns</a>
+        <a href="#visit">Visit</a>
+      </nav>
+    </div>
+    <div class="brass-bar" aria-hidden="true"></div>
+  </header>

--- a/examples/library-card/templates/index.html
+++ b/examples/library-card/templates/index.html
@@ -1,0 +1,249 @@
+{% include "header.html" %}
+
+<section class="hero-drawer">
+  <div class="drawer-inside">
+    <div class="hero-row">
+      <div class="catalog-stack" aria-label="Card catalog">
+        <article class="cat-card tilt-a">
+          <div class="card-head">
+            <span class="dewey">823.912 / WLF</span>
+            <span class="card-no">HD&middot;0014</span>
+          </div>
+          <div class="card-body">
+            <div class="author">WOOLF, VIRGINIA.</div>
+            <div class="title"><em>To the Lighthouse.</em></div>
+            <div class="pub">Hogarth Press &middot; 1927.</div>
+            <div class="meta">ADDED {{ current_year }} &middot; CHECKED OUT 14 TIMES</div>
+            <div class="pencil">a fine first&ndash;summer read &mdash; m.</div>
+          </div>
+          <div class="punch" aria-hidden="true"></div>
+          <div class="due-stamp stamp-a">
+            <div class="stamp-ring">
+              <div class="stamp-inner">
+                <span class="stamp-word">DUE</span>
+                <span class="stamp-date">14 JUN<br>{{ current_year }}</span>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <article class="cat-card tilt-b">
+          <div class="card-head">
+            <span class="dewey">895.734 / HAN</span>
+            <span class="card-no">HD&middot;0182</span>
+          </div>
+          <div class="card-body">
+            <div class="author">HAN, KANG.</div>
+            <div class="title"><em>The White Book.</em></div>
+            <div class="pub">Portobello &middot; 2017.</div>
+            <div class="meta">ADDED {{ current_year }} &middot; CHECKED OUT 09 TIMES</div>
+            <div class="pencil">read slow. read aloud. &mdash; j.</div>
+          </div>
+          <div class="punch" aria-hidden="true"></div>
+        </article>
+
+        <article class="cat-card tilt-c">
+          <div class="card-head">
+            <span class="dewey">811.54 / OLI</span>
+            <span class="card-no">HD&middot;0307</span>
+          </div>
+          <div class="card-body">
+            <div class="author">OLIVER, MARY.</div>
+            <div class="title"><em>Devotions.</em></div>
+            <div class="pub">Penguin &middot; 2017.</div>
+            <div class="meta">ADDED {{ current_year }} &middot; CHECKED OUT 22 TIMES</div>
+            <div class="pencil">page 184 &mdash; the goldfinch poem.</div>
+          </div>
+          <div class="punch" aria-hidden="true"></div>
+        </article>
+
+        <article class="cat-card tilt-d">
+          <div class="card-head">
+            <span class="dewey">741.6 / RAN</span>
+            <span class="card-no">HD&middot;0421</span>
+          </div>
+          <div class="card-body">
+            <div class="author">RAND, PAUL.</div>
+            <div class="title"><em>A Designer&rsquo;s Art.</em></div>
+            <div class="pub">Yale UP &middot; 1985.</div>
+            <div class="meta">ADDED {{ current_year }} &middot; CHECKED OUT 06 TIMES</div>
+            <div class="pencil">keep at the front desk. &mdash; s.</div>
+          </div>
+          <div class="punch" aria-hidden="true"></div>
+        </article>
+      </div>
+
+      <aside class="hero-side">
+        <div class="filing-tag">FILED UNDER &mdash; 04 / {{ current_year }}</div>
+        <h1 class="hero-head">
+          <span class="hl">ONE</span> NEIGHBORHOOD.<br>
+          <span class="hl">FOUR THOUSAND</span> BOOKS.<br>
+          <span class="hl">NO</span> LATE FEES.
+        </h1>
+        <p class="hero-manifest">
+          A converted shopfront in Seochon, lending physical books to members for a flat annual fee. We catalog by hand, stamp the date by hand, and trust you to bring it back.
+        </p>
+        <div class="hero-actions">
+          <a class="link-tag" href="{{ base_url }}/about/">Membership terms &rarr;</a>
+          <a class="link-tag plain" href="#returns">This week&rsquo;s returns &rarr;</a>
+        </div>
+      </aside>
+    </div>
+  </div>
+</section>
+
+<section class="returns-section" id="returns">
+  <div class="section-wrap">
+    <div class="section-head">
+      <div class="rule-bar" aria-hidden="true"></div>
+      <h2>This Week&rsquo;s Returns</h2>
+      <div class="section-sub">Six items back on the shelf &mdash; week of {{ current_year }}.04.</div>
+    </div>
+    <div class="returns-table">
+      <div class="ret-row ret-head">
+        <span class="col-call">Call No.</span>
+        <span class="col-author">Author</span>
+        <span class="col-title">Title</span>
+        <span class="col-date">Returned</span>
+      </div>
+      <div class="ret-row">
+        <span class="col-call">823.914 / ISH</span>
+        <span class="col-author">ISHIGURO, K.</span>
+        <span class="col-title"><em>Klara and the Sun.</em></span>
+        <span class="col-date">14 APR</span>
+      </div>
+      <div class="ret-row">
+        <span class="col-call">895.734 / KIM</span>
+        <span class="col-author">KIM, HYESOON.</span>
+        <span class="col-title"><em>Autobiography of Death.</em></span>
+        <span class="col-date">15 APR</span>
+      </div>
+      <div class="ret-row">
+        <span class="col-call">813.54 / LEG</span>
+        <span class="col-author">LE GUIN, U.K.</span>
+        <span class="col-title"><em>The Dispossessed.</em></span>
+        <span class="col-date">16 APR</span>
+      </div>
+      <div class="ret-row">
+        <span class="col-call">158.1 / NHA</span>
+        <span class="col-author">NHAT HANH, T.</span>
+        <span class="col-title"><em>The Miracle of Mindfulness.</em></span>
+        <span class="col-date">17 APR</span>
+      </div>
+      <div class="ret-row">
+        <span class="col-call">770 / BER</span>
+        <span class="col-author">BERGER, JOHN.</span>
+        <span class="col-title"><em>Ways of Seeing.</em></span>
+        <span class="col-date">18 APR</span>
+      </div>
+      <div class="ret-row">
+        <span class="col-call">641.5 / TAN</span>
+        <span class="col-author">TANIS, BIANCA.</span>
+        <span class="col-title"><em>Notes from a Small Kitchen.</em></span>
+        <span class="col-date">19 APR</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="member-section">
+  <div class="section-wrap">
+    <div class="section-head">
+      <div class="rule-bar" aria-hidden="true"></div>
+      <h2>Membership Card</h2>
+      <div class="section-sub">An annual subscription. One card per reader, kept at the desk.</div>
+    </div>
+
+    <div class="member-row">
+      <div class="member-card front">
+        <div class="mc-border" aria-hidden="true"></div>
+        <div class="mc-top">
+          <span class="mc-name">HEONGDANG LENDING LIBRARY</span>
+          <span class="mc-since">EST. 2014</span>
+        </div>
+        <div class="mc-rib">BORROWER&rsquo;S CARD</div>
+        <div class="mc-no">N&deg; <span class="mc-digits">0 0 1 4 7</span></div>
+        <div class="mc-field">
+          <span class="mc-label">NAME</span>
+          <span class="mc-line"></span>
+        </div>
+        <div class="mc-field">
+          <span class="mc-label">ADDRESS</span>
+          <span class="mc-line"></span>
+        </div>
+        <div class="mc-field half">
+          <div>
+            <span class="mc-label">SIGNED</span>
+            <span class="mc-line short"></span>
+          </div>
+          <div class="mc-year-stamp">
+            <span class="ys-ring">
+              <span class="ys-word">VALID</span>
+              <span class="ys-year">{{ current_year }}</span>
+            </span>
+          </div>
+        </div>
+        <div class="mc-foot">DRAWER 04 &middot; SUBSCRIPTION &middot; ANNUAL</div>
+      </div>
+
+      <div class="member-card back">
+        <div class="mc-back-head">
+          <span>DATE DUE</span>
+          <span>DATE DUE</span>
+          <span>DATE DUE</span>
+        </div>
+        <div class="mc-back-grid">
+          <span class="back-stamp">12 JAN<br>2025</span>
+          <span class="back-stamp">04 FEB<br>2025</span>
+          <span class="back-stamp">28 FEB<br>2025</span>
+          <span class="back-stamp">19 MAR<br>2025</span>
+          <span class="back-stamp">07 APR<br>2025</span>
+          <span class="back-stamp">02 MAY<br>2025</span>
+          <span class="back-stamp">21 MAY<br>2025</span>
+          <span class="back-stamp">14 JUN<br>2025</span>
+          <span class="back-stamp">03 JUL<br>2025</span>
+          <span class="back-stamp">29 JUL<br>2025</span>
+          <span class="back-stamp">17 AUG<br>2025</span>
+          <span class="back-stamp">09 SEP<br>2025</span>
+        </div>
+        <div class="mc-back-foot">RETURN BY DATE STAMPED &middot; NO LATE FEES &middot; PLEASE BE KIND</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="visit-section" id="visit-block">
+  <div class="section-wrap">
+    <div class="section-head">
+      <div class="rule-bar" aria-hidden="true"></div>
+      <h2>Visiting Hours</h2>
+      <div class="section-sub">Posted on the door &mdash; updated when the seasons change.</div>
+    </div>
+
+    <div class="visit-paste">
+      <div class="paste-tape tape-l" aria-hidden="true"></div>
+      <div class="paste-tape tape-r" aria-hidden="true"></div>
+      <div class="paste-head">NOTICE TO MEMBERS &amp; PASSERSBY</div>
+      <table class="hours">
+        <tr><td>MONDAY</td><td class="closed">CLOSED</td></tr>
+        <tr><td>TUESDAY</td><td>14:00 &mdash; 21:00</td></tr>
+        <tr><td>WEDNESDAY</td><td>14:00 &mdash; 21:00</td></tr>
+        <tr><td>THURSDAY</td><td>14:00 &mdash; 21:00</td></tr>
+        <tr><td>FRIDAY</td><td>14:00 &mdash; 22:00</td></tr>
+        <tr><td>SATURDAY</td><td>11:00 &mdash; 19:00</td></tr>
+        <tr><td>SUNDAY</td><td class="closed">CLOSED</td></tr>
+      </table>
+      <div class="paste-foot">
+        <p>The bell on the door is real. If we&rsquo;re behind the stacks it may take a minute &mdash; please ring twice.</p>
+      </div>
+      <div class="paste-stamp">
+        <div class="ps-ring">
+          <span class="ps-word">POSTED</span>
+          <span class="ps-date">04 / {{ current_year }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/library-card/templates/page.html
+++ b/examples/library-card/templates/page.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<section class="prose-section">
+  <div class="section-wrap">
+    <div class="prose-card">
+      <div class="prose-head">
+        <span class="prose-call">M&middot;{{ current_year }}</span>
+        <span class="prose-no">HD&middot;PAGE</span>
+      </div>
+      <article class="prose">
+        {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+        {{ content | safe }}
+      </article>
+      <div class="punch" aria-hidden="true"></div>
+    </div>
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/library-card/templates/section.html
+++ b/examples/library-card/templates/section.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+<section class="prose-section">
+  <div class="section-wrap">
+    <div class="prose-card">
+      <div class="prose-head">
+        <span class="prose-call">SECTION</span>
+        <span class="prose-no">HD&middot;DRAWER 04</span>
+      </div>
+      <article class="prose">
+        {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+        {{ content | safe }}
+      </article>
+      <div class="punch" aria-hidden="true"></div>
+    </div>
+
+    {% if section.pages %}
+    <div class="returns-table" style="margin-top:2.5rem;">
+      <div class="ret-row ret-head">
+        <span class="col-call">Filed</span>
+        <span class="col-author">&nbsp;</span>
+        <span class="col-title">Title</span>
+        <span class="col-date">Cat. No.</span>
+      </div>
+      {% for post in section.pages %}
+      <div class="ret-row">
+        <span class="col-call">{{ post.date | date(format="%Y / %m") }}</span>
+        <span class="col-author">&nbsp;</span>
+        <span class="col-title"><a href="{{ post.url }}"><em>{{ post.title | e }}</em></a></span>
+        <span class="col-date">HD&middot;{{ loop.index0 }}</span>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/library-card/templates/shortcodes/alert.html
+++ b/examples/library-card/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #d8c89e; background-color: #efe6cc; border-left: 5px solid #4a1f6e; margin: 1rem 0; font-family: 'IBM Plex Mono', monospace;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/library-card/templates/taxonomy.html
+++ b/examples/library-card/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<section class="prose-section">
+  <div class="section-wrap">
+    <div class="prose-card">
+      <div class="prose-head">
+        <span class="prose-call">SUBJECT&middot;INDEX</span>
+        <span class="prose-no">HD&middot;TAX</span>
+      </div>
+      <article class="prose">
+        <h1>{{ page.title | e }}</h1>
+        <p><em>Subject headings used across the catalog &mdash; filed alphabetically.</em></p>
+        {{ content | safe }}
+      </article>
+      <div class="punch" aria-hidden="true"></div>
+    </div>
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/library-card/templates/taxonomy_term.html
+++ b/examples/library-card/templates/taxonomy_term.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<section class="prose-section">
+  <div class="section-wrap">
+    <div class="prose-card">
+      <div class="prose-head">
+        <span class="prose-call">SUBJECT</span>
+        <span class="prose-no">HD&middot;TERM</span>
+      </div>
+      <article class="prose">
+        <h1>{{ page.title | e }}</h1>
+        <p><em>Catalog cards filed under this heading.</em></p>
+        {{ content | safe }}
+      </article>
+      <div class="punch" aria-hidden="true"></div>
+    </div>
+  </div>
+</section>
+{% include "footer.html" %}

--- a/examples/museum-vitrine/AGENTS.md
+++ b/examples/museum-vitrine/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/museum-vitrine/archetypes/default.md
+++ b/examples/museum-vitrine/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/museum-vitrine/config.toml
+++ b/examples/museum-vitrine/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "VITRINE"
+description = "A digital curation CMS for small museums, historical societies, and private collectors — published as a catalogue of small things."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/museum-vitrine/content/about.md
+++ b/examples/museum-vitrine/content/about.md
@@ -1,0 +1,43 @@
++++
+title = "About the Vitrine"
+description = "Vitrine — the collection, accession policy, conservation method, donor program, and how to visit."
++++
+
+## The collection
+
+The Vitrine is a small standing collection of objects assembled, since 1974, around a single rule of the case: that the small and overlooked is worth the same care as the great. Where larger institutions describe their holdings in tens of thousands, we describe ours in the low hundreds, and we describe each one slowly. A feather, a key, a wasp comb, a seed pod. Each receives its own plate, its own rule of provenance, and its own accession number.
+
+We hold roughly four hundred and twenty objects across nine subject cabinets. The catalog is printed quarterly for members, in a press run of three hundred numbered copies, and reissued whenever an object's record is meaningfully revised.
+
+## Accession policy
+
+We accession objects under three quiet conditions. The first is **clear provenance**: every object enters the Vitrine with the longest written record of its handling we can assemble, and that record is kept with the object as part of the lot. The second is **modest scale**: nothing in the case is larger than a child's hand, and most are smaller. The third is **the willingness to wait**: the object will rest in the holding drawer for at least one full season before its plate is drawn, so the cataloger has time to read around it.
+
+Accessions are received by gift, by bequest, by field collection (where lawful and humble), and by exchange between sympathetic institutions. We do not purchase. We do not solicit donations. The drawer fills at its own pace.
+
+## Conservation
+
+Conservation at the Vitrine is the patient kind. Plates are drawn under twenty-five lux of warm incandescent light, kept at a steady temperature of eighteen degrees, with a relative humidity held between forty and fifty percent by a small bank of cedar boxes lined with raw linen.
+
+Cleaning is mechanical, never chemical. A sable brush, a horsehair brush, a single drop of distilled water on a square of unbleached cotton, applied only after a full week of observation. Reports are written by hand in the conservator's day-book and transcribed, once a year, into the master record. The day-books themselves are accessioned alongside the objects they describe.
+
+## Donor program
+
+Members of the Vitrine support the slow work of the case. A membership covers the year and includes the quarterly printed catalog, free admission for the member and one companion, an invitation to the Wednesday reading room, and the right to request a plate be drawn for one's own small object &mdash; subject, of course, to the rules above.
+
+Memberships are offered at three quiet tiers: the **Reader** (40 per year), the **Reader with print** (90, includes the bound annual), and the **Cabinet** (300, includes the bound annual, a year of private reading-room hours, and a hand-written annual letter from the curator). We do not name donors on the wall; we name them, with their consent, on the colophon of the catalog.
+
+## Visiting
+
+The Vitrine is open Wednesday through Sunday, eleven in the morning to five in the afternoon. Mondays and Tuesdays are reserved, by appointment, for visiting scholars. The case admits at most eight visitors at any one hour. Admission is six for the day pass, free for members, and free in all cases for children under twelve, for scholars, and for the curious in passing.
+
+The address is 14, rue du Cabinet, Gallery 4, first floor. The side door bell is original to the house; ring once and wait. The reading room is small on purpose.
+
+## Correspondence
+
+- **Curator** &mdash; `curator@vitrine.museum`
+- **Accessions** &mdash; `accessions@vitrine.museum`
+- **Press and scholars** &mdash; `desk@vitrine.museum`
+- **Loans and exchange** &mdash; by letter, written by hand, to the address above.
+
+We answer correspondence on Wednesday afternoons, in the order received, within thirty days.

--- a/examples/museum-vitrine/content/index.md
+++ b/examples/museum-vitrine/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Vitrine — a catalogue of small things. A digital curation CMS for small museums, historical societies, and private collectors."
+template = "index"
++++

--- a/examples/museum-vitrine/static/css/style.css
+++ b/examples/museum-vitrine/static/css/style.css
@@ -1,0 +1,946 @@
+/* =============================================================
+   VITRINE — Catalogue of Small Things
+   Museum specimen catalog: bone parchment, hairline rules,
+   numbered plates, italic serif labels, line engravings.
+   ============================================================= */
+
+:root {
+  --bone: #f4eede;
+  --bone-deep: #e4d9bf;
+  --ink: #1a1612;
+  --oxblood: #6b1a16;
+  --shadow: #d0c5a5;
+  --ribbon-cream: #fbf4d8;
+  --hairline: 0.5px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  background: var(--bone);
+}
+
+body {
+  background: var(--bone);
+  color: var(--ink);
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  padding-bottom: 2rem;
+}
+
+a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: var(--hairline) solid var(--ink);
+}
+
+a:hover {
+  color: var(--oxblood);
+  border-bottom-color: var(--oxblood);
+}
+
+em {
+  font-family: "Cormorant Garamond", "IBM Plex Serif", serif;
+  font-style: italic;
+  font-weight: 500;
+}
+
+/* ---- Top strip ---- */
+.strip {
+  background: var(--bone);
+  padding: 1.4rem 2.5rem 0;
+}
+
+.strip-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2rem;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.strip-mark {
+  font-family: "IBM Plex Serif", serif;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.strip-nav {
+  display: flex;
+  gap: 1.6rem;
+}
+
+.strip-nav a {
+  font-family: "IBM Plex Serif", serif;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border-bottom: none;
+}
+
+.strip-nav a:hover {
+  color: var(--oxblood);
+}
+
+.strip-rule {
+  max-width: 1180px;
+  margin: 0.9rem auto 0;
+  border-top: var(--hairline) solid var(--ink);
+}
+
+/* ---- Plate (double-rule vitrine frame) ---- */
+.plate {
+  position: relative;
+  background: var(--bone);
+  border: var(--hairline) solid var(--ink);
+  padding: 0.5rem;
+  box-shadow: 8px 8px 0 var(--shadow);
+  margin: 0 auto;
+}
+
+.plate::before {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border: var(--hairline) solid var(--ink);
+  pointer-events: none;
+}
+
+.plate-inner {
+  padding: 2.4rem 2.4rem 3.2rem;
+  position: relative;
+}
+
+.plate-corner {
+  position: absolute;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink);
+  z-index: 2;
+}
+
+.plate-corner.top-l { top: 0.85rem; left: 1rem; }
+.plate-corner.top-r { top: 0.85rem; right: 1rem; }
+
+.plate-accession {
+  position: absolute;
+  bottom: 0.7rem;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+
+/* ---- Hero plate ---- */
+.hero-plate {
+  max-width: 1180px;
+  margin: 2.5rem auto;
+  padding: 0 2.5rem;
+}
+
+.plate.hero .plate-inner {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 3rem;
+  padding: 3rem 3rem 3.5rem;
+  align-items: center;
+}
+
+.hero-engraving {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  border-right: var(--hairline) solid var(--ink);
+  padding-right: 2.5rem;
+}
+
+.hero-engraving svg {
+  width: 180px;
+  height: auto;
+  display: block;
+}
+
+.hero-engraving-cap {
+  font-family: "IBM Plex Serif", serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-align: center;
+}
+
+.hero-engraving-cap em {
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.hero-eyebrow {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+}
+
+.hero-headline {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 3.6rem;
+  line-height: 1.02;
+  font-weight: 500;
+  color: var(--ink);
+  font-style: italic;
+  letter-spacing: -0.005em;
+}
+
+.hero-lede {
+  font-family: "IBM Plex Serif", serif;
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: var(--ink);
+  max-width: 38ch;
+}
+
+/* ---- Metadata table ---- */
+.meta-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "IBM Plex Serif", serif;
+  font-size: 13px;
+  margin-top: 0.6rem;
+}
+
+.meta-table tr {
+  border-top: var(--hairline) solid var(--ink);
+}
+
+.meta-table tr:last-child {
+  border-bottom: var(--hairline) solid var(--ink);
+}
+
+.meta-table th {
+  text-align: left;
+  font-weight: 500;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  padding: 0.55rem 1rem 0.55rem 0;
+  width: 30%;
+  vertical-align: top;
+}
+
+.meta-table td {
+  padding: 0.55rem 0;
+  font-family: "IBM Plex Serif", serif;
+  font-size: 13.5px;
+  color: var(--ink);
+}
+
+.meta-table.tight th,
+.meta-table.tight td {
+  padding: 0.4rem 0;
+  font-size: 12px;
+}
+
+.meta-table.tight th {
+  font-size: 9px;
+  padding-right: 0.8rem;
+}
+
+/* ---- Ornament rules ---- */
+.ornament {
+  max-width: 460px;
+  margin: 3rem auto;
+  padding: 0 2.5rem;
+}
+
+.ornament svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* ---- Section headers ---- */
+.section-head {
+  max-width: 1180px;
+  margin: 0 auto 2rem;
+  padding: 0 2.5rem;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1.5rem;
+  align-items: end;
+  border-bottom: var(--hairline) solid var(--ink);
+  padding-bottom: 1rem;
+}
+
+.section-num {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 2.2rem;
+  color: var(--oxblood);
+  line-height: 1;
+}
+
+.section-title {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 2.6rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  line-height: 1.05;
+}
+
+.section-title em {
+  font-style: italic;
+}
+
+.section-sub {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-align: right;
+}
+
+/* ---- Acquisitions grid ---- */
+.acquisitions {
+  max-width: 1180px;
+  margin: 2.5rem auto;
+  padding: 0 2.5rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.8rem;
+}
+
+.plate.small .plate-inner {
+  padding: 2rem 1.4rem 2.6rem;
+}
+
+.engraving {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 130px;
+  border-bottom: var(--hairline) solid var(--ink);
+  margin-bottom: 1rem;
+  padding-bottom: 0.6rem;
+}
+
+.engraving svg {
+  width: 110px;
+  height: auto;
+  display: block;
+}
+
+.engraving.accent svg {
+  /* stroke color set inline as oxblood */
+}
+
+.binomial {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1.25rem;
+  color: var(--ink);
+  margin-bottom: 0.8rem;
+  line-height: 1.2;
+}
+
+.binomial span {
+  font-family: "IBM Plex Serif", serif;
+  font-style: normal;
+  font-size: 11.5px;
+  display: block;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+  margin-top: 0.1rem;
+}
+
+.binomial.big {
+  font-size: 1.9rem;
+  margin-bottom: 1rem;
+}
+
+.binomial.big span {
+  font-size: 13px;
+}
+
+/* ---- Featured cabinet ---- */
+.featured {
+  max-width: 1180px;
+  margin: 2.5rem auto;
+  padding: 0 2.5rem;
+}
+
+.plate.wide .plate-inner {
+  padding: 3rem 3.2rem 3.5rem;
+}
+
+.featured-head {
+  border-bottom: var(--hairline) solid var(--ink);
+  padding-bottom: 1.4rem;
+  margin-bottom: 1.6rem;
+}
+
+.featured-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.6rem;
+  margin-top: 1rem;
+  font-family: "IBM Plex Serif", serif;
+  font-size: 12.5px;
+}
+
+.featured-meta span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.featured-meta b {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  font-weight: 500;
+}
+
+.featured-cols {
+  column-count: 2;
+  column-gap: 2.4rem;
+  column-rule: var(--hairline) solid var(--ink);
+  font-family: "IBM Plex Serif", serif;
+  font-size: 14px;
+  line-height: 1.7;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.featured-cols p {
+  margin-bottom: 1rem;
+  break-inside: avoid-column;
+}
+
+.featured-cols p:first-child::first-letter {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 3.2rem;
+  float: left;
+  line-height: 0.9;
+  padding: 0.2rem 0.5rem 0 0;
+  color: var(--oxblood);
+}
+
+.featured-foot {
+  text-align: right;
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink);
+  margin-top: 1rem;
+}
+
+/* ---- Visiting ---- */
+.visiting {
+  max-width: 1180px;
+  margin: 2.5rem auto;
+  padding: 0 2.5rem;
+}
+
+.visit-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.8rem;
+}
+
+.visit-card {
+  background: var(--bone);
+  border: var(--hairline) solid var(--ink);
+  padding: 1.8rem 1.6rem 1.6rem;
+  position: relative;
+}
+
+.visit-card.ribbon {
+  background: var(--ribbon-cream);
+}
+
+.visit-eyebrow {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  margin-bottom: 0.6rem;
+}
+
+.visit-headline {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1.7rem;
+  line-height: 1.1;
+  color: var(--ink);
+  margin-bottom: 0.4rem;
+}
+
+.visit-time {
+  font-family: "IBM Plex Serif", serif;
+  font-size: 13.5px;
+  color: var(--ink);
+  padding-bottom: 0.7rem;
+  border-bottom: var(--hairline) solid var(--ink);
+  margin-bottom: 0.7rem;
+}
+
+.visit-fine {
+  font-family: "IBM Plex Serif", serif;
+  font-size: 12px;
+  color: var(--ink);
+  line-height: 1.5;
+  font-style: italic;
+}
+
+.visit-rule {
+  margin: 2rem 0 1.6rem;
+  border-top: var(--hairline) solid var(--ink);
+}
+
+.visit-foot {
+  font-family: "IBM Plex Serif", serif;
+  font-size: 12.5px;
+  font-style: italic;
+  text-align: center;
+  color: var(--ink);
+  max-width: 70ch;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+/* ---- Colophon (footer) ---- */
+.colophon {
+  max-width: 1180px;
+  margin: 4rem auto 1rem;
+  padding: 0 2.5rem;
+}
+
+.colophon-rule {
+  border-top: var(--hairline) solid var(--ink);
+}
+
+.colophon-rule.thin {
+  margin-top: 4px;
+  border-top: var(--hairline) solid var(--ink);
+}
+
+.colophon-inner {
+  padding-top: 2.4rem;
+}
+
+.colophon-mark {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.colophon-title {
+  display: block;
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 2.6rem;
+  letter-spacing: 0.05em;
+  color: var(--ink);
+}
+
+.colophon-sub {
+  display: block;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  margin-top: 0.3rem;
+}
+
+.colophon-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2rem;
+  border-top: var(--hairline) solid var(--ink);
+  border-bottom: var(--hairline) solid var(--ink);
+  padding: 1.6rem 0;
+  margin-bottom: 1.2rem;
+}
+
+.colophon-grid h4 {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  margin-bottom: 0.7rem;
+  font-weight: 500;
+}
+
+.colophon-grid a {
+  display: block;
+  font-family: "IBM Plex Serif", serif;
+  font-size: 13px;
+  color: var(--ink);
+  margin-bottom: 0.4rem;
+  border-bottom: none;
+}
+
+.colophon-grid a:hover {
+  color: var(--oxblood);
+  font-style: italic;
+}
+
+.colophon-tab {
+  background: var(--ribbon-cream);
+  padding: 1rem 1rem;
+  border: var(--hairline) solid var(--ink);
+  align-self: start;
+}
+
+.tab-label {
+  display: block;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  margin-bottom: 0.5rem;
+}
+
+.tab-line {
+  display: block;
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 1.1rem;
+  color: var(--ink);
+  line-height: 1.3;
+}
+
+.colophon-foot {
+  display: flex;
+  justify-content: space-between;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink);
+  padding-top: 0.8rem;
+}
+
+/* ---- Prose pages (about, 404, taxonomy) ---- */
+.prose {
+  max-width: 880px;
+  margin: 3rem auto;
+  padding: 0 2.5rem;
+}
+
+.prose-plate .plate-inner {
+  padding: 3rem 3rem 3.5rem;
+}
+
+.prose-title {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 3rem;
+  line-height: 1.05;
+  color: var(--ink);
+}
+
+.prose-eyebrow {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  margin-bottom: 1.4rem;
+}
+
+.prose-rule {
+  border-top: var(--hairline) solid var(--ink);
+  margin: 1.2rem 0 1.4rem;
+}
+
+.prose-body {
+  font-family: "IBM Plex Serif", serif;
+  font-size: 15px;
+  line-height: 1.75;
+  color: var(--ink);
+}
+
+.prose-body h2 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1.9rem;
+  margin: 2.2rem 0 0.8rem;
+  color: var(--ink);
+  border-bottom: var(--hairline) solid var(--ink);
+  padding-bottom: 0.4rem;
+}
+
+.prose-body h3 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1.4rem;
+  margin: 1.6rem 0 0.6rem;
+}
+
+.prose-body p {
+  margin-bottom: 1.1rem;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.prose-body a {
+  color: var(--oxblood);
+  border-bottom: var(--hairline) solid var(--oxblood);
+}
+
+.prose-body ul,
+.prose-body ol {
+  margin: 0.8rem 0 1.2rem 1.4rem;
+}
+
+.prose-body li {
+  margin-bottom: 0.4rem;
+}
+
+.prose-body strong {
+  font-weight: 500;
+  font-family: "Cormorant Garamond", serif;
+  font-size: 1.05em;
+  font-style: italic;
+}
+
+.prose-body blockquote {
+  border-left: 2px solid var(--oxblood);
+  padding: 0.4rem 0 0.4rem 1.2rem;
+  margin: 1.2rem 0;
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 1.2rem;
+  color: var(--ink);
+}
+
+.prose-body code {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12.5px;
+  background: var(--ribbon-cream);
+  padding: 0.1rem 0.35rem;
+  border: var(--hairline) solid var(--ink);
+}
+
+.prose-body hr {
+  border: none;
+  border-top: var(--hairline) solid var(--ink);
+  margin: 2rem 0;
+}
+
+/* ---- Section list ---- */
+.section-prose {
+  max-width: 880px;
+  margin: 1.5rem auto 2rem;
+  padding: 0 2.5rem;
+  font-family: "IBM Plex Serif", serif;
+}
+
+.section-list {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 2.5rem;
+}
+
+.list-row {
+  display: grid;
+  grid-template-columns: 8rem 1fr 8rem;
+  gap: 1.5rem;
+  padding: 1rem 0;
+  border-top: var(--hairline) solid var(--ink);
+  align-items: baseline;
+}
+
+.list-row:last-child {
+  border-bottom: var(--hairline) solid var(--ink);
+}
+
+.list-num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+}
+
+.list-title {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 1.3rem;
+}
+
+.list-title a {
+  border-bottom: none;
+}
+
+.list-title a:hover {
+  color: var(--oxblood);
+}
+
+.list-date {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  text-align: right;
+  color: var(--ink);
+}
+
+/* ---- Alert shortcode ---- */
+.alert {
+  background: var(--ribbon-cream);
+  border: var(--hairline) solid var(--ink);
+  padding: 1rem 1.2rem;
+  margin: 1.4rem 0;
+  font-family: "IBM Plex Serif", serif;
+  font-size: 13.5px;
+  display: flex;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.alert-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--oxblood);
+  border: var(--hairline) solid var(--oxblood);
+  padding: 0.15rem 0.4rem;
+  flex-shrink: 0;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 980px) {
+  .strip {
+    padding: 1.2rem 1.5rem 0;
+  }
+  .strip-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.7rem;
+  }
+  .strip-nav {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+  .hero-plate,
+  .acquisitions,
+  .featured,
+  .visiting,
+  .colophon,
+  .prose,
+  .section-list,
+  .section-prose,
+  .section-head {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+  .plate.hero .plate-inner {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+    padding: 2.2rem 1.6rem 2.6rem;
+  }
+  .hero-engraving {
+    border-right: none;
+    border-bottom: var(--hairline) solid var(--ink);
+    padding-right: 0;
+    padding-bottom: 1.5rem;
+  }
+  .hero-headline {
+    font-size: 2.6rem;
+  }
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.4rem;
+  }
+  .featured-cols {
+    column-count: 1;
+  }
+  .visit-row,
+  .colophon-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .section-head {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+  .section-sub {
+    text-align: left;
+  }
+  .section-title {
+    font-size: 2rem;
+  }
+  .list-row {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+  }
+  .list-date {
+    text-align: left;
+  }
+}
+
+@media (max-width: 600px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .visit-row,
+  .colophon-grid {
+    grid-template-columns: 1fr;
+  }
+  .colophon-foot {
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .hero-headline {
+    font-size: 2.1rem;
+  }
+  .colophon-title {
+    font-size: 2rem;
+  }
+}

--- a/examples/museum-vitrine/static/favicon.svg
+++ b/examples/museum-vitrine/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f4eede"/>
+  <rect x="3" y="3" width="26" height="26" fill="none" stroke="#1a1612" stroke-width="0.5"/>
+  <rect x="5" y="5" width="22" height="22" fill="none" stroke="#1a1612" stroke-width="0.5"/>
+  <path d="M16 9 L16 23 M11 14 L21 14 M12 18 L20 18" stroke="#6b1a16" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+  <circle cx="16" cy="16" r="0.8" fill="#6b1a16"/>
+</svg>

--- a/examples/museum-vitrine/templates/404.html
+++ b/examples/museum-vitrine/templates/404.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="plate prose-plate">
+    <div class="plate-corner top-l">OBJ-{{ current_year }}.NULL</div>
+    <div class="plate-corner top-r">404</div>
+    <div class="plate-inner">
+      <h1 class="prose-title"><em>The case is empty.</em></h1>
+      <div class="prose-rule"></div>
+      <p class="prose-eyebrow">No accession by that name in this gallery.</p>
+      <div class="prose-body">
+        <p>This plate has not been printed for the Vitrine. The object may have been deaccessioned, never accessioned, or filed under a subject the cataloger has since revised.</p>
+        <p>Return to <a href="{{ base_url }}/">the front of the catalog</a>, or browse <a href="{{ base_url }}/tags/">the collections</a>.</p>
+      </div>
+    </div>
+    <div class="plate-accession">Plate withdrawn &middot; {{ current_year }}</div>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/museum-vitrine/templates/footer.html
+++ b/examples/museum-vitrine/templates/footer.html
@@ -1,0 +1,43 @@
+  <footer class="colophon">
+    <div class="colophon-rule"></div>
+    <div class="colophon-rule thin"></div>
+    <div class="colophon-inner">
+      <div class="colophon-mark">
+        <span class="colophon-title">VITRINE</span>
+        <span class="colophon-sub">Catalogue of small things</span>
+      </div>
+      <div class="colophon-grid">
+        <div>
+          <h4>Catalog</h4>
+          <a href="{{ base_url }}/">Recent acquisitions</a>
+          <a href="{{ base_url }}/tags/">Collections</a>
+          <a href="#">Loan inquiries</a>
+        </div>
+        <div>
+          <h4>The Vitrine</h4>
+          <a href="{{ base_url }}/about/">About the collection</a>
+          <a href="{{ base_url }}/about/#conservation">Conservation</a>
+          <a href="{{ base_url }}/about/#donors">Donor program</a>
+        </div>
+        <div>
+          <h4>Correspondence</h4>
+          <a href="#">curator@vitrine.museum</a>
+          <a href="#">accessions@vitrine.museum</a>
+          <a href="#">Press &amp; scholars</a>
+        </div>
+        <div class="colophon-tab">
+          <span class="tab-label">Reading hours</span>
+          <span class="tab-line">Wed &mdash; Sun</span>
+          <span class="tab-line">11:00 &mdash; 17:00</span>
+        </div>
+      </div>
+      <div class="colophon-foot">
+        <span>PRINTED FOR THE VITRINE &middot; NO. {{ current_year }}.IV</span>
+        <span>Hwaro build &middot; gallery 4</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/museum-vitrine/templates/header.html
+++ b/examples/museum-vitrine/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Serif:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip">
+    <div class="strip-inner">
+      <span class="strip-mark">VITRINE &middot; CATALOGUE OF SMALL THINGS &middot; GALLERY 4 &middot; {{ current_year }}</span>
+      <nav class="strip-nav">
+        <a href="{{ base_url }}/">Catalog</a>
+        <a href="{{ base_url }}/tags/">Collections</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="#visiting">Visit</a>
+      </nav>
+    </div>
+    <div class="strip-rule"></div>
+  </header>

--- a/examples/museum-vitrine/templates/index.html
+++ b/examples/museum-vitrine/templates/index.html
@@ -1,0 +1,284 @@
+{% include "header.html" %}
+
+<section class="hero-plate">
+  <div class="plate hero">
+    <div class="plate-corner top-l">OBJ-{{ current_year }}.0001</div>
+    <div class="plate-corner top-r">PLATE I</div>
+    <div class="plate-inner">
+      <div class="hero-engraving">
+        <svg viewBox="0 0 220 320" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <g fill="none" stroke="#1a1612" stroke-width="0.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M110 30 C 95 50, 80 100, 75 165 C 72 210, 90 260, 110 285 C 130 260, 148 210, 145 165 C 140 100, 125 50, 110 30 Z"/>
+            <path d="M110 40 L 110 280"/>
+            <path d="M110 60 L 92 80 M110 60 L 128 80"/>
+            <path d="M110 80 L 88 105 M110 80 L 132 105"/>
+            <path d="M110 100 L 84 130 M110 100 L 136 130"/>
+            <path d="M110 125 L 82 158 M110 125 L 138 158"/>
+            <path d="M110 150 L 82 185 M110 150 L 138 185"/>
+            <path d="M110 175 L 84 210 M110 175 L 136 210"/>
+            <path d="M110 200 L 88 232 M110 200 L 132 232"/>
+            <path d="M110 225 L 92 250 M110 225 L 128 250"/>
+            <path d="M110 250 L 98 268 M110 250 L 122 268"/>
+          </g>
+        </svg>
+        <div class="hero-engraving-cap">FIG. I &middot; <em>Pavo cristatus</em> remex</div>
+      </div>
+      <div class="hero-text">
+        <div class="hero-eyebrow">From the case &middot; vol. IV</div>
+        <h1 class="hero-headline">
+          <em>A catalogue</em><br>
+          <em>for the small</em><br>
+          <em>and overlooked.</em>
+        </h1>
+        <p class="hero-lede">Vitrine publishes the object record &mdash; the feather, the key, the tooth, the seed pod &mdash; with the patience the case deserves. One plate at a time.</p>
+
+        <table class="meta-table">
+          <tr><th>Accession</th><td>{{ current_year }}.0001</td></tr>
+          <tr><th>Acquired</th><td>Spring, gift of the Founder</td></tr>
+          <tr><th>Provenance</th><td>Cabinet of Mme. R., Sarlat</td></tr>
+          <tr><th>Period</th><td>Late nineteenth century</td></tr>
+        </table>
+      </div>
+    </div>
+    <div class="plate-accession">No. {{ current_year }}.0001 &middot; Vitrine &middot; Gallery 4</div>
+  </div>
+</section>
+
+<div class="ornament" aria-hidden="true">
+  <svg viewBox="0 0 320 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" stroke="#1a1612" stroke-width="0.7" stroke-linecap="round">
+      <line x1="0" y1="12" x2="120" y2="12"/>
+      <line x1="200" y1="12" x2="320" y2="12"/>
+      <circle cx="160" cy="12" r="3"/>
+      <circle cx="160" cy="12" r="7" stroke-dasharray="1 3"/>
+      <line x1="140" y1="12" x2="150" y2="12"/>
+      <line x1="170" y1="12" x2="180" y2="12"/>
+      <path d="M125 8 L 130 12 L 125 16"/>
+      <path d="M195 8 L 190 12 L 195 16"/>
+    </g>
+  </svg>
+</div>
+
+<section class="acquisitions">
+  <div class="section-head">
+    <div class="section-num">II.</div>
+    <h2 class="section-title">Recent <em>Acquisitions</em></h2>
+    <div class="section-sub">Spring catalog &middot; four plates, in the order received</div>
+  </div>
+
+  <div class="grid">
+
+    <article class="plate small">
+      <div class="plate-corner top-l">OBJ-{{ current_year }}.0014</div>
+      <div class="plate-corner top-r">II</div>
+      <div class="plate-inner">
+        <div class="engraving">
+          <svg viewBox="0 0 120 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <g fill="none" stroke="#1a1612" stroke-width="0.7" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M60 18 C 50 30, 42 45, 42 60 C 42 75, 50 85, 60 88 C 70 85, 78 75, 78 60 C 78 45, 70 30, 60 18 Z"/>
+              <path d="M60 20 L 60 86"/>
+              <path d="M60 30 L 48 38 M60 30 L 72 38"/>
+              <path d="M60 42 L 46 52 M60 42 L 74 52"/>
+              <path d="M60 56 L 44 66 M60 56 L 76 66"/>
+              <path d="M60 70 L 48 78 M60 70 L 72 78"/>
+              <circle cx="60" cy="14" r="3"/>
+              <line x1="60" y1="14" x2="60" y2="18"/>
+            </g>
+          </svg>
+        </div>
+        <h3 class="binomial"><em>Bombyx mori</em> <span>/ specimen 04</span></h3>
+        <table class="meta-table tight">
+          <tr><th>Date</th><td>Recd. III &middot; {{ current_year }}</td></tr>
+          <tr><th>Provenance</th><td>Atelier, Lyon</td></tr>
+          <tr><th>Period</th><td>c. 1890</td></tr>
+        </table>
+      </div>
+      <div class="plate-accession">No. {{ current_year }}.0014</div>
+    </article>
+
+    <article class="plate small">
+      <div class="plate-corner top-l">OBJ-{{ current_year }}.0015</div>
+      <div class="plate-corner top-r">III</div>
+      <div class="plate-inner">
+        <div class="engraving">
+          <svg viewBox="0 0 120 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <g fill="none" stroke="#1a1612" stroke-width="0.7" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="38" cy="50" r="14"/>
+              <circle cx="38" cy="50" r="6"/>
+              <line x1="50" y1="50" x2="100" y2="50"/>
+              <line x1="92" y1="50" x2="92" y2="60"/>
+              <line x1="92" y1="60" x2="98" y2="60"/>
+              <line x1="84" y1="50" x2="84" y2="58"/>
+              <path d="M30 38 L 32 36 L 36 38"/>
+              <path d="M44 62 L 42 64 L 38 62"/>
+            </g>
+          </svg>
+        </div>
+        <h3 class="binomial"><em>Clavis ferrea</em> <span>/ ward key, no. 7</span></h3>
+        <table class="meta-table tight">
+          <tr><th>Date</th><td>Recd. III &middot; {{ current_year }}</td></tr>
+          <tr><th>Provenance</th><td>Estate of A. Vergne</td></tr>
+          <tr><th>Period</th><td>Eighteenth c.</td></tr>
+        </table>
+      </div>
+      <div class="plate-accession">No. {{ current_year }}.0015</div>
+    </article>
+
+    <article class="plate small">
+      <div class="plate-corner top-l">OBJ-{{ current_year }}.0016</div>
+      <div class="plate-corner top-r">IV</div>
+      <div class="plate-inner">
+        <div class="engraving">
+          <svg viewBox="0 0 120 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <g fill="none" stroke="#1a1612" stroke-width="0.7" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M60 14 C 38 32, 28 56, 36 84 C 50 78, 70 78, 84 84 C 92 56, 82 32, 60 14 Z"/>
+              <line x1="60" y1="14" x2="60" y2="84"/>
+              <line x1="60" y1="22" x2="48" y2="40"/>
+              <line x1="60" y1="22" x2="72" y2="40"/>
+              <line x1="60" y1="34" x2="44" y2="52"/>
+              <line x1="60" y1="34" x2="76" y2="52"/>
+              <line x1="60" y1="48" x2="42" y2="64"/>
+              <line x1="60" y1="48" x2="78" y2="64"/>
+              <line x1="60" y1="62" x2="46" y2="76"/>
+              <line x1="60" y1="62" x2="74" y2="76"/>
+            </g>
+          </svg>
+        </div>
+        <h3 class="binomial"><em>Strix aluco</em> <span>/ remex sinistra</span></h3>
+        <table class="meta-table tight">
+          <tr><th>Date</th><td>Recd. IV &middot; {{ current_year }}</td></tr>
+          <tr><th>Provenance</th><td>Coll. Berthe Loubet</td></tr>
+          <tr><th>Period</th><td>c. 1912</td></tr>
+        </table>
+      </div>
+      <div class="plate-accession">No. {{ current_year }}.0016</div>
+    </article>
+
+    <article class="plate small">
+      <div class="plate-corner top-l">OBJ-{{ current_year }}.0017</div>
+      <div class="plate-corner top-r">V</div>
+      <div class="plate-inner">
+        <div class="engraving accent">
+          <svg viewBox="0 0 120 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <g fill="none" stroke="#6b1a16" stroke-width="0.8" stroke-linecap="round" stroke-linejoin="round">
+              <ellipse cx="60" cy="52" rx="22" ry="32"/>
+              <path d="M60 20 C 54 30, 50 42, 50 52 C 50 64, 54 76, 60 84 C 66 76, 70 64, 70 52 C 70 42, 66 30, 60 20"/>
+              <line x1="60" y1="20" x2="60" y2="14"/>
+              <line x1="60" y1="14" x2="56" y2="10"/>
+              <line x1="60" y1="14" x2="64" y2="10"/>
+              <circle cx="54" cy="42" r="1.2"/>
+              <circle cx="66" cy="42" r="1.2"/>
+              <circle cx="54" cy="58" r="1.2"/>
+              <circle cx="66" cy="58" r="1.2"/>
+              <circle cx="60" cy="50" r="1.2"/>
+              <circle cx="60" cy="66" r="1.2"/>
+            </g>
+          </svg>
+        </div>
+        <h3 class="binomial"><em>Pachira aquatica</em> <span>/ seed pod, opened</span></h3>
+        <table class="meta-table tight">
+          <tr><th>Date</th><td>Recd. IV &middot; {{ current_year }}</td></tr>
+          <tr><th>Provenance</th><td>Field, Guyane</td></tr>
+          <tr><th>Period</th><td>{{ current_year }}</td></tr>
+        </table>
+      </div>
+      <div class="plate-accession">No. {{ current_year }}.0017</div>
+    </article>
+
+  </div>
+</section>
+
+<div class="ornament" aria-hidden="true">
+  <svg viewBox="0 0 320 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" stroke="#1a1612" stroke-width="0.7" stroke-linecap="round">
+      <line x1="0" y1="12" x2="140" y2="12"/>
+      <line x1="180" y1="12" x2="320" y2="12"/>
+      <path d="M150 6 L 160 12 L 150 18 L 145 12 Z"/>
+      <path d="M170 6 L 160 12 L 170 18 L 175 12 Z"/>
+    </g>
+  </svg>
+</div>
+
+<section class="featured">
+  <div class="section-head">
+    <div class="section-num">III.</div>
+    <h2 class="section-title">Featured <em>Cabinet</em></h2>
+    <div class="section-sub">A longer reading &middot; for the patient visitor</div>
+  </div>
+
+  <article class="plate wide">
+    <div class="plate-corner top-l">OBJ-{{ current_year }}.0009</div>
+    <div class="plate-corner top-r">CABINET A</div>
+    <div class="plate-inner">
+      <header class="featured-head">
+        <h3 class="binomial big"><em>Aegerita candida</em> <span>/ paper wasp comb, fragment</span></h3>
+        <div class="featured-meta">
+          <span><b>Accession</b> {{ current_year }}.0009</span>
+          <span><b>Acquired</b> Winter, by exchange</span>
+          <span><b>Provenance</b> Schoolhouse attic, Saint-Cirq</span>
+          <span><b>Period</b> Recorded 1907</span>
+        </div>
+      </header>
+
+      <div class="featured-cols">
+        <p>This fragment, no larger than a child's hand, is the only surviving comb from a colony observed by the schoolmaster F. Aubain over four summers between 1903 and 1907. The schoolmaster kept a small diary of the colony's expansions and quiet collapses, written on the inside flaps of an arithmetic exercise book, and the diary is held with the object as a single accession lot.</p>
+
+        <p>The fragment was prepared for the case using a method the conservator does not name in his report &mdash; only that it involved the careful warming, in a copper bath, of beeswax thinned with turpentine, applied with a sable brush along the cell walls. The brush is in the cabinet beside the object, and is itself given a separate accession number, as the curator believes a tool used to preserve a specimen earns its own line in the record.</p>
+
+        <p>Aegerita combs of this size, dating from the early twentieth century and accompanied by a primary written record, are uncommon in French regional collections; only three are known. Visitors are reminded that the case is lit at twenty-five lux during reading hours and may not be photographed with flash, in keeping with the conservation directive of XI &middot; {{ current_year }}.</p>
+
+        <p class="featured-foot"><em>&mdash; The Curator, in the reading room, Wednesday afternoons</em></p>
+      </div>
+    </div>
+    <div class="plate-accession">No. {{ current_year }}.0009 &middot; Cabinet A &middot; reading hours only</div>
+  </article>
+</section>
+
+<div class="ornament" aria-hidden="true">
+  <svg viewBox="0 0 320 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" stroke="#1a1612" stroke-width="0.7" stroke-linecap="round">
+      <line x1="0" y1="12" x2="110" y2="12"/>
+      <line x1="210" y1="12" x2="320" y2="12"/>
+      <path d="M120 12 Q 140 4, 160 12 Q 180 20, 200 12"/>
+      <circle cx="115" cy="12" r="1.5"/>
+      <circle cx="205" cy="12" r="1.5"/>
+    </g>
+  </svg>
+</div>
+
+<section class="visiting" id="visiting">
+  <div class="section-head">
+    <div class="section-num">IV.</div>
+    <h2 class="section-title">Visiting <em>the Vitrine</em></h2>
+    <div class="section-sub">By the rule of the case &middot; quietly please</div>
+  </div>
+
+  <div class="visit-row">
+    <div class="visit-card">
+      <div class="visit-eyebrow">Reading hours</div>
+      <div class="visit-headline">Wed &mdash; Sun</div>
+      <div class="visit-time">11:00 &mdash; 17:00</div>
+      <div class="visit-fine">Mon &amp; Tues by appointment for scholars only.</div>
+    </div>
+
+    <div class="visit-card">
+      <div class="visit-eyebrow">Address</div>
+      <div class="visit-headline">14, rue du Cabinet</div>
+      <div class="visit-time">Gallery 4 &middot; first floor</div>
+      <div class="visit-fine">Side door, ring once. The bell is original to the house.</div>
+    </div>
+
+    <div class="visit-card ribbon">
+      <div class="visit-eyebrow">Admission</div>
+      <div class="visit-headline">Free for members</div>
+      <div class="visit-time">Day pass &middot; 6</div>
+      <div class="visit-fine">Children under twelve, scholars, and the curious in passing: at no charge, always.</div>
+    </div>
+  </div>
+
+  <div class="visit-rule"></div>
+
+  <p class="visit-foot">The case admits at most eight visitors at any one hour. The reading room is lit at twenty-five lux. No flash photography. The catalog is printed quarterly for members, in a press run of three hundred numbered copies.</p>
+</section>
+
+{% include "footer.html" %}

--- a/examples/museum-vitrine/templates/page.html
+++ b/examples/museum-vitrine/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="plate prose-plate">
+    <div class="plate-corner top-l">VITRINE &middot; READING</div>
+    <div class="plate-corner top-r">PAGE</div>
+    <div class="plate-inner">
+      {% if page.title is present %}<h1 class="prose-title"><em>{{ page.title | e }}</em></h1>{% endif %}
+      <div class="prose-rule"></div>
+      <div class="prose-body">
+        {{ content | safe }}
+      </div>
+    </div>
+    <div class="plate-accession">Reading copy &middot; {{ current_year }}</div>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/museum-vitrine/templates/section.html
+++ b/examples/museum-vitrine/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<section class="acquisitions">
+  <div class="section-head">
+    <div class="section-num">&middot;</div>
+    {% if page.title is present %}<h2 class="section-title"><em>{{ page.title | e }}</em></h2>{% endif %}
+    <div class="section-sub">Index of objects in this gallery</div>
+  </div>
+  <div class="section-prose">
+    {{ content | safe }}
+  </div>
+  <div class="section-list">
+    {% for post in section.pages %}
+    <article class="list-row">
+      <div class="list-num">No. {{ loop.index | string }}</div>
+      <div class="list-title"><a href="{{ post.url }}"><em>{{ post.title | e }}</em></a></div>
+      <div class="list-date">{{ post.date | date(format="%Y &middot; %m") | safe }}</div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/museum-vitrine/templates/shortcodes/alert.html
+++ b/examples/museum-vitrine/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert">
+  <span class="alert-label">{{ type | upper }}</span>
+  <span class="alert-body">{{ body }}</span>
+</div>

--- a/examples/museum-vitrine/templates/taxonomy.html
+++ b/examples/museum-vitrine/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="plate prose-plate">
+    <div class="plate-corner top-l">VITRINE &middot; INDEX</div>
+    <div class="plate-corner top-r">TAXONOMY</div>
+    <div class="plate-inner">
+      <h1 class="prose-title"><em>{{ page.title | e }}</em></h1>
+      <div class="prose-rule"></div>
+      <p class="prose-eyebrow">An index of subjects across the catalog.</p>
+      <div class="prose-body">
+        {{ content | safe }}
+      </div>
+    </div>
+    <div class="plate-accession">Index plate &middot; {{ current_year }}</div>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/museum-vitrine/templates/taxonomy_term.html
+++ b/examples/museum-vitrine/templates/taxonomy_term.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="plate prose-plate">
+    <div class="plate-corner top-l">VITRINE &middot; TERM</div>
+    <div class="plate-corner top-r">SUBJECT</div>
+    <div class="plate-inner">
+      <h1 class="prose-title"><em>{{ page.title | e }}</em></h1>
+      <div class="prose-rule"></div>
+      <p class="prose-eyebrow">Objects accessioned under this subject.</p>
+      <div class="prose-body">
+        {{ content | safe }}
+      </div>
+    </div>
+    <div class="plate-accession">Subject plate &middot; {{ current_year }}</div>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/night-pharmacy/AGENTS.md
+++ b/examples/night-pharmacy/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/night-pharmacy/archetypes/default.md
+++ b/examples/night-pharmacy/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/night-pharmacy/config.toml
+++ b/examples/night-pharmacy/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "NIGHT APOTHECARY"
+description = "A 24-hour independent pharmacy compounding custom formulations, refilling late, and delivering after dark across three districts."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/night-pharmacy/content/about.md
+++ b/examples/night-pharmacy/content/about.md
@@ -1,0 +1,38 @@
++++
+title = "About the Apothecary"
+description = "Night Apothecary — licensure, compounding tradition, dispensary process, after-dark delivery, and contact."
++++
+
+## Licensure {#licensure}
+
+Night Apothecary operates under **Compounding Pharmacy Permit KP-04417**, issued and annually re-inspected by the Yongsan District Health Office of the Republic of Korea. Our two on-duty pharmacists, *S. Park, R.Ph.* and *H. Lee, R.Ph.*, are registered with the Korean Pharmaceutical Association (KPA Reg. 11-082 and 11-114) and hold current Advanced Compounding endorsements. A copy of the permit is mounted on the dispensing window; a duplicate is available on request.
+
+We do not compound, stock, or deliver controlled substances. We do not fill prescriptions written outside the R.O.K. We do not honour photographs of prescriptions; the original must be present at the bench.
+
+## The compounding tradition {#tradition}
+
+The house was opened in **1894** by Pak Yong-su, a journeyman apothecary returning from study in Yokohama. His ledger &mdash; bound in red linen, hand-numbered to *N&deg; 04417* &mdash; is still kept on the back shelf and is still in use; new prescriptions begin where the last one ended. We compound in the *old* sense: weighing on a horn-balance scale, levigating ointments on a marble slab, triturating powders by mortar and pestle, decanting tinctures into amber glass. Where modern equivalents exist and the prescriber prefers them, we will dispense those; where the prescription specifies a galenic preparation, we make it.
+
+> *Mensura, non festinatio.* &mdash; By measure, not by haste. (Inscribed above the bench.)
+
+## The dispensary process {#process}
+
+1. **Intake.** The prescription is read aloud at the window. Patient ID is checked against the chart. Any allergies on file are read aloud back to the patient.
+2. **Weighing.** Ingredients are weighed to the *grain* on the horn-balance, then verified on a digital tare. Both weights are entered on the prescription pad.
+3. **Compounding.** Trituration, levigation, percolation, or simple mixture &mdash; whichever the formula requires &mdash; performed on the bench under the green-shade lamp.
+4. **Verification.** A second pharmacist re-reads the prescription against the finished preparation, initials the pad, applies the wax seal.
+5. **Counsel.** The preparation is handed over with verbal counsel: dose, route, frequency, expected effect, what to do if a dose is missed, when to return.
+
+The process takes **between 18 and 45 minutes** depending on formula. Wait on the wooden bench by the window; tea is on the small stove.
+
+## After-dark delivery {#delivery}
+
+A bicycle courier leaves the bench at the top of every hour from 00:00 to 06:00. Three circuits cover **Yongsan** (60-minute cycle), **Mapo** (90-minute), and **Jongno** (120-minute). Parcels are sealed in waxed paper, hand-numbered to the chart, and signed at the door against photo ID. We do not leave parcels unattended; if no one answers, the courier returns the parcel to the bench and the patient is rung at the number on the chart.
+
+## Contact {#contact}
+
+- **Desk** &mdash; `desk@night-apothecary.kr` (replies within twelve hours)
+- **Bench, after midnight** &mdash; `+82 (0)2 6477 0294`
+- **Address** &mdash; Hannam-daero 24-gil, Yongsan-gu, Seoul
+- **Hours** &mdash; 00:00 &mdash; 06:00, every night, including holidays. No closures.
+- **Walk-ins** &mdash; welcome. Bring your prescription and one piece of photo ID.

--- a/examples/night-pharmacy/content/index.md
+++ b/examples/night-pharmacy/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "NIGHT APOTHECARY — a 24-hour independent compounding pharmacy operating between midnight and dawn across Yongsan, Mapo, and Jongno."
+template = "index"
++++

--- a/examples/night-pharmacy/static/css/style.css
+++ b/examples/night-pharmacy/static/css/style.css
@@ -1,0 +1,859 @@
+/* ==========================================================================
+   NIGHT APOTHECARY  /  static/css/style.css
+   19th-century compounding pharmacy. Solid colors only — no gradients.
+   ========================================================================== */
+
+:root {
+  --cream: #f1e9d2;
+  --cream-deep: #ddd0aa;
+  --jade: #1f5b4a;
+  --jade-deep: #133b32;
+  --amber: #c98823;
+  --amber-deep: #9a6418;
+  --red: #a32a23;
+  --ink: #181613;
+  --graphite: #4c463a;
+
+  --serif: "Cormorant Garamond", "Times New Roman", serif;
+  --mono: "IBM Plex Mono", ui-monospace, monospace;
+  --type: "Special Elite", "Courier New", monospace;
+}
+
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  background: var(--cream);
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: 18px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--jade-deep); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+a:hover { color: var(--red); }
+
+img, svg { display: block; max-width: 100%; }
+
+/* ========== top strip ==================================================== */
+
+.strip-top {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 1.5rem;
+  background: var(--cream);
+  border-bottom: 2px solid var(--ink);
+  padding: 0.6rem 1.4rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+  position: relative;
+}
+
+.strip-top::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -6px;
+  height: 3px;
+  background: var(--ink);
+  border-top: 1px solid var(--cream);
+  border-bottom: 1px solid var(--cream);
+}
+
+.strip-mark { display: flex; align-items: center; gap: 0.7rem; }
+.strip-mark .cross { display: inline-flex; }
+.strip-title b { font-weight: 600; letter-spacing: 0.12em; }
+
+.strip-nav { display: flex; align-items: center; gap: 1.3rem; }
+.strip-nav a {
+  color: var(--ink);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.strip-nav a:hover { color: var(--red); border-bottom-color: var(--red); }
+
+/* ========== hero / cabinet =============================================== */
+
+.hero-cabinet {
+  background: var(--cream);
+  border-bottom: 2px solid var(--ink);
+  padding: 4rem 1.4rem 5rem;
+  position: relative;
+}
+
+.hero-cabinet::before {
+  content: "Mensura, non festinatio. \00B7  By measure, not by haste.";
+  position: absolute;
+  top: 1rem; left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--graphite);
+  letter-spacing: 0.05em;
+}
+
+.hero-frame {
+  max-width: 1280px;
+  margin: 1.4rem auto 0;
+  display: grid;
+  grid-template-columns: 1fr 1.25fr;
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  color: var(--graphite);
+  margin: 0 0 1.6rem;
+  text-transform: uppercase;
+}
+
+.hero-headline {
+  font-family: var(--serif);
+  font-size: clamp(3rem, 6.5vw, 5.8rem);
+  line-height: 0.98;
+  font-weight: 700;
+  margin: 0;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+.hero-headline em {
+  font-style: italic;
+  font-weight: 600;
+}
+.hero-after {
+  color: var(--jade-deep);
+  font-style: italic;
+  font-weight: 700;
+  border-bottom: 4px double var(--jade-deep);
+  padding-bottom: 0.05em;
+}
+
+.hero-sub {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.1rem;
+  color: var(--graphite);
+  max-width: 36ch;
+  margin: 1.6rem 0 2.4rem;
+}
+
+.dispensary-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  border: 2px solid var(--ink);
+  background: var(--cream-deep);
+  padding: 0.85rem 1.4rem;
+  font-family: var(--type);
+  color: var(--ink);
+  letter-spacing: 0.05em;
+}
+.dispensary-badge b { font-size: 1.1rem; display: block; }
+.badge-hours {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--graphite);
+  letter-spacing: 0.12em;
+}
+.badge-bar { width: 18px; height: 18px; background: var(--red); }
+
+.hero-units {
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, max-content);
+  gap: 1.2rem 2rem;
+}
+.hero-units li {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--graphite);
+  font-size: 1rem;
+  display: flex;
+  flex-direction: column;
+  border-left: 2px solid var(--amber);
+  padding-left: 0.7rem;
+}
+.hero-units i {
+  font-size: 1.4rem;
+  color: var(--ink);
+  font-weight: 600;
+}
+.hero-units span {
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  color: var(--graphite);
+  text-transform: uppercase;
+}
+
+/* cabinet ----------------------------------------------------------------- */
+
+.hero-cabinet-wrap {
+  position: relative;
+  background: var(--jade-deep);
+  border: 3px solid var(--amber-deep);
+  outline: 1px solid var(--ink);
+  outline-offset: 4px;
+  padding: 1.6rem;
+  box-shadow: 0 0 0 1px var(--amber) inset;
+}
+
+.rx-watermark {
+  position: absolute;
+  top: -10px; right: -10px;
+  width: 180px; height: 200px;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.cabinet-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(3, 110px);
+  gap: 10px;
+  position: relative;
+  z-index: 1;
+}
+
+.drawer {
+  position: relative;
+  background: var(--jade);
+  border: 2px solid var(--amber);
+  outline: 1px solid var(--jade-deep);
+  outline-offset: -5px;
+  color: var(--cream);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  font-family: var(--serif);
+  padding: 0.5rem;
+}
+.drawer-a, .drawer-f, .drawer-k { background: var(--jade-deep); }
+.drawer-c, .drawer-e, .drawer-h, .drawer-j { background: #234e42; }
+.drawer-b, .drawer-d, .drawer-g, .drawer-i, .drawer-l { background: var(--jade); }
+
+.drawer-label {
+  font-style: italic;
+  font-size: 1.25rem;
+  letter-spacing: 0.02em;
+  color: var(--cream);
+}
+.drawer-label em { font-style: italic; }
+
+.drawer-icon { width: 30px; height: 30px; }
+
+.drawer-pull {
+  position: absolute;
+  bottom: 9px; left: 50%;
+  width: 22px; height: 6px;
+  background: var(--amber);
+  border: 1px solid var(--amber-deep);
+  transform: translateX(-50%);
+}
+
+/* ========== jar row ====================================================== */
+
+.jar-row {
+  background: var(--cream-deep);
+  border-bottom: 2px solid var(--ink);
+  padding: 3rem 1.4rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+  max-width: 100%;
+}
+.jar-wrap {
+  text-align: center;
+  border-left: 1px dashed var(--graphite);
+  border-right: 1px dashed var(--graphite);
+  padding: 0 1rem;
+}
+.jar-svg { margin: 0 auto; max-width: 120px; height: auto; }
+.jar-cap {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--jade-deep);
+  margin: 0.6rem 0 0;
+  font-size: 0.95rem;
+}
+
+/* ========== section heads =============================================== */
+
+.section-head {
+  max-width: 1180px;
+  margin: 0 auto 2.4rem;
+  padding: 0 1rem;
+}
+.kicker {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  color: var(--red);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+.section-title {
+  font-family: var(--serif);
+  font-size: clamp(2.2rem, 4.5vw, 3.6rem);
+  font-weight: 700;
+  margin: 0 0 0.7rem;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+.section-title em {
+  font-style: italic;
+  color: var(--jade-deep);
+  font-weight: 600;
+}
+.section-lede {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.1rem;
+  color: var(--graphite);
+  max-width: 60ch;
+  margin: 0;
+}
+
+/* ========== Rx prescription cards ====================================== */
+
+.rx-section {
+  background: var(--cream);
+  padding: 5rem 1.4rem;
+  border-bottom: 2px solid var(--ink);
+}
+
+.rx-pad {
+  max-width: 1180px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2.2rem;
+}
+
+.rx-card {
+  position: relative;
+  background: var(--cream);
+  border: 1px solid var(--graphite);
+  padding: 1.6rem 1.6rem 3rem;
+  font-family: var(--type);
+  color: var(--ink);
+  overflow: hidden;
+}
+.rx-card::before {
+  content: "R";
+  position: absolute;
+  top: 30px; right: 18px;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 12rem;
+  font-weight: 700;
+  color: var(--red);
+  opacity: 0.06;
+  line-height: 0.8;
+  pointer-events: none;
+}
+
+.rx-card::after {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 32px;
+  background: var(--cream);
+  border-right: 1px solid var(--red);
+  pointer-events: none;
+}
+
+.rx-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-left: 40px;
+  border-bottom: 1px dashed var(--graphite);
+  padding-bottom: 0.8rem;
+  margin-bottom: 1rem;
+}
+.rx-symbol {
+  position: relative;
+  font-family: var(--serif);
+  color: var(--red);
+}
+.rx-symbol em {
+  font-style: italic;
+  font-weight: 700;
+  font-size: 2.6rem;
+  line-height: 1;
+}
+.rx-tail {
+  display: none;
+}
+.rx-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  color: var(--graphite);
+  text-transform: uppercase;
+}
+.rx-no { color: var(--red); font-weight: 600; }
+
+.rx-body {
+  padding-left: 40px;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  row-gap: 0.55rem;
+  column-gap: 1rem;
+}
+.rx-body dt {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  color: var(--graphite);
+  text-transform: uppercase;
+  padding-top: 0.25rem;
+}
+.rx-body dd {
+  margin: 0;
+  font-family: var(--type);
+  font-size: 1rem;
+  color: var(--ink);
+}
+.rx-body em {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--jade-deep);
+  font-size: 1.08rem;
+}
+
+.rx-foot {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding-left: 40px;
+  margin-top: 1.4rem;
+  gap: 1rem;
+}
+.rx-sig {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+.rx-sig-line {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--graphite);
+  font-size: 1.6rem;
+  border-bottom: 1px solid var(--graphite);
+  padding-bottom: 0.4rem;
+}
+.rx-sig-name {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--graphite);
+  letter-spacing: 0.1em;
+  margin-top: 0.3rem;
+  text-transform: uppercase;
+}
+
+.rx-stamp {
+  border: 2px solid var(--red);
+  color: var(--red);
+  padding: 0.4rem 0.7rem;
+  font-family: var(--type);
+  font-size: 0.7rem;
+  text-align: center;
+  letter-spacing: 0.2em;
+  transform: rotate(-6deg);
+  line-height: 1.1;
+}
+.rx-stamp span {
+  display: block;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  margin-top: 0.2rem;
+}
+
+.rx-tear {
+  position: absolute;
+  left: 0; right: 0;
+  bottom: 12px;
+  height: 14px;
+  background: var(--cream);
+  border-top: 1px dashed var(--graphite);
+}
+.rx-tear::before,
+.rx-tear::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  color: var(--graphite);
+  letter-spacing: 0.3em;
+}
+.rx-tear::before {
+  content: "&  --  tear here  --  &";
+  top: 0;
+  background: var(--cream);
+  padding: 0 1rem;
+  transform: translate(-50%, -55%);
+}
+
+/* ========== refills ===================================================== */
+
+.refill-section {
+  background: var(--cream-deep);
+  border-bottom: 2px solid var(--ink);
+  padding: 5rem 1.4rem;
+}
+
+.refill-table {
+  max-width: 1180px;
+  margin: 0 auto;
+  background: var(--cream);
+  border: 2px solid var(--ink);
+}
+.refill-row {
+  display: grid;
+  grid-template-columns: 1.1fr 2fr 1fr 1fr 0.8fr;
+  gap: 1rem;
+  padding: 0.95rem 1.2rem;
+  align-items: center;
+  border-bottom: 1px solid var(--cream-deep);
+  font-family: var(--type);
+  font-size: 0.95rem;
+}
+.refill-row:last-child { border-bottom: 0; }
+.refill-head {
+  background: var(--ink);
+  color: var(--cream);
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.refill-row em {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--jade-deep);
+}
+.mono { font-family: var(--mono); font-size: 0.85rem; letter-spacing: 0.08em; }
+
+.pill {
+  display: inline-block;
+  padding: 0.2rem 0.7rem;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  border: 1px solid var(--ink);
+  text-align: center;
+}
+.pill-jade { background: var(--jade); color: var(--cream); border-color: var(--jade-deep); }
+.pill-amber { background: var(--amber); color: var(--ink); border-color: var(--amber-deep); }
+.pill-red { background: var(--red); color: var(--cream); border-color: var(--ink); }
+
+.refill-note {
+  max-width: 1180px;
+  margin: 1.4rem auto 0;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.98rem;
+  color: var(--graphite);
+}
+
+/* ========== delivery ==================================================== */
+
+.delivery-section {
+  background: var(--cream);
+  padding: 5rem 1.4rem 5rem;
+}
+
+.districts {
+  max-width: 1180px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.6rem;
+}
+
+.district {
+  background: var(--jade-deep);
+  color: var(--cream);
+  border: 2px solid var(--ink);
+  outline: 1px solid var(--amber);
+  outline-offset: -7px;
+  padding: 1.8rem 1.6rem 2rem;
+  position: relative;
+  font-family: var(--serif);
+}
+
+.district-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.9rem;
+  border-bottom: 1px solid var(--amber);
+  padding-bottom: 0.7rem;
+  margin-bottom: 1rem;
+}
+.district-no {
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.2em;
+  color: var(--amber);
+}
+.district h3 {
+  margin: 0;
+  font-size: 2rem;
+  font-style: italic;
+  font-weight: 600;
+  color: var(--cream);
+}
+
+.district-stops {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.4rem;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  color: var(--cream-deep);
+  letter-spacing: 0.04em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.district-price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.7rem;
+  border-top: 1px dashed var(--amber);
+  padding-top: 1rem;
+}
+.district-price em {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--amber);
+}
+.district-price span {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.15em;
+  color: var(--cream-deep);
+  text-transform: uppercase;
+}
+
+.district-stamp {
+  position: absolute;
+  top: 16px; right: 16px;
+  font-family: var(--type);
+  border: 1.5px solid var(--red);
+  color: var(--red);
+  padding: 0.2rem 0.55rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.2em;
+  transform: rotate(4deg);
+}
+
+.delivery-note {
+  max-width: 1180px;
+  margin: 1.8rem auto 0;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.98rem;
+  color: var(--graphite);
+}
+
+/* ========== footer ====================================================== */
+
+.apothecary-foot {
+  background: var(--ink);
+  color: var(--cream);
+  padding: 4rem 1.4rem 2.6rem;
+  border-top: 6px double var(--cream);
+}
+
+.foot-wrap { max-width: 1280px; margin: 0 auto; }
+
+.foot-seal {
+  display: flex;
+  align-items: center;
+  gap: 1.4rem;
+  padding-bottom: 2rem;
+  margin-bottom: 2.6rem;
+  border-bottom: 1px solid var(--graphite);
+}
+.foot-seal .seal-cross { background: var(--cream); padding: 6px; }
+.seal-text b {
+  display: block;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.7rem;
+  color: var(--cream);
+}
+.seal-text span {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  color: var(--cream-deep);
+}
+
+.foot-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2rem;
+  margin-bottom: 2.6rem;
+}
+.foot-grid h4 {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin: 0 0 0.9rem;
+}
+.foot-grid a,
+.foot-grid span {
+  display: block;
+  font-family: var(--serif);
+  font-size: 1rem;
+  color: var(--cream);
+  text-decoration: none;
+  margin-bottom: 0.4rem;
+}
+.foot-grid a:hover { color: var(--amber); text-decoration: underline; }
+.foot-grid span { color: var(--cream-deep); font-style: italic; }
+
+.foot-disclaimer {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  line-height: 1.55;
+  color: var(--cream-deep);
+  border-top: 1px dashed var(--graphite);
+  padding-top: 1.5rem;
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+
+/* ========== prose pages ================================================= */
+
+.prose {
+  max-width: 760px;
+  margin: 3rem auto 5rem;
+  padding: 0 1.4rem;
+  font-family: var(--serif);
+  font-size: 1.12rem;
+  color: var(--ink);
+}
+.prose h1 {
+  font-family: var(--serif);
+  font-size: clamp(2.4rem, 4.5vw, 3.4rem);
+  font-weight: 700;
+  margin: 0 0 1.4rem;
+  letter-spacing: -0.01em;
+}
+.prose h1 em { font-style: italic; color: var(--jade-deep); }
+.prose h2 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.8rem;
+  color: var(--jade-deep);
+  margin: 2.5rem 0 0.9rem;
+  border-bottom: 1px solid var(--cream-deep);
+  padding-bottom: 0.4rem;
+}
+.prose h3 {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--red);
+  margin: 1.8rem 0 0.6rem;
+}
+.prose p { margin: 0 0 1.1rem; }
+.prose ul, .prose ol { margin: 0 0 1.4rem; padding-left: 1.4rem; }
+.prose li { margin-bottom: 0.4rem; }
+.prose code {
+  font-family: var(--mono);
+  font-size: 0.92rem;
+  background: var(--cream-deep);
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--graphite);
+}
+.prose blockquote {
+  font-family: var(--serif);
+  font-style: italic;
+  border-left: 4px solid var(--red);
+  margin: 1.6rem 0;
+  padding: 0.4rem 1.2rem;
+  color: var(--graphite);
+  background: var(--cream-deep);
+}
+.prose hr { border: 0; border-top: 1px dashed var(--graphite); margin: 2rem 0; }
+.prose a { color: var(--jade-deep); }
+
+.section-list .refill-row { grid-template-columns: 1fr 2.4fr 1fr; }
+
+/* ========== shortcode =================================================== */
+
+.alert {
+  border: 1px solid var(--graphite);
+  border-left: 5px solid var(--red);
+  background: var(--cream-deep);
+  padding: 0.9rem 1.1rem;
+  font-family: var(--serif);
+  margin: 1.4rem 0;
+}
+
+/* ========== responsive ================================================== */
+
+@media (max-width: 960px) {
+  .hero-frame { grid-template-columns: 1fr; gap: 2.2rem; }
+  .cabinet-grid { grid-template-rows: repeat(3, 96px); }
+  .rx-pad { grid-template-columns: 1fr; }
+  .districts { grid-template-columns: 1fr; }
+  .jar-row { grid-template-columns: 1fr; }
+  .foot-grid { grid-template-columns: repeat(2, 1fr); }
+  .refill-row {
+    grid-template-columns: 1fr 1fr;
+    row-gap: 0.3rem;
+  }
+  .refill-head { display: none; }
+}
+
+@media (max-width: 640px) {
+  .strip-top {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  .cabinet-grid { grid-template-columns: repeat(3, 1fr); grid-template-rows: repeat(4, 88px); }
+  .hero-units { grid-template-columns: repeat(2, 1fr); }
+  .foot-grid { grid-template-columns: 1fr; }
+  .foot-seal { flex-direction: column; align-items: flex-start; }
+}

--- a/examples/night-pharmacy/static/favicon.svg
+++ b/examples/night-pharmacy/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f1e9d2"/>
+  <rect x="2" y="2" width="28" height="28" fill="none" stroke="#1f5b4a" stroke-width="1.5"/>
+  <path d="M13 6h6v7h7v6h-7v7h-6v-7H6v-6h7z" fill="#a32a23"/>
+</svg>

--- a/examples/night-pharmacy/templates/404.html
+++ b/examples/night-pharmacy/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &middot; <em>Out of stock.</em></h1>
+  <p>This page is not on the shelf and not in the bench drawer. Perhaps it was compounded once and dispensed; perhaps it never had a prescription number. Walk back to the front desk and try again.</p>
+  <p><a href="{{ base_url }}/">&laquo; return to the dispensary</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/night-pharmacy/templates/footer.html
+++ b/examples/night-pharmacy/templates/footer.html
@@ -1,0 +1,47 @@
+  <footer class="apothecary-foot">
+    <div class="foot-wrap">
+      <div class="foot-seal">
+        <span class="seal-cross" aria-hidden="true">
+          <svg viewBox="0 0 60 60" width="56" height="56"><rect x="2" y="2" width="56" height="56" fill="none" stroke="#a32a23" stroke-width="2"/><path d="M22 8h16v14h14v16H38v14H22V38H8V22h14z" fill="#a32a23"/></svg>
+        </span>
+        <div class="seal-text">
+          <b>LICENSED COMPOUNDING</b>
+          <span>EST. 1894 &middot; SEAL N&deg; KP-04417</span>
+          <span>&copy; {{ current_year }} NIGHT APOTHECARY</span>
+        </div>
+      </div>
+      <div class="foot-grid">
+        <div>
+          <h4>// Dispensary</h4>
+          <a href="{{ base_url }}/#compound">Tonight&rsquo;s compounds</a>
+          <a href="{{ base_url }}/#refill">Standing refills</a>
+          <a href="{{ base_url }}/#delivery">After-dark delivery</a>
+        </div>
+        <div>
+          <h4>// House</h4>
+          <a href="{{ base_url }}/about/">About the apothecary</a>
+          <a href="{{ base_url }}/about/#process">Compounding process</a>
+          <a href="{{ base_url }}/about/#licensure">Licensure</a>
+        </div>
+        <div>
+          <h4>// Reach</h4>
+          <a href="{{ base_url }}/about/#contact">desk@night-apothecary.kr</a>
+          <a href="{{ base_url }}/about/#contact">+82 (0)2 6477 0294</a>
+          <span>Yongsan-gu &middot; Seoul</span>
+        </div>
+        <div>
+          <h4>// Hours</h4>
+          <span>Mon&ndash;Sun</span>
+          <span>00:00 &ndash; 06:00</span>
+          <span>Always. No closures.</span>
+        </div>
+      </div>
+      <p class="foot-disclaimer">
+        Regulatory notice &mdash; Night Apothecary is a licensed compounding pharmacy operating under permit KP-04417 issued by the Yongsan District Health Office. Compounded preparations are dispensed only against a valid prescription from a registered prescriber. Self-medication is dangerous; consult a licensed prescriber. Standing refills require a current chart on file. Controlled substances are not compounded or delivered. Patient information is held under the Personal Information Protection Act, R.O.K. This site is informational only and does not constitute medical advice.
+      </p>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/night-pharmacy/templates/header.html
+++ b/examples/night-pharmacy/templates/header.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=IBM+Plex+Mono:wght@400;500;600&family=Special+Elite&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <div class="strip-mark">
+      <span class="cross" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="14" height="14"><path d="M9 3h6v6h6v6h-6v6H9v-6H3V9h6z" fill="#a32a23"/></svg>
+      </span>
+      <span class="strip-title"><b>NIGHT APOTHECARY</b> &middot; COMPOUNDING &middot; OPEN 24:00&ndash;06:00 ALWAYS</span>
+    </div>
+    <nav class="strip-nav">
+      <a href="{{ base_url }}/#compound">Compound</a>
+      <a href="{{ base_url }}/#refill">Refill</a>
+      <a href="{{ base_url }}/#delivery">Delivery</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </header>

--- a/examples/night-pharmacy/templates/index.html
+++ b/examples/night-pharmacy/templates/index.html
@@ -1,0 +1,349 @@
+{% include "header.html" %}
+
+<section class="hero-cabinet">
+  <div class="hero-frame">
+    <div class="hero-left">
+      <p class="hero-eyebrow">// Est. MDCCCXCIV &middot; Yongsan</p>
+      <h1 class="hero-headline">
+        <em>Compounded</em><br>
+        <span class="hero-after">after dark</span><br>
+        <em>since 1894.</em>
+      </h1>
+      <p class="hero-sub">A 24-hour independent apothecary. We weigh, levigate, triturate &amp; dispense to the prescription &mdash; while the city sleeps.</p>
+
+      <div class="dispensary-badge">
+        <span class="badge-bar"></span>
+        <div>
+          <b>DISPENSARY OPEN</b>
+          <span class="badge-hours">00:00 &mdash; 06:00 &middot; Mon&ndash;Sun</span>
+        </div>
+        <span class="badge-bar"></span>
+      </div>
+
+      <ul class="hero-units">
+        <li><i>gtts</i><span>drops</span></li>
+        <li><i>&#658;</i><span>drachm</span></li>
+        <li><i>gr</i><span>grain</span></li>
+        <li><i>mL</i><span>millilitre</span></li>
+      </ul>
+    </div>
+
+    <div class="hero-cabinet-wrap">
+      <div class="rx-watermark" aria-hidden="true">
+        <svg viewBox="0 0 200 220" width="100%" height="100%">
+          <text x="20" y="170" font-family="Cormorant Garamond, serif" font-size="220" font-style="italic" font-weight="700" fill="#a32a23" fill-opacity="0.18">R</text>
+          <path d="M118 130 l50 70 M118 200 l50 -70" stroke="#a32a23" stroke-opacity="0.18" stroke-width="10" fill="none" stroke-linecap="round"/>
+        </svg>
+      </div>
+
+      <div class="cabinet-grid">
+        <div class="drawer drawer-a">
+          <div class="drawer-label"><em>Tinct.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M14 6h12v6l4 6v18H10V18l4-6z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><path d="M14 22h12" stroke="#f1e9d2" stroke-width="1"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-b">
+          <div class="drawer-label"><em>Pulv.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M8 30 C 14 22, 26 22, 32 30 Z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><circle cx="15" cy="26" r="0.7" fill="#f1e9d2"/><circle cx="20" cy="24" r="0.7" fill="#f1e9d2"/><circle cx="25" cy="26" r="0.7" fill="#f1e9d2"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-c">
+          <div class="drawer-label"><em>Ungt.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><rect x="12" y="14" width="16" height="18" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><rect x="14" y="10" width="12" height="4" fill="none" stroke="#f1e9d2" stroke-width="1.3"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-d">
+          <div class="drawer-label"><em>Syrup.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M16 8h8v4l3 4v18H13V16l3-4z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><path d="M13 24h14" stroke="#f1e9d2" stroke-width="1"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+
+        <div class="drawer drawer-e">
+          <div class="drawer-label"><em>Mist.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M14 10h12v22a6 6 0 0 1-12 0z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><path d="M14 18h12" stroke="#f1e9d2" stroke-width="1"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-f">
+          <div class="drawer-label"><em>Empl.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M10 22 Q 20 8 30 22 Q 20 36 10 22 Z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-g">
+          <div class="drawer-label"><em>Aq. Dest.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M20 8 C 26 18, 30 24, 26 30 A 8 8 0 0 1 14 30 C 10 24, 14 18, 20 8 Z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-h">
+          <div class="drawer-label"><em>Caps.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><rect x="8" y="16" width="24" height="8" rx="4" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><path d="M20 16v8" stroke="#f1e9d2" stroke-width="1"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+
+        <div class="drawer drawer-i">
+          <div class="drawer-label"><em>Bals.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M12 12h16v20H12z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><path d="M16 8h8v4h-8z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-j">
+          <div class="drawer-label"><em>Inf.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M10 12h20l-4 8v12H14V20z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-k">
+          <div class="drawer-label"><em>Lin.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><ellipse cx="20" cy="26" rx="10" ry="8" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><rect x="17" y="10" width="6" height="10" fill="none" stroke="#f1e9d2" stroke-width="1.3"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+        <div class="drawer drawer-l">
+          <div class="drawer-label"><em>Sp&iacute;r.</em></div>
+          <svg class="drawer-icon" viewBox="0 0 40 40"><path d="M14 10h12v22H14z" fill="none" stroke="#f1e9d2" stroke-width="1.3"/><path d="M14 22h12 M18 10v-4h4v4" stroke="#f1e9d2" stroke-width="1" fill="none"/></svg>
+          <span class="drawer-pull"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="jar-row" aria-hidden="true">
+  <div class="jar-wrap">
+    <svg class="jar-svg" viewBox="0 0 100 140">
+      <path d="M30 18h40v8H30z" fill="none" stroke="#133b32" stroke-width="2"/>
+      <path d="M28 26h44l-4 14a18 18 0 0 1 8 14v68a4 4 0 0 1-4 4H28a4 4 0 0 1-4-4V54a18 18 0 0 1 8-14z" fill="none" stroke="#133b32" stroke-width="2"/>
+      <text x="50" y="86" text-anchor="middle" font-family="Cormorant Garamond, serif" font-style="italic" font-size="16" fill="#133b32">Valeriana</text>
+      <line x1="32" y1="92" x2="68" y2="92" stroke="#133b32" stroke-width="0.6"/>
+      <text x="50" y="104" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#133b32">N&deg; 014 &middot; 1 oz.</text>
+    </svg>
+    <p class="jar-cap">Valerian root tincture &middot; 30 mL</p>
+  </div>
+  <div class="jar-wrap">
+    <svg class="jar-svg" viewBox="0 0 100 140">
+      <ellipse cx="50" cy="20" rx="18" ry="6" fill="none" stroke="#133b32" stroke-width="2"/>
+      <path d="M32 20v6h36v-6" fill="none" stroke="#133b32" stroke-width="2"/>
+      <path d="M28 26 Q 24 56, 28 110 a 6 6 0 0 0 6 6 h32 a 6 6 0 0 0 6 -6 Q 76 56, 72 26 z" fill="none" stroke="#133b32" stroke-width="2"/>
+      <text x="50" y="80" text-anchor="middle" font-family="Cormorant Garamond, serif" font-style="italic" font-size="16" fill="#133b32">Camphora</text>
+      <line x1="32" y1="86" x2="68" y2="86" stroke="#133b32" stroke-width="0.6"/>
+      <text x="50" y="98" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#133b32">N&deg; 028 &middot; 2 gr</text>
+    </svg>
+    <p class="jar-cap">Camphor crystals &middot; 2 gr</p>
+  </div>
+  <div class="jar-wrap">
+    <svg class="jar-svg" viewBox="0 0 100 140">
+      <path d="M40 10h20v10H40z" fill="none" stroke="#133b32" stroke-width="2"/>
+      <path d="M36 20h28l-2 10h-24z" fill="none" stroke="#133b32" stroke-width="2"/>
+      <path d="M30 30h40v82a6 6 0 0 1-6 6H36a6 6 0 0 1-6-6z" fill="none" stroke="#133b32" stroke-width="2"/>
+      <text x="50" y="78" text-anchor="middle" font-family="Cormorant Garamond, serif" font-style="italic" font-size="14" fill="#133b32">Tinct. Iod.</text>
+      <line x1="32" y1="84" x2="68" y2="84" stroke="#133b32" stroke-width="0.6"/>
+      <text x="50" y="96" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#133b32">N&deg; 047 &middot; 15 mL</text>
+    </svg>
+    <p class="jar-cap">Tincture of iodine &middot; 15 mL</p>
+  </div>
+</section>
+
+<section class="rx-section" id="compound">
+  <div class="section-head">
+    <p class="kicker">// N&deg; II &middot; from the bench</p>
+    <h2 class="section-title">Tonight&rsquo;s <em>Compounds</em></h2>
+    <p class="section-lede">Four preparations are mixed fresh every evening. Each is hand-numbered, sealed in waxed paper, and signed by the compounder on duty.</p>
+  </div>
+
+  <div class="rx-pad">
+    <article class="rx-card">
+      <div class="rx-header">
+        <span class="rx-symbol"><em>R</em><span class="rx-tail">&#x2114;</span></span>
+        <div class="rx-meta">
+          <span class="rx-no">N&deg; 04417&middot;A</span>
+          <span class="rx-date">{{ current_year }} / 05 / 22 &middot; 23:14</span>
+        </div>
+      </div>
+      <dl class="rx-body">
+        <dt>for</dt><dd>J. Han &middot; chart 0291</dd>
+        <dt>preparation</dt><dd><em>Tinctura Valerianae</em></dd>
+        <dt>quantity</dt><dd>30 mL &middot; amber dropper</dd>
+        <dt>sig.</dt><dd><em>5 gtts ante somnum</em> &mdash; 5 drops before sleep, sublingual, with water.</dd>
+      </dl>
+      <div class="rx-foot">
+        <div class="rx-sig"><span class="rx-sig-line">x</span><span class="rx-sig-name">&mdash; compounded by S. Park, R.Ph.</span></div>
+        <div class="rx-stamp">SEAL<br><span>04417&middot;A</span></div>
+      </div>
+      <div class="rx-tear" aria-hidden="true"></div>
+    </article>
+
+    <article class="rx-card">
+      <div class="rx-header">
+        <span class="rx-symbol"><em>R</em><span class="rx-tail">&#x2114;</span></span>
+        <div class="rx-meta">
+          <span class="rx-no">N&deg; 04417&middot;B</span>
+          <span class="rx-date">{{ current_year }} / 05 / 22 &middot; 01:48</span>
+        </div>
+      </div>
+      <dl class="rx-body">
+        <dt>for</dt><dd>M. Choi &middot; chart 0144</dd>
+        <dt>preparation</dt><dd><em>Unguentum Calendulae</em></dd>
+        <dt>quantity</dt><dd>1 &#658; &middot; lidded tin</dd>
+        <dt>sig.</dt><dd><em>App. ad partes affectas bis die</em> &mdash; apply to affected areas twice daily, thin layer.</dd>
+      </dl>
+      <div class="rx-foot">
+        <div class="rx-sig"><span class="rx-sig-line">x</span><span class="rx-sig-name">&mdash; compounded by H. Lee, R.Ph.</span></div>
+        <div class="rx-stamp">SEAL<br><span>04417&middot;B</span></div>
+      </div>
+      <div class="rx-tear" aria-hidden="true"></div>
+    </article>
+
+    <article class="rx-card">
+      <div class="rx-header">
+        <span class="rx-symbol"><em>R</em><span class="rx-tail">&#x2114;</span></span>
+        <div class="rx-meta">
+          <span class="rx-no">N&deg; 04417&middot;C</span>
+          <span class="rx-date">{{ current_year }} / 05 / 22 &middot; 02:31</span>
+        </div>
+      </div>
+      <dl class="rx-body">
+        <dt>for</dt><dd>K. Yoo &middot; chart 0307</dd>
+        <dt>preparation</dt><dd><em>Pulvis Hyoscyami compositus</em></dd>
+        <dt>quantity</dt><dd>12 caps. &middot; 2 gr each</dd>
+        <dt>sig.</dt><dd><em>I caps. q. 6h p.r.n.</em> &mdash; one capsule every six hours as needed for spasm; max 4/day.</dd>
+      </dl>
+      <div class="rx-foot">
+        <div class="rx-sig"><span class="rx-sig-line">x</span><span class="rx-sig-name">&mdash; compounded by S. Park, R.Ph.</span></div>
+        <div class="rx-stamp">SEAL<br><span>04417&middot;C</span></div>
+      </div>
+      <div class="rx-tear" aria-hidden="true"></div>
+    </article>
+
+    <article class="rx-card">
+      <div class="rx-header">
+        <span class="rx-symbol"><em>R</em><span class="rx-tail">&#x2114;</span></span>
+        <div class="rx-meta">
+          <span class="rx-no">N&deg; 04417&middot;D</span>
+          <span class="rx-date">{{ current_year }} / 05 / 22 &middot; 04:02</span>
+        </div>
+      </div>
+      <dl class="rx-body">
+        <dt>for</dt><dd>D. Im &middot; chart 0418</dd>
+        <dt>preparation</dt><dd><em>Syrupus Tussis Nocturnus</em></dd>
+        <dt>quantity</dt><dd>120 mL &middot; amber bottle</dd>
+        <dt>sig.</dt><dd><em>I cochl. mensur. h.s.</em> &mdash; one measured spoonful at bedtime; shake before use.</dd>
+      </dl>
+      <div class="rx-foot">
+        <div class="rx-sig"><span class="rx-sig-line">x</span><span class="rx-sig-name">&mdash; compounded by H. Lee, R.Ph.</span></div>
+        <div class="rx-stamp">SEAL<br><span>04417&middot;D</span></div>
+      </div>
+      <div class="rx-tear" aria-hidden="true"></div>
+    </article>
+  </div>
+</section>
+
+<section class="refill-section" id="refill">
+  <div class="section-head">
+    <p class="kicker">// N&deg; III &middot; standing orders</p>
+    <h2 class="section-title">Standing <em>Refills</em></h2>
+    <p class="section-lede">Patients on a chart receive automatic refills synchronized to their last fill. No phone call required. Disposable seal on every parcel.</p>
+  </div>
+
+  <div class="refill-table">
+    <div class="refill-row refill-head">
+      <span>Patient ID</span>
+      <span>Preparation</span>
+      <span>Last fill</span>
+      <span>Next due</span>
+      <span>Status</span>
+    </div>
+    <div class="refill-row">
+      <span class="mono">0291 &middot; J.H.</span>
+      <span><em>Tinct. Valerianae</em> 30 mL</span>
+      <span>{{ current_year }} / 04 / 24</span>
+      <span>{{ current_year }} / 05 / 24</span>
+      <span class="pill pill-jade">ready</span>
+    </div>
+    <div class="refill-row">
+      <span class="mono">0144 &middot; M.C.</span>
+      <span><em>Ungt. Calendulae</em> 1 &#658;</span>
+      <span>{{ current_year }} / 04 / 18</span>
+      <span>{{ current_year }} / 05 / 18</span>
+      <span class="pill pill-amber">on bench</span>
+    </div>
+    <div class="refill-row">
+      <span class="mono">0307 &middot; K.Y.</span>
+      <span><em>Pulv. Hyoscyami</em> 12 caps</span>
+      <span>{{ current_year }} / 05 / 02</span>
+      <span>{{ current_year }} / 05 / 30</span>
+      <span class="pill pill-jade">scheduled</span>
+    </div>
+    <div class="refill-row">
+      <span class="mono">0418 &middot; D.I.</span>
+      <span><em>Syrup. Tussis</em> 120 mL</span>
+      <span>{{ current_year }} / 05 / 08</span>
+      <span>{{ current_year }} / 05 / 25</span>
+      <span class="pill pill-jade">ready</span>
+    </div>
+    <div class="refill-row">
+      <span class="mono">0521 &middot; B.O.</span>
+      <span><em>Mist. Sedativa</em> 60 mL</span>
+      <span>{{ current_year }} / 03 / 30</span>
+      <span>{{ current_year }} / 04 / 30</span>
+      <span class="pill pill-red">overdue</span>
+    </div>
+    <div class="refill-row">
+      <span class="mono">0612 &middot; T.K.</span>
+      <span><em>Bals. Tolutanus</em> 45 mL</span>
+      <span>{{ current_year }} / 05 / 14</span>
+      <span>{{ current_year }} / 06 / 14</span>
+      <span class="pill pill-amber">on bench</span>
+    </div>
+  </div>
+  <p class="refill-note">Lost chart? Walk in with photo ID between 00:00 and 06:00. We rebuild the chart on prescription pad &mdash; no portal, no app.</p>
+</section>
+
+<section class="delivery-section" id="delivery">
+  <div class="section-head">
+    <p class="kicker">// N&deg; IV &middot; the runner</p>
+    <h2 class="section-title">After-Dark <em>Delivery</em></h2>
+    <p class="section-lede">A bicycle courier leaves the dispensary at the top of each hour. Three district circuits, fixed pricing, sealed waxed parcels, signed receipt.</p>
+  </div>
+
+  <div class="districts">
+    <article class="district">
+      <div class="district-head">
+        <span class="district-no">Z&middot;01</span>
+        <h3>Yongsan</h3>
+      </div>
+      <ul class="district-stops">
+        <li>Itaewon &middot; Hannam &middot; Huam</li>
+        <li>Cycle: every 60 min &middot; 00:00&ndash;06:00</li>
+        <li>Avg. doorstep: 22 min</li>
+      </ul>
+      <div class="district-price"><em>&#8361; 3,500</em><span>per parcel</span></div>
+      <div class="district-stamp">CIRCUIT OPEN</div>
+    </article>
+    <article class="district">
+      <div class="district-head">
+        <span class="district-no">Z&middot;02</span>
+        <h3>Mapo</h3>
+      </div>
+      <ul class="district-stops">
+        <li>Hapjeong &middot; Sangsu &middot; Mangwon</li>
+        <li>Cycle: every 90 min &middot; 00:00&ndash;05:00</li>
+        <li>Avg. doorstep: 34 min</li>
+      </ul>
+      <div class="district-price"><em>&#8361; 4,200</em><span>per parcel</span></div>
+      <div class="district-stamp">CIRCUIT OPEN</div>
+    </article>
+    <article class="district">
+      <div class="district-head">
+        <span class="district-no">Z&middot;03</span>
+        <h3>Jongno</h3>
+      </div>
+      <ul class="district-stops">
+        <li>Insadong &middot; Hyehwa &middot; Bukchon</li>
+        <li>Cycle: every 120 min &middot; 00:00&ndash;04:00</li>
+        <li>Avg. doorstep: 41 min</li>
+      </ul>
+      <div class="district-price"><em>&#8361; 4,800</em><span>per parcel</span></div>
+      <div class="district-stamp">CIRCUIT OPEN</div>
+    </article>
+  </div>
+
+  <p class="delivery-note">Controlled substances are not delivered. Photo ID matched against chart at handover &mdash; no exceptions, even for the regulars. Receipt is on a torn corner of prescription pad, hand-signed.</p>
+</section>
+
+{% include "footer.html" %}

--- a/examples/night-pharmacy/templates/page.html
+++ b/examples/night-pharmacy/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/night-pharmacy/templates/section.html
+++ b/examples/night-pharmacy/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<section class="prose section-list">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+  <div class="refill-table section-table">
+    <div class="refill-row refill-head">
+      <span>Date</span>
+      <span>Entry</span>
+      <span>Status</span>
+    </div>
+    {% for post in section.pages %}
+    <div class="refill-row">
+      <span class="mono">{{ post.date | date(format="%Y / %m / %d") }}</span>
+      <span><a href="{{ post.url }}">{{ post.title | e }}</a></span>
+      <span class="pill pill-jade">on file</span>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/night-pharmacy/templates/shortcodes/alert.html
+++ b/examples/night-pharmacy/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type }}">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/night-pharmacy/templates/taxonomy.html
+++ b/examples/night-pharmacy/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p><em>// Index of headings filed in the dispensary log.</em></p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/night-pharmacy/templates/taxonomy_term.html
+++ b/examples/night-pharmacy/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p><em>// Entries filed under this heading.</em></p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/observatory-bureau/AGENTS.md
+++ b/examples/observatory-bureau/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/observatory-bureau/archetypes/default.md
+++ b/examples/observatory-bureau/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/observatory-bureau/config.toml
+++ b/examples/observatory-bureau/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Bureau of Amateur Astronomy"
+description = "An ephemeris log and observing-session journal for backyard astronomers and small public observatories. Established 1881."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/observatory-bureau/content/about.md
+++ b/examples/observatory-bureau/content/about.md
@@ -1,0 +1,51 @@
++++
+title = "About the Bureau"
+description = "A short history of the Bureau of Amateur Astronomy, its membership, observing nights, ephemeris service, and equipment rental cabinet."
++++
+
+## A short history
+
+The Bureau of Amateur Astronomy was founded in the autumn of **1881** by three schoolteachers, a railway clerk, and an unemployed clockmaker, who had grown tired of being told that the night sky was not a fit subject for working people. They pooled their wages, bought a single four-inch refractor, and began to keep a shared log book. The Bureau has met without interruption ever since &mdash; through two wars, one fire, and the long century of city lights that followed.
+
+The current premises are on Cedar Lane, in a small brick building once used to weigh tea. The Bureau owns the roof.
+
+## Who can join
+
+Membership is open to anyone of any age, in any condition, who can be relied upon to handle the instruments gently and to keep the log books honestly. **There is no observing test.** The Bureau has only two firm rules:
+
+1. Never lend an eyepiece to a stranger without writing it in the book.
+2. Never describe a faint object as bright, nor a bright object as faint, in order to sound more learned than you are.
+
+The dues are nominal &mdash; **eighteen thousand won per quarter** &mdash; and may be waived by the Membership Secretary on a private word. About one fifth of our members pay nothing.
+
+## Observation nights
+
+The Bureau holds **public observation nights** on the first Friday and the third Saturday of every month, weather permitting. We open the roof at sunset, set out four telescopes, and stay until the last guest is ready to go home. Children are welcome at all of them; the four-inch refractor stays on the planets specifically so they have something to look at.
+
+**Members' nights** are quieter. They run on the second Tuesday of each month, and on any night the Secretary of Observations declares "clear, dark, and worth the trouble." Members may also book the roof for solo observing by signing the book a day in advance.
+
+## The ephemeris service
+
+This bulletin is the Bureau's principal publication. We compile a monthly **ephemeris** &mdash; positions of the Sun, Moon, planets, and any visible comets &mdash; together with notes on observable deep-sky objects and a short editorial on what has been most worth watching. The ephemeris is calculated by hand by a rotating team of three correspondents, against atomic time, and checked against the published catalogues twice before it goes to print.
+
+Back issues, dating to **1881**, are available in the catalogue archive. The earliest are written in the founder's own hand and are not lent out, but may be consulted at the Bureau by appointment.
+
+## Equipment rental
+
+The Bureau keeps a **loan cabinet** of instruments for members in good standing:
+
+- A 4-inch achromatic refractor on a brass equatorial mount &mdash; **seven nights**.
+- An 8-inch Dobsonian reflector &mdash; **fourteen nights**.
+- A complete Plossl eyepiece set, in the original case &mdash; **thirty nights**.
+- Quarto field log books, with red torches and pencils, given as a gift on joining.
+
+Loans are recorded in the cabinet ledger, which is the same ledger we have used since 1947. Lost or damaged equipment is replaced at the member's expense, but the cabinet has lost only three items in seventy-eight years &mdash; a remarkable record, of which we are quietly proud.
+
+## How to reach us
+
+> Send a letter. We will answer in handwriting if we can.
+
+- **Correspondence** &mdash; `desk@amateur.bureau`
+- **Membership** &mdash; `membership@amateur.bureau`
+- **The roof** &mdash; No. 14 Cedar Lane, Old Observatory Hill
+- **Office hours** &mdash; Tuesdays after sundown, or by appointment

--- a/examples/observatory-bureau/content/index.md
+++ b/examples/observatory-bureau/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Bureau of Amateur Astronomy — an ephemeris log and observing-session journal for backyard astronomers and small public observatories."
+template = "index"
++++

--- a/examples/observatory-bureau/static/css/style.css
+++ b/examples/observatory-bureau/static/css/style.css
@@ -1,0 +1,629 @@
+/* =============================================================================
+   Bureau of Amateur Astronomy — bulletin stylesheet
+   Aesthetic: 19th-century astronomical bulletin on parchment.
+   No gradients. No emojis. Hairline rules and ink-only ornament.
+   ============================================================================= */
+
+:root {
+  --parchment: #ede4cc;
+  --parchment-deep: #ddd2b2;
+  --ink-iron: #2a2117;
+  --ink-oxblood: #6f1a14;
+  --sky-deep: #0e1622;
+  --star-cream: #fdf6e1;
+
+  --serif: 'Cormorant Garamond', 'IM Fell DW Pica', Georgia, serif;
+  --display: 'IM Fell DW Pica', 'Cormorant Garamond', Georgia, serif;
+  --mono: 'IBM Plex Mono', 'Courier New', monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--parchment);
+  color: var(--ink-iron);
+  font-family: var(--serif);
+  font-size: 18px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* faint paper texture using hairline ink dots, layered solid color only */
+body {
+  background-color: var(--parchment);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='18' height='18'><circle cx='1' cy='1' r='0.7' fill='rgba(42,33,23,0.12)'/></svg>");
+  background-size: 18px 18px;
+}
+
+a {
+  color: var(--ink-oxblood);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 0.5px;
+}
+a:hover { color: var(--ink-iron); text-decoration-thickness: 1px; }
+
+::selection { background: var(--ink-oxblood); color: var(--star-cream); }
+
+/* ---------------------------------------------------------------- top strip */
+.bulletin-strip {
+  background: var(--parchment-deep);
+  border-bottom: 1px solid var(--ink-iron);
+  border-top: 3px double var(--ink-iron);
+}
+.strip-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0.55rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-iron);
+}
+.strip-mark { color: var(--ink-oxblood); font-size: 1rem; }
+.strip-text { flex: 1; }
+.strip-nav { display: flex; gap: 1.25rem; }
+.strip-nav a {
+  color: var(--ink-iron);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 1px;
+}
+.strip-nav a:hover { border-bottom-color: var(--ink-oxblood); color: var(--ink-oxblood); }
+
+/* ---------------------------------------------------------------- bulletin wrap */
+.bulletin-wrap {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  position: relative;
+}
+
+/* ---------------------------------------------------------------- hero */
+.hero {
+  position: relative;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: grid;
+  grid-template-columns: 1fr 1.05fr;
+  gap: 3rem;
+  border-bottom: 1px solid var(--ink-iron);
+}
+
+.hero-chart {
+  position: relative;
+  background: var(--sky-deep);
+  border: 1px solid var(--ink-iron);
+  padding: 1.25rem;
+  align-self: start;
+}
+.star-chart { width: 100%; height: auto; display: block; }
+.chart-caption {
+  margin-top: 0.75rem;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--star-cream);
+  text-align: center;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(253,246,225,0.35);
+}
+
+.hero-words { padding-top: 0.5rem; }
+.hero-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-iron);
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--ink-iron);
+}
+.hero-eyebrow .orn { color: var(--ink-oxblood); font-size: 0.9rem; }
+
+.hero-title {
+  font-family: var(--display);
+  font-size: clamp(3rem, 6vw, 5.2rem);
+  line-height: 1.0;
+  margin: 0 0 1.5rem;
+  font-weight: 400;
+  color: var(--ink-iron);
+  letter-spacing: -0.01em;
+}
+.hero-title em {
+  font-style: italic;
+  color: var(--ink-oxblood);
+}
+.hero-title .thin {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 0.55em;
+  letter-spacing: 0.04em;
+  color: var(--ink-iron);
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.hero-sub {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.15rem;
+  line-height: 1.55;
+  margin: 0 0 1.5rem;
+  max-width: 38ch;
+  color: var(--ink-iron);
+}
+.hero-sub .num { font-family: var(--mono); font-style: normal; font-size: 0.95em; }
+
+/* ---------------------------------------------------------------- planet table */
+.planet-table {
+  width: 100%;
+  max-width: 460px;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  margin: 0 0 1.75rem;
+  background: var(--parchment-deep);
+  border: 1px solid var(--ink-iron);
+}
+.planet-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.95rem;
+  padding: 0.5rem 0.75rem;
+  color: var(--ink-iron);
+  border-bottom: 1px solid var(--ink-iron);
+  background: var(--parchment-deep);
+}
+.planet-table thead th {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.68rem;
+  text-align: left;
+  padding: 0.45rem 0.75rem;
+  border-bottom: 1px solid var(--ink-iron);
+  color: var(--ink-oxblood);
+}
+.planet-table tbody td {
+  padding: 0.45rem 0.75rem;
+  border-bottom: 1px dotted var(--ink-iron);
+}
+.planet-table tbody tr:last-child td { border-bottom: none; }
+.planet-table tbody td:first-child {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-oxblood);
+}
+
+/* ---------------------------------------------------------------- buttons */
+.hero-ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+.bureau-btn {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 0.7rem 1.1rem;
+  background: var(--ink-iron);
+  color: var(--star-cream);
+  text-decoration: none;
+  border: 1px solid var(--ink-iron);
+}
+.bureau-btn:hover { background: var(--ink-oxblood); border-color: var(--ink-oxblood); color: var(--star-cream); }
+.bureau-btn.ghost {
+  background: transparent;
+  color: var(--ink-iron);
+  border: 1px solid var(--ink-iron);
+}
+.bureau-btn.ghost:hover { background: var(--ink-iron); color: var(--star-cream); }
+
+/* ---------------------------------------------------------------- data marks */
+.data-mark {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  pointer-events: none;
+  opacity: 0.75;
+}
+.data-mark svg { width: 100%; height: 100%; display: block; }
+.dm-1 { top: 1.5rem; right: 2rem; width: 32px; height: 32px; }
+.dm-2 { bottom: 2rem; left: 50%; width: 26px; height: 26px; }
+.dm-3 { top: 1rem; right: 4rem; width: 40px; height: 24px; }
+.dm-4 { top: 2rem; right: 2rem; width: 18px; height: 18px; opacity: 1; }
+.dm-5 { top: 1.5rem; left: 2rem; width: 28px; height: 28px; }
+.dm-6 { bottom: 3rem; right: 2.5rem; width: 32px; height: 32px; }
+.dm-7 { bottom: 4rem; left: 3rem; width: 22px; height: 22px; }
+
+/* ---------------------------------------------------------------- section heads */
+.tonight, .log, .equip {
+  position: relative;
+  padding: 3.5rem 0;
+  border-bottom: 1px solid var(--ink-iron);
+}
+.log { background: var(--parchment-deep); }
+
+.section-head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 1.5rem;
+  align-items: end;
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 3px double var(--ink-iron);
+}
+.section-num {
+  grid-row: 1 / 3;
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 4.5rem;
+  line-height: 0.9;
+  color: var(--ink-oxblood);
+  font-weight: 400;
+}
+.section-head h2 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(2rem, 3.5vw, 3rem);
+  margin: 0;
+  line-height: 1;
+  letter-spacing: -0.005em;
+}
+.section-sub {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-iron);
+  padding-top: 0.5rem;
+  max-width: 60ch;
+}
+
+/* ---------------------------------------------------------------- sky table */
+.sky-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  background: var(--parchment);
+  border-top: 1px solid var(--ink-iron);
+  border-bottom: 1px solid var(--ink-iron);
+}
+.sky-table thead th {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.68rem;
+  text-align: left;
+  padding: 0.7rem 0.75rem;
+  border-bottom: 1px solid var(--ink-iron);
+  color: var(--ink-oxblood);
+  background: var(--parchment-deep);
+}
+.sky-table tbody td {
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px dotted var(--ink-iron);
+  vertical-align: top;
+}
+.sky-table tbody tr:last-child td { border-bottom: none; }
+.sky-table tbody tr:nth-child(even) td { background: rgba(221,210,178,0.35); }
+.sky-table tbody td:first-child {
+  width: 3rem;
+  color: var(--ink-oxblood);
+  font-weight: 600;
+}
+.sky-table tbody td:nth-child(2) {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-iron);
+}
+.sky-table a { color: var(--ink-iron); text-decoration: none; border-bottom: 1px solid var(--ink-oxblood); }
+.sky-table a:hover { color: var(--ink-oxblood); }
+.table-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-top: 0.75rem;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-iron);
+  opacity: 0.8;
+}
+
+/* ---------------------------------------------------------------- log entries */
+.log-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+}
+.log-entry {
+  background: var(--parchment);
+  border: 1px solid var(--ink-iron);
+  padding: 1.5rem 1.5rem 1.25rem;
+  position: relative;
+}
+.log-entry::before {
+  content: "";
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  right: -1px;
+  height: 8px;
+  border-top: 1px solid var(--ink-iron);
+  border-bottom: 1px solid var(--ink-iron);
+  background: var(--parchment);
+}
+.entry-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-iron);
+  padding-bottom: 0.75rem;
+  margin: 0.5rem 0 1rem;
+  border-bottom: 1px dotted var(--ink-iron);
+}
+.entry-date { color: var(--ink-oxblood); font-weight: 600; }
+.entry-cond { color: var(--ink-iron); opacity: 0.85; }
+.entry-body {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.08rem;
+  line-height: 1.55;
+  margin: 0 0 1.25rem;
+  color: var(--ink-iron);
+}
+.entry-body .num { font-family: var(--mono); font-style: normal; font-size: 0.95em; }
+.entry-sign {
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 0.95rem;
+  text-align: right;
+  color: var(--ink-oxblood);
+  border-top: 1px solid var(--ink-iron);
+  padding-top: 0.6rem;
+}
+
+/* ---------------------------------------------------------------- equipment */
+.equip-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+}
+.equip-card {
+  border: 1px solid var(--ink-iron);
+  background: var(--parchment-deep);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+}
+.equip-icon {
+  background: var(--parchment);
+  border-bottom: 1px solid var(--ink-iron);
+  padding: 0.75rem;
+  margin: -1.25rem -1.25rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100px;
+}
+.equip-icon svg { width: 80%; height: 100%; }
+.equip-card h3 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.5rem;
+  margin: 0 0 0.75rem;
+  color: var(--ink-oxblood);
+  line-height: 1.1;
+}
+.equip-card dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 0.75rem;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+.equip-card dt {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-iron);
+  opacity: 0.7;
+  font-size: 0.65rem;
+  padding-top: 2px;
+}
+.equip-card dd {
+  margin: 0;
+  color: var(--ink-iron);
+}
+
+/* ---------------------------------------------------------------- footer */
+.bureau-foot {
+  background: var(--parchment);
+  border-top: 3px double var(--ink-iron);
+  padding: 3rem 0 2rem;
+}
+.foot-rule {
+  max-width: 1180px;
+  margin: 0 auto 2rem;
+  padding: 0 1.5rem;
+  height: 24px;
+}
+.foot-rule svg { width: 100%; height: 100%; }
+.foot-wrap {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+.foot-cols {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2rem;
+  margin-bottom: 2.5rem;
+}
+.foot-col h4 {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-oxblood);
+  margin: 0 0 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--ink-iron);
+}
+.foot-col p {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1rem;
+  margin: 0;
+  line-height: 1.55;
+}
+.foot-col a {
+  color: var(--ink-iron);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--ink-oxblood);
+}
+.foot-col a:hover { color: var(--ink-oxblood); }
+.foot-coda {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--ink-iron);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-iron);
+}
+.coda-orn { color: var(--ink-oxblood); font-size: 1rem; }
+
+/* ---------------------------------------------------------------- prose pages */
+.prose {
+  padding: 3rem 1.5rem 4rem;
+  max-width: 760px;
+}
+.prose-head { margin-bottom: 2rem; }
+.prose-eyebrow {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-oxblood);
+  margin-bottom: 0.75rem;
+}
+.prose h1 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(2.4rem, 4.5vw, 3.6rem);
+  line-height: 1;
+  margin: 0;
+  color: var(--ink-iron);
+}
+.prose-rule { height: 16px; margin-top: 1.25rem; }
+.prose-rule svg { width: 100%; height: 100%; }
+.prose h2 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.9rem;
+  color: var(--ink-oxblood);
+  margin: 2.5rem 0 1rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px dotted var(--ink-iron);
+}
+.prose h3 {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.4rem;
+  color: var(--ink-iron);
+  margin: 2rem 0 0.75rem;
+}
+.prose p {
+  font-family: var(--serif);
+  font-size: 1.12rem;
+  line-height: 1.65;
+  margin: 0 0 1.1rem;
+}
+.prose strong { font-weight: 700; color: var(--ink-iron); }
+.prose em { font-style: italic; color: var(--ink-oxblood); }
+.prose ul, .prose ol {
+  font-family: var(--serif);
+  font-size: 1.12rem;
+  line-height: 1.65;
+  padding-left: 1.4rem;
+  margin: 0 0 1.25rem;
+}
+.prose li { margin-bottom: 0.4rem; }
+.prose blockquote {
+  border-left: 4px double var(--ink-oxblood);
+  padding: 0.25rem 1.25rem;
+  margin: 1.5rem 0;
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 1.25rem;
+  color: var(--ink-iron);
+  background: var(--parchment-deep);
+}
+.prose code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  background: var(--parchment-deep);
+  padding: 0.08em 0.35em;
+  border: 1px solid var(--ink-iron);
+  color: var(--ink-oxblood);
+}
+
+/* ---------------------------------------------------------------- responsive */
+@media (max-width: 960px) {
+  .hero { grid-template-columns: 1fr; gap: 2rem; padding-top: 2rem; }
+  .log-grid { grid-template-columns: 1fr; }
+  .equip-grid { grid-template-columns: repeat(2, 1fr); }
+  .foot-cols { grid-template-columns: repeat(2, 1fr); }
+  .strip-inner { flex-wrap: wrap; gap: 0.75rem; font-size: 0.65rem; }
+  .strip-text { flex: 1 1 100%; order: 3; }
+  .strip-nav { gap: 0.85rem; }
+  .section-head { grid-template-columns: 1fr; }
+  .section-num { grid-row: auto; font-size: 3rem; }
+}
+@media (max-width: 600px) {
+  body { font-size: 16px; }
+  .hero { padding: 1.5rem 1rem 2.5rem; }
+  .bulletin-wrap { padding: 0 1rem; }
+  .tonight, .log, .equip { padding: 2.5rem 0; }
+  .equip-grid { grid-template-columns: 1fr; }
+  .foot-cols { grid-template-columns: 1fr; }
+  .sky-table { font-size: 0.7rem; }
+  .sky-table tbody td:nth-child(2) { font-size: 0.9rem; }
+  .table-foot { flex-direction: column; gap: 0.4rem; }
+  .foot-coda { font-size: 0.6rem; gap: 0.5rem; }
+  .hero-title { font-size: 2.6rem; }
+}

--- a/examples/observatory-bureau/static/favicon.svg
+++ b/examples/observatory-bureau/static/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="2" fill="#ede4cc"/>
+  <circle cx="16" cy="16" r="12" fill="none" stroke="#6f1a14" stroke-width="0.6"/>
+  <circle cx="16" cy="16" r="8" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+  <circle cx="16" cy="16" r="4" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+  <line x1="16" y1="2" x2="16" y2="30" stroke="#2a2117" stroke-width="0.3"/>
+  <line x1="2" y1="16" x2="30" y2="16" stroke="#2a2117" stroke-width="0.3"/>
+  <circle cx="9" cy="11" r="1" fill="#2a2117"/>
+  <circle cx="22" cy="9" r="0.7" fill="#2a2117"/>
+  <circle cx="24" cy="20" r="1.1" fill="#2a2117"/>
+  <circle cx="11" cy="22" r="0.6" fill="#2a2117"/>
+  <circle cx="16" cy="16" r="0.8" fill="#6f1a14"/>
+</svg>

--- a/examples/observatory-bureau/templates/404.html
+++ b/examples/observatory-bureau/templates/404.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<article class="prose bulletin-wrap">
+  <header class="prose-head">
+    <span class="prose-eyebrow">Plate not found in the Bureau&rsquo;s drawer</span>
+    <h1>404 &mdash; Object Below the Horizon</h1>
+    <div class="prose-rule" aria-hidden="true">
+      <svg viewBox="0 0 600 16" preserveAspectRatio="none">
+        <line x1="0" y1="8" x2="600" y2="8" stroke="#2a2117" stroke-width="0.5"/>
+        <circle cx="300" cy="8" r="3" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+      </svg>
+    </div>
+  </header>
+  <p>The page you sought is presently below the horizon &mdash; either filed under a different catalogue number, or never observed by this Bureau. Try the front of the bulletin, or consult the catalogue.</p>
+  <p><a href="{{ base_url }}/">&laquo; Return to the front page</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/observatory-bureau/templates/footer.html
+++ b/examples/observatory-bureau/templates/footer.html
@@ -1,0 +1,41 @@
+  <footer class="bureau-foot">
+    <div class="foot-rule" aria-hidden="true">
+      <svg viewBox="0 0 800 24" preserveAspectRatio="none">
+        <line x1="0" y1="6" x2="800" y2="6" stroke="#2a2117" stroke-width="0.6"/>
+        <line x1="0" y1="18" x2="800" y2="18" stroke="#2a2117" stroke-width="0.3"/>
+        <circle cx="400" cy="12" r="4" fill="none" stroke="#6f1a14" stroke-width="0.6"/>
+        <circle cx="400" cy="12" r="1.2" fill="#6f1a14"/>
+        <line x1="392" y1="12" x2="384" y2="12" stroke="#2a2117" stroke-width="0.4"/>
+        <line x1="408" y1="12" x2="416" y2="12" stroke="#2a2117" stroke-width="0.4"/>
+      </svg>
+    </div>
+    <div class="foot-wrap">
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h4>The Bureau</h4>
+          <p>No.&nbsp;14 Cedar Lane<br>Old Observatory Hill<br>Latitude 37&deg;34&prime; N<br>Longitude 126&deg;58&prime; E</p>
+        </div>
+        <div class="foot-col">
+          <h4>Correspondence</h4>
+          <p>desk@amateur.bureau<br>Office hours: Tuesdays<br>after sundown.</p>
+        </div>
+        <div class="foot-col">
+          <h4>Departments</h4>
+          <p><a href="{{ base_url }}/about/">Membership</a><br><a href="{{ base_url }}/about/">Equipment Rental</a><br><a href="{{ base_url }}/tags/">Catalogue Archive</a></p>
+        </div>
+        <div class="foot-col">
+          <h4>Bulletin</h4>
+          <p>Printed in four colours<br>upon parchment of the<br>twenty-fourth weight.<br>Vol. CXLV &middot; No. 7</p>
+        </div>
+      </div>
+      <div class="foot-coda">
+        <span class="coda-orn">&#10086;</span>
+        <span>PRINTED FOR THE BUREAU &middot; {{ current_year }} &middot; HWARO PRESS</span>
+        <span class="coda-orn">&#10086;</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/observatory-bureau/templates/header.html
+++ b/examples/observatory-bureau/templates/header.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &mdash; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=IM+Fell+DW+Pica:ital@0;1&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="bulletin-strip">
+    <div class="strip-inner">
+      <span class="strip-mark">&#9737;</span>
+      <span class="strip-text">BUREAU &middot; OBSERVATIONAL ASTRONOMY &middot; EST. 1881 &middot; LATITUDE 37&deg;34&prime; N</span>
+      <nav class="strip-nav">
+        <a href="{{ base_url }}/">Index</a>
+        <a href="{{ base_url }}/about/">Bureau</a>
+        <a href="{{ base_url }}/tags/">Catalogue</a>
+      </nav>
+    </div>
+  </header>

--- a/examples/observatory-bureau/templates/index.html
+++ b/examples/observatory-bureau/templates/index.html
@@ -1,0 +1,306 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="hero-chart" aria-hidden="true">
+    <svg viewBox="0 0 400 400" class="star-chart">
+      <rect x="0" y="0" width="400" height="400" fill="#0e1622"/>
+      <g stroke="#fdf6e1" stroke-width="0.4" fill="none" opacity="0.65">
+        <circle cx="200" cy="200" r="180"/>
+        <circle cx="200" cy="200" r="150"/>
+        <circle cx="200" cy="200" r="120"/>
+        <circle cx="200" cy="200" r="90"/>
+        <circle cx="200" cy="200" r="60"/>
+        <circle cx="200" cy="200" r="30"/>
+      </g>
+      <g stroke="#fdf6e1" stroke-width="0.3" opacity="0.45">
+        <line x1="200" y1="20" x2="200" y2="380"/>
+        <line x1="20" y1="200" x2="380" y2="200"/>
+        <line x1="73" y1="73" x2="327" y2="327"/>
+        <line x1="327" y1="73" x2="73" y2="327"/>
+      </g>
+      <g fill="#fdf6e1">
+        <circle cx="120" cy="80" r="1.6"/>
+        <circle cx="265" cy="55" r="2.4"/>
+        <circle cx="340" cy="135" r="1.1"/>
+        <circle cx="305" cy="220" r="1.8"/>
+        <circle cx="355" cy="300" r="0.9"/>
+        <circle cx="250" cy="305" r="1.5"/>
+        <circle cx="180" cy="345" r="2.1"/>
+        <circle cx="95" cy="295" r="1.3"/>
+        <circle cx="55" cy="240" r="1.7"/>
+        <circle cx="75" cy="160" r="2.0"/>
+        <circle cx="155" cy="125" r="0.8"/>
+        <circle cx="220" cy="105" r="1.2"/>
+        <circle cx="295" cy="155" r="1.4"/>
+        <circle cx="225" cy="180" r="0.9"/>
+        <circle cx="160" cy="195" r="1.6"/>
+        <circle cx="245" cy="245" r="2.6"/>
+        <circle cx="135" cy="260" r="1.0"/>
+        <circle cx="195" cy="265" r="0.7"/>
+        <circle cx="280" cy="105" r="0.9"/>
+        <circle cx="115" cy="225" r="1.2"/>
+        <circle cx="320" cy="265" r="1.5"/>
+        <circle cx="170" cy="60" r="0.6"/>
+        <circle cx="50" cy="115" r="1.1"/>
+        <circle cx="365" cy="220" r="0.7"/>
+        <circle cx="210" cy="50" r="1.0"/>
+        <circle cx="40" cy="335" r="1.4"/>
+        <circle cx="285" cy="350" r="1.2"/>
+        <circle cx="370" cy="370" r="0.8"/>
+        <circle cx="200" cy="200" r="2.8"/>
+        <circle cx="145" cy="305" r="1.5"/>
+      </g>
+      <g stroke="#fdf6e1" stroke-width="0.35" fill="none" opacity="0.55">
+        <path d="M120 80 L155 125 L220 105 L265 55"/>
+        <path d="M75 160 L160 195 L245 245 L305 220"/>
+        <path d="M95 295 L135 260 L180 345"/>
+      </g>
+      <text x="200" y="14" text-anchor="middle" fill="#fdf6e1" opacity="0.7" font-family="IBM Plex Mono, monospace" font-size="9" letter-spacing="2">N</text>
+      <text x="200" y="395" text-anchor="middle" fill="#fdf6e1" opacity="0.7" font-family="IBM Plex Mono, monospace" font-size="9" letter-spacing="2">S</text>
+      <text x="12" y="204" fill="#fdf6e1" opacity="0.7" font-family="IBM Plex Mono, monospace" font-size="9" letter-spacing="2">W</text>
+      <text x="386" y="204" fill="#fdf6e1" opacity="0.7" font-family="IBM Plex Mono, monospace" font-size="9" letter-spacing="2">E</text>
+      <text x="200" y="396" text-anchor="middle" fill="#fdf6e1" opacity="0.45" font-family="IBM Plex Mono, monospace" font-size="7"></text>
+    </svg>
+    <div class="chart-caption">PLATE I &mdash; ZENITH AT 22<sup>h</sup>00<sup>m</sup> LOCAL</div>
+  </div>
+
+  <div class="hero-words">
+    <div class="hero-eyebrow">
+      <span class="orn">&#10086;</span>
+      <span>BULLETIN No. CXLV &middot; SEVENTH ISSUE OF THE YEAR</span>
+      <span class="orn">&#10086;</span>
+    </div>
+    <h1 class="hero-title">
+      <em>Ephemeris</em><br>
+      <span class="thin">for the amateur</span><br>
+      <em>observer.</em>
+    </h1>
+    <p class="hero-sub">
+      A registry of the night sky, kept by the Bureau and its correspondents
+      since the autumn of <span class="num">1881</span> &mdash; tide of moonlight,
+      passage of planets, and the patient logging of seeing conditions.
+    </p>
+    <table class="planet-table">
+      <caption>Tonight, after sundown &mdash; principal planets</caption>
+      <thead>
+        <tr><th>Body</th><th>R.A.</th><th>Dec.</th><th>Mag.</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Venus</td><td>04<sup>h</sup>12<sup>m</sup></td><td>+21&deg;47&prime;</td><td>&minus;4.1</td></tr>
+        <tr><td>Mars</td><td>07<sup>h</sup>58<sup>m</sup></td><td>+24&deg;03&prime;</td><td>+1.2</td></tr>
+        <tr><td>Jupiter</td><td>03<sup>h</sup>31<sup>m</sup></td><td>+18&deg;22&prime;</td><td>&minus;2.4</td></tr>
+        <tr><td>Saturn</td><td>23<sup>h</sup>14<sup>m</sup></td><td>&minus;05&deg;51&prime;</td><td>+0.9</td></tr>
+      </tbody>
+    </table>
+    <div class="hero-ctas">
+      <a class="bureau-btn" href="#tonight">Tonight's Sky &mdash;&gt;</a>
+      <a class="bureau-btn ghost" href="{{ base_url }}/about/">Join the Bureau</a>
+    </div>
+  </div>
+
+  <span class="data-mark dm-1" aria-hidden="true">
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="6" fill="none" stroke="#2a2117" stroke-width="0.5"/><line x1="0" y1="12" x2="24" y2="12" stroke="#2a2117" stroke-width="0.4"/><line x1="12" y1="0" x2="12" y2="24" stroke="#2a2117" stroke-width="0.4"/></svg>
+  </span>
+  <span class="data-mark dm-2" aria-hidden="true">
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="2" fill="#6f1a14"/><circle cx="12" cy="12" r="8" fill="none" stroke="#6f1a14" stroke-width="0.4"/></svg>
+  </span>
+</section>
+
+<section id="tonight" class="tonight">
+  <div class="bulletin-wrap">
+    <div class="section-head">
+      <span class="section-num">II.</span>
+      <h2>Tonight's Sky</h2>
+      <span class="section-sub">A bulletin of observable objects, sorted by transit. Magnitudes per Bureau revision of <span class="num">{{ current_year }}</span>.</span>
+    </div>
+    <table class="sky-table">
+      <thead>
+        <tr>
+          <th>No.</th>
+          <th>Object</th>
+          <th>R.A.</th>
+          <th>Dec.</th>
+          <th>Mag.</th>
+          <th>Constellation</th>
+          <th>Best Hour</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>01</td><td>M 31 &mdash; Andromeda Galaxy</td><td>00<sup>h</sup>42<sup>m</sup></td><td>+41&deg;16&prime;</td><td>+3.4</td><td>Andromeda</td><td>21:40</td></tr>
+        <tr><td>02</td><td>M 45 &mdash; Pleiades</td><td>03<sup>h</sup>47<sup>m</sup></td><td>+24&deg;07&prime;</td><td>+1.6</td><td>Taurus</td><td>22:10</td></tr>
+        <tr><td>03</td><td>NGC 869 &mdash; Double Cluster</td><td>02<sup>h</sup>19<sup>m</sup></td><td>+57&deg;09&prime;</td><td>+3.7</td><td>Perseus</td><td>22:55</td></tr>
+        <tr><td>04</td><td>M 42 &mdash; Orion Nebula</td><td>05<sup>h</sup>35<sup>m</sup></td><td>&minus;05&deg;23&prime;</td><td>+4.0</td><td>Orion</td><td>23:20</td></tr>
+        <tr><td>05</td><td>Albireo &mdash; Beta Cygni</td><td>19<sup>h</sup>30<sup>m</sup></td><td>+27&deg;57&prime;</td><td>+3.1</td><td>Cygnus</td><td>20:05</td></tr>
+        <tr><td>06</td><td>M 13 &mdash; Hercules Cluster</td><td>16<sup>h</sup>41<sup>m</sup></td><td>+36&deg;27&prime;</td><td>+5.8</td><td>Hercules</td><td>20:45</td></tr>
+        <tr><td>07</td><td>NGC 7000 &mdash; North America Neb.</td><td>20<sup>h</sup>59<sup>m</sup></td><td>+44&deg;31&prime;</td><td>+4.0</td><td>Cygnus</td><td>21:15</td></tr>
+        <tr><td>08</td><td>Mizar &amp; Alcor</td><td>13<sup>h</sup>23<sup>m</sup></td><td>+54&deg;55&prime;</td><td>+2.3</td><td>Ursa Major</td><td>19:30</td></tr>
+        <tr><td>09</td><td>M 57 &mdash; Ring Nebula</td><td>18<sup>h</sup>53<sup>m</sup></td><td>+33&deg;02&prime;</td><td>+8.8</td><td>Lyra</td><td>20:30</td></tr>
+        <tr><td>10</td><td>Comet C/2025 Q3 &mdash; provisional</td><td>22<sup>h</sup>07<sup>m</sup></td><td>+12&deg;44&prime;</td><td>+7.2</td><td>Aquarius</td><td>23:50</td></tr>
+      </tbody>
+    </table>
+    <div class="table-foot">
+      <span>&dagger; All times local. R.A. epoch J2000.</span>
+      <span>Conditions presumed dark, transparent, no Moon.</span>
+    </div>
+  </div>
+  <span class="data-mark dm-3" aria-hidden="true">
+    <svg viewBox="0 0 24 24"><line x1="2" y1="12" x2="22" y2="12" stroke="#2a2117" stroke-width="0.5"/><line x1="6" y1="9" x2="6" y2="15" stroke="#2a2117" stroke-width="0.4"/><line x1="12" y1="9" x2="12" y2="15" stroke="#2a2117" stroke-width="0.4"/><line x1="18" y1="9" x2="18" y2="15" stroke="#2a2117" stroke-width="0.4"/></svg>
+  </span>
+</section>
+
+<section class="log">
+  <div class="bulletin-wrap">
+    <div class="section-head">
+      <span class="section-num">III.</span>
+      <h2>Observation Log</h2>
+      <span class="section-sub">Selected entries from the night-book, transcribed verbatim from the Bureau's correspondents.</span>
+    </div>
+    <div class="log-grid">
+      <article class="log-entry">
+        <div class="entry-meta">
+          <span class="entry-date">{{ current_year }} &middot; III &middot; 14</span>
+          <span class="entry-cond">Seeing: II/V &middot; Trans.: good</span>
+        </div>
+        <p class="entry-body">
+          Set the four-inch refractor against the south wall at twenty past nine.
+          Jupiter very steady &mdash; counted the four Galilean moons before the eyepiece had warmed.
+          A faint ribbon of cloud crossed the disc near eleven; held the band for some seconds, then dispersed.
+          Could not be sure whether I had seen the Great Red Spot or merely wished to.
+        </p>
+        <div class="entry-sign">&mdash; H. R., Sec. of Observations</div>
+      </article>
+      <article class="log-entry">
+        <div class="entry-meta">
+          <span class="entry-date">{{ current_year }} &middot; III &middot; 21</span>
+          <span class="entry-cond">Seeing: III/V &middot; Trans.: fair</span>
+        </div>
+        <p class="entry-body">
+          Equinox night. Walked the field with the eight-inch Dobsonian under heavy dew.
+          M 42 a slate of green wool; the Trapezium gave up its four stars without complaint.
+          A meteor of long duration entered from the west at <span class="num">22:47</span>,
+          a clean white track, no audible report. Logged in green ink.
+        </p>
+        <div class="entry-sign">&mdash; M. F. P., Field Correspondent, Yangju</div>
+      </article>
+      <article class="log-entry">
+        <div class="entry-meta">
+          <span class="entry-date">{{ current_year }} &middot; IV &middot; 02</span>
+          <span class="entry-cond">Seeing: I/V &middot; Trans.: poor</span>
+        </div>
+        <p class="entry-body">
+          A poor night for fine work but excellent for the broader sweeps.
+          Held Albireo for the better part of half an hour &mdash; the gold and the blue
+          never failing to undo the rest of the day. The cat sat at my left foot the entire time.
+          She does not understand stellar magnitudes, and yet she chose the right star.
+        </p>
+        <div class="entry-sign">&mdash; J. L., Membership No. 0042</div>
+      </article>
+    </div>
+  </div>
+  <span class="data-mark dm-4" aria-hidden="true">
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="1.5" fill="#6f1a14"/></svg>
+  </span>
+</section>
+
+<section class="equip">
+  <div class="bulletin-wrap">
+    <div class="section-head">
+      <span class="section-num">IV.</span>
+      <h2>Equipment of Record</h2>
+      <span class="section-sub">Instruments held in the Bureau's loan cabinet, available to members in good standing.</span>
+    </div>
+    <div class="equip-grid">
+      <article class="equip-card">
+        <div class="equip-icon">
+          <svg viewBox="0 0 80 60">
+            <rect x="6" y="22" width="60" height="14" fill="none" stroke="#2a2117" stroke-width="0.8"/>
+            <rect x="3" y="20" width="6" height="18" fill="none" stroke="#2a2117" stroke-width="0.8"/>
+            <rect x="62" y="20" width="9" height="18" fill="none" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="36" y1="36" x2="36" y2="50" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="28" y1="56" x2="44" y2="56" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="36" y1="50" x2="28" y2="56" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="36" y1="50" x2="44" y2="56" stroke="#2a2117" stroke-width="0.8"/>
+            <circle cx="68" cy="29" r="2" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+          </svg>
+        </div>
+        <h3>Achromatic Refractor</h3>
+        <dl>
+          <dt>Aperture</dt><dd>4.0 in (102 mm)</dd>
+          <dt>Focal length</dt><dd>1000 mm &middot; f/9.8</dd>
+          <dt>Mount</dt><dd>German equatorial, brass</dd>
+          <dt>Cabinet</dt><dd>No. 02 &middot; loan 7 nights</dd>
+        </dl>
+      </article>
+      <article class="equip-card">
+        <div class="equip-icon">
+          <svg viewBox="0 0 80 60">
+            <rect x="14" y="6" width="52" height="38" fill="none" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="14" y1="44" x2="6" y2="56" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="66" y1="44" x2="74" y2="56" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="6" y1="56" x2="74" y2="56" stroke="#2a2117" stroke-width="0.8"/>
+            <circle cx="40" cy="25" r="12" fill="none" stroke="#6f1a14" stroke-width="0.6"/>
+            <circle cx="40" cy="25" r="6" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+          </svg>
+        </div>
+        <h3>Dobsonian Reflector</h3>
+        <dl>
+          <dt>Aperture</dt><dd>8.0 in (203 mm)</dd>
+          <dt>Focal length</dt><dd>1200 mm &middot; f/5.9</dd>
+          <dt>Mount</dt><dd>Alt-azimuth, lazy Susan</dd>
+          <dt>Cabinet</dt><dd>No. 05 &middot; loan 14 nights</dd>
+        </dl>
+      </article>
+      <article class="equip-card">
+        <div class="equip-icon">
+          <svg viewBox="0 0 80 60">
+            <circle cx="40" cy="30" r="20" fill="none" stroke="#2a2117" stroke-width="0.8"/>
+            <circle cx="40" cy="30" r="14" fill="none" stroke="#2a2117" stroke-width="0.6"/>
+            <circle cx="40" cy="30" r="8" fill="none" stroke="#2a2117" stroke-width="0.5"/>
+            <line x1="40" y1="8" x2="40" y2="52" stroke="#2a2117" stroke-width="0.3"/>
+            <line x1="18" y1="30" x2="62" y2="30" stroke="#2a2117" stroke-width="0.3"/>
+            <circle cx="40" cy="30" r="1.5" fill="#6f1a14"/>
+          </svg>
+        </div>
+        <h3>Plossl Eyepiece Set</h3>
+        <dl>
+          <dt>Focal lengths</dt><dd>32, 25, 15, 9, 6 mm</dd>
+          <dt>Barrel</dt><dd>1.25 in (31.7 mm)</dd>
+          <dt>Field of view</dt><dd>52&deg; nominal</dd>
+          <dt>Cabinet</dt><dd>No. 11 &middot; loan 30 nights</dd>
+        </dl>
+      </article>
+      <article class="equip-card">
+        <div class="equip-icon">
+          <svg viewBox="0 0 80 60">
+            <rect x="12" y="14" width="56" height="32" fill="none" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="20" y1="22" x2="60" y2="22" stroke="#2a2117" stroke-width="0.4"/>
+            <line x1="20" y1="28" x2="60" y2="28" stroke="#2a2117" stroke-width="0.4"/>
+            <line x1="20" y1="34" x2="50" y2="34" stroke="#2a2117" stroke-width="0.4"/>
+            <line x1="20" y1="40" x2="55" y2="40" stroke="#2a2117" stroke-width="0.4"/>
+            <line x1="12" y1="46" x2="12" y2="54" stroke="#2a2117" stroke-width="0.8"/>
+            <line x1="68" y1="46" x2="68" y2="54" stroke="#2a2117" stroke-width="0.8"/>
+            <circle cx="58" cy="42" r="2" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+          </svg>
+        </div>
+        <h3>Field Log Books</h3>
+        <dl>
+          <dt>Format</dt><dd>Quarto, ruled with chart pockets</dd>
+          <dt>Pages</dt><dd>192 &middot; sewn binding</dd>
+          <dt>Issued with</dt><dd>Red-shielded torch &middot; pencil</dd>
+          <dt>Cabinet</dt><dd>No. 14 &middot; member gift</dd>
+        </dl>
+      </article>
+    </div>
+  </div>
+  <span class="data-mark dm-5" aria-hidden="true">
+    <svg viewBox="0 0 24 24"><line x1="12" y1="2" x2="12" y2="22" stroke="#2a2117" stroke-width="0.4"/><line x1="2" y1="12" x2="22" y2="12" stroke="#2a2117" stroke-width="0.4"/><circle cx="12" cy="12" r="3" fill="none" stroke="#6f1a14" stroke-width="0.5"/></svg>
+  </span>
+  <span class="data-mark dm-6" aria-hidden="true">
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" fill="none" stroke="#2a2117" stroke-width="0.4"/><circle cx="12" cy="12" r="5" fill="none" stroke="#2a2117" stroke-width="0.4"/></svg>
+  </span>
+  <span class="data-mark dm-7" aria-hidden="true">
+    <svg viewBox="0 0 24 24"><line x1="12" y1="4" x2="12" y2="20" stroke="#6f1a14" stroke-width="0.5"/><line x1="4" y1="12" x2="20" y2="12" stroke="#6f1a14" stroke-width="0.5"/></svg>
+  </span>
+</section>
+
+{% include "footer.html" %}

--- a/examples/observatory-bureau/templates/page.html
+++ b/examples/observatory-bureau/templates/page.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<article class="prose bulletin-wrap">
+  {% if page.title is present %}
+  <header class="prose-head">
+    <span class="prose-eyebrow">From the Bureau&rsquo;s record &mdash; folio {{ current_year }}</span>
+    <h1>{{ page.title | e }}</h1>
+    <div class="prose-rule" aria-hidden="true">
+      <svg viewBox="0 0 600 16" preserveAspectRatio="none">
+        <line x1="0" y1="8" x2="600" y2="8" stroke="#2a2117" stroke-width="0.5"/>
+        <circle cx="300" cy="8" r="3" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+      </svg>
+    </div>
+  </header>
+  {% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/observatory-bureau/templates/section.html
+++ b/examples/observatory-bureau/templates/section.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+<section class="tonight">
+  <div class="bulletin-wrap">
+    <div class="section-head">
+      <span class="section-num">&sect;</span>
+      {% if page.title is present %}<h2>{{ page.title | e }}</h2>{% endif %}
+      <span class="section-sub">An indexed register of bulletin entries, kept in order of publication.</span>
+    </div>
+    {{ content | safe }}
+    <table class="sky-table">
+      <thead>
+        <tr><th>No.</th><th>Date</th><th>Title</th><th>&nbsp;</th></tr>
+      </thead>
+      <tbody>
+        {% for post in section.pages %}
+        <tr>
+          <td>{{ loop.index0 + 1 }}</td>
+          <td>{{ post.date | date(format="%Y &middot; %m &middot; %d") }}</td>
+          <td><a href="{{ post.url }}">{{ post.title | e }}</a></td>
+          <td>&rarr;</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/observatory-bureau/templates/shortcodes/alert.html
+++ b/examples/observatory-bureau/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem 1.25rem; border: 1px solid #2a2117; background-color: #ddd2b2; border-left: 6px solid #6f1a14; margin: 1.25rem 0; font-family: 'Cormorant Garamond', serif;">
+  <strong style="font-family: 'IBM Plex Mono', monospace; letter-spacing: 0.08em; text-transform: uppercase; color: #6f1a14;">{{ type }}:</strong> {{ body }}
+</div>

--- a/examples/observatory-bureau/templates/taxonomy.html
+++ b/examples/observatory-bureau/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<article class="prose bulletin-wrap">
+  <header class="prose-head">
+    <span class="prose-eyebrow">The Bureau&rsquo;s catalogue &mdash; classified entries</span>
+    <h1>{{ page.title | e }}</h1>
+    <div class="prose-rule" aria-hidden="true">
+      <svg viewBox="0 0 600 16" preserveAspectRatio="none">
+        <line x1="0" y1="8" x2="600" y2="8" stroke="#2a2117" stroke-width="0.5"/>
+        <circle cx="300" cy="8" r="3" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+      </svg>
+    </div>
+  </header>
+  <p>An index of classification stamps used in the Bureau&rsquo;s bulletin archive.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/observatory-bureau/templates/taxonomy_term.html
+++ b/examples/observatory-bureau/templates/taxonomy_term.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<article class="prose bulletin-wrap">
+  <header class="prose-head">
+    <span class="prose-eyebrow">Catalogue stamp &mdash; collected entries</span>
+    <h1>{{ page.title | e }}</h1>
+    <div class="prose-rule" aria-hidden="true">
+      <svg viewBox="0 0 600 16" preserveAspectRatio="none">
+        <line x1="0" y1="8" x2="600" y2="8" stroke="#2a2117" stroke-width="0.5"/>
+        <circle cx="300" cy="8" r="3" fill="none" stroke="#6f1a14" stroke-width="0.5"/>
+      </svg>
+    </div>
+  </header>
+  <p>Bulletin entries filed under this stamp.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/paperfold-mag/AGENTS.md
+++ b/examples/paperfold-mag/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/paperfold-mag/archetypes/default.md
+++ b/examples/paperfold-mag/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/paperfold-mag/config.toml
+++ b/examples/paperfold-mag/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Fold Quarterly"
+description = "A paper-craft newsletter shipped four times a year as a single broadsheet that folds down into a pocket pamphlet."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/paperfold-mag/content/about.md
+++ b/examples/paperfold-mag/content/about.md
@@ -1,0 +1,31 @@
++++
+title = "About Fold Quarterly"
+description = "The editorial principles, the paper choice, the fold engineer, the mailing room, and how to subscribe."
++++
+
+## Editorial principles
+
+Fold Quarterly is one sheet, eight panels, four issues a year. We commission writing that survives a re-read — pieces on craft, slow making, and the strange engineering of paper. **No filler. No sponsored panels. No web-only addenda.** What ships in the envelope is the whole magazine.
+
+## The paper
+
+We print on **Mohawk Superfine 350gsm Eggshell White**, a long-fibered cotton-blend sheet that takes a sharp crease without cracking. The grain is run vertical so the eight folds settle without fighting the press. We test each issue on the actual stock before locking the plates — substitutes never ship.
+
+## The fold engineer
+
+Every issue is folded by **Hanae Ogawa**, our resident fold engineer, who trained in book conservation and spent six years at a kirigami studio in Kyoto. She designs the fold sequence first, then the editorial grid is laid against it. The result: a broadsheet that opens like a poster and closes like a wallet.
+
+## Mailing
+
+Issues mail **flat in a rigid envelope** — never pre-folded. You make the first crease yourself, by hand, following the printed mountain and valley marks. Most readers report this takes about ninety seconds and is, by their own admission, the best part of their week.
+
+## Subscriptions
+
+> One sheet. Eight panels. Four times a year. Mailed flat.
+
+A yearly subscription is **four issues**, posted on the equinoxes and solstices. We ship worldwide on uncoated kraft mailers. We do not offer digital. We do not offer back issues after the next equinox.
+
+- **Desk** — `desk@fold.quarterly`
+- **Subscriptions** — `room@fold.quarterly`
+- **The fold engineer** — `hanae@fold.quarterly`
+- **Lost in the post** — write us; we re-mail at our cost, once.

--- a/examples/paperfold-mag/content/index.md
+++ b/examples/paperfold-mag/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Fold Quarterly — a paper-craft newsletter shipped four times a year as a single broadsheet, folded down into a pocket pamphlet."
+template = "index"
++++

--- a/examples/paperfold-mag/static/css/style.css
+++ b/examples/paperfold-mag/static/css/style.css
@@ -1,0 +1,598 @@
+/* =============================================================================
+   Fold Quarterly — paper-craft newsletter, broadsheet that folds to a pamphlet.
+   Palette: paper #fbfaf3, paper-shadow #ece7d4, ink #131310, ochre #c69226,
+            pencil #6b665a.
+   Type: DM Serif Display (display), Inter (body), IBM Plex Mono (annotation).
+   Solid colors only. No gradients. No emoji.
+   ============================================================================= */
+
+:root {
+  --paper: #fbfaf3;
+  --paper-shadow: #ece7d4;
+  --ink: #131310;
+  --ochre: #c69226;
+  --pencil: #6b665a;
+  --rule: #131310;
+  --serif: "DM Serif Display", "Times New Roman", serif;
+  --sans: "Inter", "Helvetica Neue", system-ui, sans-serif;
+  --mono: "IBM Plex Mono", "Geist Mono", ui-monospace, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--ink); text-decoration: none; }
+a:hover { color: var(--ochre); }
+
+.mono { font-family: var(--mono); font-weight: 500; letter-spacing: 0.04em; text-transform: uppercase; }
+
+/* ---------- Top strip ---------- */
+.strip-top {
+  border-bottom: 1px solid var(--ink);
+  padding: 14px 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--paper);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.strip-left { font-weight: 600; }
+.strip-nav { display: flex; gap: 28px; }
+.strip-nav a { color: var(--ink); font-weight: 500; }
+.strip-nav a:hover { color: var(--ochre); }
+
+/* ---------- Hero broadsheet ---------- */
+.hero-broadsheet {
+  padding: 28px 36px 60px;
+  border-bottom: 1px solid var(--ink);
+  position: relative;
+}
+.hero-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--pencil);
+  padding-bottom: 16px;
+  margin-bottom: 24px;
+  border-bottom: 1px dashed var(--pencil);
+}
+.hero-panels {
+  display: grid;
+  grid-template-columns: 1fr 10px 1fr 10px 1fr;
+  gap: 0;
+  min-height: 540px;
+  align-items: stretch;
+}
+.hero-panel {
+  position: relative;
+  padding: 36px 32px;
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.hp-1 { transform: translateY(0); }
+.hp-2 { transform: translateY(18px); background: var(--paper); }
+.hp-3 { transform: translateY(-12px); }
+
+.hero-fold { width: 10px; height: 100%; align-self: stretch; }
+
+.panel-corner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  font-size: 9px;
+  color: var(--pencil);
+  letter-spacing: 0.08em;
+}
+
+.fold-tick {
+  position: absolute;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  background: var(--ochre);
+  transform: translateX(-50%) rotate(45deg);
+}
+.fold-tick-top { top: -4px; }
+.fold-tick-bot { bottom: -4px; }
+
+.hero-word {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(72px, 12vw, 168px);
+  line-height: 0.85;
+  letter-spacing: -0.02em;
+  margin: 0 0 22px 0;
+  color: var(--ink);
+}
+.hp-2 .hero-word { font-style: italic; color: var(--ink); }
+
+.hero-line {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink);
+  padding-top: 4px;
+  border-top: 1px solid var(--ink);
+  margin-top: 6px;
+  width: fit-content;
+}
+.hero-line.small {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: none;
+  color: var(--pencil);
+  border-top-color: var(--pencil);
+  font-style: italic;
+}
+
+.hero-foot {
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 48px;
+}
+.hero-lede {
+  font-family: var(--serif);
+  font-size: 22px;
+  line-height: 1.4;
+  margin: 0;
+  color: var(--ink);
+  max-width: 56ch;
+}
+.hero-foot-right {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 18px;
+  font-size: 11px;
+  align-content: start;
+}
+.hero-foot-right span { color: var(--pencil); }
+.hero-foot-right b { color: var(--ink); font-weight: 600; }
+
+/* ---------- Inside Issue (zigzag) ---------- */
+.inside {
+  padding: 80px 36px;
+  border-bottom: 1px solid var(--ink);
+}
+.inside-head {
+  max-width: 720px;
+  margin-bottom: 56px;
+}
+.inside-eyebrow {
+  font-size: 11px;
+  color: var(--ochre);
+  margin-bottom: 18px;
+  display: inline-block;
+  border-bottom: 1px solid var(--ochre);
+  padding-bottom: 4px;
+}
+.inside-title {
+  font-family: var(--serif);
+  font-size: clamp(40px, 5vw, 72px);
+  line-height: 1.0;
+  margin: 0 0 18px 0;
+  letter-spacing: -0.01em;
+}
+.inside-sub {
+  font-size: 17px;
+  color: var(--pencil);
+  font-style: italic;
+  margin: 0;
+  max-width: 56ch;
+}
+
+.inside-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+
+.zig {
+  position: relative;
+  padding: 44px 48px;
+  border: 1px dashed var(--pencil);
+  background: var(--paper);
+  max-width: 760px;
+  margin-bottom: -1px;
+}
+.zig-1 { margin-left: 0; }
+.zig-2 { margin-left: auto; margin-right: 30px; transform: translateY(0); background: var(--paper-shadow); }
+.zig-3 { margin-left: 30px; }
+.zig-4 { margin-left: auto; margin-right: 0; background: var(--paper-shadow); }
+
+.zig-label {
+  font-size: 10px;
+  color: var(--ochre);
+  margin-bottom: 14px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--ochre);
+  display: inline-block;
+}
+.zig-title {
+  font-family: var(--serif);
+  font-size: 38px;
+  line-height: 1.05;
+  margin: 0 0 18px 0;
+  letter-spacing: -0.01em;
+}
+.pull {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 20px;
+  line-height: 1.4;
+  color: var(--ochre);
+  margin: 0 0 18px 0;
+  padding-left: 16px;
+  border-left: 2px solid var(--ochre);
+  quotes: "\201C" "\201D";
+}
+.zig-body {
+  font-size: 15px;
+  line-height: 1.7;
+  margin: 0 0 22px 0;
+  color: var(--ink);
+  max-width: 52ch;
+}
+.zig-meta {
+  font-size: 10px;
+  color: var(--pencil);
+  border-top: 1px solid var(--pencil);
+  padding-top: 8px;
+}
+
+/* ---------- How it folds ---------- */
+.how-fold {
+  padding: 80px 36px;
+  border-bottom: 1px solid var(--ink);
+  background: var(--paper);
+}
+.how-head {
+  max-width: 720px;
+  margin-bottom: 48px;
+}
+
+.how-strip {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+.how-step {
+  position: relative;
+  padding: 28px 18px;
+  text-align: center;
+  border-right: 1px dashed var(--pencil);
+}
+.how-step:last-child { border-right: none; }
+
+.how-num {
+  position: absolute;
+  top: 8px;
+  left: 10px;
+  font-size: 10px;
+  color: var(--ochre);
+}
+.how-svg {
+  width: 96px;
+  height: 96px;
+  display: block;
+  margin: 14px auto 18px;
+}
+.how-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.how-sub {
+  font-size: 9px;
+  color: var(--pencil);
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0.04em;
+  font-style: italic;
+}
+
+.how-foldline { margin-top: 36px; }
+.how-foldline svg { width: 100%; height: 12px; display: block; }
+
+/* ---------- Subscribe ---------- */
+.subscribe {
+  padding: 80px 36px;
+  border-bottom: 1px solid var(--ink);
+  background: var(--paper);
+}
+.sub-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 64px;
+  align-items: start;
+}
+
+.form-card {
+  margin-top: 28px;
+  padding: 32px;
+  background: var(--paper);
+  border: 1px solid var(--ink);
+  position: relative;
+}
+.form-card::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -1px;
+  right: -1px;
+  height: 1px;
+  border-top: 1px dashed var(--ochre);
+}
+.field { display: block; margin-bottom: 18px; }
+.field-label {
+  display: block;
+  font-size: 10px;
+  color: var(--pencil);
+  margin-bottom: 6px;
+}
+.field input {
+  width: 100%;
+  padding: 10px 0;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--ink);
+  font-family: var(--sans);
+  font-size: 15px;
+  color: var(--ink);
+  outline: none;
+}
+.field input::placeholder { color: var(--pencil); font-style: italic; }
+.field input:focus { border-bottom-color: var(--ochre); }
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 24px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.btn-fold {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 14px 22px;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+  cursor: pointer;
+}
+.btn-fold:hover { background: var(--ochre); border-color: var(--ochre); color: var(--ink); }
+.btn-arrow { margin-left: 6px; }
+.form-note { font-size: 10px; color: var(--pencil); }
+
+.sub-blurb {
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.5;
+  margin: 0;
+  color: var(--ink);
+  max-width: 44ch;
+}
+
+.sub-specs { padding-top: 8px; }
+.specs-list {
+  margin: 18px 0 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px 16px;
+  font-size: 13px;
+}
+.specs-list dt {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--pencil);
+  padding-top: 2px;
+}
+.specs-list dd {
+  margin: 0;
+  color: var(--ink);
+  border-bottom: 1px dashed var(--pencil);
+  padding-bottom: 10px;
+}
+.specs-list dt { border-bottom: 1px dashed var(--pencil); padding-bottom: 10px; }
+.specs-list dt:last-of-type, .specs-list dd:last-of-type { border-bottom: none; }
+
+/* ---------- Colophon / footer ---------- */
+.colophon {
+  padding: 0 36px 56px;
+  background: var(--paper);
+}
+.footer-fold { width: 100%; height: 12px; display: block; margin-bottom: 36px; }
+
+.colophon-grid {
+  display: grid;
+  grid-template-columns: 1.4fr repeat(3, 1fr);
+  gap: 36px;
+}
+.colophon-mark .mark-num {
+  font-family: var(--serif);
+  font-size: 44px;
+  line-height: 0.95;
+  letter-spacing: -0.01em;
+}
+.colophon-mark .mark-sub {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--pencil);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-top: 10px;
+}
+.colophon-col h4 {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ochre);
+  margin: 0 0 14px 0;
+  padding-bottom: 6px;
+  border-bottom: 1px dashed var(--ochre);
+}
+.colophon-col a {
+  display: block;
+  font-size: 13px;
+  padding: 4px 0;
+  color: var(--ink);
+}
+.colophon-col a:hover { color: var(--ochre); }
+
+.colophon-note {
+  grid-column: 1 / -1;
+  margin-top: 32px;
+  padding-top: 18px;
+  border-top: 1px solid var(--ink);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--pencil);
+}
+.colophon-note .mono { color: var(--pencil); }
+
+/* ---------- Prose pages (about, taxonomy) ---------- */
+.prose {
+  max-width: 760px;
+  margin: 60px auto;
+  padding: 0 36px;
+}
+.prose h1 {
+  font-family: var(--serif);
+  font-size: clamp(38px, 4.4vw, 64px);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  margin: 0 0 32px 0;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--ink);
+}
+.prose h2 {
+  font-family: var(--serif);
+  font-size: 30px;
+  line-height: 1.15;
+  margin: 48px 0 16px 0;
+  letter-spacing: -0.005em;
+}
+.prose h3 {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin: 32px 0 12px 0;
+  color: var(--ochre);
+}
+.prose p {
+  font-size: 17px;
+  line-height: 1.7;
+  margin: 0 0 18px 0;
+}
+.prose strong { color: var(--ink); font-weight: 600; }
+.prose em { font-style: italic; color: var(--ochre); }
+.prose blockquote {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.45;
+  color: var(--ochre);
+  margin: 28px 0;
+  padding-left: 20px;
+  border-left: 2px solid var(--ochre);
+}
+.prose ul, .prose ol { padding-left: 22px; margin: 0 0 18px 0; }
+.prose li { font-size: 16px; line-height: 1.7; margin-bottom: 6px; }
+.prose a { color: var(--ochre); border-bottom: 1px solid var(--ochre); }
+.prose a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+.prose code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  background: var(--paper-shadow);
+  padding: 2px 6px;
+}
+
+/* ---------- Section list ---------- */
+.section-list { padding: 60px 36px; }
+.section-wrap { max-width: 960px; margin: 0 auto; }
+.section-title {
+  font-family: var(--serif);
+  font-size: 52px;
+  margin: 0 0 36px 0;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--ink);
+}
+.section-row {
+  display: grid;
+  grid-template-columns: 120px 1fr 40px;
+  gap: 18px;
+  align-items: baseline;
+  padding: 18px 0;
+  border-bottom: 1px dashed var(--pencil);
+}
+.section-date { font-size: 11px; color: var(--pencil); }
+.section-row-title {
+  font-family: var(--serif);
+  font-size: 22px;
+  margin: 0;
+  line-height: 1.25;
+}
+.section-row-arrow { font-size: 20px; color: var(--ochre); text-align: right; }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 1024px) {
+  .hero-panels { grid-template-columns: 1fr 10px 1fr; min-height: 0; }
+  .hp-3, .hero-panels > svg:last-of-type { display: none; }
+  .hero-foot { grid-template-columns: 1fr; }
+  .sub-grid { grid-template-columns: 1fr; gap: 40px; }
+  .colophon-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 720px) {
+  .strip-top { flex-direction: column; gap: 10px; padding: 14px 20px; }
+  .strip-nav { gap: 18px; }
+  .hero-broadsheet, .inside, .how-fold, .subscribe, .colophon { padding-left: 20px; padding-right: 20px; }
+  .hero-panels { grid-template-columns: 1fr; min-height: 0; gap: 16px; }
+  .hero-panels > svg { display: none; }
+  .hp-1, .hp-2, .hp-3 { transform: none; border-bottom: 1px dashed var(--pencil); padding: 24px 16px; }
+  .hero-word { font-size: clamp(56px, 16vw, 88px); }
+  .how-strip { grid-template-columns: repeat(2, 1fr); }
+  .how-step { border-right: 1px dashed var(--pencil); border-bottom: 1px dashed var(--pencil); }
+  .how-step:nth-child(2n) { border-right: none; }
+  .zig { max-width: 100%; padding: 28px 22px; }
+  .zig-2, .zig-3, .zig-4 { margin-left: 0; margin-right: 0; }
+  .zig-title { font-size: 28px; }
+  .colophon-grid { grid-template-columns: 1fr; }
+  .section-row { grid-template-columns: 1fr; gap: 4px; }
+}

--- a/examples/paperfold-mag/static/favicon.svg
+++ b/examples/paperfold-mag/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="2" fill="#fbfaf3"/>
+  <path d="M4 4 H28 V28 H4 Z" fill="none" stroke="#131310" stroke-width="1.5"/>
+  <path d="M4 16 H28" stroke="#c69226" stroke-width="1.2" stroke-dasharray="2,2"/>
+  <path d="M16 4 V28" stroke="#6b665a" stroke-width="0.8" stroke-dasharray="1.5,1.5"/>
+  <path d="M14 16 L16 14 L18 16 Z" fill="#c69226"/>
+</svg>

--- a/examples/paperfold-mag/templates/404.html
+++ b/examples/paperfold-mag/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 / This panel was never printed.</h1>
+  <p>This page must have been folded into another issue — or it simply did not survive the press run. The mail room apologises.</p>
+  <p><a href="{{ base_url }}/">&laquo; Return to Issue 09</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/paperfold-mag/templates/footer.html
+++ b/examples/paperfold-mag/templates/footer.html
@@ -1,0 +1,39 @@
+  <footer class="colophon">
+    <svg class="footer-fold" viewBox="0 0 1200 12" preserveAspectRatio="none" aria-hidden="true">
+      <line x1="0" y1="6" x2="1200" y2="6" stroke="#6b665a" stroke-width="1" stroke-dasharray="6,6"/>
+      <polygon points="10,2 16,6 10,10" fill="#c69226"/>
+      <polygon points="1190,2 1184,6 1190,10" fill="#c69226"/>
+    </svg>
+    <div class="colophon-grid">
+      <div class="colophon-mark">
+        <div class="mark-num">FOLD<br>QUARTERLY</div>
+        <div class="mark-sub">ISSUE 09 / SPRING {{ current_year }}</div>
+      </div>
+      <div class="colophon-col">
+        <h4>Editorial</h4>
+        <a href="{{ base_url }}/about/">About the magazine</a>
+        <a href="{{ base_url }}/about/">The fold engineer</a>
+        <a href="{{ base_url }}/about/">Paper specs</a>
+      </div>
+      <div class="colophon-col">
+        <h4>Mail Room</h4>
+        <a href="#subscribe">Subscribe</a>
+        <a href="#subscribe">Renew</a>
+        <a href="#subscribe">Gift a year</a>
+      </div>
+      <div class="colophon-col">
+        <h4>Desk</h4>
+        <a href="#">desk@fold.quarterly</a>
+        <a href="#">room@fold.quarterly</a>
+        <a href="#">Lost in the post</a>
+      </div>
+      <div class="colophon-note">
+        <span>&copy; {{ current_year }} Fold Quarterly &middot; Folded by hand. Mailed flat. Folds itself.</span>
+        <span class="mono">Hwaro build / press run {{ current_year }}.Q2</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/paperfold-mag/templates/header.html
+++ b/examples/paperfold-mag/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Inter:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <div class="strip-left">FOLD QUARTERLY &middot; ISSUE 09 &middot; SPRING {{ current_year }}</div>
+    <nav class="strip-nav">
+      <a href="{{ base_url }}/">Issues</a>
+      <a href="#subscribe">Subscribe</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </header>

--- a/examples/paperfold-mag/templates/index.html
+++ b/examples/paperfold-mag/templates/index.html
@@ -1,0 +1,262 @@
+{% include "header.html" %}
+
+<section class="hero-broadsheet">
+  <div class="hero-meta">
+    <span class="mono">SHEET A / FRONT SPREAD</span>
+    <span class="mono">PANEL 01 / OF 08</span>
+  </div>
+
+  <div class="hero-panels">
+    <div class="hero-panel hp-1">
+      <div class="panel-corner mono">P.01</div>
+      <span class="fold-tick fold-tick-top"></span>
+      <span class="fold-tick fold-tick-bot"></span>
+      <h1 class="hero-word">ONE</h1>
+      <div class="hero-line mono">SHEET</div>
+    </div>
+
+    <svg class="hero-fold" viewBox="0 0 10 600" preserveAspectRatio="none" aria-hidden="true">
+      <line x1="5" y1="0" x2="5" y2="600" stroke="#6b665a" stroke-width="1" stroke-dasharray="4,5"/>
+      <polygon points="0,40 5,46 0,52" fill="#c69226"/>
+      <polygon points="0,140 5,146 0,152" fill="#c69226"/>
+      <polygon points="0,240 5,246 0,252" fill="#c69226"/>
+      <polygon points="0,340 5,346 0,352" fill="#c69226"/>
+      <polygon points="0,440 5,446 0,452" fill="#c69226"/>
+      <polygon points="0,540 5,546 0,552" fill="#c69226"/>
+    </svg>
+
+    <div class="hero-panel hp-2">
+      <div class="panel-corner mono">P.02</div>
+      <span class="fold-tick fold-tick-top"></span>
+      <span class="fold-tick fold-tick-bot"></span>
+      <h1 class="hero-word">SHEET</h1>
+      <div class="hero-line mono">EIGHT PANELS</div>
+      <div class="hero-line mono small">folded down the centre</div>
+    </div>
+
+    <svg class="hero-fold" viewBox="0 0 10 600" preserveAspectRatio="none" aria-hidden="true">
+      <line x1="5" y1="0" x2="5" y2="600" stroke="#6b665a" stroke-width="1" stroke-dasharray="4,5"/>
+      <polygon points="10,40 5,46 10,52" fill="#c69226"/>
+      <polygon points="10,140 5,146 10,152" fill="#c69226"/>
+      <polygon points="10,240 5,246 10,252" fill="#c69226"/>
+      <polygon points="10,340 5,346 10,352" fill="#c69226"/>
+      <polygon points="10,440 5,446 10,452" fill="#c69226"/>
+      <polygon points="10,540 5,546 10,552" fill="#c69226"/>
+    </svg>
+
+    <div class="hero-panel hp-3">
+      <div class="panel-corner mono">P.03</div>
+      <span class="fold-tick fold-tick-top"></span>
+      <span class="fold-tick fold-tick-bot"></span>
+      <h1 class="hero-word">EIGHT</h1>
+      <div class="hero-line mono">FOLDED</div>
+      <div class="hero-line mono">TO YOU.</div>
+    </div>
+  </div>
+
+  <div class="hero-foot">
+    <div class="hero-foot-left">
+      <p class="hero-lede">A paper-craft newsletter, printed on a single broadsheet and folded down to a pocket pamphlet. One sheet. Eight panels. Four times a year. Mailed flat.</p>
+    </div>
+    <div class="hero-foot-right mono">
+      <span>EDITION</span><b>09 / SPRING {{ current_year }}</b>
+      <span>STOCK</span><b>MOHAWK SUPERFINE 350gsm</b>
+      <span>FORMAT</span><b>BROADSHEET / 8-PANEL</b>
+      <span>PRESS</span><b>4C ONE-SIDE / PANTONE 145</b>
+    </div>
+  </div>
+</section>
+
+<section class="inside" id="inside">
+  <div class="inside-head">
+    <div class="inside-eyebrow mono">INSIDE ISSUE 09 / FOUR FEATURES</div>
+    <h2 class="inside-title">Inside this fold.</h2>
+    <p class="inside-sub">Four panels you unfold to read, four panels you fold back to keep.</p>
+  </div>
+
+  <div class="inside-grid">
+
+    <article class="zig zig-1">
+      <div class="panel-corner mono">PANEL 03 / OF 08</div>
+      <span class="fold-tick fold-tick-top"></span>
+      <span class="fold-tick fold-tick-bot"></span>
+      <div class="zig-label mono">PANEL 01 &middot; THE PLEAT</div>
+      <h3 class="zig-title">The Pleat</h3>
+      <blockquote class="pull">&ldquo;A pleat is a fold that remembers itself. You only need to show it once.&rdquo;</blockquote>
+      <p class="zig-body">A short essay on the accordion fold and why it survives reading rooms, train carriages, and back-pocket commutes. Three hundred years of paper engineering pressed into the gutter of one sheet.</p>
+      <div class="zig-meta mono">WORDS / Eun-mi Park &middot; 4 panels</div>
+    </article>
+
+    <article class="zig zig-2">
+      <div class="panel-corner mono">PANEL 04 / OF 08</div>
+      <span class="fold-tick fold-tick-top"></span>
+      <span class="fold-tick fold-tick-bot"></span>
+      <div class="zig-label mono">PANEL 02 &middot; INTERVIEW</div>
+      <h3 class="zig-title">An interview with a paper engineer.</h3>
+      <blockquote class="pull">&ldquo;The first fold tells the paper what kind of object it&rsquo;s about to become.&rdquo;</blockquote>
+      <p class="zig-body">Hanae Ogawa on training in book conservation, why she runs grain vertical, and the morning she folded eight hundred sheets without a single misalignment. A conversation, lightly creased.</p>
+      <div class="zig-meta mono">INTERVIEW / Mo Han &middot; 6 panels</div>
+    </article>
+
+    <article class="zig zig-3">
+      <div class="panel-corner mono">PANEL 05 / OF 08</div>
+      <span class="fold-tick fold-tick-top"></span>
+      <span class="fold-tick fold-tick-bot"></span>
+      <div class="zig-label mono">PANEL 03 &middot; FIELD NOTES</div>
+      <h3 class="zig-title">Six months at the press.</h3>
+      <blockquote class="pull">&ldquo;The plate held a sneeze, a static charge, and the long shadow of a magpie at the window.&rdquo;</blockquote>
+      <p class="zig-body">Field notes from the print floor at Hwacheong Press, where Issue 09 went to bed at four in the morning under a Pantone 145 ochre that took three pulls to settle.</p>
+      <div class="zig-meta mono">FIELD / Desk &middot; 2 panels</div>
+    </article>
+
+    <article class="zig zig-4">
+      <div class="panel-corner mono">PANEL 06 / OF 08</div>
+      <span class="fold-tick fold-tick-top"></span>
+      <span class="fold-tick fold-tick-bot"></span>
+      <div class="zig-label mono">PANEL 04 &middot; SHORT FICTION</div>
+      <h3 class="zig-title">A pamphlet returns to its sender.</h3>
+      <blockquote class="pull">&ldquo;She refolded the magazine along its original creases. Twice was enough; the paper had learned.&rdquo;</blockquote>
+      <p class="zig-body">A short fiction from Anwar Idris about a magazine that gets mailed back, unfolded once, and read on a tram between two unnamed cities. Twelve hundred words, two paper folds.</p>
+      <div class="zig-meta mono">FICTION / Anwar Idris &middot; 4 panels</div>
+    </article>
+
+  </div>
+</section>
+
+<section class="how-fold" id="how">
+  <div class="how-head">
+    <div class="inside-eyebrow mono">HOW IT FOLDS &middot; SEQUENCE</div>
+    <h2 class="inside-title">From broadsheet to pocket.</h2>
+    <p class="inside-sub">Six gestures. Ninety seconds. The paper, once folded, holds its own shape.</p>
+  </div>
+
+  <div class="how-strip">
+
+    <div class="how-step">
+      <div class="how-num mono">01</div>
+      <svg class="how-svg" viewBox="0 0 100 100" aria-hidden="true">
+        <rect x="10" y="10" width="80" height="80" fill="#fbfaf3" stroke="#131310" stroke-width="1.4"/>
+        <line x1="50" y1="10" x2="50" y2="90" stroke="#c69226" stroke-width="1.2" stroke-dasharray="3,3"/>
+        <polygon points="46,18 50,22 54,18" fill="#c69226"/>
+        <polygon points="46,82 50,78 54,82" fill="#c69226"/>
+      </svg>
+      <div class="how-label">MOUNTAIN</div>
+      <div class="how-sub mono">Crease away.</div>
+    </div>
+
+    <div class="how-step">
+      <div class="how-num mono">02</div>
+      <svg class="how-svg" viewBox="0 0 100 100" aria-hidden="true">
+        <rect x="10" y="10" width="80" height="80" fill="#fbfaf3" stroke="#131310" stroke-width="1.4"/>
+        <line x1="10" y1="50" x2="90" y2="50" stroke="#c69226" stroke-width="1.2" stroke-dasharray="3,3"/>
+        <polygon points="18,46 22,50 18,54" fill="#c69226"/>
+        <polygon points="82,46 78,50 82,54" fill="#c69226"/>
+      </svg>
+      <div class="how-label">VALLEY</div>
+      <div class="how-sub mono">Crease toward.</div>
+    </div>
+
+    <div class="how-step">
+      <div class="how-num mono">03</div>
+      <svg class="how-svg" viewBox="0 0 100 100" aria-hidden="true">
+        <rect x="10" y="10" width="80" height="80" fill="#fbfaf3" stroke="#131310" stroke-width="1.4"/>
+        <line x1="33" y1="10" x2="33" y2="90" stroke="#c69226" stroke-width="1.2" stroke-dasharray="3,3"/>
+        <line x1="66" y1="10" x2="66" y2="90" stroke="#c69226" stroke-width="1.2" stroke-dasharray="3,3"/>
+        <polygon points="29,18 33,22 37,18" fill="#c69226"/>
+        <polygon points="62,18 66,22 70,18" fill="#c69226"/>
+      </svg>
+      <div class="how-label">MOUNTAIN</div>
+      <div class="how-sub mono">Once more.</div>
+    </div>
+
+    <div class="how-step">
+      <div class="how-num mono">04</div>
+      <svg class="how-svg" viewBox="0 0 100 100" aria-hidden="true">
+        <rect x="10" y="10" width="80" height="80" fill="#fbfaf3" stroke="#131310" stroke-width="1.4"/>
+        <rect x="30" y="30" width="40" height="40" fill="#ece7d4" stroke="#131310" stroke-width="1"/>
+        <polygon points="30,30 50,40 70,30 70,50 50,40 30,50" fill="none" stroke="#c69226" stroke-width="1" stroke-dasharray="2,2"/>
+      </svg>
+      <div class="how-label">TUCK</div>
+      <div class="how-sub mono">Inside corner.</div>
+    </div>
+
+    <div class="how-step">
+      <div class="how-num mono">05</div>
+      <svg class="how-svg" viewBox="0 0 100 100" aria-hidden="true">
+        <rect x="10" y="10" width="80" height="80" fill="#fbfaf3" stroke="#131310" stroke-width="1.4"/>
+        <rect x="20" y="40" width="60" height="20" fill="#ece7d4"/>
+        <line x1="20" y1="50" x2="80" y2="50" stroke="#131310" stroke-width="1.4"/>
+        <polygon points="50,32 46,38 54,38" fill="#c69226"/>
+        <polygon points="50,68 46,62 54,62" fill="#c69226"/>
+      </svg>
+      <div class="how-label">PRESS</div>
+      <div class="how-sub mono">Bone folder.</div>
+    </div>
+
+    <div class="how-step">
+      <div class="how-num mono">06</div>
+      <svg class="how-svg" viewBox="0 0 100 100" aria-hidden="true">
+        <rect x="20" y="20" width="60" height="60" fill="#ece7d4" stroke="#131310" stroke-width="1.4"/>
+        <rect x="20" y="20" width="60" height="20" fill="#fbfaf3" stroke="#131310" stroke-width="1"/>
+        <line x1="20" y1="40" x2="80" y2="40" stroke="#c69226" stroke-width="1.2" stroke-dasharray="3,3"/>
+        <text x="50" y="65" font-family="IBM Plex Mono" font-size="9" fill="#131310" text-anchor="middle">FOLD Q.</text>
+      </svg>
+      <div class="how-label">POCKET</div>
+      <div class="how-sub mono">Pamphlet.</div>
+    </div>
+
+  </div>
+
+  <div class="how-foldline" aria-hidden="true">
+    <svg viewBox="0 0 1200 12" preserveAspectRatio="none">
+      <line x1="0" y1="6" x2="1200" y2="6" stroke="#6b665a" stroke-width="1" stroke-dasharray="6,6"/>
+    </svg>
+  </div>
+</section>
+
+<section class="subscribe" id="subscribe">
+  <div class="sub-grid">
+
+    <div class="sub-form">
+      <div class="inside-eyebrow mono">SUBSCRIBE / PANEL 08</div>
+      <h2 class="inside-title">Mailed flat, four times a year.</h2>
+      <p class="sub-blurb">A subscription is four issues, shipped on the equinoxes and solstices, in a rigid kraft envelope so the first fold is yours to make.</p>
+
+      <form class="form-card" onsubmit="event.preventDefault();">
+        <label class="field">
+          <span class="field-label mono">YOUR NAME</span>
+          <input type="text" placeholder="As it should appear on the envelope" />
+        </label>
+        <label class="field">
+          <span class="field-label mono">MAILING ADDRESS</span>
+          <input type="text" placeholder="Street, city, postal code, country" />
+        </label>
+        <label class="field">
+          <span class="field-label mono">EMAIL</span>
+          <input type="email" placeholder="For the mail room only" />
+        </label>
+        <div class="form-actions">
+          <button type="submit" class="btn-fold">Begin a subscription <span class="btn-arrow">&rarr;</span></button>
+          <span class="form-note mono">First issue ships next equinox.</span>
+        </div>
+      </form>
+    </div>
+
+    <aside class="sub-specs">
+      <div class="inside-eyebrow mono">PRINT SPECS</div>
+      <dl class="specs-list">
+        <dt>Paper</dt><dd>Mohawk Superfine 350gsm Eggshell White</dd>
+        <dt>Press</dt><dd>Four-colour, one side, Pantone 145 ochre on the fold marks</dd>
+        <dt>Folds</dt><dd>Eight, mountain &amp; valley, mixed sequence</dd>
+        <dt>Trim</dt><dd>Broadsheet 580 x 410 mm, folded to 145 x 102 mm</dd>
+        <dt>Binding</dt><dd>None &mdash; the fold is the binding</dd>
+        <dt>Mailing</dt><dd>Flat, in a 600gsm kraft envelope, worldwide</dd>
+        <dt>Run</dt><dd>1,200 numbered copies per issue</dd>
+        <dt>Year</dt><dd>Four issues &mdash; SPRING, SUMMER, AUTUMN, WINTER</dd>
+      </dl>
+    </aside>
+
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/paperfold-mag/templates/page.html
+++ b/examples/paperfold-mag/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/paperfold-mag/templates/section.html
+++ b/examples/paperfold-mag/templates/section.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+<section class="section-list">
+  <div class="section-wrap">
+    {% if page.title is present %}<h2 class="section-title">{{ page.title | e }}</h2>{% endif %}
+    {{ content | safe }}
+    {% for post in section.pages %}
+    <article class="section-row">
+      <div class="section-date mono">{{ post.date | date(format="%Y / %m") }}</div>
+      <h3 class="section-row-title"><a href="{{ post.url }}">{{ post.title | e }}</a></h3>
+      <div class="section-row-arrow">&rarr;</div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/paperfold-mag/templates/shortcodes/alert.html
+++ b/examples/paperfold-mag/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/paperfold-mag/templates/taxonomy.html
+++ b/examples/paperfold-mag/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p class="mono">// An index of subjects across the back issues.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/paperfold-mag/templates/taxonomy_term.html
+++ b/examples/paperfold-mag/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p class="mono">// Pieces filed under this subject.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/postcard-route/AGENTS.md
+++ b/examples/postcard-route/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/postcard-route/archetypes/default.md
+++ b/examples/postcard-route/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/postcard-route/config.toml
+++ b/examples/postcard-route/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Postcard Route"
+description = "Postcard Route — a slow-travel itinerary platform that mails one physical postcard per stop to your home address as your trip progresses."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/postcard-route/content/about.md
+++ b/examples/postcard-route/content/about.md
@@ -1,0 +1,37 @@
++++
+title = "About the Bureau"
+description = "How Postcard Route plans, writes, prints, and posts every card on a route."
++++
+
+## How the route is built
+
+Every route starts in a paper notebook on Desk 12. We map the stops by train table, ferry schedule, and walking distance — never by drive time. A route is only added to the catalogue once the desk has slept in each of its overnight stops at least twice, in different seasons, and confirmed that a working post office is within ten minutes of each bed.
+
+If a town loses its post office, the route is retired. We do not reroute through couriers.
+
+## Who writes the cards
+
+The cards are written by hand by one of three desk writers — Hyejin, Marcos, and Pa Yan. Each writer carries the route for a full season so that the voice on every card is the same hand that walked the road. We do not use ghostwriters and we do not generate the prose by machine.
+
+You will see the draft of every card before the trip starts. You may ask for changes, but the writer reserves the right to keep their own opening line.
+
+## The postage
+
+Cards are 105 by 148 millimetres on 350 gsm cotton stock, milled in Andong. Each card carries one stamp from the country it is posted in, hand-cancelled at the local post office where possible. International postage is included in the route price — we do not pass it through to you as a line item, and we do not surcharge for distant addresses.
+
+Cards mailed in Europe typically arrive in two to four weeks. Cards from Japan in three to five. Cards from Mexico in four to seven. We mail tracked replacements at our cost if a card never arrives.
+
+## The print run
+
+We print 24 of each route's card set per year. Once a route is sold out for a season, the cards are not reprinted with the same date — a {{ current_year }} card stays a {{ current_year }} card. The blocks are then donated to a printing school in Daegu.
+
+## How to commission a route
+
+You can also commission a private route. Send the bureau a list of overnight stops, your home address, and any constraints (anniversaries, language, kosher kitchens, step-free trains). We will reply within ten working days with a route quote and a sample card written in the chosen voice.
+
+Commissioned routes ship within sixty days of approval.
+
+- **Desk** — `desk12@postcardroute.example`
+- **Phone** — listed in the bureau front window, by appointment only
+- **Letters** — to the return address printed in the footer, opened on Fridays
+- **No email lists.** The mailing list is paper, posted twice a year.

--- a/examples/postcard-route/content/index.md
+++ b/examples/postcard-route/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Postcard Route — a slow-travel itinerary platform that mails one physical postcard per stop to your home address as your trip progresses."
+template = "index"
++++

--- a/examples/postcard-route/static/css/style.css
+++ b/examples/postcard-route/static/css/style.css
@@ -1,0 +1,491 @@
+/* Postcard Route — vintage airmail postcard landing */
+
+:root {
+  --card-cream: #f1ead6;
+  --card-cream-deep: #e3d9b8;
+  --airmail-red: #b81d28;
+  --airmail-blue: #1d4699;
+  --postmark-black: #1a1a1a;
+  --pencil: #4a4540;
+  --pencil-soft: #6b6357;
+  --hand: "Caveat", "Reenie Beanie", "Comic Sans MS", cursive;
+  --hand-2: "Reenie Beanie", "Caveat", cursive;
+  --serif-d: "Rozha One", "Playfair Display", "Times New Roman", serif;
+  --mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; background: var(--card-cream); color: var(--postmark-black); overflow-x: hidden; }
+
+body {
+  font-family: var(--mono);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='40'><circle cx='1' cy='1' r='0.6' fill='rgba(26,26,26,0.14)'/><line x1='0' y1='39.5' x2='4' y2='39.5' stroke='rgba(74,69,64,0.1)' stroke-width='1'/></svg>");
+  background-size: 4px 40px;
+}
+
+a { color: var(--airmail-blue); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+a:hover { color: var(--airmail-red); }
+
+::selection { background: var(--airmail-red); color: var(--card-cream); }
+
+/* AIRMAIL STRIPED BORDER (no gradients — alternating box-shadow + linear-pattern via SVG repeat) */
+.airmail-border {
+  position: relative;
+  padding: 12px;
+  background: var(--card-cream);
+  border: 2px solid var(--postmark-black);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><polygon points='0,0 16,0 0,16' fill='%23b81d28'/><polygon points='16,0 32,0 32,16 0,32 0,16' fill='%23f1ead6'/><polygon points='32,16 32,32 16,32' fill='%231d4699'/></svg>");
+  background-size: 32px 32px;
+  background-repeat: repeat;
+}
+.airmail-border.thin {
+  padding: 8px;
+  background-size: 22px 22px;
+}
+.airmail-border > .card-inner,
+.airmail-border > .route-inner,
+.airmail-border > .dispatch-inner,
+.airmail-border > .prose-inner {
+  background: var(--card-cream);
+  position: relative;
+}
+
+/* TOP STRIP */
+.strip-top {
+  background: var(--card-cream);
+  color: var(--postmark-black);
+  padding: 14px 28px 0;
+  border-bottom: 0;
+  position: relative;
+}
+.strip-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+.bureau { font-weight: 600; color: var(--postmark-black); }
+.bureau .dot { color: var(--airmail-red); padding: 0 4px; }
+.strip-nav { display: flex; gap: 18px; }
+.strip-nav a {
+  color: var(--postmark-black);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--pencil);
+  padding-bottom: 2px;
+}
+.strip-nav a:hover { color: var(--airmail-red); border-bottom-color: var(--airmail-red); }
+.strip-underline {
+  height: 10px;
+  margin-top: 12px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='10' viewBox='0 0 32 10'><rect width='16' height='5' fill='%23b81d28'/><rect x='16' width='16' height='5' fill='%231d4699'/><rect y='5' width='16' height='5' fill='%231d4699'/><rect x='16' y='5' width='16' height='5' fill='%23b81d28'/></svg>");
+  background-repeat: repeat-x;
+  background-size: 32px 10px;
+}
+
+/* HERO */
+.hero {
+  position: relative;
+  padding: 80px 28px 110px;
+  overflow: hidden;
+}
+.hero-bg { position: absolute; inset: 0; pointer-events: none; }
+.hero-wrap { max-width: 1180px; margin: 0 auto; position: relative; }
+
+.hero-deck {
+  position: relative;
+  min-height: 720px;
+  display: block;
+}
+.card { position: absolute; width: 720px; max-width: 92vw; }
+.card-rot-l { top: 30px; left: -10px; transform: rotate(-8deg); z-index: 1; }
+.card-rot-r { top: 60px; right: -20px; transform: rotate(3deg); z-index: 2; }
+.card-rot-c { top: 130px; left: 50%; transform: translateX(-50%) rotate(-2deg); z-index: 3; }
+
+.card .card-inner {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  min-height: 460px;
+}
+.card.back .card-inner { min-height: 280px; }
+.card-side { padding: 30px 32px; position: relative; }
+.card-left { border-right: 1px dashed var(--pencil); }
+
+.card-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--airmail-red);
+  margin: 0 0 14px;
+  border-bottom: 1px solid var(--pencil);
+  padding-bottom: 8px;
+  display: inline-block;
+}
+.card-headline {
+  font-family: var(--serif-d);
+  font-weight: 400;
+  font-size: clamp(38px, 6vw, 76px);
+  line-height: 0.95;
+  margin: 0 0 22px;
+  color: var(--postmark-black);
+  letter-spacing: -0.01em;
+}
+.hand-note {
+  font-family: var(--hand);
+  font-size: 22px;
+  line-height: 1.4;
+  color: var(--pencil);
+  margin: 0 0 18px;
+}
+.hand-tiny {
+  font-family: var(--hand);
+  font-size: 21px;
+  line-height: 1.35;
+  color: var(--pencil);
+  margin: 0;
+  transform: rotate(-2deg);
+}
+.signoff {
+  font-family: var(--hand);
+  font-size: 24px;
+  color: var(--airmail-blue);
+  margin: 0 0 22px;
+}
+.card-cta { display: flex; gap: 10px; flex-wrap: wrap; }
+
+.btn {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 11px 16px;
+  text-decoration: none;
+  border: 2px solid var(--postmark-black);
+  background: var(--card-cream);
+  color: var(--postmark-black);
+  font-weight: 600;
+}
+.btn:hover { background: var(--postmark-black); color: var(--card-cream); }
+.btn.red { background: var(--airmail-red); color: var(--card-cream); border-color: var(--airmail-red); }
+.btn.red:hover { background: var(--postmark-black); border-color: var(--postmark-black); color: var(--card-cream); }
+.btn.blue { background: var(--airmail-blue); color: var(--card-cream); border-color: var(--airmail-blue); }
+.btn.blue:hover { background: var(--postmark-black); border-color: var(--postmark-black); }
+
+/* STAMP CORNER */
+.stamp-corner {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  width: 96px;
+  text-align: center;
+}
+.stamp-bg {
+  background: var(--airmail-red);
+  border: 3px dashed var(--card-cream);
+  outline: 2px solid var(--airmail-red);
+  padding: 10px 8px 6px;
+  position: relative;
+}
+.king-head {
+  display: block;
+  width: 44px;
+  height: 56px;
+  margin: 0 auto 4px;
+  background-color: var(--card-cream);
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 44 56'><path d='M22 4 C 10 4 8 18 12 24 C 10 26 10 30 14 30 L 14 34 C 14 40 18 44 22 44 C 26 44 30 40 30 34 L 30 30 C 34 30 34 26 32 24 C 36 18 34 4 22 4 Z M 6 52 L 38 52 L 36 56 L 8 56 Z' fill='black'/></svg>") center/contain no-repeat;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 44 56'><path d='M22 4 C 10 4 8 18 12 24 C 10 26 10 30 14 30 L 14 34 C 14 40 18 44 22 44 C 26 44 30 40 30 34 L 30 30 C 34 30 34 26 32 24 C 36 18 34 4 22 4 Z M 6 52 L 38 52 L 36 56 L 8 56 Z' fill='black'/></svg>") center/contain no-repeat;
+}
+.stamp-val {
+  display: block;
+  font-family: var(--serif-d);
+  font-size: 13px;
+  color: var(--card-cream);
+  background: var(--airmail-red);
+  margin-top: 2px;
+}
+.stamp-cap {
+  display: block;
+  font-family: var(--mono);
+  font-size: 7px;
+  letter-spacing: 0.18em;
+  color: var(--card-cream);
+  background: var(--airmail-red);
+  padding-bottom: 4px;
+}
+
+/* POSTMARK (concentric circles via CSS) */
+.postmark {
+  position: relative;
+  border: 2px solid var(--postmark-black);
+  border-radius: 50%;
+  width: 130px;
+  height: 130px;
+  display: grid;
+  place-items: center;
+  color: var(--postmark-black);
+  background: transparent;
+  opacity: 0.85;
+}
+.postmark::before {
+  content: "";
+  position: absolute;
+  inset: 9px;
+  border: 1px solid var(--postmark-black);
+  border-radius: 50%;
+}
+.postmark::after {
+  content: "";
+  position: absolute;
+  inset: 36px;
+  border: 1px dashed var(--postmark-black);
+  border-radius: 50%;
+}
+.postmark.tilted { transform: rotate(-14deg); }
+.postmark.lg { position: absolute; left: 30px; bottom: 36px; width: 160px; height: 160px; }
+.postmark.md { position: absolute; right: 12px; bottom: 10px; width: 100px; height: 100px; }
+.postmark.sm { width: 88px; height: 88px; }
+.postmark.sm::before { inset: 6px; }
+.postmark.sm::after { inset: 22px; }
+.postmark .ring-top,
+.postmark .ring-mid,
+.postmark .ring-bot {
+  position: absolute;
+  left: 0; right: 0;
+  text-align: center;
+  font-family: var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--postmark-black);
+}
+.postmark .ring-top { top: 12px; font-size: 9px; }
+.postmark .ring-mid { top: 50%; transform: translateY(-50%); font-size: 11px; font-weight: 600; }
+.postmark .ring-bot { bottom: 12px; font-size: 9px; }
+.postmark.sm .ring-top { top: 8px; font-size: 7px; }
+.postmark.sm .ring-mid { font-size: 8px; }
+.postmark.sm .ring-bot { bottom: 8px; font-size: 7px; }
+.postmark.lg .ring-top { font-size: 11px; }
+.postmark.lg .ring-mid { font-size: 13px; }
+.postmark.lg .ring-bot { font-size: 11px; }
+
+/* ADDRESS BLOCK */
+.addr-block { position: absolute; bottom: 30px; right: 28px; width: 60%; }
+.addr-rules { display: flex; flex-direction: column; gap: 18px; }
+.addr-rules span { display: block; height: 1px; background: var(--pencil); opacity: 0.55; }
+.addr-text { position: absolute; inset: 0; padding: 2px 0; }
+.addr-to { font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--pencil); margin-bottom: 8px; }
+.addr-lines { display: flex; flex-direction: column; gap: 6px; font-family: var(--hand); font-size: 17px; color: var(--pencil); }
+.addr-mini { font-family: var(--mono); font-size: 11px; color: var(--pencil); padding: 24px 0 0; }
+.addr-mini p { font-family: var(--hand); font-size: 20px; color: var(--pencil); margin: 4px 0 0; }
+
+/* ORNAMENTS — PAR AVION etc */
+.ornament { position: absolute; font-family: var(--mono); font-weight: 600; letter-spacing: 0.32em; color: var(--airmail-blue); text-transform: uppercase; font-size: 10px; }
+.par-avion { padding: 4px 12px; border-top: 1px solid var(--airmail-blue); border-bottom: 1px solid var(--airmail-blue); }
+.par-avion.top-left { top: 40px; left: -40px; transform: rotate(-12deg); }
+.par-avion.bot-right { bottom: 60px; right: -30px; transform: rotate(8deg); color: var(--airmail-red); border-color: var(--airmail-red); }
+
+/* SECTIONS */
+section { padding: 90px 28px; position: relative; }
+.wrap { max-width: 1180px; margin: 0 auto; }
+.section-head { max-width: 720px; margin: 0 0 56px; }
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--airmail-red);
+  margin: 0 0 18px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--postmark-black);
+  display: inline-block;
+}
+.section-title {
+  font-family: var(--serif-d);
+  font-weight: 400;
+  font-size: clamp(34px, 4.6vw, 56px);
+  line-height: 0.98;
+  margin: 0 0 18px;
+  color: var(--postmark-black);
+}
+.section-lede {
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--pencil);
+  max-width: 56ch;
+}
+
+/* ROUTES */
+.routes { background: var(--card-cream-deep); border-top: 2px solid var(--postmark-black); border-bottom: 2px solid var(--postmark-black); }
+.route-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 60px 40px;
+}
+.route-card { transform-origin: center; }
+.r-rot-1 { transform: rotate(-2deg); }
+.r-rot-2 { transform: rotate(1.5deg); }
+.r-rot-3 { transform: rotate(-1deg); }
+.r-rot-4 { transform: rotate(2.4deg); }
+.route-card:hover { transform: rotate(0); transition: transform 0.4s ease; }
+.route-inner { padding: 26px 28px 24px; min-height: 280px; position: relative; }
+.route-top { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--airmail-blue); margin-bottom: 14px; padding-bottom: 10px; border-bottom: 1px dashed var(--pencil); }
+.route-no { color: var(--airmail-red); font-weight: 600; }
+.route-title { font-family: var(--serif-d); font-weight: 400; font-size: 38px; line-height: 0.96; margin: 0 0 16px; color: var(--postmark-black); }
+.route-title .arrow { font-family: var(--mono); font-size: 14px; color: var(--airmail-red); padding: 0 4px; vertical-align: middle; }
+.route-meta { font-family: var(--mono); font-size: 13px; color: var(--pencil); margin: 0 0 22px; }
+.route-foot { display: flex; justify-content: space-between; align-items: center; margin-top: auto; padding-top: 12px; border-top: 1px solid var(--postmark-black); }
+.price-stamp {
+  display: inline-block;
+  font-family: var(--serif-d);
+  font-size: 22px;
+  color: var(--card-cream);
+  background: var(--airmail-red);
+  padding: 6px 12px;
+  transform: rotate(-4deg);
+  border: 2px dashed var(--card-cream);
+  outline: 2px solid var(--airmail-red);
+}
+.price-stamp .krw { font-family: var(--mono); font-size: 14px; margin-right: 2px; }
+.route-link { font-family: var(--mono); font-size: 11px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--airmail-blue); text-decoration: none; border-bottom: 1px solid var(--airmail-blue); padding-bottom: 2px; }
+.route-link:hover { color: var(--airmail-red); border-color: var(--airmail-red); }
+
+/* POST / How it works */
+.post { background: var(--card-cream); }
+.post-map { position: relative; padding-top: 20px; }
+.post-svg { display: block; width: 100%; height: auto; margin-bottom: -20px; position: relative; z-index: 0; }
+.post-steps {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 30px;
+  margin-top: -40px;
+}
+.post-step {
+  background: var(--card-cream);
+  border: 2px solid var(--postmark-black);
+  padding: 26px 24px;
+  position: relative;
+}
+.post-step:nth-child(1) { transform: rotate(-1.5deg); }
+.post-step:nth-child(2) { transform: rotate(0.8deg); }
+.post-step:nth-child(3) { transform: rotate(-0.6deg); }
+.step-num {
+  font-family: var(--serif-d);
+  font-size: 56px;
+  line-height: 1;
+  color: var(--airmail-red);
+  margin-bottom: 4px;
+}
+.post-step h3 { font-family: var(--serif-d); font-weight: 400; font-size: 34px; margin: 0 0 12px; color: var(--postmark-black); line-height: 1; }
+.post-step p { font-family: var(--mono); font-size: 13px; color: var(--pencil); margin: 0 0 18px; }
+.step-tag { font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--card-cream); background: var(--airmail-blue); padding: 4px 10px; }
+
+/* DISPATCHES */
+.dispatches { background: var(--card-cream-deep); border-top: 2px solid var(--postmark-black); position: relative; }
+.dispatch-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 36px;
+  margin-top: 12px;
+}
+.dispatch { transform-origin: center; }
+.d-rot-1 { transform: rotate(-2.5deg); }
+.d-rot-2 { transform: rotate(1.5deg); }
+.d-rot-3 { transform: rotate(-1deg); }
+.dispatch-inner { padding: 24px 24px 22px; position: relative; min-height: 240px; }
+.dispatch-inner .postmark { position: absolute; top: 12px; right: 12px; }
+.dispatch .quote { font-family: var(--hand); font-size: 22px; line-height: 1.35; color: var(--pencil); margin: 0 0 18px; padding-right: 90px; }
+.dispatch .signer { font-family: var(--mono); font-size: 12px; letter-spacing: 0.06em; color: var(--postmark-black); margin: 0 0 6px; font-weight: 600; }
+.dispatch .stop { font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--airmail-blue); margin: 0; }
+
+.dispatch-ornament { margin-top: 80px; display: flex; justify-content: center; }
+.oval-seal {
+  width: 320px;
+  height: 130px;
+  border: 2px solid var(--airmail-blue);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  transform: rotate(-3deg);
+  position: relative;
+}
+.oval-seal::before { content: ""; position: absolute; inset: 8px; border: 1px solid var(--airmail-blue); border-radius: 50%; }
+.oval-seal span { font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--airmail-blue); padding: 0 16px; text-align: center; }
+
+/* PROSE */
+.prose { padding: 80px 28px; }
+.prose-card { max-width: 820px; margin: 0 auto; }
+.prose-inner { padding: 48px 56px; }
+.prose-inner h1 { font-family: var(--serif-d); font-weight: 400; font-size: clamp(38px, 4.8vw, 60px); line-height: 1; margin: 0 0 28px; color: var(--postmark-black); }
+.prose-inner h2 { font-family: var(--serif-d); font-weight: 400; font-size: 32px; margin: 38px 0 14px; color: var(--airmail-blue); }
+.prose-inner h3 { font-family: var(--mono); font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; margin: 28px 0 10px; color: var(--airmail-red); }
+.prose-inner p { font-family: var(--mono); font-size: 14px; line-height: 1.7; color: var(--pencil); margin: 0 0 16px; }
+.prose-inner ul, .prose-inner ol { padding-left: 22px; }
+.prose-inner li { font-family: var(--mono); font-size: 14px; line-height: 1.7; color: var(--pencil); margin: 0 0 6px; }
+.prose-inner blockquote { border-left: 3px solid var(--airmail-red); margin: 22px 0; padding: 8px 0 8px 22px; font-family: var(--hand); font-size: 24px; color: var(--postmark-black); }
+.prose-inner code { font-family: var(--mono); font-size: 13px; background: var(--card-cream-deep); padding: 1px 6px; border: 1px solid var(--pencil); }
+.prose-inner a { color: var(--airmail-blue); }
+.prose-inner a:hover { color: var(--airmail-red); }
+
+/* FOOTER */
+.foot { background: var(--card-cream); border-top: 2px solid var(--postmark-black); padding: 0 0 36px; position: relative; }
+.foot-border {
+  height: 14px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='14' viewBox='0 0 32 14'><polygon points='0,0 16,0 0,14' fill='%23b81d28'/><polygon points='16,0 32,0 32,14 0,14' fill='%23f1ead6'/><polygon points='32,0 32,14 16,14' fill='%231d4699'/></svg>");
+  background-repeat: repeat-x;
+  background-size: 32px 14px;
+}
+.foot-wrap { max-width: 1180px; margin: 0 auto; padding: 50px 28px 0; display: grid; grid-template-columns: 1fr 2fr 1fr; gap: 40px; position: relative; }
+.foot-return { font-family: var(--mono); font-size: 12px; color: var(--postmark-black); }
+.foot-label { font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em; text-transform: uppercase; color: var(--airmail-red); margin-bottom: 12px; padding-bottom: 6px; border-bottom: 1px solid var(--postmark-black); }
+.foot-return address { font-style: normal; font-family: var(--hand); font-size: 19px; color: var(--pencil); line-height: 1.4; }
+.foot-cols { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.foot-cols h4 { font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--airmail-blue); margin: 0 0 12px; padding-bottom: 6px; border-bottom: 1px dashed var(--pencil); }
+.foot-cols a { display: block; font-family: var(--mono); font-size: 12px; color: var(--postmark-black); text-decoration: none; padding: 4px 0; border: 0; }
+.foot-cols a:hover { color: var(--airmail-red); }
+.foot-stamps { display: flex; align-items: flex-start; justify-content: flex-end; }
+.foot-stamps .rot-l { transform: rotate(-12deg); }
+.foot-copy { grid-column: 1 / -1; display: flex; justify-content: space-between; flex-wrap: wrap; gap: 12px; margin-top: 30px; padding-top: 20px; border-top: 1px solid var(--postmark-black); font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--pencil); }
+.foot-copy .printed { color: var(--airmail-red); font-weight: 600; }
+
+/* RESPONSIVE */
+@media (max-width: 1000px) {
+  .route-grid { grid-template-columns: 1fr; }
+  .post-steps { grid-template-columns: 1fr; margin-top: 20px; gap: 20px; }
+  .post-svg { display: none; }
+  .dispatch-row { grid-template-columns: 1fr; gap: 50px; }
+  .foot-wrap { grid-template-columns: 1fr; }
+  .foot-cols { grid-template-columns: 1fr 1fr; }
+  .foot-stamps { justify-content: flex-start; margin-top: 10px; }
+}
+
+@media (max-width: 720px) {
+  body { font-size: 14px; }
+  section { padding: 60px 20px; }
+  .hero { padding: 50px 16px 60px; }
+  .hero-deck { min-height: 0; }
+  .card { position: relative; top: auto; left: auto; right: auto; transform: none !important; width: 100%; max-width: 100%; margin-bottom: 24px; }
+  .card .card-inner { grid-template-columns: 1fr; min-height: 0; }
+  .card-left { border-right: 0; border-bottom: 1px dashed var(--pencil); }
+  .postmark.lg, .postmark.md { position: static; margin: 14px auto; transform: rotate(-10deg); }
+  .addr-block { position: static; width: 100%; margin-top: 14px; }
+  .stamp-corner { position: static; margin: 0 0 14px; width: 100%; display: flex; align-items: center; gap: 12px; text-align: left; }
+  .stamp-corner .stamp-bg { width: 96px; }
+  .par-avion.top-left, .par-avion.bot-right { display: none; }
+  .strip-inner { font-size: 9px; gap: 10px; }
+  .foot-cols { grid-template-columns: 1fr; }
+  .prose-inner { padding: 30px 24px; }
+  .section-head { margin-bottom: 36px; }
+  .strip-nav { gap: 10px; flex-wrap: wrap; }
+}

--- a/examples/postcard-route/static/favicon.svg
+++ b/examples/postcard-route/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#f1ead6"/>
+  <rect x="2" y="2" width="28" height="2" fill="#b81d28"/>
+  <rect x="2" y="4" width="28" height="2" fill="#1d4699"/>
+  <rect x="2" y="28" width="28" height="2" fill="#1d4699"/>
+  <rect x="2" y="26" width="28" height="2" fill="#b81d28"/>
+  <circle cx="16" cy="16" r="6" fill="none" stroke="#1a1a1a" stroke-width="1"/>
+  <circle cx="16" cy="16" r="3" fill="none" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="16" y="17" font-family="serif" font-size="3" text-anchor="middle" fill="#1a1a1a">PR</text>
+</svg>

--- a/examples/postcard-route/templates/404.html
+++ b/examples/postcard-route/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-card">
+    <div class="airmail-border thin">
+      <div class="prose-inner">
+        <p class="eyebrow">Return to sender / 404</p>
+        <h1>This card was never posted.</h1>
+        <p>The address you tried to reach has no postmark on file at the bureau. Maybe the route was retired, maybe the slug was misspelled, maybe the desk lost the carbon copy.</p>
+        <p><a href="{{ base_url }}/">&laquo; back to the front desk</a></p>
+      </div>
+    </div>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/postcard-route/templates/footer.html
+++ b/examples/postcard-route/templates/footer.html
@@ -1,0 +1,49 @@
+  <footer class="foot">
+    <div class="foot-border" aria-hidden="true"></div>
+    <div class="foot-wrap">
+      <div class="foot-return">
+        <div class="foot-label">RETURN TO SENDER</div>
+        <address>
+          Bureau of Slow Travel<br>
+          Desk 12, Postcard Route<br>
+          18 Mailroom Lane<br>
+          Seoul 04-021, KR
+        </address>
+      </div>
+      <div class="foot-cols">
+        <div>
+          <h4>The Bureau</h4>
+          <a href="{{ base_url }}/about/">About the desk</a>
+          <a href="#routes">Routes for {{ current_year }}</a>
+          <a href="#dispatches">Recent dispatches</a>
+        </div>
+        <div>
+          <h4>Postage</h4>
+          <a href="#post">How the post works</a>
+          <a href="{{ base_url }}/about/#postage">Stamps &amp; printing</a>
+          <a href="{{ base_url }}/about/#commission">Commission a route</a>
+        </div>
+        <div>
+          <h4>Letters</h4>
+          <a href="mailto:desk12@postcardroute.example">desk12@postcardroute.example</a>
+          <a href="{{ base_url }}/tags/">Read the archive</a>
+          <a href="#post">Mailing list (paper only)</a>
+        </div>
+      </div>
+      <div class="foot-stamps">
+        <div class="postmark sm rot-l" aria-hidden="true">
+          <span class="ring-top">BUREAU OF SLOW TRAVEL</span>
+          <span class="ring-mid">{{ current_year }}</span>
+          <span class="ring-bot">DESK 12</span>
+        </div>
+      </div>
+      <div class="foot-copy">
+        <span>Copyright {{ current_year }} Postcard Route &middot; one card per stop</span>
+        <span class="printed">PRINTED IN SEOUL &middot; press run {{ current_year }}/04</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/postcard-route/templates/header.html
+++ b/examples/postcard-route/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;600;700&family=Reenie+Beanie&family=Rozha+One&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <div class="strip-inner">
+      <span class="bureau">POSTCARD ROUTE <span class="dot">&middot;</span> BUREAU OF SLOW TRAVEL <span class="dot">&middot;</span> DESK 12</span>
+      <nav class="strip-nav">
+        <a href="{{ base_url }}/">Index</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Dispatches</a>
+        <a href="#routes">Routes</a>
+      </nav>
+    </div>
+    <div class="strip-underline" aria-hidden="true"></div>
+  </header>

--- a/examples/postcard-route/templates/index.html
+++ b/examples/postcard-route/templates/index.html
@@ -1,0 +1,284 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="hero-bg">
+    <span class="ornament par-avion top-left" aria-hidden="true">PAR AVION &middot; BY AIR MAIL &middot; PAR AVION</span>
+    <span class="ornament par-avion bot-right" aria-hidden="true">PAR AVION &middot; BY AIR MAIL &middot; PAR AVION</span>
+  </div>
+  <div class="hero-wrap">
+    <div class="hero-deck">
+      <article class="card back card-rot-l">
+        <div class="airmail-border">
+          <div class="card-inner">
+            <div class="card-side card-left">
+              <p class="hand-tiny">Dear traveler,<br>your route begins<br>here. Pack light.</p>
+            </div>
+            <div class="card-side card-right">
+              <div class="addr-mini">
+                <span>To:</span>
+                <p>You<br>Your address</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="card back card-rot-r">
+        <div class="airmail-border">
+          <div class="card-inner">
+            <div class="card-side card-left">
+              <p class="hand-tiny">Sintra in fog. The<br>bakery you wanted<br>was closed. Joy<br>anyway.</p>
+            </div>
+            <div class="card-side card-right">
+              <div class="stamp-corner">
+                <div class="stamp-bg"><span class="king-head" aria-hidden="true"></span></div>
+                <span class="stamp-val">220 KRW</span>
+              </div>
+              <div class="postmark md tilted" aria-hidden="true">
+                <span class="ring-top">SINTRA &middot; PT</span>
+                <span class="ring-mid">{{ current_year }}</span>
+                <span class="ring-bot">DESK 12</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="card front card-rot-c">
+        <div class="airmail-border">
+          <div class="card-inner">
+            <div class="card-side card-left">
+              <p class="card-eyebrow">Specimen postcard / no. 037</p>
+              <h1 class="card-headline">
+                We mail<br>
+                a postcard<br>
+                from every<br>
+                stop.
+              </h1>
+              <p class="hand-note">
+                You pin a route. We post one card per place,<br>
+                stamped and written, while you travel. By the<br>
+                time you are home, the trip already waits<br>
+                in your mailbox.
+              </p>
+              <p class="signoff">&mdash; the desk</p>
+              <div class="card-cta">
+                <a class="btn red" href="#routes">See routes &raquo;</a>
+                <a class="btn blue" href="{{ base_url }}/about/">How it works &raquo;</a>
+              </div>
+            </div>
+            <div class="card-side card-right">
+              <div class="stamp-corner">
+                <div class="stamp-bg"><span class="king-head" aria-hidden="true"></span></div>
+                <span class="stamp-val">220 KRW</span>
+                <span class="stamp-cap">POSTCARD ROUTE</span>
+              </div>
+              <div class="postmark lg tilted" aria-hidden="true">
+                <span class="ring-top">SEOUL &middot; BUREAU 12</span>
+                <span class="ring-mid">{{ current_year }} / 04 / 18</span>
+                <span class="ring-bot">SLOW TRAVEL POST</span>
+              </div>
+              <div class="addr-block">
+                <div class="addr-rules">
+                  <span></span><span></span><span></span><span></span>
+                </div>
+                <div class="addr-text">
+                  <div class="addr-to">To the traveler,</div>
+                  <div class="addr-lines">
+                    <span>Their kitchen table</span>
+                    <span>A quiet street</span>
+                    <span>A city you call home</span>
+                    <span>By the front door</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="routes" id="routes">
+  <div class="wrap">
+    <div class="section-head">
+      <p class="eyebrow">Catalogue / Routes for {{ current_year }}</p>
+      <h2 class="section-title">Pick a route.<br>We do the writing.</h2>
+      <p class="section-lede">Each route ships one card per stop, posted from the town on the day we leave it. Prices include postage to anywhere we can reach by surface or air.</p>
+    </div>
+
+    <div class="route-grid">
+      <article class="route-card r-rot-1">
+        <div class="airmail-border thin">
+          <div class="route-inner">
+            <div class="route-top">
+              <span class="route-no">Route 014</span>
+              <span class="route-len">9 nights &middot; 7 cards</span>
+            </div>
+            <h3 class="route-title">Galway<br><span class="arrow">to</span> Aran<br><span class="arrow">to</span> Connemara</h3>
+            <p class="route-meta">Stone walls, bog roads, the Atlantic always to your left. Mailed from village post offices.</p>
+            <div class="route-foot">
+              <span class="price-stamp"><span class="krw">&#8361;</span>420,000</span>
+              <a class="route-link" href="#">Book this route &rarr;</a>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="route-card r-rot-2">
+        <div class="airmail-border thin">
+          <div class="route-inner">
+            <div class="route-top">
+              <span class="route-no">Route 015</span>
+              <span class="route-len">6 nights &middot; 5 cards</span>
+            </div>
+            <h3 class="route-title">Lisbon<br><span class="arrow">to</span> Sintra<br><span class="arrow">to</span> &Eacute;vora</h3>
+            <p class="route-meta">Tiled walls, slow trains, and a country bakery that closes whenever it wants.</p>
+            <div class="route-foot">
+              <span class="price-stamp"><span class="krw">&#8361;</span>365,000</span>
+              <a class="route-link" href="#">Book this route &rarr;</a>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="route-card r-rot-3">
+        <div class="airmail-border thin">
+          <div class="route-inner">
+            <div class="route-top">
+              <span class="route-no">Route 016</span>
+              <span class="route-len">11 nights &middot; 8 cards</span>
+            </div>
+            <h3 class="route-title">Matsumoto<br><span class="arrow">to</span> Takayama<br><span class="arrow">to</span> Kanazawa</h3>
+            <p class="route-meta">Alpine post-towns by local train. One card per overnight stop, dropped at the morning market.</p>
+            <div class="route-foot">
+              <span class="price-stamp"><span class="krw">&#8361;</span>540,000</span>
+              <a class="route-link" href="#">Book this route &rarr;</a>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="route-card r-rot-4">
+        <div class="airmail-border thin">
+          <div class="route-inner">
+            <div class="route-top">
+              <span class="route-no">Route 017</span>
+              <span class="route-len">7 nights &middot; 6 cards</span>
+            </div>
+            <h3 class="route-title">Oaxaca<br><span class="arrow">to</span> Mitla<br><span class="arrow">to</span> Hierve el Agua</h3>
+            <p class="route-meta">Mezcal towns and limestone terraces. Cards mailed from the central correo, hand-cancelled.</p>
+            <div class="route-foot">
+              <span class="price-stamp"><span class="krw">&#8361;</span>485,000</span>
+              <a class="route-link" href="#">Book this route &rarr;</a>
+            </div>
+          </div>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="post" id="post">
+  <div class="wrap">
+    <div class="section-head">
+      <p class="eyebrow">Mechanics / How the post works</p>
+      <h2 class="section-title">Pin a place.<br>We carry the route.</h2>
+    </div>
+
+    <div class="post-map">
+      <svg class="post-svg" viewBox="0 0 1000 320" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M 80 220 Q 240 60 420 180 T 760 140 Q 880 110 940 200" fill="none" stroke="#1d4699" stroke-width="3" stroke-dasharray="2 14" stroke-linecap="round"/>
+        <circle cx="80" cy="220" r="9" fill="#b81d28" stroke="#1a1a1a" stroke-width="2"/>
+        <circle cx="500" cy="170" r="9" fill="#b81d28" stroke="#1a1a1a" stroke-width="2"/>
+        <circle cx="940" cy="200" r="9" fill="#b81d28" stroke="#1a1a1a" stroke-width="2"/>
+      </svg>
+
+      <div class="post-steps">
+        <article class="post-step">
+          <div class="step-num">01</div>
+          <h3>Pin.</h3>
+          <p>Choose a route from the catalogue or send us a list of places. We confirm postmark availability for each stop.</p>
+          <span class="step-tag">Two-week lead time</span>
+        </article>
+        <article class="post-step">
+          <div class="step-num">02</div>
+          <h3>Plan.</h3>
+          <p>The desk drafts a card for each overnight stop, in pencil first, then in ink. You read drafts before you leave.</p>
+          <span class="step-tag">One card per night</span>
+        </article>
+        <article class="post-step">
+          <div class="step-num">03</div>
+          <h3>Receive.</h3>
+          <p>Each card is mailed the morning we depart the town. They arrive at your address over the following six weeks.</p>
+          <span class="step-tag">Surface or airmail</span>
+        </article>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="dispatches" id="dispatches">
+  <div class="wrap">
+    <div class="section-head">
+      <p class="eyebrow">Mailbag / Recent dispatches</p>
+      <h2 class="section-title">Cards that already<br>arrived somewhere.</h2>
+    </div>
+
+    <div class="dispatch-row">
+      <article class="dispatch d-rot-1">
+        <div class="airmail-border thin">
+          <div class="dispatch-inner">
+            <div class="postmark sm" aria-hidden="true">
+              <span class="ring-top">GALWAY &middot; IE</span>
+              <span class="ring-mid">{{ current_year }} / 03</span>
+              <span class="ring-bot">SLOW POST</span>
+            </div>
+            <p class="quote">&ldquo;The card from Inisheer arrived three weeks after I came home. I had forgotten the wind. The card hadn&rsquo;t.&rdquo;</p>
+            <p class="signer">&mdash; H. Park, Seoul</p>
+            <p class="stop">Route 014 &middot; stop 4 of 7</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="dispatch d-rot-2">
+        <div class="airmail-border thin">
+          <div class="dispatch-inner">
+            <div class="postmark sm" aria-hidden="true">
+              <span class="ring-top">&Eacute;VORA &middot; PT</span>
+              <span class="ring-mid">{{ current_year }} / 02</span>
+              <span class="ring-bot">SLOW POST</span>
+            </div>
+            <p class="quote">&ldquo;Every card was a small interruption of ordinary Tuesday post. The bakery one is on the fridge.&rdquo;</p>
+            <p class="signer">&mdash; M. Lefevre, Lyon</p>
+            <p class="stop">Route 015 &middot; stop 5 of 5</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="dispatch d-rot-3">
+        <div class="airmail-border thin">
+          <div class="dispatch-inner">
+            <div class="postmark sm" aria-hidden="true">
+              <span class="ring-top">KANAZAWA &middot; JP</span>
+              <span class="ring-mid">2025 / 11</span>
+              <span class="ring-bot">SLOW POST</span>
+            </div>
+            <p class="quote">&ldquo;I trusted them to write about a trip I was already on. They knew the streets better than my own notes did.&rdquo;</p>
+            <p class="signer">&mdash; J. Otieno, Nairobi</p>
+            <p class="stop">Route 016 &middot; stop 8 of 8</p>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <div class="dispatch-ornament" aria-hidden="true">
+      <div class="oval-seal">
+        <span>BUREAU OF SLOW TRAVEL &middot; DESK 12 &middot; EST {{ current_year }} &middot;</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/postcard-route/templates/page.html
+++ b/examples/postcard-route/templates/page.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-card">
+    <div class="airmail-border thin">
+      <div class="prose-inner">
+        {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+        {{ content | safe }}
+      </div>
+    </div>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/postcard-route/templates/section.html
+++ b/examples/postcard-route/templates/section.html
@@ -1,0 +1,38 @@
+{% include "header.html" %}
+<section class="dispatches">
+  <div class="wrap">
+    <div class="section-head">
+      {% if page.title is present %}
+      <p class="eyebrow">Section</p>
+      <h2 class="section-title">{{ page.title | e }}</h2>
+      {% endif %}
+    </div>
+    <div class="prose-card">
+      <div class="airmail-border thin">
+        <div class="prose-inner">
+          {{ content | safe }}
+        </div>
+      </div>
+    </div>
+
+    <div class="dispatch-row">
+      {% for post in section.pages %}
+      <article class="dispatch d-rot-1">
+        <div class="airmail-border thin">
+          <div class="dispatch-inner">
+            <div class="postmark sm" aria-hidden="true">
+              <span class="ring-top">{{ post.title | e | truncate(length=12) | upper }}</span>
+              <span class="ring-mid">{{ post.date | date(format="%Y / %m") }}</span>
+              <span class="ring-bot">SLOW POST</span>
+            </div>
+            <p class="quote"><a href="{{ post.url }}">{{ post.title | e }}</a></p>
+            {% if post.description is present %}<p class="signer">{{ post.description | e }}</p>{% endif %}
+          </div>
+        </div>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/postcard-route/templates/shortcodes/alert.html
+++ b/examples/postcard-route/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/postcard-route/templates/taxonomy.html
+++ b/examples/postcard-route/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-card">
+    <div class="airmail-border thin">
+      <div class="prose-inner">
+        <p class="eyebrow">Index of dispatches</p>
+        <h1>{{ page.title | e }}</h1>
+        <p>An index of subjects across the bureau's archive of mailed cards.</p>
+        {{ content | safe }}
+      </div>
+    </div>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/postcard-route/templates/taxonomy_term.html
+++ b/examples/postcard-route/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-card">
+    <div class="airmail-border thin">
+      <div class="prose-inner">
+        <p class="eyebrow">Dispatches under stamp</p>
+        <h1>{{ page.title | e }}</h1>
+        <p>Cards stamped with this subject during the current press run.</p>
+        {{ content | safe }}
+      </div>
+    </div>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/railway-flap/AGENTS.md
+++ b/examples/railway-flap/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/railway-flap/archetypes/default.md
+++ b/examples/railway-flap/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/railway-flap/config.toml
+++ b/examples/railway-flap/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "TRACK 7"
+description = "Track 7 — a sleeper-train booking platform for European overnight rail. Thirty-one cities, one ticket, one bunk."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/railway-flap/content/about.md
+++ b/examples/railway-flap/content/about.md
@@ -1,0 +1,43 @@
++++
+title = "About Track 7"
+description = "Track 7 — company history, sleeper categories, booking policy, refunds, and contact desks."
++++
+
+## A short company history
+
+Track 7 was set up in **2013** by three former carriage attendants who could no longer keep recommending the same six overnight services to friends over coffee. The first version was a printed leaflet with a phone number on the back. The current version sells tickets across **thirty-one European cities** and seven operators, and we still answer the phone.
+
+We have offices behind the station concourse in **Wien Hbf**, a desk in **Zürich HB**, and a posting box in **Paris Gare de l'Est**. The night clerks rotate.
+
+## Sleeper categories explained
+
+We sell every onward berth in three plain categories. The names are ours; the carriages belong to the operators.
+
+- **Seat** — a reserved seat in an open carriage. Bring a coat. Cheapest option, never sold above face value.
+- **Couchette** — a shared compartment, four or six bunks, sheets and a pillow included. Mixed or single-sex on request. Lights out by 23:00.
+- **Sleeper** — a private one- or two-berth cabin with a basin, locking door, and breakfast tray. Single, double, and the rarer **deluxe** with shower.
+
+Children under twelve travel half-price in any class. A dog under ten kilos is free in seat and couchette, twelve euros in sleeper.
+
+## Booking policy
+
+Bookings open **180 days** before departure for most operators, **120 days** for the rest. We hold the inventory; you hold the bunk. We do not oversell.
+
+Tickets are issued as a PDF and a paper voucher on request. **The conductor honours either.** If we cannot issue a ticket within twenty minutes of payment we refund the lot, no questions, no fee.
+
+## Refunds and changes
+
+- **Up to 7 days before departure** — full refund, minus a four-euro desk fee.
+- **48 hours to 7 days** — 50 percent refund.
+- **Under 48 hours** — no cash refund; we will rebook you onto the next available service in the same class within 30 days at no charge.
+- **Service cancelled by the operator** — full refund within five working days, regardless of when you booked.
+
+Changes of name, date, or class can be made by writing to the desk. We answer in order of departure, soonest first.
+
+## Contact desks
+
+- **Vienna desk** — `wien@track7.example` &middot; +43 1 555 0707
+- **Zürich desk** — `zrh@track7.example` &middot; +41 44 555 0707
+- **Paris box** — Gare de l'Est, voie 7, casier 12
+- **General** — `desk@track7.example`
+- **Working hours** — 06:00 to 22:00, every day the trains run.

--- a/examples/railway-flap/content/index.md
+++ b/examples/railway-flap/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Track 7 — a sleeper-train booking platform for European overnight rail. Thirty-one cities, one ticket, one bunk."
+template = "index"
++++

--- a/examples/railway-flap/static/css/style.css
+++ b/examples/railway-flap/static/css/style.css
@@ -1,0 +1,713 @@
+/* TRACK 7 — 1960s British Railways departure board */
+
+:root {
+  --slate: #1a1a1a;
+  --slate-2: #0f0f0f;
+  --flap-edge: #2c2c2c;
+  --chalk: #f4ecd6;
+  --chalk-deep: #e0d6bb;
+  --chalk-rule: #b9ad8a;
+  --oxford-blue: #11315e;
+  --signal-red: #c8232c;
+  --mustard: #c39627;
+  --ink: #0a0a0a;
+  --sans: "Roboto Condensed", "Arial Narrow", Arial, sans-serif;
+  --display: "Oswald", "Bebas Neue", "Roboto Condensed", "Arial Narrow", sans-serif;
+  --board: "Bebas Neue", "Oswald", "Roboto Condensed", "Arial Narrow", sans-serif;
+  --mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--chalk);
+  color: var(--ink);
+  overflow-x: hidden;
+}
+
+body {
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--oxford-blue);
+  text-decoration: none;
+  border-bottom: 1px solid var(--oxford-blue);
+}
+a:hover { background: var(--oxford-blue); color: var(--chalk); }
+
+::selection { background: var(--signal-red); color: var(--chalk); }
+
+/* ============================================================
+   TOP STRIP — slate header
+   ============================================================ */
+.strip-top {
+  background: var(--slate);
+  color: var(--chalk);
+  padding: 10px 28px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 24px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  border-bottom: 3px double var(--chalk);
+}
+.strip-top .brand {
+  color: var(--chalk);
+  border: 0;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 0.14em;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.strip-top .brand:hover { background: transparent; color: var(--signal-red); }
+.strip-top .brand .dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--signal-red);
+  border-radius: 50%;
+}
+.strip-top .mid { text-align: center; color: var(--chalk-deep); }
+.strip-top nav { display: inline-flex; gap: 22px; justify-self: end; }
+.strip-top nav a {
+  color: var(--chalk);
+  border: 0;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.strip-top nav a:hover { background: transparent; border-bottom-color: var(--signal-red); color: var(--chalk); }
+
+/* ============================================================
+   BOARD — hero flap-board
+   ============================================================ */
+.board {
+  background: var(--chalk);
+  padding: 48px 28px 56px;
+  border-bottom: 1px solid var(--chalk-rule);
+}
+.board-frame {
+  max-width: 1240px;
+  margin: 0 auto;
+  background: var(--slate);
+  border: 6px solid var(--slate);
+  outline: 2px solid var(--chalk);
+  outline-offset: -14px;
+  padding: 22px 22px 28px;
+  position: relative;
+}
+.board-frame::before,
+.board-frame::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background: var(--chalk);
+  border: 2px solid var(--slate);
+  border-radius: 50%;
+}
+.board-frame::before { top: 8px; left: 8px; }
+.board-frame::after { top: 8px; right: 8px; }
+
+.board-header {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  color: var(--chalk-deep);
+  padding: 4px 12px 14px;
+  border-bottom: 1px solid var(--flap-edge);
+}
+.board-header .bh-mid { text-align: center; color: var(--signal-red); font-weight: 700; }
+.board-header .bh-right { text-align: right; }
+
+.board-col-head {
+  display: grid;
+  grid-template-columns: 96px 1fr 90px 160px;
+  gap: 20px;
+  padding: 12px 12px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  color: var(--chalk-deep);
+  border-bottom: 1px solid var(--flap-edge);
+}
+
+.board-grid { padding-bottom: 14px; }
+
+.board-row {
+  display: grid;
+  grid-template-columns: 96px 1fr 90px 160px;
+  gap: 20px;
+  align-items: center;
+  padding: 14px 12px;
+  border-bottom: 1px solid var(--flap-edge);
+}
+.board-row:last-child { border-bottom: 0; }
+
+.board-row .time {
+  font-family: var(--mono);
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--chalk);
+  letter-spacing: 0.05em;
+}
+
+.board-row .dest {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* The flap tile */
+.flap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--slate-2);
+  color: var(--chalk);
+  font-family: var(--board);
+  font-weight: 700;
+  font-size: 6vw;
+  line-height: 1;
+  width: 6.4vw;
+  height: 8vw;
+  max-width: 84px;
+  max-height: 108px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  box-shadow:
+    inset 0 1px 0 var(--flap-edge),
+    inset 0 -1px 0 var(--flap-edge),
+    inset 0 0 0 1px #050505;
+  position: relative;
+  border-radius: 2px;
+}
+.flap::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  background: rgba(0, 0, 0, 0.55);
+  box-shadow: 0 -1px 0 rgba(255, 255, 255, 0.04);
+}
+.flap.sp {
+  background: transparent;
+  box-shadow: none;
+  width: 1.6vw;
+}
+.flap.sp::after { display: none; }
+
+.board-row .plat {
+  font-family: var(--mono);
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--chalk);
+  text-align: center;
+  border: 1px solid var(--flap-edge);
+  padding: 6px 0;
+}
+
+.board-row .status {
+  text-align: center;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 0.16em;
+  padding: 10px 6px;
+  border: 1px solid transparent;
+}
+.status.ok { color: var(--chalk); border-color: var(--flap-edge); }
+.status.hot { background: var(--signal-red); color: var(--chalk); }
+.status.delay { background: var(--mustard); color: var(--slate); }
+
+.board-foot {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 3px double var(--flap-edge);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: end;
+}
+.tagline {
+  margin: 0;
+  font-family: var(--display);
+  font-size: 22px;
+  font-weight: 400;
+  color: var(--chalk);
+  line-height: 1.25;
+  max-width: 580px;
+  letter-spacing: 0.01em;
+}
+.board-cta { display: inline-flex; gap: 10px; flex-wrap: wrap; }
+
+.btn {
+  display: inline-block;
+  padding: 12px 18px;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border: 1px solid var(--chalk);
+  color: var(--chalk);
+  background: transparent;
+}
+.btn:hover { background: var(--chalk); color: var(--slate); }
+.btn.primary { background: var(--signal-red); border-color: var(--signal-red); color: var(--chalk); }
+.btn.primary:hover { background: var(--chalk); color: var(--signal-red); border-color: var(--chalk); }
+.btn.ghost { color: var(--chalk); }
+
+/* ============================================================
+   SECTION HEADS
+   ============================================================ */
+.wrap { max-width: 1240px; margin: 0 auto; padding: 0 28px; }
+
+.section-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: 24px;
+  padding-bottom: 18px;
+  margin-bottom: 28px;
+  border-bottom: 3px double var(--ink);
+}
+.section-head .kicker {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  color: var(--signal-red);
+  margin-bottom: 6px;
+}
+.section-head h2 {
+  margin: 0;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: clamp(28px, 3.4vw, 44px);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.section-head .sh-right {
+  display: inline-flex;
+  gap: 14px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: var(--slate);
+}
+.section-head .legend b {
+  display: inline-block;
+  background: var(--ink);
+  color: var(--chalk);
+  width: 16px;
+  height: 16px;
+  text-align: center;
+  font-weight: 700;
+  margin-right: 4px;
+}
+
+/* ============================================================
+   ROUTES — fares table
+   ============================================================ */
+.routes { background: var(--chalk); padding: 64px 0 72px; }
+
+.fares {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--sans);
+  font-size: 15px;
+  background: var(--chalk);
+  border: 1px solid var(--ink);
+  border-top: 4px solid var(--ink);
+  border-bottom: 4px solid var(--ink);
+}
+.fares thead th {
+  background: var(--ink);
+  color: var(--chalk);
+  text-align: left;
+  padding: 12px 14px;
+  font-family: var(--display);
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.fares thead th.r, .fares td.r { text-align: right; }
+.fares thead th.num, .fares td.num { width: 60px; text-align: center; }
+.fares tbody td {
+  padding: 14px;
+  border-bottom: 1px solid var(--chalk-rule);
+  vertical-align: middle;
+}
+.fares tbody tr:nth-child(even) td { background: var(--chalk-deep); }
+.fares tbody tr:last-child td { border-bottom: 0; }
+.fares td.num {
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--signal-red);
+}
+.fares td.mn { font-family: var(--mono); font-size: 14px; }
+.fares td b { font-weight: 700; color: var(--ink); }
+.fares td.r b { color: var(--oxford-blue); }
+
+.table-note {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--slate);
+  margin: 14px 0 0;
+}
+
+/* ============================================================
+   HOW — platform-direction sign steps
+   ============================================================ */
+.how {
+  background: var(--oxford-blue);
+  color: var(--chalk);
+  padding: 64px 0 72px;
+}
+.how .section-head { border-bottom-color: var(--chalk); }
+.how .section-head h2 { color: var(--chalk); }
+.how .section-head .kicker { color: var(--mustard); }
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.step {
+  background: var(--chalk);
+  color: var(--ink);
+  padding: 0;
+  border: 3px solid var(--ink);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+.step .arrow {
+  background: var(--ink);
+  color: var(--chalk);
+  padding: 18px 22px;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+}
+.step .arrow::before {
+  content: "";
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  background: var(--ink);
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+}
+.step .arrow.left::before { left: -11px; }
+.step .arrow.right::before { right: -11px; }
+.step .arrow .num {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 44px;
+  letter-spacing: 0;
+  color: var(--chalk);
+}
+.step h3 {
+  margin: 0;
+  padding: 22px 22px 6px;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.step p {
+  margin: 0;
+  padding: 6px 22px 24px;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+/* ============================================================
+   BULLETINS
+   ============================================================ */
+.bulletins { background: var(--chalk); padding: 64px 0 72px; }
+
+.bulletins .section-head .stamp {
+  border: 2px solid var(--signal-red);
+  color: var(--signal-red);
+  padding: 4px 10px;
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  transform: rotate(-1.5deg);
+}
+
+.bull-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+.bull {
+  background: var(--chalk-deep);
+  border: 1px solid var(--ink);
+  border-left: 8px solid var(--signal-red);
+  padding: 18px 22px;
+}
+.bull header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--slate);
+  align-items: center;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px dashed var(--chalk-rule);
+}
+.bull .b-no {
+  background: var(--ink);
+  color: var(--chalk);
+  padding: 3px 8px;
+  font-weight: 700;
+}
+.bull .b-tag {
+  background: var(--signal-red);
+  color: var(--chalk);
+  padding: 3px 8px;
+  font-weight: 700;
+}
+.bull .b-tag.warn { background: var(--mustard); color: var(--slate); }
+.bull .b-tag.good { background: var(--oxford-blue); color: var(--chalk); }
+.bull .b-when { margin-left: auto; color: var(--slate); }
+.bull h3 {
+  margin: 0 0 6px;
+  font-family: var(--display);
+  font-size: 22px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.bull h3 a { color: inherit; border: 0; }
+.bull h3 a:hover { background: transparent; color: var(--signal-red); }
+.bull p { margin: 0; font-size: 15px; line-height: 1.6; color: var(--slate); }
+.bull p b { color: var(--ink); }
+
+/* ============================================================
+   PROSE — about / page
+   ============================================================ */
+.prose {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 56px 28px 72px;
+}
+.page-head {
+  border-bottom: 3px double var(--ink);
+  padding-bottom: 18px;
+  margin-bottom: 28px;
+}
+.page-head .kicker {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  color: var(--signal-red);
+  margin-bottom: 8px;
+}
+.prose h1 {
+  margin: 0;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: clamp(32px, 4vw, 48px);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.prose h2 {
+  margin: 38px 0 12px;
+  font-family: var(--display);
+  font-size: 24px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--ink);
+  padding-bottom: 4px;
+}
+.prose h3 {
+  margin: 24px 0 8px;
+  font-family: var(--display);
+  font-size: 18px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.prose p, .prose li { font-size: 16px; line-height: 1.7; }
+.prose ul, .prose ol { padding-left: 22px; }
+.prose ul li { margin-bottom: 6px; }
+.prose blockquote {
+  margin: 22px 0;
+  padding: 14px 22px;
+  background: var(--chalk-deep);
+  border-left: 6px solid var(--signal-red);
+  font-family: var(--display);
+  font-size: 19px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.prose code {
+  font-family: var(--mono);
+  background: var(--chalk-deep);
+  padding: 1px 6px;
+  font-size: 14px;
+}
+
+/* ============================================================
+   FOOTER — BR colophon
+   ============================================================ */
+.foot {
+  background: var(--slate);
+  color: var(--chalk);
+  padding: 56px 0 28px;
+  border-top: 4px solid var(--signal-red);
+}
+.foot .wrap { padding: 0 28px; }
+
+.colophon {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 28px;
+  padding-bottom: 28px;
+  border-bottom: 1px solid var(--flap-edge);
+  margin-bottom: 28px;
+}
+.colophon .mark {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 3px solid var(--chalk);
+  padding: 10px 16px;
+}
+.colophon .mark .seven {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 56px;
+  line-height: 1;
+  color: var(--signal-red);
+}
+.colophon .mark .lines {
+  display: flex;
+  flex-direction: column;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 20px;
+  letter-spacing: 0.18em;
+  color: var(--chalk);
+  line-height: 1.05;
+}
+.colophon .working {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.28em;
+  color: var(--chalk-deep);
+  text-align: right;
+}
+
+.foot .grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 28px;
+  padding-bottom: 28px;
+  border-bottom: 1px solid var(--flap-edge);
+}
+.foot h4 {
+  margin: 0 0 12px;
+  font-family: var(--display);
+  font-size: 13px;
+  letter-spacing: 0.24em;
+  color: var(--signal-red);
+}
+.foot a {
+  display: block;
+  color: var(--chalk-deep);
+  border: 0;
+  font-size: 13px;
+  padding: 3px 0;
+  font-family: var(--sans);
+}
+.foot a:hover { background: transparent; color: var(--chalk); }
+
+.foot .copy {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 18px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--chalk-deep);
+  padding-top: 22px;
+}
+.foot .copy span:last-child { text-align: right; }
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width: 980px) {
+  .strip-top { grid-template-columns: 1fr; text-align: center; gap: 10px; }
+  .strip-top nav { justify-self: center; flex-wrap: wrap; justify-content: center; }
+  .board-col-head, .board-row {
+    grid-template-columns: 80px 1fr 60px 110px;
+    gap: 12px;
+  }
+  .board-row .time { font-size: 22px; }
+  .board-row .plat { font-size: 20px; }
+  .board-row .status { font-size: 14px; }
+  .flap { font-size: 8vw; width: 8.6vw; height: 11vw; }
+  .board-foot { grid-template-columns: 1fr; }
+  .steps { grid-template-columns: 1fr; }
+  .foot .grid { grid-template-columns: repeat(2, 1fr); }
+  .colophon { grid-template-columns: 1fr; }
+  .colophon .working { text-align: left; }
+  .foot .copy { grid-template-columns: 1fr; }
+  .foot .copy span:last-child { text-align: left; }
+}
+
+@media (max-width: 640px) {
+  .board { padding: 28px 12px 36px; }
+  .board-frame { padding: 16px 12px 20px; }
+  .board-header { font-size: 9px; }
+  .board-col-head { display: none; }
+  .board-row {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: "time status" "dest dest" "plat plat";
+    gap: 10px;
+  }
+  .board-row .time { grid-area: time; }
+  .board-row .dest { grid-area: dest; }
+  .board-row .plat { grid-area: plat; }
+  .board-row .status { grid-area: status; }
+  .flap { font-size: 10vw; width: 11vw; height: 14vw; }
+  .fares { font-size: 13px; }
+  .fares thead th, .fares tbody td { padding: 10px 8px; }
+}

--- a/examples/railway-flap/static/favicon.svg
+++ b/examples/railway-flap/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#1a1a1a"/>
+  <rect x="3" y="14" width="26" height="4" fill="#f4ecd6"/>
+  <rect x="3" y="15.5" width="26" height="1" fill="#2c2c2c"/>
+  <text x="16" y="11" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#f4ecd6">7</text>
+  <rect x="3" y="22" width="26" height="2" fill="#c8232c"/>
+</svg>

--- a/examples/railway-flap/templates/404.html
+++ b/examples/railway-flap/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="page-head">
+    <span class="kicker">/ TRACK 7 &middot; OFFICE NOTICE</span>
+    <h1>404 &middot; SERVICE NOT FOUND</h1>
+  </div>
+  <p>This train is not on the board. Either the service has been withdrawn, the platform has changed, or you have entered the wrong working timetable extract.</p>
+  <p>Try the <a href="{{ base_url }}/">front board</a>, or speak to the duty clerk at the <a href="{{ base_url }}/about/#contact-desks">Vienna desk</a>.</p>
+</article>
+{% include "footer.html" %}

--- a/examples/railway-flap/templates/footer.html
+++ b/examples/railway-flap/templates/footer.html
@@ -1,0 +1,48 @@
+  <footer class="foot">
+    <div class="wrap">
+      <div class="colophon">
+        <div class="mark">
+          <div class="seven">7</div>
+          <div class="lines">
+            <span>TRACK</span>
+            <span>SEVEN</span>
+          </div>
+        </div>
+        <p class="working">&mdash; FOR PRIVATE WORKING TIMETABLE USE ONLY &mdash;</p>
+      </div>
+      <div class="grid">
+        <div>
+          <h4>BOOKING</h4>
+          <a href="#routes">Routes &amp; fares</a>
+          <a href="{{ base_url }}/about/#sleeper-categories-explained">Sleeper categories</a>
+          <a href="{{ base_url }}/about/#refunds-and-changes">Refunds &amp; changes</a>
+        </div>
+        <div>
+          <h4>DESKS</h4>
+          <a href="{{ base_url }}/about/#contact-desks">Wien Hbf &mdash; office 7</a>
+          <a href="{{ base_url }}/about/#contact-desks">Z&uuml;rich HB &mdash; desk 4</a>
+          <a href="{{ base_url }}/about/#contact-desks">Paris Gare de l'Est</a>
+        </div>
+        <div>
+          <h4>SERVICE</h4>
+          <a href="{{ base_url }}/tags/">Bulletins</a>
+          <a href="{{ base_url }}/about/">About Track 7</a>
+          <a href="#bulletins">Engineering work</a>
+        </div>
+        <div>
+          <h4>REACH</h4>
+          <a href="{{ base_url }}/about/#contact-desks">desk@track7.example</a>
+          <a href="{{ base_url }}/about/#contact-desks">+43 1 555 0707</a>
+          <a href="{{ base_url }}/about/#contact-desks">06:00&ndash;22:00 CET</a>
+        </div>
+      </div>
+      <div class="copy">
+        <span>&copy; {{ current_year }} TRACK 7 BOOKING OFFICE &middot; WIEN &middot; Z&Uuml;RICH &middot; PARIS</span>
+        <span>HWARO BUILD &middot; ISSUE {{ current_year }}.04 &middot; PWTT EXTRACT</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/railway-flap/templates/header.html
+++ b/examples/railway-flap/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=IBM+Plex+Mono:wght@400;500;700&family=Oswald:wght@400;500;700&family=Roboto+Condensed:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <a class="brand" href="{{ base_url }}/"><span class="dot"></span> TRACK 7</a>
+    <span class="mid">NIGHT SERVICE &middot; DESKS OPEN 06:00&ndash;22:00 &middot; CET</span>
+    <nav>
+      <a href="{{ base_url }}/about/">ABOUT</a>
+      <a href="{{ base_url }}/tags/">BULLETINS</a>
+      <a href="#routes">ROUTES</a>
+    </nav>
+  </header>

--- a/examples/railway-flap/templates/index.html
+++ b/examples/railway-flap/templates/index.html
@@ -1,0 +1,230 @@
+{% include "header.html" %}
+
+<section class="board">
+  <div class="board-frame">
+    <div class="board-header">
+      <span class="bh-left">DEPARTURES &middot; ABFAHRT &middot; D&Eacute;PARTS</span>
+      <span class="bh-mid">TRACK 7 / NIGHT SERVICE</span>
+      <span class="bh-right">{{ current_year }}.04.18 &middot; CET</span>
+    </div>
+
+    <div class="board-grid">
+      <div class="board-col-head">
+        <span>TIME</span><span>DESTINATION</span><span>PLATFORM</span><span>STATUS</span>
+      </div>
+
+      <div class="board-row">
+        <div class="time">21:42</div>
+        <div class="dest">
+          <span class="flap">P</span><span class="flap">A</span><span class="flap">R</span><span class="flap">I</span><span class="flap">S</span><span class="flap sp"></span><span class="flap">N</span><span class="flap">O</span><span class="flap">R</span><span class="flap">D</span>
+        </div>
+        <div class="plat">12</div>
+        <div class="status ok">ON TIME</div>
+      </div>
+
+      <div class="board-row">
+        <div class="time">22:08</div>
+        <div class="dest">
+          <span class="flap">V</span><span class="flap">I</span><span class="flap">E</span><span class="flap">N</span><span class="flap">N</span><span class="flap">A</span>
+        </div>
+        <div class="plat">04</div>
+        <div class="status hot">BOARDING</div>
+      </div>
+
+      <div class="board-row">
+        <div class="time">22:35</div>
+        <div class="dest">
+          <span class="flap">Z</span><span class="flap">U</span><span class="flap">R</span><span class="flap">I</span><span class="flap">C</span><span class="flap">H</span>
+        </div>
+        <div class="plat">07</div>
+        <div class="status ok">ON TIME</div>
+      </div>
+
+      <div class="board-row">
+        <div class="time">23:11</div>
+        <div class="dest">
+          <span class="flap">V</span><span class="flap">E</span><span class="flap">N</span><span class="flap">I</span><span class="flap">C</span><span class="flap">E</span>
+        </div>
+        <div class="plat">02</div>
+        <div class="status delay">+12 MIN</div>
+      </div>
+    </div>
+
+    <div class="board-foot">
+      <p class="tagline">Sleeper trains to thirty-one European cities &mdash; booked end to end.</p>
+      <div class="board-cta">
+        <a class="btn primary" href="#routes">SEE THE ROUTES &raquo;</a>
+        <a class="btn ghost" href="{{ base_url }}/about/">HOW IT WORKS &raquo;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="routes" id="routes">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="sh-left">
+        <span class="kicker">/ 02 &middot; FARES</span>
+        <h2>OVERNIGHT ROUTES &mdash; SUMMER TIMETABLE</h2>
+      </div>
+      <div class="sh-right">
+        <span class="legend"><b>S</b> sleeper</span>
+        <span class="legend"><b>C</b> couchette</span>
+        <span class="legend"><b>R</b> seat</span>
+      </div>
+    </div>
+
+    <table class="fares">
+      <thead>
+        <tr>
+          <th class="num">No.</th>
+          <th>Route</th>
+          <th>Depart</th>
+          <th>Arrive</th>
+          <th>Train</th>
+          <th class="r">Sleeper</th>
+          <th class="r">Couchette</th>
+          <th class="r">Seat</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="num">01</td>
+          <td><b>Paris</b> &rarr; Vienna</td>
+          <td class="mn">19:58</td>
+          <td class="mn">10:14</td>
+          <td>NJ 463</td>
+          <td class="r"><b>&euro;229</b></td>
+          <td class="r">&euro;119</td>
+          <td class="r">&euro;69</td>
+        </tr>
+        <tr>
+          <td class="num">02</td>
+          <td><b>Munich</b> &rarr; Rome</td>
+          <td class="mn">19:42</td>
+          <td class="mn">09:36</td>
+          <td>NJ 295</td>
+          <td class="r"><b>&euro;199</b></td>
+          <td class="r">&euro;109</td>
+          <td class="r">&euro;59</td>
+        </tr>
+        <tr>
+          <td class="num">03</td>
+          <td><b>Berlin</b> &rarr; Z&uuml;rich</td>
+          <td class="mn">20:54</td>
+          <td class="mn">08:31</td>
+          <td>NJ 471</td>
+          <td class="r"><b>&euro;189</b></td>
+          <td class="r">&euro;99</td>
+          <td class="r">&euro;55</td>
+        </tr>
+        <tr>
+          <td class="num">04</td>
+          <td><b>Amsterdam</b> &rarr; Innsbruck</td>
+          <td class="mn">20:30</td>
+          <td class="mn">09:10</td>
+          <td>NJ 421</td>
+          <td class="r"><b>&euro;219</b></td>
+          <td class="r">&euro;115</td>
+          <td class="r">&euro;65</td>
+        </tr>
+        <tr>
+          <td class="num">05</td>
+          <td><b>Stockholm</b> &rarr; Hamburg</td>
+          <td class="mn">17:20</td>
+          <td class="mn">07:48</td>
+          <td>SJ 301</td>
+          <td class="r"><b>&euro;239</b></td>
+          <td class="r">&euro;129</td>
+          <td class="r">&euro;79</td>
+        </tr>
+        <tr>
+          <td class="num">06</td>
+          <td><b>Brussels</b> &rarr; Prague</td>
+          <td class="mn">19:22</td>
+          <td class="mn">10:56</td>
+          <td>EN 457</td>
+          <td class="r"><b>&euro;209</b></td>
+          <td class="r">&euro;105</td>
+          <td class="r">&euro;62</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="table-note">&mdash; Fares quoted per adult, one-way, including bed linen and morning tray where applicable. Subject to operator availability. PWTT extract; supersedes all earlier prints.</p>
+  </div>
+</section>
+
+<section class="how">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="sh-left">
+        <span class="kicker">/ 03 &middot; PROCEDURE</span>
+        <h2>HOW TRACK 7 WORKS</h2>
+      </div>
+    </div>
+
+    <div class="steps">
+      <article class="step">
+        <div class="arrow left"><span class="num">01</span></div>
+        <h3>PICK THE TRAIN</h3>
+        <p>Search by city or by night. We show <b>every operator</b> on the night corridor &mdash; NJ, EN, IC, the private carriages &mdash; in one list, sorted by time.</p>
+      </article>
+      <article class="step">
+        <div class="arrow right"><span class="num">02</span></div>
+        <h3>PICK THE BUNK</h3>
+        <p>Seat, couchette, sleeper. We hold the exact berth and confirm it with the operator before we take a euro. <b>No oversells.</b></p>
+      </article>
+      <article class="step">
+        <div class="arrow left"><span class="num">03</span></div>
+        <h3>BOARD AT TRACK 7</h3>
+        <p>PDF voucher to your phone, paper voucher on request. The conductor honours either &mdash; <b>you keep the bed</b>.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="bulletins" id="bulletins">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="sh-left">
+        <span class="kicker">/ 04 &middot; AMENDMENTS</span>
+        <h2>SERVICE BULLETINS &mdash; THIS WEEK</h2>
+      </div>
+      <div class="sh-right"><span class="stamp">PWTT 04 / {{ current_year }}</span></div>
+    </div>
+
+    <div class="bull-list">
+      <article class="bull">
+        <header>
+          <span class="b-no">BULL. 047</span>
+          <span class="b-tag">ENGINEERING WORK</span>
+          <span class="b-when">SUN 21:00 &rarr; MON 05:00</span>
+        </header>
+        <h3>MUNICH &rarr; VENICE &mdash; Brenner detour</h3>
+        <p>Track works between Innsbruck and Brennero. Service NJ 295 will be diverted via the Reschenpass; <b>arrival delayed 78 minutes</b>. Sleeper passengers will receive a complimentary tray service. Couchette curtains remain closed until 07:30.</p>
+      </article>
+
+      <article class="bull">
+        <header>
+          <span class="b-no">BULL. 048</span>
+          <span class="b-tag warn">PLATFORM CHANGE</span>
+          <span class="b-when">NIGHTLY UNTIL FRI</span>
+        </header>
+        <h3>PARIS GARE DE L'EST &mdash; voie 7 closed</h3>
+        <p>Voie 7 is out of use for night-bag screening installation. The Track 7 desk and all NJ 463 boardings will move to <b>voie 4</b>. Signage is posted; the porter knows; the conductor knows.</p>
+      </article>
+
+      <article class="bull">
+        <header>
+          <span class="b-no">BULL. 049</span>
+          <span class="b-tag good">NEW SERVICE</span>
+          <span class="b-when">FROM 18 MAY</span>
+        </header>
+        <h3>BERLIN &rarr; STOCKHOLM &mdash; restored</h3>
+        <p>The Berlin&ndash;Stockholm night service returns on 18 May after a four-year gap. Three sleepers, two couchette cars, one seat carriage. Booking opens 180 days out, as usual. Tickets at the desk before they reach the screens.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/railway-flap/templates/page.html
+++ b/examples/railway-flap/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="page-head">
+    <span class="kicker">/ TRACK 7 &middot; OFFICE NOTICE</span>
+    {% if page.title is present %}<h1>{{ page.title | e | upper }}</h1>{% endif %}
+  </div>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/railway-flap/templates/section.html
+++ b/examples/railway-flap/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<section class="bulletins">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="sh-left">
+        <span class="kicker">/ TRACK 7 &middot; INDEX</span>
+        {% if page.title is present %}<h2>{{ page.title | e | upper }}</h2>{% endif %}
+      </div>
+    </div>
+    {{ content | safe }}
+    <div class="bull-list">
+      {% for post in section.pages %}
+      <article class="bull">
+        <header>
+          <span class="b-no">BULL. {{ loop.index | string | pad_start(3, "0") }}</span>
+          <span class="b-when">{{ post.date | date(format="%Y / %m / %d") }}</span>
+        </header>
+        <h3><a href="{{ post.url }}">{{ post.title | e | upper }}</a></h3>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/railway-flap/templates/shortcodes/alert.html
+++ b/examples/railway-flap/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/railway-flap/templates/taxonomy.html
+++ b/examples/railway-flap/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="page-head">
+    <span class="kicker">/ TRACK 7 &middot; INDEX</span>
+    <h1>{{ page.title | e | upper }}</h1>
+  </div>
+  <p>&mdash; Subject index across the bulletins and notices.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/railway-flap/templates/taxonomy_term.html
+++ b/examples/railway-flap/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="page-head">
+    <span class="kicker">/ TRACK 7 &middot; FILED UNDER</span>
+    <h1>{{ page.title | e | upper }}</h1>
+  </div>
+  <p>&mdash; Bulletins filed under this stamp.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/rink-zamboni/AGENTS.md
+++ b/examples/rink-zamboni/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/rink-zamboni/archetypes/default.md
+++ b/examples/rink-zamboni/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/rink-zamboni/config.toml
+++ b/examples/rink-zamboni/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "SHEET 4"
+description = "Sheet 4 — a pickup ice-hockey league running stick-time, drop-in shinny, and adult-beginner sessions at the community rink. Sign up by the session."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/rink-zamboni/content/about.md
+++ b/examples/rink-zamboni/content/about.md
@@ -1,0 +1,37 @@
++++
+title = "About Sheet 4"
+description = "Sheet 4 — the community rink, the pickup league, age groups, gear and safety, and how to reach the desk."
++++
+
+## The rink
+
+Sheet 4 is the smallest of four sheets at the community rink &mdash; barn 2, door C. NHL spec, 200 by 85, dasher boards painted black, glass to the top. The compressor's older than most of us; the ice is harder than most rinks. The zamboni runs every thirty minutes on the half-hour, and that's the rule we keep above everything else.
+
+## The league
+
+We're a pickup league, not a registered association. Sign up by the session. Pay by the session. Show up by the session. There is no playoff, no trophy, no standings sheet, no captains. Lines are drawn by the desk at 20:55 from whoever made the gate. Goalies are slotted first, then skaters in order of arrival.
+
+## Age groups
+
+- **Family Ice (Sun 10:00)** &mdash; all ages. Kids under twelve skate with a hand. No pucks on the ice.
+- **Beginner Clinic (Tue 19:30)** &mdash; ages 18+. Adults who have never played, or have not played in a long time. Skates and a stick; we lend the rest.
+- **Stick-Time (Mon/Thu)** &mdash; ages 16+. No game, no scoring &mdash; pass, shoot, work on edges.
+- **Shinny (Wed/Sat)** &mdash; ages 18+ on Wednesday, 21+ on Saturday late. Game format. No slapshots, no body contact.
+
+## Gear and safety
+
+Required, every session, no exceptions: **helmet** (cage or visor), **mouthguard** for clinic and shinny, **hockey gloves** (not work gloves, not gardening gloves), and **shin guards** at a minimum. Full pads &mdash; elbows, shoulders, breezers, jock &mdash; are strongly recommended for shinny, and required for the under-18 sessions when we run them. The rink ref will turn you away at the gate, and we'll back her.
+
+> Helmets are not negotiable. We've seen the alternative.
+
+A first-aid kit is on the wall next to the timing console. The barn manager keeps a defibrillator behind the desk. If somebody goes down, the buzzer is the signal &mdash; clear the ice and stay clear until the manager waves you back on.
+
+## How to reach the desk
+
+- **Sign-up** &mdash; opens Sunday at noon; closes one hour before puck drop.
+- **Email** &mdash; `ice@sheet-four.rink`
+- **Sub list** &mdash; text the desk; we don't keep an email list anymore.
+- **Lost & found** &mdash; bin 4B in barn 2. Sticks lean on the rack outside it. Anything that's been there four weeks goes to the youth program.
+- **Cancellations** &mdash; by 18:00 on session day for credit. After that, the seat's gone, and so is the fee. Subs are welcome; arrange them yourself and tell the desk who's skating.
+
+The rink doesn't take cards. We don't take cards. Cash or e-transfer, both at the desk.

--- a/examples/rink-zamboni/content/index.md
+++ b/examples/rink-zamboni/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "SHEET 4 — pickup ice-hockey at the community rink. Stick-time, drop-in shinny, adult-beginner clinics. Sign up by the session."
+template = "index"
++++

--- a/examples/rink-zamboni/static/css/style.css
+++ b/examples/rink-zamboni/static/css/style.css
@@ -1,0 +1,509 @@
+/* =============================================================================
+   SHEET 4 — community-rink pickup league
+   Scoreboard + rink-line aesthetic. Solid colors only, no gradients.
+   ============================================================================= */
+
+:root {
+  --ice-white: #eef3f6;
+  --ice-shadow: #d5dee4;
+  --rink-blue: #1e64a3;
+  --center-red: #c1232b;
+  --scoreboard-black: #0c0c0c;
+  --panel-charcoal: #1a1a1a;
+  --penalty-orange: #ff8c1a;
+  --jersey-cream: #f0e8ce;
+  --crease-blue: #b8d5e8;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  background: var(--ice-white);
+  color: var(--scoreboard-black);
+  font-family: 'Inter Tight', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+a:hover { color: var(--center-red); }
+img, svg { display: block; max-width: 100%; }
+
+/* TOP STRIP — scoreboard header ---------------------------------------------- */
+.top-strip {
+  background: var(--scoreboard-black);
+  color: var(--ice-white);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 24px;
+  border-bottom: 4px solid var(--center-red);
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.ts-left { display: flex; align-items: center; gap: 12px; }
+.ts-left .dot {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--center-red); border: 2px solid var(--ice-white);
+}
+.ts-title {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 13px; letter-spacing: 0.18em; font-weight: 600;
+}
+.ts-clock {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 18px; letter-spacing: 0.1em;
+  color: var(--penalty-orange); background: #000;
+  padding: 4px 14px; border: 2px solid #2a2a2a;
+  display: flex; gap: 8px; align-items: center;
+}
+.ts-clock .period { color: var(--ice-white); }
+.ts-clock .sep { color: #555; }
+.ts-clock .time { font-weight: 700; }
+.ts-clock .score { color: var(--center-red); font-weight: 700; }
+.ts-nav { display: flex; gap: 18px; }
+.ts-nav a {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--ice-white);
+  border-bottom: 2px solid transparent; padding-bottom: 2px;
+}
+.ts-nav a:hover { border-bottom-color: var(--penalty-orange); color: var(--penalty-orange); }
+
+/* HERO ----------------------------------------------------------------------- */
+.hero {
+  background: var(--ice-white);
+  padding: 40px 24px 60px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 40px;
+  max-width: 1400px;
+  margin: 0 auto;
+  border-bottom: 4px solid var(--scoreboard-black);
+}
+.hero-rink {
+  position: relative;
+  background: var(--ice-white);
+  border: 4px solid var(--scoreboard-black);
+  padding: 28px;
+  box-shadow: 10px 10px 0 var(--ice-shadow);
+}
+.rink-tag {
+  position: absolute; top: -2px; left: 24px;
+  background: var(--scoreboard-black); color: var(--ice-white);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px; letter-spacing: 0.18em;
+  padding: 6px 14px; display: flex; gap: 14px;
+}
+.rink-tag .rt-id { color: var(--penalty-orange); }
+.rink-tag .rt-dim { color: var(--jersey-cream); }
+.rink-svg { width: 100%; height: auto; margin-top: 8px; }
+
+.hero-text { display: flex; flex-direction: column; justify-content: center; }
+.hero-eyebrow {
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 16px;
+  border-bottom: 2px solid var(--scoreboard-black);
+  padding-bottom: 12px;
+}
+.he-num {
+  font-family: 'Anton', sans-serif;
+  font-size: 42px; color: var(--center-red); line-height: 1;
+}
+.he-name {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; letter-spacing: 0.2em; font-weight: 600;
+}
+.hero-h {
+  font-family: 'Anton', sans-serif;
+  font-size: clamp(48px, 7vw, 96px);
+  line-height: 0.92; letter-spacing: -0.01em;
+  text-transform: uppercase; margin-bottom: 20px;
+  color: var(--scoreboard-black);
+}
+.hh-line { display: block; }
+.hh-line:nth-child(2) { color: var(--rink-blue); }
+.hh-line:nth-child(3) { color: var(--center-red); }
+.hero-sub {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 14px; letter-spacing: 0.18em; font-weight: 600;
+  padding: 10px 14px;
+  background: var(--scoreboard-black); color: var(--ice-white);
+  display: inline-block; margin-bottom: 24px;
+  border-left: 4px solid var(--center-red);
+}
+.hero-meta {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border: 3px solid var(--scoreboard-black);
+  margin-bottom: 24px;
+}
+.hero-meta > div {
+  padding: 10px 12px;
+  border-right: 2px solid var(--scoreboard-black);
+  display: flex; flex-direction: column;
+}
+.hero-meta > div:last-child { border-right: 0; }
+.hero-meta span {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px; letter-spacing: 0.18em;
+  color: var(--rink-blue); font-weight: 600;
+}
+.hero-meta b {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 18px; color: var(--scoreboard-black); font-weight: 700;
+}
+.hero-cta { display: flex; gap: 12px; flex-wrap: wrap; }
+.rink-btn {
+  font-family: 'Anton', sans-serif;
+  font-size: 18px; letter-spacing: 0.06em;
+  background: var(--center-red); color: var(--ice-white);
+  padding: 14px 22px; border: 3px solid var(--scoreboard-black);
+  text-transform: uppercase; display: inline-block;
+}
+.rink-btn:hover { background: var(--scoreboard-black); color: var(--penalty-orange); }
+.rink-btn.alt { background: var(--ice-white); color: var(--scoreboard-black); }
+.rink-btn.alt:hover { background: var(--rink-blue); color: var(--ice-white); }
+
+/* SCOREBOARD SCHEDULE -------------------------------------------------------- */
+.board {
+  background: var(--scoreboard-black); color: var(--ice-white);
+  padding: 60px 24px;
+  border-bottom: 4px solid var(--center-red);
+}
+.board-head {
+  max-width: 1400px; margin: 0 auto 28px;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 20px; flex-wrap: wrap;
+}
+.board-title { display: flex; align-items: center; gap: 16px; }
+.bt-pill {
+  background: var(--center-red); color: var(--ice-white);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px; letter-spacing: 0.2em;
+  padding: 4px 10px; border: 2px solid var(--ice-white);
+}
+.board-title h2 {
+  font-family: 'Anton', sans-serif;
+  font-size: clamp(28px, 4vw, 48px);
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+.board-clock {
+  font-family: 'IBM Plex Mono', monospace;
+  display: flex; gap: 12px; align-items: center;
+  background: #000; padding: 10px 16px;
+  border: 2px solid var(--panel-charcoal);
+}
+.bc-label { font-size: 11px; letter-spacing: 0.18em; color: var(--ice-shadow); }
+.bc-time { font-size: 22px; color: var(--penalty-orange); font-weight: 700; }
+.board-table-wrap {
+  max-width: 1400px; margin: 0 auto;
+  border: 3px solid var(--ice-white);
+  background: var(--panel-charcoal); overflow-x: auto;
+}
+.board-table { width: 100%; border-collapse: collapse; font-family: 'Inter Tight', sans-serif; }
+.board-table th {
+  background: var(--center-red); color: var(--ice-white);
+  text-align: left; padding: 14px 16px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; letter-spacing: 0.18em;
+  border-bottom: 3px solid var(--ice-white);
+  border-right: 2px solid var(--scoreboard-black);
+}
+.board-table th:last-child { border-right: 0; }
+.board-table td {
+  padding: 16px;
+  border-bottom: 2px solid #2a2a2a;
+  border-right: 2px solid #2a2a2a;
+  font-size: 15px;
+}
+.board-table td:last-child { border-right: 0; }
+.board-table tbody tr:last-child td { border-bottom: 0; }
+.board-table tbody tr:hover { background: #222; }
+.bt-day {
+  font-family: 'Anton', sans-serif;
+  font-size: 22px; letter-spacing: 0.05em; color: var(--penalty-orange);
+}
+.bt-time {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 22px; font-weight: 700;
+  color: var(--ice-white); letter-spacing: 0.04em;
+}
+.chip {
+  display: inline-block;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px; letter-spacing: 0.18em;
+  padding: 4px 10px; border: 2px solid; font-weight: 700;
+}
+.chip-open { color: #5ad17a; border-color: #5ad17a; }
+.chip-filling { color: var(--penalty-orange); border-color: var(--penalty-orange); }
+.chip-full { background: var(--center-red); color: var(--ice-white); border-color: var(--ice-white); }
+.board-fine {
+  max-width: 1400px; margin: 20px auto 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; letter-spacing: 0.12em; color: var(--ice-shadow);
+}
+
+/* STICK DROP — league rules signage ------------------------------------------ */
+.stick-drop {
+  background: var(--ice-white);
+  padding: 70px 24px;
+  border-bottom: 4px solid var(--scoreboard-black);
+}
+.sd-head { max-width: 1400px; margin: 0 auto 36px; }
+.sd-tag {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; letter-spacing: 0.2em;
+  background: var(--rink-blue); color: var(--ice-white);
+  padding: 6px 12px; display: inline-block; margin-bottom: 14px;
+}
+.sd-head h2 {
+  font-family: 'Anton', sans-serif;
+  font-size: clamp(36px, 5vw, 64px);
+  letter-spacing: 0.02em; text-transform: uppercase;
+  color: var(--scoreboard-black); line-height: 0.96; margin-bottom: 14px;
+}
+.sd-head p { font-size: 16px; max-width: 640px; color: #333; }
+.sd-grid {
+  max-width: 1400px; margin: 0 auto;
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border: 4px solid var(--scoreboard-black);
+}
+.sd-card {
+  background: var(--panel-charcoal); color: var(--ice-white);
+  padding: 28px 22px;
+  border-right: 4px solid var(--scoreboard-black);
+  min-height: 280px;
+  display: flex; flex-direction: column;
+}
+.sd-card:last-child { border-right: 0; }
+.sd-num {
+  font-family: 'Anton', sans-serif;
+  font-size: 72px; color: var(--center-red);
+  line-height: 1; margin-bottom: 12px; display: block;
+}
+.sd-card h3 {
+  font-family: 'Anton', sans-serif;
+  font-size: 24px; letter-spacing: 0.04em; text-transform: uppercase;
+  margin-bottom: 12px; color: var(--ice-white);
+  border-bottom: 2px solid var(--center-red); padding-bottom: 8px;
+}
+.sd-card p { font-size: 14px; color: var(--ice-shadow); line-height: 1.55; }
+
+/* PENALTY BOX ---------------------------------------------------------------- */
+.penalty {
+  background: var(--jersey-cream);
+  padding: 70px 24px;
+  border-bottom: 4px solid var(--scoreboard-black);
+}
+.pen-head {
+  max-width: 1400px; margin: 0 auto 36px;
+  border-bottom: 4px solid var(--penalty-orange);
+  padding-bottom: 18px;
+}
+.pen-tag {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; letter-spacing: 0.2em;
+  background: var(--penalty-orange); color: var(--scoreboard-black);
+  padding: 6px 12px; display: inline-block; margin-bottom: 14px;
+  border: 2px solid var(--scoreboard-black);
+}
+.pen-head h2 {
+  font-family: 'Anton', sans-serif;
+  font-size: clamp(36px, 5vw, 64px);
+  letter-spacing: 0.02em; text-transform: uppercase;
+  color: var(--scoreboard-black); margin-bottom: 10px;
+}
+.pen-head p { font-size: 16px; color: #333; max-width: 640px; }
+.pen-grid {
+  max-width: 1400px; margin: 0 auto;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
+}
+.pen-card {
+  background: var(--ice-white);
+  border: 3px solid var(--scoreboard-black);
+  padding: 24px;
+}
+.pen-head-row {
+  display: flex; justify-content: space-between; align-items: center;
+  border-bottom: 2px solid var(--scoreboard-black);
+  padding-bottom: 10px; margin-bottom: 14px;
+}
+.pen-min {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 26px; font-weight: 700; color: var(--penalty-orange);
+}
+.pen-call {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px; letter-spacing: 0.18em;
+  background: var(--scoreboard-black); color: var(--ice-white);
+  padding: 4px 10px;
+}
+.pen-card h3 {
+  font-family: 'Anton', sans-serif;
+  font-size: 22px; letter-spacing: 0.04em; text-transform: uppercase;
+  margin-bottom: 10px; color: var(--scoreboard-black);
+}
+.pen-card p { font-size: 14px; color: #333; margin-bottom: 14px; line-height: 1.55; }
+.pen-list { list-style: none; border-top: 2px solid var(--scoreboard-black); padding-top: 10px; }
+.pen-list li {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; letter-spacing: 0.06em;
+  padding: 6px 0; border-bottom: 1px dashed #999;
+  color: var(--scoreboard-black);
+}
+.pen-list li:last-child { border-bottom: 0; }
+
+/* TICKER STRIP --------------------------------------------------------------- */
+.ticker-strip {
+  background: var(--center-red); color: var(--ice-white);
+  padding: 36px 24px;
+  display: flex; align-items: center; justify-content: space-around;
+  gap: 20px; flex-wrap: wrap;
+  border-bottom: 4px solid var(--scoreboard-black);
+}
+.ts-item { display: flex; flex-direction: column; align-items: center; }
+.tsi-n { font-family: 'Anton', sans-serif; font-size: 64px; line-height: 1; color: var(--ice-white); }
+.tsi-l {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px; letter-spacing: 0.2em;
+  margin-top: 6px; color: var(--jersey-cream);
+}
+.ts-sep { width: 4px; height: 60px; background: var(--ice-white); }
+
+/* SHINNY MANIFESTO ----------------------------------------------------------- */
+.shinny {
+  background: var(--scoreboard-black); color: var(--ice-white);
+  padding: 80px 24px;
+  border-bottom: 4px solid var(--center-red);
+}
+.sh-wrap { max-width: 1400px; margin: 0 auto; }
+.sh-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; letter-spacing: 0.2em;
+  color: var(--penalty-orange); display: block;
+  margin-bottom: 22px;
+  border-bottom: 2px solid var(--center-red); padding-bottom: 12px;
+}
+.shinny h2 {
+  font-family: 'Anton', sans-serif;
+  font-size: clamp(40px, 6vw, 84px);
+  letter-spacing: 0.01em; text-transform: uppercase;
+  line-height: 1; margin-bottom: 22px;
+}
+.sh-hi { color: var(--center-red); }
+.sh-sign {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 13px; letter-spacing: 0.16em; color: var(--ice-shadow);
+}
+
+/* FOOTER --------------------------------------------------------------------- */
+.rink-foot {
+  background: var(--scoreboard-black); color: var(--ice-white);
+  padding: 60px 24px 30px;
+  border-top: 6px solid var(--center-red);
+}
+.rf-wrap { max-width: 1400px; margin: 0 auto; }
+.rf-mark {
+  display: flex; align-items: baseline; gap: 18px;
+  border-bottom: 3px solid var(--center-red);
+  padding-bottom: 24px; margin-bottom: 32px;
+}
+.rf-num {
+  font-family: 'Anton', sans-serif;
+  font-size: clamp(80px, 14vw, 180px);
+  color: var(--center-red); line-height: 0.85;
+}
+.rf-name {
+  font-family: 'Anton', sans-serif;
+  font-size: clamp(36px, 6vw, 80px);
+  color: var(--ice-white); line-height: 0.85; letter-spacing: 0.02em;
+}
+.rf-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 30px; margin-bottom: 30px;
+}
+.rf-grid h4 {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px; letter-spacing: 0.2em;
+  color: var(--penalty-orange);
+  margin-bottom: 14px; padding-bottom: 6px;
+  border-bottom: 2px solid var(--panel-charcoal);
+}
+.rf-grid a {
+  display: block; font-size: 14px; padding: 4px 0;
+  color: var(--ice-white);
+  border-bottom: 1px dashed transparent;
+}
+.rf-grid a:hover { color: var(--center-red); border-bottom-color: var(--center-red); }
+.rf-colophon {
+  border-top: 2px solid var(--panel-charcoal);
+  padding-top: 18px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px; letter-spacing: 0.18em; color: var(--ice-shadow);
+  display: flex; justify-content: space-between;
+  flex-wrap: wrap; gap: 10px;
+}
+
+/* PROSE (about, 404, taxonomies) --------------------------------------------- */
+.prose { max-width: 800px; margin: 60px auto; padding: 0 24px; }
+.prose h1 {
+  font-family: 'Anton', sans-serif;
+  font-size: clamp(40px, 6vw, 72px);
+  letter-spacing: 0.02em; text-transform: uppercase;
+  color: var(--scoreboard-black);
+  border-bottom: 4px solid var(--center-red);
+  padding-bottom: 14px; margin-bottom: 24px;
+}
+.prose h2 {
+  font-family: 'Anton', sans-serif;
+  font-size: 28px; letter-spacing: 0.03em; text-transform: uppercase;
+  color: var(--rink-blue); margin: 32px 0 14px;
+  border-left: 4px solid var(--center-red); padding-left: 12px;
+}
+.prose h3 {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 18px; font-weight: 700;
+  margin: 22px 0 10px; color: var(--scoreboard-black);
+}
+.prose p { margin-bottom: 14px; color: #222; }
+.prose a { color: var(--center-red); border-bottom: 1px solid var(--center-red); }
+.prose ul, .prose ol { margin: 14px 0 18px 20px; }
+.prose li { margin-bottom: 6px; }
+.prose strong { color: var(--scoreboard-black); font-weight: 700; }
+.prose blockquote {
+  border-left: 6px solid var(--center-red);
+  background: var(--jersey-cream);
+  padding: 14px 18px; margin: 20px 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 14px; color: var(--scoreboard-black);
+}
+.prose code {
+  font-family: 'IBM Plex Mono', monospace;
+  background: var(--ice-shadow);
+  padding: 2px 6px; font-size: 14px;
+}
+
+/* RESPONSIVE ----------------------------------------------------------------- */
+@media (max-width: 1080px) {
+  .hero { grid-template-columns: 1fr; }
+  .sd-grid { grid-template-columns: repeat(2, 1fr); }
+  .sd-card { border-right: 0; border-bottom: 4px solid var(--scoreboard-black); }
+  .pen-grid { grid-template-columns: 1fr; }
+  .rf-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 700px) {
+  .top-strip { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .ts-nav { flex-wrap: wrap; gap: 10px; }
+  .hero { padding: 24px 16px 40px; }
+  .hero-meta { grid-template-columns: repeat(2, 1fr); }
+  .hero-meta > div:nth-child(2) { border-right: 0; }
+  .hero-meta > div:nth-child(1), .hero-meta > div:nth-child(2) { border-bottom: 2px solid var(--scoreboard-black); }
+  .sd-grid { grid-template-columns: 1fr; }
+  .board-head { flex-direction: column; align-items: flex-start; }
+  .ticker-strip { gap: 16px; }
+  .tsi-n { font-size: 44px; }
+  .ts-sep { display: none; }
+  .rf-grid { grid-template-columns: 1fr; }
+  .rf-colophon { flex-direction: column; }
+}

--- a/examples/rink-zamboni/static/favicon.svg
+++ b/examples/rink-zamboni/static/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#0c0c0c"/>
+  <rect x="3" y="3" width="26" height="26" rx="6" fill="#eef3f6"/>
+  <line x1="3" y1="16" x2="29" y2="16" stroke="#c1232b" stroke-width="2"/>
+  <line x1="11" y1="3" x2="11" y2="29" stroke="#1e64a3" stroke-width="2"/>
+  <line x1="21" y1="3" x2="21" y2="29" stroke="#1e64a3" stroke-width="2"/>
+  <circle cx="16" cy="16" r="2.6" fill="none" stroke="#c1232b" stroke-width="1.4"/>
+  <circle cx="16" cy="16" r="0.9" fill="#c1232b"/>
+</svg>

--- a/examples/rink-zamboni/templates/404.html
+++ b/examples/rink-zamboni/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 // OFFSIDE.</h1>
+  <p>That page isn't on the roster. Wrong line, wrong shift, wrong sheet. Back through the gate.</p>
+  <p><a href="{{ base_url }}/">&laquo; back to sheet 4</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/rink-zamboni/templates/footer.html
+++ b/examples/rink-zamboni/templates/footer.html
@@ -1,0 +1,46 @@
+  <footer class="rink-foot">
+    <div class="rf-wrap">
+      <div class="rf-mark">
+        <span class="rf-num">04</span>
+        <span class="rf-name">SHEET FOUR</span>
+      </div>
+      <div class="rf-grid">
+        <div>
+          <h4>Ice Times</h4>
+          <a href="#schedule">Weekly schedule</a>
+          <a href="#stick-time">Stick-time slots</a>
+          <a href="#shinny">Drop-in shinny</a>
+          <a href="#beginner">Adult-beginner</a>
+        </div>
+        <div>
+          <h4>Rink</h4>
+          <a href="{{ base_url }}/about/">The community rink</a>
+          <a href="#rules">Rink rules</a>
+          <a href="#penalty">Gear required</a>
+          <a href="#penalty">Fees &amp; refunds</a>
+        </div>
+        <div>
+          <h4>League</h4>
+          <a href="#rules">Stick Drop bylaws</a>
+          <a href="{{ base_url }}/about/">Age groups</a>
+          <a href="#penalty">No-show policy</a>
+          <a href="#schedule">Sign-up window</a>
+        </div>
+        <div>
+          <h4>Desk</h4>
+          <a href="#">ice@sheet-four.rink</a>
+          <a href="#">Sub-list &mdash; text only</a>
+          <a href="#">Lost &amp; found bin 4B</a>
+          <a href="#">Found a stick? Bring it.</a>
+        </div>
+      </div>
+      <div class="rf-colophon">
+        <span>ZAMBONI RUNS HALF-HOUR &middot; SHEET 4 &middot; {{ current_year }}</span>
+        <span>1424 GLACIER AVE &middot; BARN 2 &middot; DOOR C</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/rink-zamboni/templates/header.html
+++ b/examples/rink-zamboni/templates/header.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Anton&family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter+Tight:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="top-strip">
+    <div class="ts-left">
+      <span class="dot"></span>
+      <span class="ts-title">SHEET 4 &middot; PUBLIC ICE &middot; COMMUNITY RINK</span>
+    </div>
+    <div class="ts-clock">
+      <span class="period">P1</span>
+      <span class="sep">&middot;</span>
+      <span class="time">12:34</span>
+      <span class="sep">&middot;</span>
+      <span class="score">0-0</span>
+    </div>
+    <nav class="ts-nav">
+      <a href="#schedule">Schedule</a>
+      <a href="#stick-time">Stick-Time</a>
+      <a href="#shinny">Shinny</a>
+      <a href="#rules">Rink Rules</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </header>

--- a/examples/rink-zamboni/templates/index.html
+++ b/examples/rink-zamboni/templates/index.html
@@ -1,0 +1,278 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="hero-rink">
+    <div class="rink-tag">
+      <span class="rt-label">OVERHEAD</span>
+      <span class="rt-id">SHEET 4 // BARN 2</span>
+      <span class="rt-dim">200&times;85 FT &middot; NHL SPEC</span>
+    </div>
+    <svg class="rink-svg" viewBox="0 0 1000 425" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" aria-label="Overhead view of an ice-hockey rink with face-off circles, blue lines, center red line, and goal creases.">
+      <!-- ice surface -->
+      <rect x="10" y="10" width="980" height="405" rx="80" ry="80" fill="#eef3f6" stroke="#0c0c0c" stroke-width="4"/>
+      <!-- goal lines (thin red) -->
+      <line x1="100" y1="10" x2="100" y2="415" stroke="#c1232b" stroke-width="2"/>
+      <line x1="900" y1="10" x2="900" y2="415" stroke="#c1232b" stroke-width="2"/>
+      <!-- creases (light blue zones) -->
+      <path d="M 100 180 L 130 180 A 30 30 0 0 1 130 245 L 100 245 Z" fill="#b8d5e8" stroke="#c1232b" stroke-width="2"/>
+      <path d="M 900 180 L 870 180 A 30 30 0 0 0 870 245 L 900 245 Z" fill="#b8d5e8" stroke="#c1232b" stroke-width="2"/>
+      <!-- goal markers -->
+      <rect x="92" y="195" width="8" height="35" fill="#c1232b" stroke="#0c0c0c" stroke-width="2"/>
+      <rect x="900" y="195" width="8" height="35" fill="#c1232b" stroke="#0c0c0c" stroke-width="2"/>
+      <!-- blue lines -->
+      <rect x="370" y="10" width="4" height="405" fill="#1e64a3"/>
+      <rect x="626" y="10" width="4" height="405" fill="#1e64a3"/>
+      <!-- center red line (dashed) -->
+      <line x1="500" y1="10" x2="500" y2="415" stroke="#c1232b" stroke-width="4" stroke-dasharray="14 8"/>
+      <!-- center face-off circle -->
+      <circle cx="500" cy="212" r="55" fill="none" stroke="#1e64a3" stroke-width="3"/>
+      <circle cx="500" cy="212" r="4" fill="#1e64a3"/>
+      <!-- end-zone face-off circles (4) -->
+      <g fill="none" stroke="#c1232b" stroke-width="3">
+        <circle cx="200" cy="125" r="45"/>
+        <circle cx="200" cy="300" r="45"/>
+        <circle cx="800" cy="125" r="45"/>
+        <circle cx="800" cy="300" r="45"/>
+      </g>
+      <g fill="#c1232b">
+        <circle cx="200" cy="125" r="3.5"/>
+        <circle cx="200" cy="300" r="3.5"/>
+        <circle cx="800" cy="125" r="3.5"/>
+        <circle cx="800" cy="300" r="3.5"/>
+      </g>
+      <!-- hash marks on end-zone circles -->
+      <g stroke="#c1232b" stroke-width="2">
+        <line x1="180" y1="80" x2="180" y2="92"/><line x1="220" y1="80" x2="220" y2="92"/>
+        <line x1="180" y1="158" x2="180" y2="170"/><line x1="220" y1="158" x2="220" y2="170"/>
+        <line x1="180" y1="255" x2="180" y2="267"/><line x1="220" y1="255" x2="220" y2="267"/>
+        <line x1="180" y1="333" x2="180" y2="345"/><line x1="220" y1="333" x2="220" y2="345"/>
+        <line x1="780" y1="80" x2="780" y2="92"/><line x1="820" y1="80" x2="820" y2="92"/>
+        <line x1="780" y1="158" x2="780" y2="170"/><line x1="820" y1="158" x2="820" y2="170"/>
+        <line x1="780" y1="255" x2="780" y2="267"/><line x1="820" y1="255" x2="820" y2="267"/>
+        <line x1="780" y1="333" x2="780" y2="345"/><line x1="820" y1="333" x2="820" y2="345"/>
+      </g>
+      <!-- neutral zone face-off dots -->
+      <circle cx="420" cy="125" r="5" fill="#c1232b"/>
+      <circle cx="420" cy="300" r="5" fill="#c1232b"/>
+      <circle cx="580" cy="125" r="5" fill="#c1232b"/>
+      <circle cx="580" cy="300" r="5" fill="#c1232b"/>
+      <!-- referee crease at center -->
+      <path d="M 945 415 A 35 35 0 0 1 875 415" fill="none" stroke="#c1232b" stroke-width="2"/>
+      <!-- zone labels -->
+      <text x="200" y="385" text-anchor="middle" font-family="IBM Plex Mono" font-size="14" font-weight="600" fill="#0c0c0c">DEFENSIVE ZONE</text>
+      <text x="500" y="385" text-anchor="middle" font-family="IBM Plex Mono" font-size="14" font-weight="600" fill="#0c0c0c">NEUTRAL ZONE</text>
+      <text x="800" y="385" text-anchor="middle" font-family="IBM Plex Mono" font-size="14" font-weight="600" fill="#0c0c0c">OFFENSIVE ZONE</text>
+    </svg>
+  </div>
+  <div class="hero-text">
+    <div class="hero-eyebrow">
+      <span class="he-num">04</span>
+      <span class="he-name">SHEET FOUR // PICKUP LEAGUE</span>
+    </div>
+    <h1 class="hero-h">
+      <span class="hh-line">DROP IN.</span>
+      <span class="hh-line">LACE UP.</span>
+      <span class="hh-line">RUN A LINE.</span>
+    </h1>
+    <p class="hero-sub">PUCK DROPS 21:00 &middot; WEDNESDAYS &middot; {{ current_year }}</p>
+    <div class="hero-meta">
+      <div><span>SEASON</span><b>WK 14 / 24</b></div>
+      <div><span>SKATERS</span><b>22 / 24</b></div>
+      <div><span>GOALIES</span><b>2 / 2</b></div>
+      <div><span>NEXT FLOOD</span><b>20:30</b></div>
+    </div>
+    <div class="hero-cta">
+      <a class="rink-btn" href="#schedule">SEE THE BOARD</a>
+      <a class="rink-btn alt" href="#rules">RINK RULES</a>
+    </div>
+  </div>
+</section>
+
+<section class="board" id="schedule">
+  <div class="board-head">
+    <div class="board-title">
+      <span class="bt-pill">LIVE</span>
+      <h2>SCOREBOARD SCHEDULE</h2>
+    </div>
+    <div class="board-clock">
+      <span class="bc-label">DOORS</span>
+      <span class="bc-time">20:00</span>
+      <span class="bc-label">DROP</span>
+      <span class="bc-time">21:00</span>
+    </div>
+  </div>
+  <div class="board-table-wrap">
+    <table class="board-table">
+      <thead>
+        <tr>
+          <th>DAY</th>
+          <th>TIME</th>
+          <th>SESSION</th>
+          <th>ICE TIME</th>
+          <th>FEE</th>
+          <th>STATUS</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="bt-day">MON</td>
+          <td class="bt-time">06:00</td>
+          <td>STICK-TIME &middot; OPEN</td>
+          <td>60 MIN</td>
+          <td>$12</td>
+          <td><span class="chip chip-open">OPEN</span></td>
+        </tr>
+        <tr>
+          <td class="bt-day">TUE</td>
+          <td class="bt-time">19:30</td>
+          <td>BEGINNER CLINIC &middot; AGES 18+</td>
+          <td>75 MIN</td>
+          <td>$18</td>
+          <td><span class="chip chip-filling">FILLING</span></td>
+        </tr>
+        <tr>
+          <td class="bt-day">WED</td>
+          <td class="bt-time">21:00</td>
+          <td>SHINNY &middot; FULL CONTACT NO</td>
+          <td>90 MIN</td>
+          <td>$15</td>
+          <td><span class="chip chip-full">FULL</span></td>
+        </tr>
+        <tr>
+          <td class="bt-day">THU</td>
+          <td class="bt-time">07:15</td>
+          <td>STICK-TIME &middot; GOALIE PRIORITY</td>
+          <td>60 MIN</td>
+          <td>$12</td>
+          <td><span class="chip chip-open">OPEN</span></td>
+        </tr>
+        <tr>
+          <td class="bt-day">SAT</td>
+          <td class="bt-time">22:30</td>
+          <td>LATE SHINNY &middot; AGES 21+</td>
+          <td>90 MIN</td>
+          <td>$15</td>
+          <td><span class="chip chip-filling">FILLING</span></td>
+        </tr>
+        <tr>
+          <td class="bt-day">SUN</td>
+          <td class="bt-time">10:00</td>
+          <td>FAMILY ICE &middot; ALL AGES</td>
+          <td>60 MIN</td>
+          <td>$8</td>
+          <td><span class="chip chip-open">OPEN</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <p class="board-fine">SIGN-UP OPENS SUNDAY 12:00 &middot; CLOSES 1 HOUR BEFORE PUCK DROP &middot; ROSTERS POST ON THE GLASS BY BARN 2 DOOR C</p>
+</section>
+
+<section class="stick-drop" id="rules">
+  <div class="sd-head">
+    <span class="sd-tag">STICK DROP</span>
+    <h2>FOUR RULES, THEN WE SKATE.</h2>
+    <p>League rules are stencilled on the boards. We reprint them here in case the rink finally washed the dasher.</p>
+  </div>
+  <div class="sd-grid">
+    <article class="sd-card">
+      <span class="sd-num">01</span>
+      <h3>NO SLAPSHOTS.</h3>
+      <p>Wrist, snap, backhand &mdash; all welcome. A slapper above the knee in shinny is a one-shift sit. Twice is a beer for the goalies.</p>
+    </article>
+    <article class="sd-card">
+      <span class="sd-num">02</span>
+      <h3>EQUAL ICE.</h3>
+      <p>We run 4-minute shifts on the buzzer. You skate when the buzzer says. You sit when the buzzer says. The bench is part of the team.</p>
+    </article>
+    <article class="sd-card">
+      <span class="sd-num">03</span>
+      <h3>RESPECT THE GOALIES.</h3>
+      <p>Two goalies, two nets, two sessions a week. They donate their time. No pinging the post for fun. No body contact in the crease, ever.</p>
+    </article>
+    <article class="sd-card">
+      <span class="sd-num">04</span>
+      <h3>OFF THE ICE AT 22:30.</h3>
+      <p>Zamboni rolls every 30 minutes on the half. Be at the door when the gate opens. Late skaters wait the flood. Don't be that line.</p>
+    </article>
+  </div>
+</section>
+
+<section class="penalty" id="penalty">
+  <div class="pen-head">
+    <span class="pen-tag">PENALTY BOX</span>
+    <h2>FACING A PENALTY?</h2>
+    <p>Three things to read before you sign up. Read them. Then sign up.</p>
+  </div>
+  <div class="pen-grid">
+    <article class="pen-card">
+      <div class="pen-head-row">
+        <span class="pen-min">2:00</span>
+        <span class="pen-call">MINOR &middot; FEE</span>
+      </div>
+      <h3>HOW WE TAKE PAYMENT.</h3>
+      <p>Cash or e-transfer to the desk in barn 2. Receipts are printed on the back of last week's roster. We do not run cards. We do not save details.</p>
+      <ul class="pen-list">
+        <li>Stick-time &middot; $12 / 60 min</li>
+        <li>Shinny &middot; $15 / 90 min</li>
+        <li>Clinic &middot; $18 / 75 min</li>
+        <li>Family &middot; $8 / 60 min</li>
+      </ul>
+    </article>
+    <article class="pen-card">
+      <div class="pen-head-row">
+        <span class="pen-min">5:00</span>
+        <span class="pen-call">MAJOR &middot; NO-SHOW</span>
+      </div>
+      <h3>IF YOU DON'T SHOW.</h3>
+      <p>Sign-up holds a seat. A no-show holds a seat from somebody else. We will not refund. We will not rebook. We will remember.</p>
+      <ul class="pen-list">
+        <li>Cancel by 18:00 &mdash; full credit</li>
+        <li>Cancel after &mdash; no credit</li>
+        <li>Three strikes &mdash; out for the month</li>
+        <li>Subs welcome &mdash; text the desk</li>
+      </ul>
+    </article>
+    <article class="pen-card">
+      <div class="pen-head-row">
+        <span class="pen-min">10:00</span>
+        <span class="pen-call">MISCONDUCT &middot; GEAR</span>
+      </div>
+      <h3>GEAR. FULL STOP.</h3>
+      <p>The rink ref will turn you away. We will not argue at the gate. Pads are recommended; the four items below are required, every session, no exceptions.</p>
+      <ul class="pen-list">
+        <li>HELMET &middot; cage or visor</li>
+        <li>MOUTHGUARD &middot; clinic + shinny</li>
+        <li>GLOVES &middot; hockey, not work</li>
+        <li>SHIN GUARDS &middot; minimum</li>
+      </ul>
+    </article>
+  </div>
+</section>
+
+<section class="ticker-strip" id="stick-time">
+  <div class="ts-item"><span class="tsi-n">14</span><span class="tsi-l">WEEKS / SEASON</span></div>
+  <div class="ts-sep"></div>
+  <div class="ts-item"><span class="tsi-n">24</span><span class="tsi-l">SKATERS / NIGHT</span></div>
+  <div class="ts-sep"></div>
+  <div class="ts-item"><span class="tsi-n">02</span><span class="tsi-l">GOALIES / NIGHT</span></div>
+  <div class="ts-sep"></div>
+  <div class="ts-item"><span class="tsi-n">04</span><span class="tsi-l">PERIODS / GAME</span></div>
+  <div class="ts-sep"></div>
+  <div class="ts-item"><span class="tsi-n">00</span><span class="tsi-l">SPONSORS / EVER</span></div>
+</section>
+
+<section class="shinny" id="shinny">
+  <div class="sh-wrap">
+    <span class="sh-label">SIDE BOARDS &middot; SHEET 4 &middot; {{ current_year }}</span>
+    <h2>
+      WE RUN <span class="sh-hi">FOUR-MIN</span> SHIFTS.<br>
+      WE FLOOD <span class="sh-hi">EVERY HALF.</span><br>
+      WE PASS <span class="sh-hi">TO THE WEAK SIDE.</span><br>
+      WE GO HOME BY <span class="sh-hi">23:00.</span>
+    </h2>
+    <div class="sh-sign">&mdash; the desk // signed // sheet 4 // {{ current_year }}</div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/rink-zamboni/templates/page.html
+++ b/examples/rink-zamboni/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/rink-zamboni/templates/section.html
+++ b/examples/rink-zamboni/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<section class="board">
+  <div class="board-head">
+    {% if page.title is present %}<div class="board-title"><span class="bt-pill">INDEX</span><h2>{{ page.title | e | upper }}</h2></div>{% endif %}
+  </div>
+  {{ content | safe }}
+  <div class="board-table-wrap">
+    <table class="board-table">
+      <thead>
+        <tr><th>DATE</th><th>ENTRY</th><th>GO</th></tr>
+      </thead>
+      <tbody>
+        {% for post in section.pages %}
+        <tr>
+          <td class="bt-time">{{ post.date | date(format="%Y / %m") }}</td>
+          <td><a href="{{ post.url }}">{{ post.title | e | upper }}</a></td>
+          <td>&rarr;</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/rink-zamboni/templates/shortcodes/alert.html
+++ b/examples/rink-zamboni/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 2px solid #0c0c0c; background-color: #eef3f6; border-left: 6px solid #c1232b; margin: 1rem 0; font-family: 'IBM Plex Mono', monospace;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/rink-zamboni/templates/taxonomy.html
+++ b/examples/rink-zamboni/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Tagged across the league boards.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/rink-zamboni/templates/taxonomy_term.html
+++ b/examples/rink-zamboni/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e | upper }}</h1>
+  <p>// Entries logged under this stamp.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/shadow-puppet/AGENTS.md
+++ b/examples/shadow-puppet/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/shadow-puppet/archetypes/default.md
+++ b/examples/shadow-puppet/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/shadow-puppet/config.toml
+++ b/examples/shadow-puppet/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "WAYANG LENTERA"
+description = "A touring shadow-puppet (wayang kulit) theater company performing traditional Javanese and original modern repertoire on rented stages."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/shadow-puppet/content/about.md
+++ b/examples/shadow-puppet/content/about.md
@@ -1,0 +1,35 @@
++++
+title = "About the Kompani"
+description = "Wayang Lentera — the company's history, the puppet maker, the gamelan ensemble, the tour, and how to book us."
++++
+
+## A short history
+
+The kompani was founded in 1962 by **Mas Ruslan** in a back room behind a coffee stand on Jalan Malioboro. The room had one lamp, two cushions, and a cloth screen sewn from a borrowed bedsheet. The first audience was six people, including the coffee-stand owner, who did not pay. The play was *Begawan Lentera*. We still perform it.
+
+We have toured every year since &mdash; quietly during the years when touring was impolite, loudly otherwise. Fourteen kompanies have taken the name. This is the fourteenth.
+
+## The puppet maker {#dalang}
+
+Every figure on the screen is cut by hand, from buffalo hide, in the same back room in Yogyakarta. The hide is soaked, scraped, dried in the dry season only. A single figure takes between two weeks and four months, depending on how many holes the carver wants you to see.
+
+> We do not buy figures. We do not sell figures. A figure made by the kompani stays with the kompani until the kompani ends.
+
+Apprentices begin on rough paper and end &mdash; if they end &mdash; on hide. Three of the current six apprentices were sent to us by their teachers from another island. One arrived on foot. One arrived because we asked.
+
+## The gamelan ensemble {#gamelan}
+
+The gamelan travels with the play. We do not perform to a recording. The ensemble is built around a single bronze **gong ageng** cast in 1947, which has cracked twice and been repaired twice, and which the kompani considers the senior member.
+
+The full ensemble is twelve players. The touring ensemble is anywhere between four and twelve, depending on the venue's floor.
+
+## Touring practice {#touring}
+
+We tour by van and by ferry. We do not fly the gong. We arrive two days before the performance and we leave two days after. We rent the stage; we do not own one. The screen, the lamp, the figures and the gong arrive in seven cases. The cases are numbered. Case 1 is the gong. Case 7 is the lamp.
+
+## Booking the kompani {#booking}
+
+- **Desk** &mdash; `dalang@wayang.lentera`
+- **Tour** &mdash; `tour@wayang.lentera`
+- **Letters** &mdash; PO Box 014, Yogyakarta. Letters are preferred. We reply inside fourteen days, in the language you wrote in.
+- **Press kit** &mdash; sent on request, by post. We do not email it.

--- a/examples/shadow-puppet/content/index.md
+++ b/examples/shadow-puppet/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Wayang Lentera — a touring shadow-puppet (wayang kulit) theater company that performs traditional Javanese and original modern repertoire on rented stages."
+template = "index"
++++

--- a/examples/shadow-puppet/static/css/style.css
+++ b/examples/shadow-puppet/static/css/style.css
@@ -1,0 +1,455 @@
+/* =============================================================================
+   Wayang Lentera — shadow-puppet theatre
+   Palette: lamp cloth (yellow), cutout silhouettes (black), lacquer (red), gilt.
+   NO gradients. Solids only.
+   ============================================================================= */
+
+:root {
+  --lamp-yellow: #efce7a;
+  --lamp-cream: #f4ddae;
+  --cutout-black: #0d0a05;
+  --lacquer-red: #aa1f20;
+  --lacquer-red-deep: #781817;
+  --gilt: #a87b1b;
+  --shadow-deep: #2a200f;
+  --screen-edge: #6e4a13;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  background-color: var(--lamp-yellow);
+  color: var(--cutout-black);
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* The "back-lit" cloth — a slightly brighter inner band, solid ellipse */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-color: var(--lamp-cream);
+  clip-path: ellipse(60% 50% at 50% 50%);
+  z-index: -1;
+  pointer-events: none;
+}
+
+a { color: var(--cutout-black); text-decoration: none; }
+a:hover { color: var(--lacquer-red); }
+img, svg { display: block; max-width: 100%; }
+
+/* ============================================================================
+   Bamboo top + masthead
+   The top strip evokes the carved bamboo border that frames a wayang screen:
+   solid screen-edge bg, a triangular notch pattern (SVG), then a brand row.
+   ============================================================================ */
+
+.bamboo-top {
+  background-color: var(--screen-edge);
+  color: var(--cutout-black);
+  border-bottom: 4px solid var(--cutout-black);
+  position: relative;
+}
+.bamboo-top .notch { line-height: 0; }
+.bamboo-top .notch svg { display: block; }
+.bamboo-top .strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 0.9rem 2rem;
+  background-color: var(--screen-edge);
+  position: relative;
+}
+.bamboo-top .strip::before,
+.bamboo-top .strip::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  background-color: var(--gilt);
+  transform: translateY(-50%) rotate(45deg);
+  border: 2px solid var(--cutout-black);
+}
+.bamboo-top .strip::before { left: 12px; }
+.bamboo-top .strip::after { right: 12px; }
+
+.brand {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  color: var(--lacquer-red);
+  font-family: "DM Serif Display", serif;
+  font-size: 1.05rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding-left: 1.4rem;
+}
+.brand:hover { color: var(--lacquer-red); }
+.brand-mark { font-weight: 400; color: var(--lacquer-red); }
+.brand-sub {
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  color: var(--cutout-black);
+  letter-spacing: 0.22em;
+}
+
+.masthead-nav {
+  display: flex;
+  gap: 1.4rem;
+  font-size: 0.78rem;
+  font-family: "Inter", sans-serif;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding-right: 1.4rem;
+}
+.masthead-nav a {
+  color: var(--cutout-black);
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+}
+.masthead-nav a:hover {
+  color: var(--cutout-black);
+  border-bottom-color: var(--cutout-black);
+}
+
+/* ============================================================================
+   Stage frame (poles + screen)
+   ============================================================================ */
+
+.stage { position: relative; max-width: 1320px; margin: 0 auto; padding: 0 56px; }
+.pole { position: absolute; top: 0; bottom: 0; width: 12px; background-color: var(--cutout-black); }
+.pole-left { left: 16px; }
+.pole-right { right: 16px; }
+.pole::before, .pole::after {
+  content: ""; position: absolute; left: -6px; right: -6px;
+  height: 8px; background-color: var(--cutout-black);
+}
+.pole::before { top: 36px; }
+.pole::after { bottom: 36px; }
+.screen { padding: 2.5rem 1rem 3rem; }
+
+/* ============================================================================
+   Hero
+   ============================================================================ */
+
+.hero { padding: 2rem 0 3rem; border-bottom: 2px dashed var(--cutout-black); }
+.hero-grid {
+  display: grid; grid-template-columns: minmax(280px, 420px) 1fr;
+  gap: 3rem; align-items: center;
+}
+.hero-figure { display: flex; justify-content: center; align-items: flex-end; }
+.hero-figure svg { height: 520px; width: auto; filter: drop-shadow(2px 6px 0 rgba(42, 32, 15, 0.18)); }
+.hero-text { padding-right: 1rem; }
+.hero-eyebrow {
+  font-family: "Inter", sans-serif; font-size: 0.78rem;
+  letter-spacing: 0.3em; text-transform: uppercase; color: var(--lacquer-red-deep);
+  margin-bottom: 1.4rem; padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--cutout-black); display: inline-block;
+}
+.hero-headline {
+  font-family: "Cormorant Garamond", serif; font-style: italic; font-weight: 500;
+  color: var(--lacquer-red); font-size: clamp(2.2rem, 4.6vw, 3.6rem);
+  line-height: 1.04; margin-bottom: 2rem;
+}
+.hero-headline span { display: block; }
+.hero-headline span:nth-child(even) { padding-left: 2.4rem; color: var(--lacquer-red-deep); }
+.hero-headline span:nth-child(3) { padding-left: 1.2rem; }
+.hero-headline span:nth-child(4) { padding-left: 3.6rem; }
+.hero-sigil { display: flex; align-items: center; gap: 1.4rem; margin-top: 1.6rem; }
+.sigil-ring { width: 150px; height: 150px; flex-shrink: 0; }
+.hero-stamp {
+  font-family: "Inter", sans-serif; font-size: 0.78rem;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--cutout-black);
+  padding: 0.8rem 1rem; border-top: 1px solid var(--cutout-black); border-bottom: 1px solid var(--cutout-black);
+}
+.hero-stamp .stamp-line { display: block; margin-bottom: 0.3rem; }
+.hero-stamp .stamp-num { display: block; color: var(--lacquer-red); font-weight: 500; }
+
+/* ============================================================================
+   Section heads (shared)
+   ============================================================================ */
+
+.section-head { text-align: center; padding: 3.6rem 0 2rem; max-width: 720px; margin: 0 auto; }
+.sec-eye {
+  display: inline-block; font-family: "Inter", sans-serif; font-size: 0.72rem;
+  letter-spacing: 0.36em; text-transform: uppercase; color: var(--lacquer-red-deep);
+  margin-bottom: 0.8rem; padding: 0.2rem 0.8rem; border: 1px solid var(--cutout-black);
+}
+.section-head h2 {
+  font-family: "DM Serif Display", serif; font-weight: 400;
+  font-size: clamp(1.8rem, 3.6vw, 2.8rem); line-height: 1.1;
+  color: var(--cutout-black); margin-bottom: 1rem;
+}
+.section-head h2 em { font-family: "Cormorant Garamond", serif; color: var(--lacquer-red); }
+.section-head p {
+  font-family: "Cormorant Garamond", serif; font-style: italic; font-size: 1.1rem;
+  color: var(--shadow-deep); max-width: 540px; margin: 0 auto;
+}
+
+/* ============================================================================
+   Repertoire grid
+   ============================================================================ */
+
+.repertoire { padding: 1rem 0 3rem; border-bottom: 2px dashed var(--cutout-black); }
+.rep-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.6rem; margin-top: 1.4rem; }
+.rep-card {
+  background-color: var(--lamp-cream);
+  border: 1px solid var(--cutout-black);
+  padding: 1.4rem 1.2rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+.rep-card::before,
+.rep-card::after {
+  content: "";
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background-color: var(--lacquer-red);
+}
+.rep-card::before { top: -5px; left: -5px; }
+.rep-card::after { bottom: -5px; right: -5px; }
+.rep-figure {
+  height: 280px; display: flex; align-items: flex-end; justify-content: center;
+  margin-bottom: 1rem; padding-bottom: 0.6rem; border-bottom: 1px solid var(--cutout-black);
+}
+.rep-figure svg { height: 260px; width: auto; filter: drop-shadow(1px 3px 0 rgba(42, 32, 15, 0.16)); }
+.rep-body h3 {
+  font-family: "DM Serif Display", serif; font-weight: 400;
+  font-size: 1.25rem; line-height: 1.2; color: var(--cutout-black); margin-bottom: 0.8rem;
+}
+.rep-body h3 em { font-family: "Cormorant Garamond", serif; color: var(--lacquer-red); font-weight: 500; }
+.rep-meta {
+  display: grid; grid-template-columns: auto 1fr; gap: 0.2rem 0.8rem;
+  font-size: 0.78rem; margin-bottom: 0.8rem; padding-bottom: 0.8rem;
+  border-bottom: 1px dotted var(--cutout-black);
+}
+.rep-meta dt { font-family: "Inter", sans-serif; text-transform: uppercase; letter-spacing: 0.18em; color: var(--shadow-deep); }
+.rep-meta dd { font-family: "Cormorant Garamond", serif; font-style: italic; color: var(--cutout-black); }
+.rep-body p { font-family: "Cormorant Garamond", serif; font-style: italic; font-size: 1rem; color: var(--shadow-deep); line-height: 1.5; }
+
+/* ============================================================================
+   Tour table
+   ============================================================================ */
+
+.tour { padding: 1rem 0 3rem; border-bottom: 2px dashed var(--cutout-black); }
+.tour-table { width: 100%; max-width: 960px; margin: 1.4rem auto 1rem; border-collapse: collapse; font-family: "Inter", sans-serif; }
+.tour-table thead th {
+  text-align: left;
+  font-size: 0.72rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--lacquer-red-deep);
+  padding: 0.6rem 1rem;
+  border-bottom: 2px solid var(--cutout-black);
+  border-top: 1px solid var(--cutout-black);
+  background-color: var(--lamp-cream);
+}
+.tour-table tbody tr:not(.tour-rule) {
+  border-left: 4px solid var(--cutout-black);
+}
+.tour-table tbody tr:not(.tour-rule):hover {
+  background-color: var(--lamp-cream);
+  border-left-color: var(--lacquer-red);
+}
+.tour-table tbody td { padding: 1rem 1rem; vertical-align: baseline; font-size: 0.94rem; }
+.tour-table tbody td:first-child {
+  font-family: "Cormorant Garamond", serif; font-style: italic;
+  font-size: 1.3rem; color: var(--lacquer-red);
+}
+.tour-table tbody td em { font-family: "Cormorant Garamond", serif; font-style: italic; }
+.tour-table tbody td:nth-child(2) { font-family: "DM Serif Display", serif; font-size: 1.05rem; }
+.tour-table tbody td:nth-child(3),
+.tour-table tbody td:nth-child(4) {
+  font-family: "Inter", sans-serif; font-size: 0.82rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--shadow-deep);
+}
+.tour-rule td { padding: 0 !important; height: 18px; }
+.tour-rule svg { height: 16px; width: 100%; }
+.tour-note { text-align: center; font-family: "Cormorant Garamond", serif; font-style: italic; color: var(--shadow-deep); font-size: 1rem; margin-top: 1.4rem; }
+
+/* ============================================================================
+   Lentera Lab
+   ============================================================================ */
+
+.lab { padding: 1rem 0 3rem; }
+.lab-grid { display: grid; grid-template-columns: 1fr 1.4fr; gap: 2.4rem; align-items: center; margin-top: 1.4rem; }
+.lab-text p { font-family: "Cormorant Garamond", serif; font-style: italic; font-size: 1.15rem; line-height: 1.6; color: var(--cutout-black); margin-bottom: 1rem; }
+.lab-text p.lab-sign { font-size: 0.95rem; color: var(--lacquer-red-deep); padding-top: 0.8rem; border-top: 1px solid var(--cutout-black); display: inline-block; }
+.lab-details { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+.lab-detail { position: relative; }
+.lab-detail svg {
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--cutout-black);
+  background-color: var(--cutout-black);
+}
+.lab-detail::before {
+  content: "";
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  right: -4px;
+  bottom: -4px;
+  border: 1px solid var(--gilt);
+  pointer-events: none;
+}
+.lab-detail figcaption {
+  font-family: "Inter", sans-serif; font-size: 0.72rem;
+  letter-spacing: 0.18em; text-transform: uppercase; text-align: center;
+  margin-top: 0.6rem; color: var(--shadow-deep);
+}
+
+/* ============================================================================
+   Footer / colophon
+   ============================================================================ */
+
+.colophon { background-color: var(--lamp-yellow); border-top: 4px solid var(--cutout-black); padding: 3rem 56px 2rem; }
+.ornament-row {
+  display: flex; justify-content: center; align-items: flex-end;
+  gap: 1.6rem; margin-bottom: 1.6rem; padding-bottom: 1.6rem; border-bottom: 1px solid var(--cutout-black);
+}
+.orn-fig { height: 92px; width: auto; }
+.orn-mid { height: 78px; }
+.gamelan-row { display: flex; justify-content: center; margin-bottom: 1.4rem; }
+.gamelan { height: 110px; width: auto; }
+.colo-text {
+  text-align: center; font-family: "DM Serif Display", serif; font-size: 0.96rem;
+  letter-spacing: 0.28em; text-transform: uppercase; color: var(--lacquer-red);
+  margin-bottom: 2rem; padding-bottom: 1.6rem; border-bottom: 1px solid var(--cutout-black);
+}
+.colo-mark { display: inline-block; padding: 0 0.6rem; }
+.colo-dot { color: var(--cutout-black); }
+.colo-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.6rem; max-width: 1100px; margin: 0 auto 2rem; }
+.colo-grid h4 {
+  font-family: "Inter", sans-serif; font-size: 0.72rem;
+  letter-spacing: 0.28em; text-transform: uppercase; color: var(--lacquer-red-deep);
+  margin-bottom: 0.8rem; padding-bottom: 0.4rem; border-bottom: 1px solid var(--cutout-black);
+}
+.colo-grid a {
+  display: block; font-family: "Cormorant Garamond", serif; font-style: italic;
+  font-size: 1rem; color: var(--cutout-black); padding: 0.2rem 0;
+}
+.colo-grid a:hover { color: var(--lacquer-red); }
+.colo-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: "Inter", sans-serif; font-size: 0.74rem; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--shadow-deep);
+  padding-top: 1.4rem; border-top: 1px solid var(--cutout-black);
+}
+
+/* ============================================================================
+   Prose pages (about, 404, taxonomy)
+   ============================================================================ */
+
+.prose { max-width: 720px; margin: 2rem auto; padding: 1.4rem 1rem 3rem; }
+.prose h1 {
+  font-family: "DM Serif Display", serif; font-weight: 400;
+  font-size: clamp(2rem, 4vw, 3rem); color: var(--lacquer-red);
+  margin-bottom: 1.6rem; padding-bottom: 0.8rem;
+  border-bottom: 2px solid var(--cutout-black); line-height: 1.1;
+}
+.prose h1 em { font-family: "Cormorant Garamond", serif; }
+.prose h2 { font-family: "DM Serif Display", serif; font-weight: 400; font-size: 1.6rem; margin: 2.4rem 0 0.8rem; color: var(--cutout-black); }
+.prose h3 { font-family: "Cormorant Garamond", serif; font-style: italic; font-size: 1.3rem; color: var(--lacquer-red); margin: 1.6rem 0 0.6rem; }
+.prose p { font-family: "Cormorant Garamond", serif; font-size: 1.15rem; line-height: 1.7; margin-bottom: 1rem; color: var(--cutout-black); }
+.prose p strong { font-weight: 600; color: var(--lacquer-red-deep); font-style: normal; }
+.prose blockquote {
+  border-left: 4px solid var(--lacquer-red); padding: 0.6rem 1.2rem;
+  margin: 1.4rem 0; font-family: "Cormorant Garamond", serif; font-style: italic;
+  font-size: 1.2rem; color: var(--lacquer-red-deep); background-color: var(--lamp-cream);
+}
+.prose ul, .prose ol { margin: 1rem 0 1rem 1.4rem; font-family: "Cormorant Garamond", serif; font-size: 1.1rem; }
+.prose ul li, .prose ol li { margin-bottom: 0.4rem; }
+.prose a { color: var(--lacquer-red); border-bottom: 1px solid var(--lacquer-red); }
+.prose a:hover { color: var(--lacquer-red-deep); border-bottom-color: var(--lacquer-red-deep); }
+.prose code {
+  font-family: "JetBrains Mono", "Menlo", monospace;
+  background-color: var(--lamp-cream); border: 1px solid var(--cutout-black);
+  padding: 0.05rem 0.4rem; font-size: 0.9rem; color: var(--cutout-black);
+}
+.not-found { text-align: center; }
+.not-found h1 { border-bottom: none; }
+
+/* ============================================================================
+   Archive (section.html)
+   ============================================================================ */
+
+.archive { padding: 1rem 0 3rem; }
+.archive-list { max-width: 720px; margin: 1.4rem auto; list-style: none; padding: 0; }
+.archive-list li {
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 1.4rem; padding: 0.8rem 0; border-bottom: 1px dotted var(--cutout-black);
+}
+.archive-date {
+  font-family: "Inter", sans-serif; font-size: 0.78rem;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--shadow-deep); flex-shrink: 0;
+}
+.archive-list a { font-family: "DM Serif Display", serif; font-size: 1.1rem; color: var(--cutout-black); }
+.archive-list a:hover { color: var(--lacquer-red); }
+
+/* ============================================================================
+   Shortcode alert
+   ============================================================================ */
+
+.alert {
+  background-color: var(--lamp-cream); border: 1px solid var(--cutout-black);
+  border-left: 6px solid var(--lacquer-red); padding: 1rem 1.2rem;
+  margin: 1.4rem 0; font-family: "Cormorant Garamond", serif;
+  font-style: italic; font-size: 1.05rem;
+}
+.alert strong {
+  font-family: "Inter", sans-serif; font-style: normal; font-size: 0.74rem;
+  letter-spacing: 0.22em; color: var(--lacquer-red-deep);
+  display: block; margin-bottom: 0.4rem;
+}
+
+/* ============================================================================
+   Responsive
+   ============================================================================ */
+
+@media (max-width: 980px) {
+  .stage { padding: 0 32px; }
+  .pole-left { left: 8px; }
+  .pole-right { right: 8px; }
+  .hero-grid { grid-template-columns: 1fr; gap: 1.6rem; }
+  .hero-figure svg { height: 380px; }
+  .hero-headline span { padding-left: 0 !important; }
+  .rep-grid { grid-template-columns: repeat(2, 1fr); }
+  .lab-grid { grid-template-columns: 1fr; }
+  .colo-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 640px) {
+  .bamboo-top .strip { flex-direction: column; align-items: flex-start; gap: 0.8rem; padding: 0.9rem 1rem; }
+  .masthead-nav { flex-wrap: wrap; gap: 0.8rem; }
+  .stage { padding: 0 18px; }
+  .pole { width: 6px; }
+  .pole-left { left: 4px; }
+  .pole-right { right: 4px; }
+  .screen { padding: 1.4rem 0.4rem 2rem; }
+  .hero-figure svg { height: 300px; }
+  .hero-sigil { flex-direction: column; align-items: flex-start; gap: 0.8rem; }
+  .rep-grid { grid-template-columns: 1fr; gap: 1.2rem; }
+  .rep-figure { height: 240px; }
+  .rep-figure svg { height: 220px; }
+  .tour-table tbody td { padding: 0.6rem; font-size: 0.8rem; }
+  .tour-table tbody td:first-child { font-size: 1.05rem; }
+  .lab-details { grid-template-columns: 1fr; }
+  .colo-grid { grid-template-columns: 1fr; gap: 1.2rem; }
+  .colo-foot { flex-direction: column; gap: 0.4rem; text-align: center; }
+  .colophon { padding: 2rem 1rem 1.4rem; }
+  .ornament-row { gap: 0.8rem; }
+  .orn-fig { height: 60px; }
+  .orn-mid { height: 52px; }
+  .gamelan { height: 80px; }
+}

--- a/examples/shadow-puppet/static/favicon.svg
+++ b/examples/shadow-puppet/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#efce7a"/>
+  <path d="M16,3 L18,6 L20,4 L20,9 L23,10 L21,13 L24,16 L20,18 L21,22 L17,24 L18,28 L16,30 L14,28 L15,24 L11,22 L12,18 L8,16 L11,13 L9,10 L12,9 L12,4 L14,6 Z" fill="#0d0a05"/>
+  <circle cx="16" cy="11" r="1" fill="#efce7a"/>
+  <circle cx="16" cy="18" r="0.8" fill="#efce7a"/>
+</svg>

--- a/examples/shadow-puppet/templates/404.html
+++ b/examples/shadow-puppet/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose not-found">
+  <h1><em>404 &middot; The lamp went out.</em></h1>
+  <p>This page is not in tonight's repertoire. Maybe it was retired after the tour, maybe the cloth tore, maybe you mistook the venue. Return to the screen.</p>
+  <p><a href="{{ base_url }}/">&laquo; back to the screen</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/shadow-puppet/templates/footer.html
+++ b/examples/shadow-puppet/templates/footer.html
@@ -1,0 +1,107 @@
+    </div><!-- /.screen -->
+  </div><!-- /.stage -->
+  <footer class="colophon" aria-label="colophon">
+    <div class="ornament-row" aria-hidden="true">
+      <svg viewBox="0 0 80 100" class="orn-fig" xmlns="http://www.w3.org/2000/svg">
+        <!-- small puppet 1: kayon-like -->
+        <path d="M40,2 C46,12 56,16 56,30 C56,38 50,42 50,50 C56,60 58,72 50,86 L52,96 L40,92 L28,96 L30,86 C22,72 24,60 30,50 C30,42 24,38 24,30 C24,16 34,12 40,2 Z" fill="#0d0a05"/>
+        <circle cx="40" cy="22" r="2" fill="#efce7a"/>
+        <circle cx="40" cy="34" r="1.5" fill="#efce7a"/>
+        <circle cx="36" cy="50" r="1" fill="#efce7a"/>
+        <circle cx="44" cy="50" r="1" fill="#efce7a"/>
+        <path d="M40,60 Q36,68 40,76 Q44,68 40,60 Z" fill="#efce7a"/>
+      </svg>
+      <svg viewBox="0 0 60 100" class="orn-fig" xmlns="http://www.w3.org/2000/svg">
+        <!-- small puppet 2: dancer -->
+        <path d="M30,4 C34,4 36,8 36,12 C36,16 34,18 32,20 L34,30 C40,32 44,38 42,46 L48,52 L44,58 L40,56 L38,66 C42,74 40,84 36,92 L34,96 L28,96 L24,84 C20,76 22,68 26,62 L22,54 L16,52 L20,46 C18,40 22,34 28,32 L28,20 C24,16 24,8 30,4 Z" fill="#0d0a05"/>
+        <circle cx="30" cy="14" r="1.4" fill="#efce7a"/>
+        <circle cx="34" cy="40" r="1" fill="#efce7a"/>
+        <circle cx="26" cy="40" r="1" fill="#efce7a"/>
+        <path d="M30,46 Q28,52 30,58 Q32,52 30,46 Z" fill="#efce7a"/>
+      </svg>
+      <svg viewBox="0 0 100 80" class="orn-fig orn-mid" xmlns="http://www.w3.org/2000/svg">
+        <!-- ornament 1: kala mask -->
+        <path d="M50,2 C70,2 86,14 90,32 C92,42 86,52 78,58 L84,68 L74,66 L70,74 L62,68 L54,74 L50,66 L46,74 L38,68 L30,74 L26,66 L16,68 L22,58 C14,52 8,42 10,32 C14,14 30,2 50,2 Z" fill="#0d0a05"/>
+        <circle cx="40" cy="32" r="3" fill="#efce7a"/>
+        <circle cx="60" cy="32" r="3" fill="#efce7a"/>
+        <path d="M50,38 L46,46 L54,46 Z" fill="#efce7a"/>
+        <path d="M40,52 Q50,58 60,52 Q50,56 40,52 Z" fill="#efce7a"/>
+      </svg>
+      <svg viewBox="0 0 60 100" class="orn-fig" xmlns="http://www.w3.org/2000/svg">
+        <!-- small puppet 3: warrior -->
+        <path d="M30,2 L36,10 L40,8 L38,18 L44,24 L40,28 L42,38 L48,44 L42,50 L46,62 L40,68 L42,82 L38,92 L34,96 L26,96 L22,92 L18,82 L20,68 L14,62 L18,50 L12,44 L18,38 L20,28 L16,24 L22,18 L20,8 L24,10 Z" fill="#0d0a05"/>
+        <circle cx="30" cy="14" r="1.4" fill="#efce7a"/>
+        <circle cx="30" cy="30" r="1.2" fill="#efce7a"/>
+        <path d="M30,46 Q28,54 30,62 Q32,54 30,46 Z" fill="#efce7a"/>
+      </svg>
+      <svg viewBox="0 0 80 100" class="orn-fig" xmlns="http://www.w3.org/2000/svg">
+        <!-- ornament 2: gunungan small -->
+        <path d="M40,2 L46,14 L54,12 L52,24 L62,28 L56,38 L62,48 L54,56 L58,68 L48,72 L52,84 L40,86 L28,84 L32,72 L22,68 L26,56 L18,48 L24,38 L18,28 L28,24 L26,12 L34,14 Z" fill="#0d0a05"/>
+        <circle cx="40" cy="22" r="1.6" fill="#efce7a"/>
+        <circle cx="40" cy="40" r="1.6" fill="#efce7a"/>
+        <circle cx="40" cy="58" r="1.6" fill="#efce7a"/>
+      </svg>
+    </div>
+    <div class="gamelan-row" aria-hidden="true">
+      <svg viewBox="0 0 200 120" class="gamelan" xmlns="http://www.w3.org/2000/svg">
+        <!-- gong on stand -->
+        <path d="M30,108 L30,80 L18,80 L26,72 L46,72 L54,80 L42,80 L42,108 Z" fill="#0d0a05"/>
+        <circle cx="36" cy="46" r="32" fill="#0d0a05"/>
+        <circle cx="36" cy="46" r="22" fill="none" stroke="#efce7a" stroke-width="1.4"/>
+        <circle cx="36" cy="46" r="8" fill="#efce7a"/>
+        <circle cx="36" cy="46" r="3" fill="#0d0a05"/>
+        <path d="M36,14 L36,8 M64,46 L70,46 M36,78 L36,84 M8,46 L2,46" stroke="#0d0a05" stroke-width="2"/>
+        <!-- kendang drum -->
+        <path d="M120,30 L180,30 L184,40 L184,80 L180,90 L120,90 L116,80 L116,40 Z" fill="#0d0a05"/>
+        <ellipse cx="120" cy="60" rx="6" ry="26" fill="#efce7a"/>
+        <ellipse cx="180" cy="60" rx="6" ry="26" fill="#efce7a"/>
+        <ellipse cx="120" cy="60" rx="3" ry="22" fill="#0d0a05"/>
+        <ellipse cx="180" cy="60" rx="3" ry="22" fill="#0d0a05"/>
+        <path d="M124,38 L176,38 M124,82 L176,82" stroke="#efce7a" stroke-width="1" fill="none"/>
+        <circle cx="140" cy="60" r="1.4" fill="#efce7a"/>
+        <circle cx="150" cy="60" r="1.4" fill="#efce7a"/>
+        <circle cx="160" cy="60" r="1.4" fill="#efce7a"/>
+      </svg>
+    </div>
+    <div class="colo-text">
+      <span class="colo-mark">CUT BY HAND</span>
+      <span class="colo-dot">&middot;</span>
+      <span class="colo-mark">LIT BY OIL</span>
+      <span class="colo-dot">&middot;</span>
+      <span class="colo-mark">{{ current_year }}</span>
+    </div>
+    <div class="colo-grid">
+      <div>
+        <h4>Kompani</h4>
+        <a href="{{ base_url }}/about/">A short history</a>
+        <a href="{{ base_url }}/about/#dalang">The puppet maker</a>
+        <a href="{{ base_url }}/about/#gamelan">The gamelan ensemble</a>
+      </div>
+      <div>
+        <h4>Tour</h4>
+        <a href="#tour">Upcoming dates</a>
+        <a href="{{ base_url }}/about/#touring">Touring practice</a>
+        <a href="{{ base_url }}/about/#booking">Booking the kompani</a>
+      </div>
+      <div>
+        <h4>Lentera Lab</h4>
+        <a href="#lab">Apprentice cuts</a>
+        <a href="{{ base_url }}/tags/">Field tags</a>
+        <a href="#repertoire">The repertoire</a>
+      </div>
+      <div>
+        <h4>Desk</h4>
+        <a href="#">dalang@wayang.lentera</a>
+        <a href="#">tour@wayang.lentera</a>
+        <a href="#">Press, by letter only</a>
+      </div>
+    </div>
+    <div class="colo-foot">
+      <span>&copy; {{ current_year }} Wayang Lentera Kompani</span>
+      <span>Hwaro build &middot; lantern {{ current_year }}.04</span>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/shadow-puppet/templates/header.html
+++ b/examples/shadow-puppet/templates/header.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,400;1,500;1,600;0,500&family=DM+Serif+Display:ital@0;1&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="bamboo-top" aria-label="masthead">
+    <div class="notch" aria-hidden="true">
+      <svg width="100%" height="22" viewBox="0 0 1200 22" preserveAspectRatio="none">
+        <rect width="1200" height="22" fill="#6e4a13"/>
+        <g fill="#0d0a05">
+          {% for i in range(end=60) %}
+          <path d="M{{ i * 20 }},0 L{{ i * 20 + 10 }},14 L{{ i * 20 + 20 }},0 Z"/>
+          {% endfor %}
+        </g>
+        <rect y="18" width="1200" height="4" fill="#0d0a05"/>
+      </svg>
+    </div>
+    <div class="strip">
+      <a href="{{ base_url }}/" class="brand">
+        <span class="brand-mark">WAYANG LENTERA</span>
+        <span class="brand-sub">&middot; KULIT THEATRE &middot; KOMPANI 14</span>
+      </a>
+      <nav class="masthead-nav">
+        <a href="#repertoire">Repertoire</a>
+        <a href="#cast">Cast</a>
+        <a href="#tour">Tour</a>
+        <a href="#lab">Lentera Lab</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>
+  <div class="stage">
+    <div class="pole pole-left" aria-hidden="true"></div>
+    <div class="pole pole-right" aria-hidden="true"></div>
+    <div class="screen">

--- a/examples/shadow-puppet/templates/index.html
+++ b/examples/shadow-puppet/templates/index.html
@@ -1,0 +1,591 @@
+{% include "header.html" %}
+
+<section class="hero" aria-label="hero">
+  <div class="hero-grid">
+    <figure class="hero-figure" aria-label="Arjuna shadow puppet">
+      <svg viewBox="0 0 320 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+        <!-- The figure: pure black silhouette with carved interior holes revealing background -->
+        <!-- Headdress / crown (jamang) -->
+        <path d="M150,12 L156,4 L162,12 L166,6 L170,14 L174,8 L178,16 L184,10 L186,20 L192,16 L192,26 L198,24 L196,34 L202,34 L198,42 L204,44 L196,52 L202,56 L194,60 L198,68 L188,68 L186,76 L178,72 L176,80 L168,76 L166,84 L160,80 L154,84 L152,76 L144,80 L142,72 L134,76 L132,68 L122,68 L126,60 L118,56 L124,52 L116,44 L122,42 L118,34 L124,34 L122,24 L128,26 L128,16 L134,20 L136,10 L142,16 L146,8 Z" fill="#0d0a05"/>
+        <!-- holes in headdress -->
+        <ellipse cx="160" cy="22" rx="2" ry="3" fill="#efce7a"/>
+        <ellipse cx="148" cy="28" rx="1.4" ry="2.4" fill="#efce7a"/>
+        <ellipse cx="172" cy="28" rx="1.4" ry="2.4" fill="#efce7a"/>
+        <ellipse cx="140" cy="38" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="180" cy="38" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="160" cy="42" rx="1.8" ry="3" fill="#efce7a"/>
+        <ellipse cx="152" cy="54" rx="1" ry="2" fill="#efce7a"/>
+        <ellipse cx="168" cy="54" rx="1" ry="2" fill="#efce7a"/>
+
+        <!-- Face profile - long curved nose, low forehead -->
+        <path d="M150,80 C140,86 134,98 134,112 C134,118 132,124 128,128 L120,130 L118,138 L122,144 L116,152 L120,158 L116,166 L122,170 L120,176 L128,178 C132,184 138,188 146,188 L150,194 L156,188 L160,184 L162,176 L168,170 L162,162 L168,156 L166,148 L170,140 L166,134 L170,128 C168,124 168,118 168,112 C168,98 162,86 152,80 Z" fill="#0d0a05"/>
+        <!-- carved eye -->
+        <path d="M126,134 L138,134 L138,140 L126,140 Z" fill="#efce7a"/>
+        <circle cx="132" cy="137" r="1.8" fill="#0d0a05"/>
+        <!-- nostril hole -->
+        <ellipse cx="120" cy="148" rx="1.2" ry="1.6" fill="#efce7a"/>
+        <!-- mouth slit -->
+        <path d="M124,166 L134,166 L134,168 L124,168 Z" fill="#efce7a"/>
+        <!-- ear decoration holes -->
+        <ellipse cx="160" cy="148" rx="1" ry="2" fill="#efce7a"/>
+        <ellipse cx="160" cy="156" rx="1" ry="2" fill="#efce7a"/>
+
+        <!-- Neck and necklace (kalung) -->
+        <path d="M148,194 L152,194 L156,212 L144,212 Z" fill="#0d0a05"/>
+        <path d="M118,212 C132,206 168,206 182,212 L188,224 C168,218 132,218 112,224 Z" fill="#0d0a05"/>
+        <ellipse cx="140" cy="216" rx="1.4" ry="1.4" fill="#efce7a"/>
+        <ellipse cx="150" cy="217" rx="1.4" ry="1.4" fill="#efce7a"/>
+        <ellipse cx="160" cy="217" rx="1.4" ry="1.4" fill="#efce7a"/>
+        <ellipse cx="170" cy="216" rx="1.4" ry="1.4" fill="#efce7a"/>
+
+        <!-- Torso (badan) - thin elongated -->
+        <path d="M120,224 C116,240 114,260 116,284 L118,316 C120,332 124,346 130,358 L150,366 L170,358 C176,346 180,332 182,316 L184,284 C186,260 184,240 180,224 Z" fill="#0d0a05"/>
+        <!-- carved chest patterns -->
+        <ellipse cx="150" cy="240" rx="3" ry="2" fill="#efce7a"/>
+        <path d="M140,254 L160,254 L160,258 L140,258 Z" fill="#efce7a"/>
+        <ellipse cx="135" cy="270" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="165" cy="270" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="150" cy="276" rx="1.4" ry="2" fill="#efce7a"/>
+        <path d="M138,290 Q150,296 162,290 Q150,294 138,290 Z" fill="#efce7a"/>
+        <ellipse cx="142" cy="306" rx="1.2" ry="1.8" fill="#efce7a"/>
+        <ellipse cx="158" cy="306" rx="1.2" ry="1.8" fill="#efce7a"/>
+        <ellipse cx="150" cy="320" rx="1.4" ry="2" fill="#efce7a"/>
+        <path d="M138,332 L162,332 L162,336 L138,336 Z" fill="#efce7a"/>
+        <ellipse cx="146" cy="346" rx="1" ry="1.4" fill="#efce7a"/>
+        <ellipse cx="154" cy="346" rx="1" ry="1.4" fill="#efce7a"/>
+
+        <!-- Belt (sabuk) -->
+        <path d="M114,358 L186,358 L188,378 L112,378 Z" fill="#0d0a05"/>
+        <circle cx="130" cy="368" r="2" fill="#efce7a"/>
+        <circle cx="150" cy="368" r="2.4" fill="#efce7a"/>
+        <circle cx="170" cy="368" r="2" fill="#efce7a"/>
+        <path d="M120,372 L138,372 M162,372 L180,372" stroke="#efce7a" stroke-width="0.8"/>
+
+        <!-- Skirt/cloth (kain) -->
+        <path d="M112,378 L188,378 L196,440 L194,470 L184,498 L116,498 L106,470 L104,440 Z" fill="#0d0a05"/>
+        <!-- batik holes -->
+        <ellipse cx="130" cy="396" rx="1.4" ry="2.4" fill="#efce7a"/>
+        <ellipse cx="150" cy="394" rx="1.4" ry="2.4" fill="#efce7a"/>
+        <ellipse cx="170" cy="396" rx="1.4" ry="2.4" fill="#efce7a"/>
+        <path d="M120,408 Q150,414 180,408 Q150,412 120,408 Z" fill="#efce7a"/>
+        <ellipse cx="124" cy="422" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="138" cy="424" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="150" cy="422" rx="1.4" ry="2.4" fill="#efce7a"/>
+        <ellipse cx="162" cy="424" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="176" cy="422" rx="1.2" ry="2" fill="#efce7a"/>
+        <path d="M118,440 L182,440 L182,444 L118,444 Z" fill="#efce7a"/>
+        <ellipse cx="128" cy="456" rx="1" ry="2" fill="#efce7a"/>
+        <ellipse cx="144" cy="458" rx="1.4" ry="2.4" fill="#efce7a"/>
+        <ellipse cx="156" cy="458" rx="1.4" ry="2.4" fill="#efce7a"/>
+        <ellipse cx="172" cy="456" rx="1" ry="2" fill="#efce7a"/>
+        <path d="M124,476 Q150,482 176,476" stroke="#efce7a" stroke-width="1" fill="none"/>
+        <ellipse cx="138" cy="488" rx="1" ry="1.6" fill="#efce7a"/>
+        <ellipse cx="150" cy="488" rx="1" ry="1.6" fill="#efce7a"/>
+        <ellipse cx="162" cy="488" rx="1" ry="1.6" fill="#efce7a"/>
+
+        <!-- Right arm reaching down -->
+        <path d="M180,234 C198,238 214,254 224,278 L232,316 L236,348 L240,376 L246,402 L248,422 L240,420 L234,396 L228,372 L222,348 L216,322 L208,300 L198,282 L188,266 L180,250 Z" fill="#0d0a05"/>
+        <ellipse cx="220" cy="294" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="228" cy="328" rx="1" ry="1.6" fill="#efce7a"/>
+        <ellipse cx="236" cy="362" rx="1" ry="1.6" fill="#efce7a"/>
+        <ellipse cx="242" cy="396" rx="1" ry="1.6" fill="#efce7a"/>
+        <!-- right hand holding weapon stalk -->
+        <path d="M240,422 L256,422 L260,418 L262,422 L258,426 L242,428 Z" fill="#0d0a05"/>
+        <!-- weapon (panah/kris) -->
+        <path d="M254,418 L252,360 L254,300 L256,240 L260,180 L264,180 L264,240 L262,300 L260,360 L260,418 Z" fill="#0d0a05"/>
+        <path d="M258,170 L262,170 L260,150 Z" fill="#0d0a05"/>
+        <ellipse cx="260" cy="240" rx="0.8" ry="2" fill="#efce7a"/>
+        <ellipse cx="260" cy="300" rx="0.8" ry="2" fill="#efce7a"/>
+        <ellipse cx="260" cy="360" rx="0.8" ry="2" fill="#efce7a"/>
+
+        <!-- Left arm bent across body -->
+        <path d="M120,234 C108,240 96,256 88,278 L82,308 L80,338 L84,362 L92,380 L98,374 L94,358 L92,338 L94,316 L100,294 L108,276 L116,260 L122,248 Z" fill="#0d0a05"/>
+        <ellipse cx="88" cy="304" rx="1.2" ry="2" fill="#efce7a"/>
+        <ellipse cx="86" cy="332" rx="1" ry="1.6" fill="#efce7a"/>
+        <ellipse cx="90" cy="358" rx="1" ry="1.6" fill="#efce7a"/>
+
+        <!-- Legs - bent stance -->
+        <path d="M124,498 C118,520 116,544 118,568 L122,576 L132,576 L134,560 L138,540 L142,520 L146,506 Z" fill="#0d0a05"/>
+        <path d="M154,506 C158,520 162,540 166,560 L168,576 L178,576 L182,568 C184,544 182,520 176,498 Z" fill="#0d0a05"/>
+        <ellipse cx="128" cy="520" rx="1" ry="2" fill="#efce7a"/>
+        <ellipse cx="126" cy="544" rx="1" ry="2" fill="#efce7a"/>
+        <ellipse cx="172" cy="520" rx="1" ry="2" fill="#efce7a"/>
+        <ellipse cx="174" cy="544" rx="1" ry="2" fill="#efce7a"/>
+
+        <!-- feet -->
+        <path d="M118,576 L138,576 L142,586 L114,586 Z" fill="#0d0a05"/>
+        <path d="M162,576 L182,576 L186,586 L158,586 Z" fill="#0d0a05"/>
+
+        <!-- control stick (gapit) -->
+        <path d="M150,586 L150,598 L154,598 L154,586 Z" fill="#0d0a05"/>
+      </svg>
+    </figure>
+
+    <div class="hero-text">
+      <p class="hero-eyebrow">Pertunjukan &middot; Performance &middot; Tonight</p>
+      <h1 class="hero-headline">
+        <span>From cloth and lamp.</span>
+        <span>From bamboo and reed.</span>
+        <span>We carry the night</span>
+        <span>from town to town.</span>
+      </h1>
+      <div class="hero-sigil">
+        <svg viewBox="0 0 200 200" class="sigil-ring" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="100" cy="100" r="92" fill="none" stroke="#aa1f20" stroke-width="2"/>
+          <circle cx="100" cy="100" r="80" fill="none" stroke="#aa1f20" stroke-width="0.8" stroke-dasharray="2 4"/>
+          <circle cx="100" cy="100" r="62" fill="none" stroke="#aa1f20" stroke-width="1"/>
+          <path d="M100,8 L102,16 L100,24 L98,16 Z" fill="#aa1f20"/>
+          <path d="M192,100 L184,102 L176,100 L184,98 Z" fill="#aa1f20"/>
+          <path d="M100,192 L102,184 L100,176 L98,184 Z" fill="#aa1f20"/>
+          <path d="M8,100 L16,102 L24,100 L16,98 Z" fill="#aa1f20"/>
+          <text x="100" y="92" text-anchor="middle" font-family="DM Serif Display" font-size="14" fill="#aa1f20" font-style="italic">PERFORMING</text>
+          <text x="100" y="108" text-anchor="middle" font-family="DM Serif Display" font-size="20" fill="#aa1f20">14 NIGHTS</text>
+          <text x="100" y="126" text-anchor="middle" font-family="Inter" font-size="11" fill="#aa1f20" letter-spacing="2">{{ current_year }}</text>
+        </svg>
+        <div class="hero-stamp">
+          <span class="stamp-line">Hand-stamped by the dalang</span>
+          <span class="stamp-num">N&deg; 014 &middot; tour {{ current_year }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="repertoire" id="repertoire" aria-label="repertoire">
+  <header class="section-head">
+    <span class="sec-eye">Bab 1</span>
+    <h2><em>Repertoire,</em> the plays we carry.</h2>
+    <p>Four nights, four worlds. Each cut by hand, each lit by oil. Performance length is given without intermission. The gamelan ensemble travels with the play.</p>
+  </header>
+  <div class="rep-grid">
+    <article class="rep-card">
+      <div class="rep-figure">
+        <svg viewBox="0 0 200 320" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- Princess (Srikandi) -->
+          <path d="M100,8 L106,2 L110,10 L116,4 L118,14 L124,10 L124,20 L130,18 L128,28 L132,32 L126,38 L130,44 L122,46 L122,54 L114,52 L112,60 L104,56 L100,62 L96,56 L88,60 L86,52 L78,54 L78,46 L70,44 L74,38 L68,32 L72,28 L70,18 L76,20 L76,10 L82,14 L84,4 L90,10 L94,2 Z" fill="#0d0a05"/>
+          <ellipse cx="100" cy="16" rx="1.6" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="92" cy="22" rx="1" ry="1.8" fill="#efce7a"/>
+          <ellipse cx="108" cy="22" rx="1" ry="1.8" fill="#efce7a"/>
+          <ellipse cx="100" cy="34" rx="1.4" ry="2.2" fill="#efce7a"/>
+          <ellipse cx="86" cy="42" rx="1" ry="1.4" fill="#efce7a"/>
+          <ellipse cx="114" cy="42" rx="1" ry="1.4" fill="#efce7a"/>
+          <!-- face -->
+          <path d="M100,62 C92,66 86,76 86,88 L82,94 L86,100 L82,108 L86,114 L82,122 L88,128 L96,130 L100,134 L104,130 L112,128 L118,122 L114,114 L118,108 L114,100 L118,94 L114,88 C114,76 108,66 100,62 Z" fill="#0d0a05"/>
+          <path d="M82,96 L92,96 L92,100 L82,100 Z" fill="#efce7a"/>
+          <ellipse cx="78" cy="108" rx="0.8" ry="1.2" fill="#efce7a"/>
+          <path d="M82,120 L90,120 L90,122 L82,122 Z" fill="#efce7a"/>
+          <!-- neck/shoulders -->
+          <path d="M96,134 L104,134 L106,144 L94,144 Z" fill="#0d0a05"/>
+          <path d="M70,148 C84,142 116,142 130,148 L134,156 C116,150 84,150 66,156 Z" fill="#0d0a05"/>
+          <circle cx="80" cy="152" r="1" fill="#efce7a"/>
+          <circle cx="90" cy="152" r="1" fill="#efce7a"/>
+          <circle cx="100" cy="152" r="1.2" fill="#efce7a"/>
+          <circle cx="110" cy="152" r="1" fill="#efce7a"/>
+          <circle cx="120" cy="152" r="1" fill="#efce7a"/>
+          <!-- torso -->
+          <path d="M72,156 C70,176 70,196 74,216 L84,232 L100,238 L116,232 L126,216 C130,196 130,176 128,156 Z" fill="#0d0a05"/>
+          <path d="M86,172 L114,172 L114,176 L86,176 Z" fill="#efce7a"/>
+          <ellipse cx="100" cy="186" rx="1.4" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="88" cy="196" rx="1" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="112" cy="196" rx="1" ry="1.6" fill="#efce7a"/>
+          <path d="M90,210 Q100,216 110,210" stroke="#efce7a" stroke-width="0.8" fill="none"/>
+          <!-- arms -->
+          <path d="M72,158 C58,168 50,184 46,204 L44,224 L50,222 L54,206 L60,188 L70,174 Z" fill="#0d0a05"/>
+          <path d="M128,158 C142,168 150,184 154,204 L156,224 L150,222 L146,206 L140,188 L130,174 Z" fill="#0d0a05"/>
+          <ellipse cx="52" cy="200" rx="0.8" ry="1.4" fill="#efce7a"/>
+          <ellipse cx="148" cy="200" rx="0.8" ry="1.4" fill="#efce7a"/>
+          <!-- skirt -->
+          <path d="M76,232 L124,232 L132,278 L126,308 L74,308 L68,278 Z" fill="#0d0a05"/>
+          <ellipse cx="86" cy="248" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="100" cy="246" rx="1.4" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="114" cy="248" rx="1.2" ry="2" fill="#efce7a"/>
+          <path d="M78,264 L122,264 L122,268 L78,268 Z" fill="#efce7a"/>
+          <ellipse cx="92" cy="280" rx="1" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="108" cy="280" rx="1" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="100" cy="294" rx="1.2" ry="2" fill="#efce7a"/>
+        </svg>
+      </div>
+      <div class="rep-body">
+        <h3><em>Srikandi Larasati</em></h3>
+        <dl class="rep-meta">
+          <dt>Duration</dt><dd>2 hours, 40 minutes</dd>
+          <dt>Language</dt><dd>Javanese</dd>
+          <dt>Gamelan</dt><dd>Slendro pelog &middot; full ensemble</dd>
+        </dl>
+        <p>A princess takes the bow that her teacher cannot lift. A coming-of-age. A standing ovation, every time, every village.</p>
+      </div>
+    </article>
+
+    <article class="rep-card">
+      <div class="rep-figure">
+        <svg viewBox="0 0 200 320" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- Giant (Buta / Cakil) - wild hair, fangs, muscular -->
+          <path d="M100,4 L108,2 L104,12 L116,8 L112,18 L124,16 L118,26 L130,28 L122,36 L132,42 L124,48 L132,56 L122,58 L126,68 L116,66 L116,76 L108,72 L106,82 L100,78 L94,82 L92,72 L84,76 L84,66 L74,68 L78,58 L68,56 L76,48 L68,42 L78,36 L70,28 L82,26 L76,16 L88,18 L84,8 L96,12 L92,2 Z" fill="#0d0a05"/>
+          <ellipse cx="100" cy="20" rx="1.6" ry="2" fill="#efce7a"/>
+          <ellipse cx="88" cy="30" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="112" cy="30" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="80" cy="44" rx="1" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="120" cy="44" rx="1" ry="1.6" fill="#efce7a"/>
+          <!-- face -->
+          <path d="M100,82 C90,86 82,98 82,112 L78,120 L82,128 L78,138 L84,144 L80,154 L88,158 L94,158 L100,162 L106,158 L112,158 L120,154 L116,144 L122,138 L118,128 L122,120 L118,112 C118,98 110,86 100,82 Z" fill="#0d0a05"/>
+          <!-- bulging eye -->
+          <circle cx="86" cy="124" r="4" fill="#efce7a"/>
+          <circle cx="86" cy="124" r="2" fill="#0d0a05"/>
+          <!-- snout/teeth -->
+          <path d="M76,140 L82,140 L80,150 Z" fill="#efce7a"/>
+          <path d="M82,148 L86,148 L84,156 Z" fill="#efce7a"/>
+          <path d="M88,150 L92,150 L90,158 Z" fill="#efce7a"/>
+          <!-- nostril -->
+          <ellipse cx="80" cy="132" rx="1.4" ry="1.8" fill="#efce7a"/>
+          <!-- neck -->
+          <path d="M94,162 L106,162 L110,176 L90,176 Z" fill="#0d0a05"/>
+          <!-- huge shoulders -->
+          <path d="M60,180 C76,170 124,170 140,180 L146,196 C124,184 76,184 54,196 Z" fill="#0d0a05"/>
+          <circle cx="74" cy="186" r="1.4" fill="#efce7a"/>
+          <circle cx="100" cy="184" r="1.6" fill="#efce7a"/>
+          <circle cx="126" cy="186" r="1.4" fill="#efce7a"/>
+          <!-- big torso -->
+          <path d="M58,196 C56,222 56,250 64,278 L100,290 L136,278 C144,250 144,222 142,196 Z" fill="#0d0a05"/>
+          <!-- chest carving -->
+          <path d="M80,210 L120,210 L120,216 L80,216 Z" fill="#efce7a"/>
+          <ellipse cx="100" cy="228" rx="3" ry="4" fill="#efce7a"/>
+          <ellipse cx="100" cy="228" rx="1.4" ry="2" fill="#0d0a05"/>
+          <ellipse cx="84" cy="238" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="116" cy="238" rx="1.2" ry="2" fill="#efce7a"/>
+          <path d="M76,252 Q100,260 124,252" stroke="#efce7a" stroke-width="1" fill="none"/>
+          <ellipse cx="90" cy="266" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="110" cy="266" rx="1.2" ry="2" fill="#efce7a"/>
+          <!-- arms muscular -->
+          <path d="M58,200 C40,206 28,220 22,240 L18,266 L26,266 L32,246 L42,228 L56,216 Z" fill="#0d0a05"/>
+          <path d="M142,200 C160,206 172,220 178,240 L182,266 L174,266 L168,246 L158,228 L144,216 Z" fill="#0d0a05"/>
+          <ellipse cx="32" cy="240" rx="1" ry="2" fill="#efce7a"/>
+          <ellipse cx="168" cy="240" rx="1" ry="2" fill="#efce7a"/>
+          <!-- loincloth -->
+          <path d="M66,290 L134,290 L142,308 L58,308 Z" fill="#0d0a05"/>
+          <ellipse cx="80" cy="298" rx="1" ry="2" fill="#efce7a"/>
+          <ellipse cx="100" cy="298" rx="1.4" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="120" cy="298" rx="1" ry="2" fill="#efce7a"/>
+        </svg>
+      </div>
+      <div class="rep-body">
+        <h3><em>Buta Cakil &mdash; The Giant Who Bargained</em></h3>
+        <dl class="rep-meta">
+          <dt>Duration</dt><dd>1 hour, 50 minutes</dd>
+          <dt>Language</dt><dd>Indonesian</dd>
+          <dt>Gamelan</dt><dd>Slendro &middot; four-piece percussion</dd>
+        </dl>
+        <p>A roadside giant proposes terms a prince cannot refuse. Comedy, then violence, then a long quiet. Suitable for older children.</p>
+      </div>
+    </article>
+
+    <article class="rep-card">
+      <div class="rep-figure">
+        <svg viewBox="0 0 220 320" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- Deer (kijang) - leaping pose -->
+          <!-- antlers -->
+          <path d="M70,22 L66,2 L72,10 L74,4 L78,14 L82,8 L82,22 Z" fill="#0d0a05"/>
+          <path d="M88,22 L94,4 L96,12 L100,2 L102,12 L108,6 L100,22 Z" fill="#0d0a05"/>
+          <ellipse cx="74" cy="16" rx="0.8" ry="1.4" fill="#efce7a"/>
+          <ellipse cx="98" cy="16" rx="0.8" ry="1.4" fill="#efce7a"/>
+          <!-- head + ears -->
+          <path d="M64,24 L58,18 L54,28 L48,34 L46,46 L48,56 L54,62 L64,66 L72,70 L86,72 L100,70 L110,64 L106,52 L106,38 L100,28 L90,22 Z" fill="#0d0a05"/>
+          <ellipse cx="60" cy="44" rx="2.4" ry="3" fill="#efce7a"/>
+          <circle cx="60" cy="44" r="1.4" fill="#0d0a05"/>
+          <ellipse cx="50" cy="38" rx="1" ry="2" fill="#efce7a"/>
+          <ellipse cx="56" cy="58" rx="1" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="74" cy="38" rx="1.2" ry="1.8" fill="#efce7a"/>
+          <ellipse cx="84" cy="40" rx="1" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="94" cy="44" rx="1" ry="1.6" fill="#efce7a"/>
+          <!-- neck -->
+          <path d="M104,72 L116,76 L130,86 L138,98 L142,112 L138,124 L128,116 L120,104 L112,94 L102,86 Z" fill="#0d0a05"/>
+          <ellipse cx="124" cy="106" rx="1" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="130" cy="116" rx="1" ry="1.6" fill="#efce7a"/>
+          <!-- body -->
+          <path d="M138,98 C156,96 178,104 192,120 C204,138 208,160 204,182 C200,202 188,218 170,224 L150,222 L130,216 L116,206 L106,192 L102,176 L104,158 L114,142 L124,128 Z" fill="#0d0a05"/>
+          <!-- body carved pattern -->
+          <ellipse cx="150" cy="140" rx="2" ry="3" fill="#efce7a"/>
+          <ellipse cx="170" cy="144" rx="2" ry="3" fill="#efce7a"/>
+          <ellipse cx="188" cy="150" rx="1.6" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="158" cy="160" rx="2" ry="3" fill="#efce7a"/>
+          <ellipse cx="178" cy="166" rx="2" ry="3" fill="#efce7a"/>
+          <ellipse cx="148" cy="178" rx="1.6" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="168" cy="184" rx="2" ry="3" fill="#efce7a"/>
+          <ellipse cx="188" cy="180" rx="1.6" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="142" cy="196" rx="1.4" ry="2" fill="#efce7a"/>
+          <ellipse cx="162" cy="200" rx="1.4" ry="2" fill="#efce7a"/>
+          <ellipse cx="182" cy="204" rx="1.4" ry="2" fill="#efce7a"/>
+          <!-- front legs (leaping forward) -->
+          <path d="M116,206 L110,224 L106,244 L102,266 L98,286 L96,300 L102,302 L106,288 L112,270 L116,250 L122,232 L126,218 Z" fill="#0d0a05"/>
+          <path d="M132,214 L128,232 L126,254 L122,276 L120,296 L120,308 L126,308 L130,296 L134,278 L138,258 L142,238 L146,220 Z" fill="#0d0a05"/>
+          <ellipse cx="108" cy="248" rx="0.8" ry="1.4" fill="#efce7a"/>
+          <ellipse cx="128" cy="258" rx="0.8" ry="1.4" fill="#efce7a"/>
+          <!-- hind legs -->
+          <path d="M186,224 L190,246 L194,270 L196,292 L196,306 L202,306 L204,290 L208,266 L208,244 L204,224 Z" fill="#0d0a05"/>
+          <path d="M168,224 L168,244 L172,266 L174,290 L174,306 L180,306 L182,290 L184,268 L186,246 L186,224 Z" fill="#0d0a05"/>
+          <ellipse cx="196" cy="260" rx="0.8" ry="1.4" fill="#efce7a"/>
+          <ellipse cx="178" cy="270" rx="0.8" ry="1.4" fill="#efce7a"/>
+          <!-- tail -->
+          <path d="M204,178 L216,170 L220,178 L214,184 Z" fill="#0d0a05"/>
+        </svg>
+      </div>
+      <div class="rep-body">
+        <h3><em>Kijang Kanaka &mdash; The Golden Deer</em></h3>
+        <dl class="rep-meta">
+          <dt>Duration</dt><dd>2 hours, 10 minutes</dd>
+          <dt>Language</dt><dd>Indonesian / Korean (subtitle scroll)</dd>
+          <dt>Gamelan</dt><dd>Pelog &middot; three suling, one rebab</dd>
+        </dl>
+        <p>The animal you chase is the animal that taught you to chase. The Ramayana, told from the deer's side, in a single breath.</p>
+      </div>
+    </article>
+
+    <article class="rep-card">
+      <div class="rep-figure">
+        <svg viewBox="0 0 200 320" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- Sage (Begawan / Semar-like) - rounded, wise, staff in hand -->
+          <!-- topknot -->
+          <path d="M100,8 L106,2 L110,14 L116,8 L116,20 L122,18 L120,28 L100,32 L80,28 L78,18 L84,20 L84,8 L90,14 L94,2 Z" fill="#0d0a05"/>
+          <ellipse cx="100" cy="18" rx="1.4" ry="2" fill="#efce7a"/>
+          <ellipse cx="90" cy="22" rx="1" ry="1.4" fill="#efce7a"/>
+          <ellipse cx="110" cy="22" rx="1" ry="1.4" fill="#efce7a"/>
+          <!-- round face -->
+          <path d="M100,32 C82,32 70,46 70,68 C70,82 76,94 86,100 L78,108 L84,116 L80,124 L86,130 L88,138 L96,142 L104,142 L112,138 L114,130 L120,124 L116,116 L122,108 L114,100 C124,94 130,82 130,68 C130,46 118,32 100,32 Z" fill="#0d0a05"/>
+          <!-- closed eye line -->
+          <path d="M78,76 L94,76 L94,78 L78,78 Z" fill="#efce7a"/>
+          <path d="M106,76 L122,76 L122,78 L106,78 Z" fill="#efce7a"/>
+          <!-- nose -->
+          <ellipse cx="100" cy="92" rx="2.4" ry="3" fill="#efce7a"/>
+          <ellipse cx="100" cy="93" rx="1.2" ry="1.4" fill="#0d0a05"/>
+          <!-- mouth smile -->
+          <path d="M88,116 Q100,124 112,116" stroke="#efce7a" stroke-width="1.4" fill="none"/>
+          <!-- beard suggestion -->
+          <path d="M88,128 L92,140 L96,128 Z" fill="#efce7a"/>
+          <path d="M104,128 L108,140 L112,128 Z" fill="#efce7a"/>
+          <!-- neck -->
+          <path d="M94,142 L106,142 L108,152 L92,152 Z" fill="#0d0a05"/>
+          <!-- rounded body (large belly) -->
+          <path d="M60,162 C56,182 54,210 60,236 C68,260 84,272 100,274 C116,272 132,260 140,236 C146,210 144,182 140,162 C128,154 116,150 100,150 C84,150 72,154 60,162 Z" fill="#0d0a05"/>
+          <!-- chest carving -->
+          <path d="M80,170 L120,170 L120,174 L80,174 Z" fill="#efce7a"/>
+          <ellipse cx="100" cy="186" rx="1.6" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="86" cy="196" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="114" cy="196" rx="1.2" ry="2" fill="#efce7a"/>
+          <!-- belly button -->
+          <circle cx="100" cy="218" r="3" fill="#efce7a"/>
+          <circle cx="100" cy="218" r="1.4" fill="#0d0a05"/>
+          <ellipse cx="80" cy="226" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="120" cy="226" rx="1.2" ry="2" fill="#efce7a"/>
+          <path d="M82,242 Q100,250 118,242" stroke="#efce7a" stroke-width="1" fill="none"/>
+          <ellipse cx="90" cy="258" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="110" cy="258" rx="1.2" ry="2" fill="#efce7a"/>
+          <!-- arm holding staff -->
+          <path d="M62,166 C48,178 40,196 36,216 L34,238 L42,238 L46,220 L54,202 L62,188 Z" fill="#0d0a05"/>
+          <path d="M138,166 C152,178 160,196 164,216 L166,238 L158,238 L154,220 L146,202 L138,188 Z" fill="#0d0a05"/>
+          <ellipse cx="44" cy="216" rx="1" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="156" cy="216" rx="1" ry="1.6" fill="#efce7a"/>
+          <!-- staff (tongkat) -->
+          <path d="M30,180 L32,180 L34,310 L28,310 Z" fill="#0d0a05"/>
+          <path d="M26,178 L36,178 L34,186 L28,186 Z" fill="#0d0a05"/>
+          <ellipse cx="31" cy="240" rx="0.8" ry="1.6" fill="#efce7a"/>
+          <ellipse cx="31" cy="270" rx="0.8" ry="1.6" fill="#efce7a"/>
+          <!-- skirt -->
+          <path d="M68,274 L132,274 L138,300 L62,300 Z" fill="#0d0a05"/>
+          <ellipse cx="82" cy="286" rx="1.2" ry="2" fill="#efce7a"/>
+          <ellipse cx="100" cy="284" rx="1.4" ry="2.4" fill="#efce7a"/>
+          <ellipse cx="118" cy="286" rx="1.2" ry="2" fill="#efce7a"/>
+        </svg>
+      </div>
+      <div class="rep-body">
+        <h3><em>Begawan Lentera &mdash; The Lamp Sage</em></h3>
+        <dl class="rep-meta">
+          <dt>Duration</dt><dd>3 hours, 20 minutes</dd>
+          <dt>Language</dt><dd>Javanese / Korean</dd>
+          <dt>Gamelan</dt><dd>Slendro pelog &middot; full ensemble + suling</dd>
+        </dl>
+        <p>An original work. A village sage carries his lamp into a city he no longer recognises. Adapted from a 1962 essay by Mas Ruslan.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="tour" id="tour" aria-label="tour dates">
+  <header class="section-head">
+    <span class="sec-eye">Bab 2</span>
+    <h2><em>Tour Dates,</em> the lamp moves.</h2>
+    <p>Doors at the listed time; show starts on the hour. Most venues are floor-seated. Bring a cushion if you can; we bring spares if you can't.</p>
+  </header>
+  <table class="tour-table">
+    <thead>
+      <tr><th>City</th><th>Venue</th><th>Date</th><th>Doors</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><em>Yogyakarta</em></td>
+        <td>Pendopo Tirta Banyu</td>
+        <td>{{ current_year }} &middot; 06 &middot; 14</td>
+        <td>19:30 &middot; show 20:00</td>
+      </tr>
+      <tr class="tour-rule"><td colspan="4">
+        <svg viewBox="0 0 600 16" preserveAspectRatio="none" aria-hidden="true">
+          <path d="M0,8 L260,8" stroke="#0d0a05" stroke-width="0.8"/>
+          <path d="M300,2 L294,8 L300,14 L306,8 Z M286,8 L294,8 M306,8 L314,8 M280,4 L280,12 M320,4 L320,12" fill="#0d0a05" stroke="#0d0a05" stroke-width="0.8"/>
+          <path d="M340,8 L600,8" stroke="#0d0a05" stroke-width="0.8"/>
+        </svg>
+      </td></tr>
+      <tr>
+        <td><em>Surakarta</em></td>
+        <td>Balai Sukma Kraton</td>
+        <td>{{ current_year }} &middot; 06 &middot; 28</td>
+        <td>19:00 &middot; show 19:30</td>
+      </tr>
+      <tr class="tour-rule"><td colspan="4">
+        <svg viewBox="0 0 600 16" preserveAspectRatio="none" aria-hidden="true">
+          <path d="M0,8 L260,8" stroke="#0d0a05" stroke-width="0.8"/>
+          <path d="M300,2 L294,8 L300,14 L306,8 Z M286,8 L294,8 M306,8 L314,8 M280,4 L280,12 M320,4 L320,12" fill="#0d0a05" stroke="#0d0a05" stroke-width="0.8"/>
+          <path d="M340,8 L600,8" stroke="#0d0a05" stroke-width="0.8"/>
+        </svg>
+      </td></tr>
+      <tr>
+        <td><em>Seoul</em></td>
+        <td>Bukchon Madang (rented stage)</td>
+        <td>{{ current_year }} &middot; 08 &middot; 09</td>
+        <td>19:00 &middot; show 19:30</td>
+      </tr>
+      <tr class="tour-rule"><td colspan="4">
+        <svg viewBox="0 0 600 16" preserveAspectRatio="none" aria-hidden="true">
+          <path d="M0,8 L260,8" stroke="#0d0a05" stroke-width="0.8"/>
+          <path d="M300,2 L294,8 L300,14 L306,8 Z M286,8 L294,8 M306,8 L314,8 M280,4 L280,12 M320,4 L320,12" fill="#0d0a05" stroke="#0d0a05" stroke-width="0.8"/>
+          <path d="M340,8 L600,8" stroke="#0d0a05" stroke-width="0.8"/>
+        </svg>
+      </td></tr>
+      <tr>
+        <td><em>Busan</em></td>
+        <td>Yeongdo Open Pendopo</td>
+        <td>{{ current_year }} &middot; 08 &middot; 23</td>
+        <td>19:30 &middot; show 20:00</td>
+      </tr>
+      <tr class="tour-rule"><td colspan="4">
+        <svg viewBox="0 0 600 16" preserveAspectRatio="none" aria-hidden="true">
+          <path d="M0,8 L260,8" stroke="#0d0a05" stroke-width="0.8"/>
+          <path d="M300,2 L294,8 L300,14 L306,8 Z M286,8 L294,8 M306,8 L314,8 M280,4 L280,12 M320,4 L320,12" fill="#0d0a05" stroke="#0d0a05" stroke-width="0.8"/>
+          <path d="M340,8 L600,8" stroke="#0d0a05" stroke-width="0.8"/>
+        </svg>
+      </td></tr>
+      <tr>
+        <td><em>Bandung</em></td>
+        <td>Saung Lentera Ciumbuleuit</td>
+        <td>{{ current_year }} &middot; 09 &middot; 13</td>
+        <td>19:00 &middot; show 19:30</td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="tour-note">Bookings open through the desk only. Letters preferred over email; replies inside fourteen days.</p>
+</section>
+
+<section class="lab" id="lab" aria-label="lentera lab">
+  <header class="section-head">
+    <span class="sec-eye">Bab 3</span>
+    <h2><em>Lentera Lab,</em> the apprentice cuts.</h2>
+  </header>
+  <div class="lab-grid">
+    <div class="lab-text">
+      <p>The Lab is two tables and four lamps, in a back room behind the green-room. Six apprentices, one master cutter, all the patience the night demands. We accept new students each autumn, after the harvest, never by application alone.</p>
+      <p>An apprentice begins on rough paper, then waxed paper, then buffalo hide. A single hand &mdash; the small carved hand of Arjuna &mdash; takes three weeks to complete. The pattern below took two evenings. The master will tell you it took twenty-two years.</p>
+      <p class="lab-sign"><em>&mdash; Mas Ruslan, dalang &amp; head cutter</em></p>
+    </div>
+    <div class="lab-details">
+      <figure class="lab-detail">
+        <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- carved detail panel 1: floral lozenge -->
+          <rect x="2" y="2" width="196" height="196" fill="#0d0a05"/>
+          <path d="M100,20 C140,40 160,80 140,120 C160,140 180,160 100,180 C20,160 40,140 60,120 C40,80 60,40 100,20 Z" fill="none" stroke="#efce7a" stroke-width="0.6"/>
+          <ellipse cx="100" cy="40" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="100" cy="60" rx="2" ry="4" fill="#efce7a"/>
+          <ellipse cx="100" cy="100" rx="4" ry="8" fill="#efce7a"/>
+          <ellipse cx="100" cy="140" rx="2" ry="4" fill="#efce7a"/>
+          <ellipse cx="100" cy="160" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="70" cy="100" rx="6" ry="3" fill="#efce7a"/>
+          <ellipse cx="130" cy="100" rx="6" ry="3" fill="#efce7a"/>
+          <ellipse cx="80" cy="80" rx="2" ry="3" fill="#efce7a"/>
+          <ellipse cx="120" cy="80" rx="2" ry="3" fill="#efce7a"/>
+          <ellipse cx="80" cy="120" rx="2" ry="3" fill="#efce7a"/>
+          <ellipse cx="120" cy="120" rx="2" ry="3" fill="#efce7a"/>
+          <circle cx="60" cy="60" r="2" fill="#efce7a"/>
+          <circle cx="140" cy="60" r="2" fill="#efce7a"/>
+          <circle cx="60" cy="140" r="2" fill="#efce7a"/>
+          <circle cx="140" cy="140" r="2" fill="#efce7a"/>
+          <circle cx="40" cy="100" r="1.4" fill="#efce7a"/>
+          <circle cx="160" cy="100" r="1.4" fill="#efce7a"/>
+          <circle cx="100" cy="100" r="1.6" fill="#0d0a05"/>
+          <path d="M100,12 L100,2 M100,188 L100,198 M12,100 L2,100 M188,100 L198,100" stroke="#a87b1b" stroke-width="1.4"/>
+        </svg>
+        <figcaption>Lozenge, hand of Arjuna (left)</figcaption>
+      </figure>
+      <figure class="lab-detail">
+        <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- carved detail panel 2: chain pattern -->
+          <rect x="2" y="2" width="196" height="196" fill="#0d0a05"/>
+          <g stroke="#efce7a" stroke-width="0.8" fill="none">
+            <circle cx="50" cy="50" r="14"/>
+            <circle cx="100" cy="50" r="14"/>
+            <circle cx="150" cy="50" r="14"/>
+            <circle cx="50" cy="100" r="14"/>
+            <circle cx="100" cy="100" r="14"/>
+            <circle cx="150" cy="100" r="14"/>
+            <circle cx="50" cy="150" r="14"/>
+            <circle cx="100" cy="150" r="14"/>
+            <circle cx="150" cy="150" r="14"/>
+          </g>
+          <g fill="#efce7a">
+            <circle cx="50" cy="50" r="2"/>
+            <circle cx="100" cy="50" r="2"/>
+            <circle cx="150" cy="50" r="2"/>
+            <circle cx="50" cy="100" r="2"/>
+            <circle cx="100" cy="100" r="3"/>
+            <circle cx="150" cy="100" r="2"/>
+            <circle cx="50" cy="150" r="2"/>
+            <circle cx="100" cy="150" r="2"/>
+            <circle cx="150" cy="150" r="2"/>
+            <circle cx="75" cy="75" r="1.2"/>
+            <circle cx="125" cy="75" r="1.2"/>
+            <circle cx="75" cy="125" r="1.2"/>
+            <circle cx="125" cy="125" r="1.2"/>
+          </g>
+          <g stroke="#a87b1b" stroke-width="0.8" fill="none">
+            <path d="M2,2 L20,2 L20,20 L2,20 Z"/>
+            <path d="M180,2 L198,2 L198,20 L180,20 Z"/>
+            <path d="M2,180 L20,180 L20,198 L2,198 Z"/>
+            <path d="M180,180 L198,180 L198,198 L180,198 Z"/>
+          </g>
+        </svg>
+        <figcaption>Chain, sash of Bima (centre)</figcaption>
+      </figure>
+      <figure class="lab-detail">
+        <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- carved detail panel 3: vine + slits -->
+          <rect x="2" y="2" width="196" height="196" fill="#0d0a05"/>
+          <path d="M20,100 Q60,40 100,100 T180,100" stroke="#efce7a" stroke-width="1" fill="none"/>
+          <path d="M20,100 Q60,160 100,100 T180,100" stroke="#efce7a" stroke-width="1" fill="none"/>
+          <ellipse cx="40" cy="70" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="60" cy="60" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="80" cy="70" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="120" cy="70" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="140" cy="60" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="160" cy="70" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="40" cy="130" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="60" cy="140" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="80" cy="130" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="120" cy="130" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="140" cy="140" rx="3" ry="6" fill="#efce7a"/>
+          <ellipse cx="160" cy="130" rx="3" ry="6" fill="#efce7a"/>
+          <circle cx="100" cy="100" r="6" fill="#efce7a"/>
+          <circle cx="100" cy="100" r="3" fill="#0d0a05"/>
+          <path d="M20,20 L40,20 M160,20 L180,20 M20,180 L40,180 M160,180 L180,180" stroke="#a87b1b" stroke-width="1.4"/>
+        </svg>
+        <figcaption>Vine, edge of the kayon (right)</figcaption>
+      </figure>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/shadow-puppet/templates/page.html
+++ b/examples/shadow-puppet/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/shadow-puppet/templates/section.html
+++ b/examples/shadow-puppet/templates/section.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+<section class="archive">
+  <header class="section-head">
+    {% if page.title is present %}<h2><em>{{ page.title | e }}</em></h2>{% endif %}
+  </header>
+  <div class="prose">{{ content | safe }}</div>
+  <ul class="archive-list">
+    {% for post in section.pages %}
+    <li>
+      <span class="archive-date">{{ post.date | date(format="%Y &middot; %m &middot; %d") | safe }}</span>
+      <a href="{{ post.url }}"><em>{{ post.title | e }}</em></a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/shadow-puppet/templates/shortcodes/alert.html
+++ b/examples/shadow-puppet/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<div class="alert">
+  <strong>{{ type | upper }}</strong>
+  <span>{{ body }}</span>
+</div>

--- a/examples/shadow-puppet/templates/taxonomy.html
+++ b/examples/shadow-puppet/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>An index of subjects across the kompani's letters and field notes.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/shadow-puppet/templates/taxonomy_term.html
+++ b/examples/shadow-puppet/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1><em>{{ page.title | e }}</em></h1>
+  <p>Entries filed under this lamp.</p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/tide-bureau/AGENTS.md
+++ b/examples/tide-bureau/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/tide-bureau/archetypes/default.md
+++ b/examples/tide-bureau/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/tide-bureau/config.toml
+++ b/examples/tide-bureau/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "BUREAU OF TIDES"
+description = "Tide-table almanac for harbormasters, kayakers, oyster farmers, and small-craft pilots — published in the style of the admiralty volumes."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/tide-bureau/content/about.md
+++ b/examples/tide-bureau/content/about.md
@@ -1,0 +1,46 @@
++++
+title = "The Bureau"
+description = "On the Bureau of Tides — its work, its surveyors, the chart datum system, its publication schedule, and the keepers who answer its mail."
++++
+
+## The Bureau
+
+The Bureau of Tides keeps the tables. It has done so, in one form or another, since the founding of the Admiralty Almanac in the late nineteenth century. The work has changed; the discipline has not. Every figure printed in this volume has been reduced, checked, and signed off by a named keeper before it leaves the press at the Almanac House.
+
+We exist for the people who read tide tables for a living: **harbormasters** plotting the night's berthings, **oyster farmers** walking out at low water, **kayakers** picking a window through a tidal race, and **pilots of small craft** for whom the bar at the harbour entrance is a daily proposition.
+
+## On surveying a station
+
+A station is more than a gauge. It is a register: latitude and longitude to the arc-second, the founding datum, the run of past surveys, the keeper of record. Before a station enters this volume the Bureau requires three things:
+
+- **Two years of continuous observation** at a single fixed gauge, or a reduced equivalent.
+- **A reference survey** to the national geodetic mark, repeated every six months.
+- **A keeper's note** of any seasonal anomaly: ice, freshwater outflow, port construction, or shift of the channel.
+
+The reduced figures are what you read in the right-hand columns of the daily tables. The full survey papers are kept at the Bureau and may be requested by correspondence; we do not publish them in full because the bound paper is too expensive for what would, in candor, be read by very few.
+
+## On the chart datum system
+
+All heights in this volume are reduced to the **Lowest Astronomical Tide** (LAT) at each station. The datum is the level below which the sea is not expected to fall under astronomical conditions alone. It is a useful fiction: storm surges, atmospheric pressure, and freshwater outflow can and do drive the actual water lower. The tables make no allowance for these. The Bureau prints **datum corrections** quarterly, and any keeper may issue an interim correction when a resurvey demands it.
+
+> No table replaces a lead and line. The Bureau has printed this caution in every volume since 1881 and sees no reason to retire it.
+
+The datum is fixed; the figure is not. If you find a discrepancy of more than 0.10 m between the printed height and your own gauge, please report it. We log every such report, and we publish a roll of corrections in the December issue.
+
+## Publication schedule
+
+The Bureau presses one volume per year, in a single edition, in **December**, for the following year. **Quarterly amendments** are issued in March, June, September, and December, and are appended to the bound volume by means of an inserted folio. Subscribers receive each amendment in the post; non-subscribers may collect them at the Almanac House by prior notice.
+
+Daily tables are published online for the convenience of those at sea. The printed volume remains the volume of record.
+
+## Contacting the keepers
+
+Correspondence is read by hand. Most letters are answered within thirty days; survey enquiries take longer because they require us to consult papers that are not in our front office.
+
+- **Bureau desk** &mdash; `desk@bureau.tides`
+- **Survey enquiries** &mdash; `survey@bureau.tides`
+- **Subscriptions** &mdash; `subscriptions@bureau.tides`
+- **Errata &amp; corrections** &mdash; `errata@bureau.tides`
+- **The keepers' roll** &mdash; printed in the front matter of every volume
+
+We do not maintain a telephone line. We do not answer enquiries through social channels. The post is slow and the post is sufficient.

--- a/examples/tide-bureau/content/index.md
+++ b/examples/tide-bureau/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "Bureau of Tides — tide-table almanac for harbormasters, kayakers, oyster farmers, and small-craft pilots, in the style of the admiralty volumes."
+template = "index"
++++

--- a/examples/tide-bureau/static/css/style.css
+++ b/examples/tide-bureau/static/css/style.css
@@ -1,0 +1,520 @@
+/* =======================================================================
+   BUREAU OF TIDES — Admiralty almanac stylesheet
+   Solid colors only. No gradients anywhere.
+   ======================================================================= */
+
+:root {
+  --bone:        #efe7d2;
+  --bone-deep:   #ddd0ac;
+  --navy:        #102540;
+  --navy-deep:   #07182c;
+  --brass:       #b48720;
+  --brass-deep:  #8c641a;
+  --tide:        #38628f;
+  --ensign:      #a32328;
+  --rule:        #102540;
+  --hair:        rgba(16, 37, 64, 0.32);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  background-color: var(--bone);
+  /* Paper texture: tiled tiny SVG data-URI, NOT a gradient */
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='80' height='80'><rect width='80' height='80' fill='%23efe7d2'/><circle cx='12' cy='18' r='0.6' fill='%23bda87a' opacity='0.35'/><circle cx='54' cy='8' r='0.4' fill='%23bda87a' opacity='0.3'/><circle cx='30' cy='44' r='0.5' fill='%23bda87a' opacity='0.3'/><circle cx='68' cy='62' r='0.7' fill='%23bda87a' opacity='0.35'/><circle cx='44' cy='72' r='0.4' fill='%23bda87a' opacity='0.3'/><circle cx='6' cy='66' r='0.5' fill='%23bda87a' opacity='0.3'/></svg>");
+  color: var(--navy-deep);
+  font-family: "Inter", -apple-system, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--navy); text-decoration: none; }
+a:hover { color: var(--brass-deep); text-decoration: underline; text-underline-offset: 3px; }
+
+::selection { background: var(--brass); color: var(--bone); }
+
+/* ---------- Top strip ---------- */
+.strip-top {
+  background: var(--navy);
+  color: var(--bone);
+  border-bottom: 4px double var(--brass);
+  padding: 10px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.strip-top .vol { color: var(--brass); font-weight: 700; }
+.strip-top nav { display: flex; gap: 22px; }
+.strip-top nav a { color: var(--bone); border-bottom: 1px solid transparent; padding-bottom: 2px; }
+.strip-top nav a:hover { color: var(--brass); border-bottom-color: var(--brass); text-decoration: none; }
+
+/* ---------- Hero ---------- */
+.hero {
+  border-bottom: 1px solid var(--navy);
+  padding: 0;
+}
+.hero-grid {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  border-bottom: 4px double var(--navy);
+}
+.hero-compass {
+  background: var(--bone);
+  border-right: 1px solid var(--navy);
+  padding: 36px 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+}
+.hero-compass .meta {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--navy);
+  text-align: center;
+  line-height: 1.7;
+}
+.hero-compass .meta b { color: var(--brass-deep); }
+
+.hero-right {
+  padding: 44px 48px;
+  background: var(--bone);
+  position: relative;
+}
+.hero-right .kicker {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--brass-deep);
+  border-top: 1px solid var(--navy);
+  border-bottom: 1px solid var(--navy);
+  padding: 6px 0;
+  display: inline-block;
+  margin-bottom: 24px;
+}
+.hero-right h1 {
+  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: clamp(40px, 5.6vw, 78px);
+  line-height: 1.02;
+  color: var(--navy-deep);
+  letter-spacing: -0.005em;
+  margin-bottom: 16px;
+}
+.hero-right h1 .sl { display: block; }
+.hero-right h1 .brass { color: var(--brass-deep); font-style: normal; }
+.hero-right .standfirst {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 18px;
+  line-height: 1.5;
+  color: var(--navy);
+  max-width: 56ch;
+  margin: 18px 0 28px;
+}
+
+/* tide table beneath headline */
+.tide-now {
+  border: 1px solid var(--navy);
+  background: var(--bone);
+  margin-top: 16px;
+}
+.tide-now-head {
+  background: var(--navy);
+  color: var(--bone);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  padding: 7px 14px;
+  text-transform: uppercase;
+  display: flex;
+  justify-content: space-between;
+}
+.tide-now-head .b { color: var(--brass); }
+.tide-now table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+}
+.tide-now td, .tide-now th {
+  border: 1px solid var(--brass);
+  padding: 9px 12px;
+  vertical-align: middle;
+}
+.tide-now th {
+  background: var(--bone-deep);
+  color: var(--navy-deep);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  text-align: left;
+}
+.tide-now td.station {
+  font-weight: 700;
+  color: var(--navy);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.tide-now td.hw { color: var(--tide); }
+.tide-now td.lw { color: var(--brass-deep); }
+.tide-now td.hw b, .tide-now td.lw b { color: var(--navy-deep); }
+
+/* ---------- Cartouche divider (no gradients) ---------- */
+.cartouche {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 28px 8px;
+  color: var(--navy);
+}
+.cartouche .line {
+  flex: 1;
+  height: 0;
+  border-top: 1px solid var(--navy);
+  position: relative;
+}
+.cartouche .line::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 3px;
+  border-top: 1px solid var(--brass);
+}
+.cartouche .mark {
+  padding: 0 18px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--brass-deep);
+}
+.cartouche .mark svg { vertical-align: middle; margin: 0 8px; }
+
+/* ---------- Generic section frame ---------- */
+.frame {
+  padding: 48px 36px;
+  border-bottom: 1px solid var(--navy);
+}
+.frame .wrap { max-width: 1200px; margin: 0 auto; }
+.frame .head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--navy);
+  padding-bottom: 10px;
+  margin-bottom: 22px;
+}
+.frame .head h2 {
+  font-family: "Cormorant Garamond", serif;
+  font-weight: 500;
+  font-style: italic;
+  font-size: 38px;
+  color: var(--navy-deep);
+  letter-spacing: -0.01em;
+}
+.frame .head .roman {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  color: var(--brass-deep);
+  text-transform: uppercase;
+}
+
+/* ---------- Stations table ---------- */
+.stations table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+  background: var(--bone);
+}
+.stations th {
+  background: var(--navy);
+  color: var(--bone);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid var(--navy);
+}
+.stations td {
+  padding: 9px 12px;
+  border-top: 1px solid var(--hair);
+  border-right: 1px solid var(--hair);
+  border-left: 1px solid var(--hair);
+}
+.stations tr:last-child td { border-bottom: 1px solid var(--navy); }
+.stations td.name {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 16px;
+  color: var(--navy-deep);
+  letter-spacing: 0.02em;
+}
+.stations td.code { color: var(--brass-deep); font-weight: 700; }
+.stations tr:nth-child(even) td { background: rgba(221, 208, 172, 0.32); }
+.stations td.range { color: var(--tide); }
+
+/* ---------- Moon phases ---------- */
+.moons {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+  margin-top: 8px;
+}
+.moon {
+  border: 1px solid var(--navy);
+  background: var(--bone);
+  padding: 22px 18px 18px;
+  text-align: center;
+  position: relative;
+}
+.moon::before {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border: 1px solid var(--brass);
+  pointer-events: none;
+}
+.moon svg { display: block; margin: 6px auto 14px; }
+.moon .phase {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 19px;
+  color: var(--navy-deep);
+  margin-bottom: 4px;
+}
+.moon .date {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--brass-deep);
+}
+.moon .rise {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11.5px;
+  margin-top: 8px;
+  color: var(--navy);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- Warnings ---------- */
+.warnings { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.warn {
+  background: var(--bone);
+  border: 2px solid var(--ensign);
+  padding: 0;
+  position: relative;
+}
+.warn header {
+  background: var(--ensign);
+  color: var(--bone);
+  padding: 8px 14px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  display: flex;
+  justify-content: space-between;
+}
+.warn .body { padding: 16px 18px 18px; }
+.warn h3 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ensign);
+  margin-bottom: 8px;
+}
+.warn p {
+  font-family: "Inter", sans-serif;
+  font-size: 14px;
+  color: var(--navy-deep);
+  line-height: 1.55;
+}
+.warn .stamp {
+  display: inline-block;
+  margin-top: 12px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ensign);
+  border: 1px solid var(--ensign);
+  padding: 3px 8px;
+}
+
+/* ---------- Bureau notice strip ---------- */
+.notice {
+  background: var(--bone-deep);
+  border-top: 1px solid var(--navy);
+  border-bottom: 1px solid var(--navy);
+  padding: 22px 36px;
+  text-align: center;
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 20px;
+  color: var(--navy-deep);
+}
+.notice b { color: var(--brass-deep); font-style: normal; letter-spacing: 0.06em; }
+
+/* ---------- Footer ---------- */
+.foot {
+  background: var(--navy-deep);
+  color: var(--bone);
+  padding: 56px 36px 28px;
+  border-top: 4px double var(--brass);
+}
+.foot .wrap { max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: 240px 1fr; gap: 48px; align-items: start; }
+.foot .seal { display: flex; flex-direction: column; align-items: flex-start; gap: 14px; }
+.foot .seal .colophon {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--brass);
+  line-height: 1.7;
+}
+.foot .cols { display: grid; grid-template-columns: repeat(4, 1fr); gap: 32px; }
+.foot .cols h4 {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.26em;
+  color: var(--brass);
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--brass);
+  padding-bottom: 6px;
+  margin-bottom: 10px;
+}
+.foot .cols a {
+  display: block;
+  color: var(--bone);
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-size: 15px;
+  padding: 4px 0;
+  border-bottom: 1px dotted rgba(239, 231, 210, 0.18);
+}
+.foot .cols a:hover { color: var(--brass); }
+.foot .stripe {
+  grid-column: 1 / -1;
+  margin-top: 32px;
+  border-top: 1px solid var(--brass);
+  padding-top: 16px;
+  display: flex;
+  justify-content: space-between;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--bone-deep);
+}
+
+/* ---------- Prose pages ---------- */
+.prose {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 60px 36px 80px;
+  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  font-size: 19px;
+  line-height: 1.7;
+  color: var(--navy-deep);
+}
+.prose h1 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 56px;
+  line-height: 1.05;
+  color: var(--navy-deep);
+  border-bottom: 4px double var(--brass);
+  padding-bottom: 18px;
+  margin-bottom: 28px;
+}
+.prose h2 {
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 32px;
+  color: var(--navy);
+  margin: 40px 0 14px;
+  border-bottom: 1px solid var(--navy);
+  padding-bottom: 6px;
+}
+.prose h3 {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--brass-deep);
+  margin: 28px 0 10px;
+}
+.prose p { margin-bottom: 16px; }
+.prose strong { color: var(--ensign); }
+.prose em { color: var(--brass-deep); }
+.prose a { color: var(--tide); text-decoration: underline; text-underline-offset: 3px; }
+.prose ul, .prose ol { margin: 14px 0 18px 24px; }
+.prose li { margin-bottom: 6px; }
+.prose blockquote {
+  border-left: 4px solid var(--brass);
+  padding: 8px 20px;
+  margin: 22px 0;
+  background: var(--bone-deep);
+  font-style: italic;
+  color: var(--navy);
+}
+.prose code {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 14px;
+  background: var(--bone-deep);
+  padding: 1px 6px;
+  border: 1px solid var(--hair);
+}
+.prose hr {
+  border: 0;
+  border-top: 1px solid var(--navy);
+  margin: 32px 0;
+  position: relative;
+}
+.prose hr::after {
+  content: "";
+  display: block;
+  border-top: 1px solid var(--brass);
+  margin-top: 3px;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 1000px) {
+  .hero-grid { grid-template-columns: 1fr; }
+  .hero-compass { border-right: 0; border-bottom: 1px solid var(--navy); }
+  .moons { grid-template-columns: repeat(2, 1fr); }
+  .warnings { grid-template-columns: 1fr; }
+  .foot .wrap { grid-template-columns: 1fr; }
+  .foot .cols { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .strip-top { flex-direction: column; gap: 8px; padding: 12px 18px; }
+  .strip-top nav { gap: 14px; flex-wrap: wrap; justify-content: center; }
+  .hero-right { padding: 28px 22px; }
+  .frame { padding: 36px 18px; }
+  .moons { grid-template-columns: 1fr; }
+  .tide-now table { font-size: 11px; }
+  .stations table { font-size: 11px; }
+  .stations td, .stations th { padding: 7px 6px; }
+  .foot .cols { grid-template-columns: 1fr; }
+  .prose { padding: 36px 22px 60px; font-size: 17px; }
+  .prose h1 { font-size: 42px; }
+}

--- a/examples/tide-bureau/static/favicon.svg
+++ b/examples/tide-bureau/static/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#efe7d2"/>
+  <circle cx="16" cy="16" r="11" fill="none" stroke="#102540" stroke-width="1.4"/>
+  <circle cx="16" cy="16" r="6.5" fill="none" stroke="#b48720" stroke-width="0.9"/>
+  <path d="M16 4 L16 28 M4 16 L28 16" stroke="#102540" stroke-width="1.2"/>
+  <path d="M16 4 L14 16 L16 28 L18 16 Z" fill="#102540"/>
+  <path d="M4 16 L16 14 L28 16 L16 18 Z" fill="#b48720"/>
+  <circle cx="16" cy="16" r="1.5" fill="#07182c"/>
+</svg>

--- a/examples/tide-bureau/templates/404.html
+++ b/examples/tide-bureau/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>404 &middot; Off the Chart</h1>
+  <p>This page is not found in the present volume. It may have been struck from the register, awaiting resurvey, or simply mis-bound at the press. The keepers regret the inconvenience.</p>
+  <p><a href="{{ base_url }}/">Return to the front matter &raquo;</a></p>
+</article>
+{% include "footer.html" %}

--- a/examples/tide-bureau/templates/footer.html
+++ b/examples/tide-bureau/templates/footer.html
@@ -1,0 +1,71 @@
+  <footer class="foot">
+    <div class="wrap">
+      <div class="seal">
+        <svg width="160" height="160" viewBox="0 0 160 160" aria-hidden="true">
+          <circle cx="80" cy="80" r="74" fill="none" stroke="#b48720" stroke-width="1.6"/>
+          <circle cx="80" cy="80" r="66" fill="none" stroke="#b48720" stroke-width="0.8"/>
+          <circle cx="80" cy="80" r="44" fill="none" stroke="#efe7d2" stroke-width="1"/>
+          <!-- compass cardinal points -->
+          <path d="M80 18 L76 80 L80 142 L84 80 Z" fill="#efe7d2"/>
+          <path d="M18 80 L80 76 L142 80 L80 84 Z" fill="#b48720"/>
+          <!-- intercardinal stroke arms -->
+          <line x1="34" y1="34" x2="126" y2="126" stroke="#efe7d2" stroke-width="0.6"/>
+          <line x1="126" y1="34" x2="34" y2="126" stroke="#efe7d2" stroke-width="0.6"/>
+          <!-- cardinal letters -->
+          <text x="80" y="14" text-anchor="middle" fill="#b48720" font-family="Cormorant Garamond, serif" font-style="italic" font-size="12">N</text>
+          <text x="80" y="156" text-anchor="middle" fill="#b48720" font-family="Cormorant Garamond, serif" font-style="italic" font-size="12">S</text>
+          <text x="6" y="84" fill="#b48720" font-family="Cormorant Garamond, serif" font-style="italic" font-size="12">W</text>
+          <text x="148" y="84" fill="#b48720" font-family="Cormorant Garamond, serif" font-style="italic" font-size="12">E</text>
+          <!-- anchor in middle -->
+          <g stroke="#efe7d2" stroke-width="1.6" fill="none">
+            <circle cx="80" cy="62" r="4"/>
+            <line x1="80" y1="66" x2="80" y2="104"/>
+            <path d="M64 96 Q80 116 96 96"/>
+            <line x1="72" y1="74" x2="88" y2="74"/>
+          </g>
+          <!-- outer dotted ring -->
+          <circle cx="80" cy="80" r="58" fill="none" stroke="#efe7d2" stroke-width="0.6" stroke-dasharray="1 4"/>
+        </svg>
+        <div class="colophon">
+          Engraved for the Bureau<br>
+          Volume XIV &middot; {{ current_year }}<br>
+          Printed at the Almanac House
+        </div>
+      </div>
+      <div class="cols">
+        <div>
+          <h4>Tables</h4>
+          <a href="{{ base_url }}/">Daily heights</a>
+          <a href="{{ base_url }}/">Spring &amp; neap</a>
+          <a href="{{ base_url }}/">Annual mean</a>
+          <a href="{{ base_url }}/">Datum corrections</a>
+        </div>
+        <div>
+          <h4>Stations</h4>
+          <a href="{{ base_url }}/#stations">Survey register</a>
+          <a href="{{ base_url }}/#stations">Gauge condition</a>
+          <a href="{{ base_url }}/#stations">Keepers&rsquo; roll</a>
+        </div>
+        <div>
+          <h4>Charts</h4>
+          <a href="{{ base_url }}/#moons">Lunar phases</a>
+          <a href="{{ base_url }}/#moons">Tidal currents</a>
+          <a href="{{ base_url }}/#warnings">Bar advisories</a>
+        </div>
+        <div>
+          <h4>The Bureau</h4>
+          <a href="{{ base_url }}/about/">About</a>
+          <a href="{{ base_url }}/about/">Schedule</a>
+          <a href="{{ base_url }}/about/">Correspondence</a>
+        </div>
+        <div class="stripe">
+          <span>&copy; {{ current_year }} Bureau of Tides &middot; All readings reduced to chart datum</span>
+          <span>Hwaro press &middot; XIV / {{ current_year }}</span>
+        </div>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/tide-bureau/templates/header.html
+++ b/examples/tide-bureau/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=IBM+Plex+Mono:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <span><span class="vol">BUREAU OF TIDES</span> &middot; ADMIRALTY VOL XIV &middot; {{ current_year }}</span>
+    <nav>
+      <a href="{{ base_url }}/">Tables</a>
+      <a href="#stations">Stations</a>
+      <a href="#moons">Charts</a>
+      <a href="{{ base_url }}/about/">Bureau</a>
+    </nav>
+  </header>

--- a/examples/tide-bureau/templates/index.html
+++ b/examples/tide-bureau/templates/index.html
@@ -1,0 +1,298 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="hero-grid">
+    <div class="hero-compass">
+      <svg width="280" height="280" viewBox="0 0 280 280" aria-hidden="true">
+        <!-- outer ring -->
+        <circle cx="140" cy="140" r="132" fill="none" stroke="#102540" stroke-width="1.4"/>
+        <circle cx="140" cy="140" r="118" fill="none" stroke="#102540" stroke-width="0.6"/>
+        <!-- inner ring -->
+        <circle cx="140" cy="140" r="78" fill="none" stroke="#b48720" stroke-width="0.9"/>
+        <circle cx="140" cy="140" r="58" fill="none" stroke="#b48720" stroke-width="0.5"/>
+        <!-- 32 tick marks -->
+        <g stroke="#102540" stroke-width="0.7">
+          <line x1="140" y1="8" x2="140" y2="22"/>
+          <line x1="140" y1="258" x2="140" y2="272"/>
+          <line x1="8" y1="140" x2="22" y2="140"/>
+          <line x1="258" y1="140" x2="272" y2="140"/>
+        </g>
+        <g stroke="#102540" stroke-width="0.5">
+          <line x1="46" y1="46" x2="55" y2="55"/>
+          <line x1="234" y1="46" x2="225" y2="55"/>
+          <line x1="46" y1="234" x2="55" y2="225"/>
+          <line x1="234" y1="234" x2="225" y2="225"/>
+          <!-- 16-point ticks -->
+          <line x1="91" y1="20" x2="95" y2="32"/>
+          <line x1="189" y1="20" x2="185" y2="32"/>
+          <line x1="20" y1="91" x2="32" y2="95"/>
+          <line x1="20" y1="189" x2="32" y2="185"/>
+          <line x1="260" y1="91" x2="248" y2="95"/>
+          <line x1="260" y1="189" x2="248" y2="185"/>
+          <line x1="91" y1="260" x2="95" y2="248"/>
+          <line x1="189" y1="260" x2="185" y2="248"/>
+        </g>
+        <!-- 32-point fine ticks -->
+        <g stroke="#102540" stroke-width="0.3">
+          <line x1="115" y1="14" x2="118" y2="26"/>
+          <line x1="165" y1="14" x2="162" y2="26"/>
+          <line x1="115" y1="266" x2="118" y2="254"/>
+          <line x1="165" y1="266" x2="162" y2="254"/>
+          <line x1="14" y1="115" x2="26" y2="118"/>
+          <line x1="14" y1="165" x2="26" y2="162"/>
+          <line x1="266" y1="115" x2="254" y2="118"/>
+          <line x1="266" y1="165" x2="254" y2="162"/>
+          <line x1="70" y1="28" x2="76" y2="40"/>
+          <line x1="210" y1="28" x2="204" y2="40"/>
+          <line x1="70" y1="252" x2="76" y2="240"/>
+          <line x1="210" y1="252" x2="204" y2="240"/>
+          <line x1="28" y1="70" x2="40" y2="76"/>
+          <line x1="28" y1="210" x2="40" y2="204"/>
+          <line x1="252" y1="70" x2="240" y2="76"/>
+          <line x1="252" y1="210" x2="240" y2="204"/>
+        </g>
+        <!-- four cardinal arrows (stroke only) -->
+        <path d="M140 22 L132 140 L140 130 L148 140 Z" fill="none" stroke="#102540" stroke-width="1.2"/>
+        <path d="M140 258 L132 140 L140 150 L148 140 Z" fill="none" stroke="#102540" stroke-width="0.9"/>
+        <path d="M22 140 L140 132 L130 140 L140 148 Z" fill="none" stroke="#b48720" stroke-width="1"/>
+        <path d="M258 140 L140 132 L150 140 L140 148 Z" fill="none" stroke="#b48720" stroke-width="1"/>
+        <!-- intercardinal arrows -->
+        <path d="M48 48 L138 138 L132 132 Z" fill="none" stroke="#102540" stroke-width="0.5"/>
+        <path d="M232 48 L142 138 L148 132 Z" fill="none" stroke="#102540" stroke-width="0.5"/>
+        <path d="M48 232 L138 142 L132 148 Z" fill="none" stroke="#102540" stroke-width="0.5"/>
+        <path d="M232 232 L142 142 L148 148 Z" fill="none" stroke="#102540" stroke-width="0.5"/>
+        <!-- cardinal letters -->
+        <text x="140" y="6" text-anchor="middle" fill="#102540" font-family="Cormorant Garamond, serif" font-style="italic" font-size="14">N</text>
+        <text x="140" y="278" text-anchor="middle" fill="#102540" font-family="Cormorant Garamond, serif" font-style="italic" font-size="14">S</text>
+        <text x="2" y="144" fill="#102540" font-family="Cormorant Garamond, serif" font-style="italic" font-size="14">W</text>
+        <text x="270" y="144" fill="#102540" font-family="Cormorant Garamond, serif" font-style="italic" font-size="14">E</text>
+        <text x="50" y="42" text-anchor="middle" fill="#b48720" font-family="Cormorant Garamond, serif" font-style="italic" font-size="9">NW</text>
+        <text x="230" y="42" text-anchor="middle" fill="#b48720" font-family="Cormorant Garamond, serif" font-style="italic" font-size="9">NE</text>
+        <text x="50" y="244" text-anchor="middle" fill="#b48720" font-family="Cormorant Garamond, serif" font-style="italic" font-size="9">SW</text>
+        <text x="230" y="244" text-anchor="middle" fill="#b48720" font-family="Cormorant Garamond, serif" font-style="italic" font-size="9">SE</text>
+        <!-- center hub -->
+        <circle cx="140" cy="140" r="6" fill="none" stroke="#102540" stroke-width="1"/>
+        <circle cx="140" cy="140" r="2" fill="#b48720"/>
+      </svg>
+      <div class="meta">
+        Lat. 50&deg; 42&prime; 51&Prime; N &middot; Long. 1&deg; 59&prime; 03&Prime; W<br>
+        <b>Reduced to chart datum</b><br>
+        Variation 1&deg; 14&prime; W &middot; {{ current_year }}
+      </div>
+    </div>
+
+    <div class="hero-right">
+      <span class="kicker">No. CXLII &middot; Issued of the Bureau &middot; {{ current_year }}</span>
+      <h1>
+        <span class="sl">Tide Tables</span>
+        <span class="sl">for every</span>
+        <span class="sl"><span class="brass">Admiralty</span> Station.</span>
+      </h1>
+      <p class="standfirst">Heights are reduced to Lowest Astronomical Tide. Times stated as Greenwich Mean &mdash; one hour added when summer time is in force. The Bureau holds no responsibility for craft attempting bar crossings outside the printed window.</p>
+
+      <div class="tide-now">
+        <div class="tide-now-head">
+          <span>This day &middot; high &amp; low water at four admiralty stations</span>
+          <span class="b">04 MAY {{ current_year }}</span>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Station</th>
+              <th>First HW</th>
+              <th>First LW</th>
+              <th>Second HW</th>
+              <th>Range</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="station">Poole Harbour</td>
+              <td class="hw">06:14 <b>2.40m</b></td>
+              <td class="lw">12:38 <b>0.31m</b></td>
+              <td class="hw">18:51 <b>2.34m</b></td>
+              <td>2.09m</td>
+            </tr>
+            <tr>
+              <td class="station">Falmouth Roads</td>
+              <td class="hw">04:48 <b>4.92m</b></td>
+              <td class="lw">11:02 <b>0.74m</b></td>
+              <td class="hw">17:11 <b>4.86m</b></td>
+              <td>4.18m</td>
+            </tr>
+            <tr>
+              <td class="station">Whitby Pier</td>
+              <td class="hw">02:36 <b>5.18m</b></td>
+              <td class="lw">08:54 <b>0.96m</b></td>
+              <td class="hw">15:02 <b>5.04m</b></td>
+              <td>4.22m</td>
+            </tr>
+            <tr>
+              <td class="station">Stromness Bay</td>
+              <td class="hw">07:21 <b>3.66m</b></td>
+              <td class="lw">13:44 <b>0.52m</b></td>
+              <td class="hw">19:58 <b>3.58m</b></td>
+              <td>3.14m</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="cartouche">
+  <span class="line"></span>
+  <span class="mark">
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+      <path d="M7 1 L9 6 L13 7 L9 8 L7 13 L5 8 L1 7 L5 6 Z" fill="none" stroke="#b48720" stroke-width="0.8"/>
+    </svg>
+    Bureau of Tides &middot; Stations
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+      <path d="M7 1 L9 6 L13 7 L9 8 L7 13 L5 8 L1 7 L5 6 Z" fill="none" stroke="#b48720" stroke-width="0.8"/>
+    </svg>
+  </span>
+  <span class="line"></span>
+</div>
+
+<section class="frame stations" id="stations">
+  <div class="wrap">
+    <div class="head">
+      <h2>Register of Stations</h2>
+      <span class="roman">Tabula I &middot; Stationes</span>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Code</th>
+          <th>Station</th>
+          <th>Latitude</th>
+          <th>Longitude</th>
+          <th class="range">Mean Range</th>
+          <th>Datum</th>
+          <th>Last Survey</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td class="code">A-014</td><td class="name">Poole Harbour</td><td>50&deg; 42&prime; N</td><td>1&deg; 59&prime; W</td><td class="range">2.09 m</td><td>LAT &minus;0.42</td><td>11 March {{ current_year }}</td></tr>
+        <tr><td class="code">A-027</td><td class="name">Falmouth Roads</td><td>50&deg; 09&prime; N</td><td>5&deg; 04&prime; W</td><td class="range">4.18 m</td><td>LAT &minus;0.61</td><td>02 April {{ current_year }}</td></tr>
+        <tr><td class="code">B-005</td><td class="name">Whitby Pier</td><td>54&deg; 29&prime; N</td><td>0&deg; 36&prime; W</td><td class="range">4.22 m</td><td>LAT &minus;0.58</td><td>28 February {{ current_year }}</td></tr>
+        <tr><td class="code">B-019</td><td class="name">Lowestoft Ness</td><td>52&deg; 28&prime; N</td><td>1&deg; 45&prime; E</td><td class="range">1.84 m</td><td>LAT &minus;0.36</td><td>14 January {{ current_year }}</td></tr>
+        <tr><td class="code">C-002</td><td class="name">Stromness Bay</td><td>58&deg; 57&prime; N</td><td>3&deg; 17&prime; W</td><td class="range">3.14 m</td><td>LAT &minus;0.49</td><td>08 April {{ current_year }}</td></tr>
+        <tr><td class="code">C-011</td><td class="name">Oban Pier</td><td>56&deg; 24&prime; N</td><td>5&deg; 28&prime; W</td><td class="range">3.07 m</td><td>LAT &minus;0.47</td><td>22 March {{ current_year }}</td></tr>
+        <tr><td class="code">D-003</td><td class="name">Holyhead Harbour</td><td>53&deg; 19&prime; N</td><td>4&deg; 38&prime; W</td><td class="range">4.86 m</td><td>LAT &minus;0.68</td><td>05 February {{ current_year }}</td></tr>
+        <tr><td class="code">D-014</td><td class="name">Milford Haven</td><td>51&deg; 42&prime; N</td><td>5&deg; 02&prime; W</td><td class="range">5.62 m</td><td>LAT &minus;0.74</td><td>19 March {{ current_year }}</td></tr>
+        <tr><td class="code">E-008</td><td class="name">Cobh Quay</td><td>51&deg; 51&prime; N</td><td>8&deg; 18&prime; W</td><td class="range">3.42 m</td><td>LAT &minus;0.54</td><td>27 January {{ current_year }}</td></tr>
+        <tr><td class="code">E-021</td><td class="name">Lerwick Sound</td><td>60&deg; 09&prime; N</td><td>1&deg; 09&prime; W</td><td class="range">1.62 m</td><td>LAT &minus;0.31</td><td>30 March {{ current_year }}</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<div class="notice">
+  <em>Bar crossings are reckoned safe only within</em> <b>two hours</b> <em>of high water.</em>
+</div>
+
+<section class="frame" id="moons">
+  <div class="wrap">
+    <div class="head">
+      <h2>Phases of the Moon</h2>
+      <span class="roman">Tabula II &middot; Lunaria</span>
+    </div>
+    <div class="moons">
+      <!-- Waxing crescent -->
+      <div class="moon">
+        <svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
+          <circle cx="48" cy="48" r="36" fill="none" stroke="#102540" stroke-width="1.2"/>
+          <path d="M48 12 A36 36 0 0 0 48 84 A24 36 0 0 1 48 12 Z" fill="none" stroke="#102540" stroke-width="1.2"/>
+        </svg>
+        <div class="phase">Waxing Crescent</div>
+        <div class="date">02 May &middot; First Light</div>
+        <div class="rise">Rise 09:14 &middot; Set 23:42</div>
+      </div>
+      <!-- First quarter -->
+      <div class="moon">
+        <svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
+          <circle cx="48" cy="48" r="36" fill="none" stroke="#102540" stroke-width="1.2"/>
+          <path d="M48 12 L48 84" stroke="#102540" stroke-width="1.2"/>
+          <path d="M48 12 A36 36 0 0 1 48 84" fill="none" stroke="#102540" stroke-width="1.2"/>
+        </svg>
+        <div class="phase">First Quarter</div>
+        <div class="date">09 May &middot; Quadrature</div>
+        <div class="rise">Rise 12:58 &middot; Set 02:11</div>
+      </div>
+      <!-- Full moon -->
+      <div class="moon">
+        <svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
+          <circle cx="48" cy="48" r="36" fill="none" stroke="#102540" stroke-width="1.2"/>
+          <circle cx="48" cy="48" r="26" fill="none" stroke="#b48720" stroke-width="0.6"/>
+          <circle cx="48" cy="48" r="16" fill="none" stroke="#b48720" stroke-width="0.6"/>
+        </svg>
+        <div class="phase">Full Moon</div>
+        <div class="date">16 May &middot; Spring Tide</div>
+        <div class="rise">Rise 20:34 &middot; Set 05:08</div>
+      </div>
+      <!-- Waning gibbous -->
+      <div class="moon">
+        <svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
+          <circle cx="48" cy="48" r="36" fill="none" stroke="#102540" stroke-width="1.2"/>
+          <path d="M48 12 A36 36 0 0 1 48 84 A18 36 0 0 1 48 12 Z" fill="none" stroke="#102540" stroke-width="1.2"/>
+        </svg>
+        <div class="phase">Waning Gibbous</div>
+        <div class="date">22 May &middot; After Full</div>
+        <div class="rise">Rise 22:12 &middot; Set 08:46</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="cartouche">
+  <span class="line"></span>
+  <span class="mark">
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+      <path d="M7 1 L9 6 L13 7 L9 8 L7 13 L5 8 L1 7 L5 6 Z" fill="none" stroke="#b48720" stroke-width="0.8"/>
+    </svg>
+    Notices to Mariners
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+      <path d="M7 1 L9 6 L13 7 L9 8 L7 13 L5 8 L1 7 L5 6 Z" fill="none" stroke="#b48720" stroke-width="0.8"/>
+    </svg>
+  </span>
+  <span class="line"></span>
+</div>
+
+<section class="frame" id="warnings">
+  <div class="wrap">
+    <div class="head">
+      <h2>Warnings &amp; Bulletins</h2>
+      <span class="roman">Tabula III &middot; Monitiones</span>
+    </div>
+    <div class="warnings">
+      <article class="warn">
+        <header><span>Bar Crossing Advisory</span><span>No. 041</span></header>
+        <div class="body">
+          <h3>Poole &middot; 04 May</h3>
+          <p>The Training Bank has shoaled to 0.18 m below datum at low water. Vessels drawing more than 1.4 m are to delay outbound passage to within ninety minutes of high water.</p>
+          <span class="stamp">Issued 04:00 GMT</span>
+        </div>
+      </article>
+      <article class="warn">
+        <header><span>Gale Notice</span><span>No. 042</span></header>
+        <div class="body">
+          <h3>Lerwick Sound &middot; 05 May</h3>
+          <p>South-westerly winds Force 7, veering Force 8 by the second watch. Small craft to remain in moorings. The keeper of Bressay reports breaking seas across the outer reef.</p>
+          <span class="stamp">Issued 18:00 GMT</span>
+        </div>
+      </article>
+      <article class="warn">
+        <header><span>Datum Correction</span><span>No. 043</span></header>
+        <div class="body">
+          <h3>Cobh Quay &middot; 06 May</h3>
+          <p>Following resurvey of the Spit Bank, the chart datum at Cobh is to be lowered by 0.04 m, effective the second of June. All printed tables of subsequent date carry the amendment.</p>
+          <span class="stamp">Issued 12:00 GMT</span>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/tide-bureau/templates/page.html
+++ b/examples/tide-bureau/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+<article class="prose">
+  {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/tide-bureau/templates/section.html
+++ b/examples/tide-bureau/templates/section.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+<section class="frame">
+  <div class="wrap">
+    <div class="head">
+      {% if page.title is present %}<h2>{{ page.title | e }}</h2>{% endif %}
+      <span class="roman">Index &middot; Bureau Press</span>
+    </div>
+    <article class="prose" style="padding: 0; max-width: none;">
+      {{ content | safe }}
+      <ul>
+      {% for post in section.pages %}
+        <li>
+          <span style="font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: #8c641a; letter-spacing: 0.16em; text-transform: uppercase;">{{ post.date | date(format="%d %B %Y") }}</span>
+          &middot;
+          <a href="{{ post.url }}">{{ post.title | e }}</a>
+        </li>
+      {% endfor %}
+      </ul>
+    </article>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/tide-bureau/templates/taxonomy.html
+++ b/examples/tide-bureau/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p><em>An index of subjects gathered by the Bureau across published volumes.</em></p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/tide-bureau/templates/taxonomy_term.html
+++ b/examples/tide-bureau/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+<article class="prose">
+  <h1>{{ page.title | e }}</h1>
+  <p><em>Entries filed under this term in the Bureau register.</em></p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/typesetter-strike/AGENTS.md
+++ b/examples/typesetter-strike/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/typesetter-strike/archetypes/default.md
+++ b/examples/typesetter-strike/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/typesetter-strike/config.toml
+++ b/examples/typesetter-strike/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "STRIKE & RULE"
+description = "Strike & Rule — a one-person wood-type letterpress shop printing show posters, broadsides, and broadcasts on a Vandercook 219."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/typesetter-strike/content/about.md
+++ b/examples/typesetter-strike/content/about.md
@@ -1,0 +1,46 @@
++++
+title = "The Colophon"
+description = "STRIKE & RULE — the press, the cabinet, the paper, the ink, and how to commission a run."
++++
+
+## The Press
+
+The shop runs on a single **Vandercook 219 proof press**, restored in 2018 from the back room of a closed county newspaper. It takes a sheet up to 19 by 25 inches, prints one colour at a time, and asks for an hour of warm-up before it will hold registration. Most days it prints two pulls; on a clean run with a willing ink, three.
+
+Everything else in the shop is in service of the press: the cabinet, the rollers, the lock-up table, the drying rack along the north wall. There is no second machine, no digital backup, and no plan to add one.
+
+## The Type Cabinet
+
+Eight faces of wood type and four of foundry metal, kept in a cabinet from the same shop the press came out of. The wood-type sorts are end-grain maple above 72 point, pine for the very large display sizes, and a single drawer of cherry that was hand-cut in the late 1920s and is still tight. The faces in active service:
+
+- **Antique Tuscan** — 10-line maple, the only face the shop will set in caps and lowercase together.
+- **Gothic Condensed** — 12-line pine, the workhorse, used on every other show poster.
+- **French Clarendon** — 8-line cherry, slab-serif, reserved for the loudest words.
+- **Old Style No 7** — 36-point foundry lead, the only face with a comma worth printing.
+
+Smaller sorts are kept in a job case at the lock-up table. We do not set from photopolymer or digital plates. If a job calls for a face the cabinet doesn&rsquo;t hold, it gets re-designed around what is in the drawer.
+
+## The Paper
+
+A single house stock: **cream rag, 90 lb., short grain**, milled in lots of two thousand sheets. It takes the impression deep, holds vermilion and black without bleed, and warms about half a shade in the first year of light. A cooler **oat rag** is kept in a single drawer for handbills and the occasional broadside that wants a different colour temperature.
+
+Sheets are torn down to size by hand at the cutting table, signed in the margin in pencil, and shipped flat between two boards.
+
+## The Ink
+
+Two inks live on the slab at all times: **vermilion** (a hand-mixed warm red, run at a fairly heavy film for the saturated body it gives the wood type) and a dense **carbon black** that the shop has used since the first month. A third ink, a deep **press blue**, comes out for broadsides on commission.
+
+We do not run process colour, do not run metallic, and do not run fluorescents. The ink is mixed at the start of the day, run wet, and the slab is wiped down at the end of the pressing.
+
+## How to Commission a Run
+
+A short letter is enough. Tell the shop:
+
+- What the poster is for (a show, a reading, a notice, a broadcast).
+- The date, the room, the names, and any words that have to be exact.
+- The size you have in mind &mdash; *handbill, show poster, broadside, broadcast* &mdash; or leave it to the shop.
+- The edition size. Most commissions are pulled in **fifty**; we will pull twenty-five if the room is small, and one hundred and fifty if you mean to paper a city.
+
+The shop quotes once the cabinet is consulted. Proofs are pulled by hand and sent flat. We do not email proofs &mdash; if you want to see the impression, you will see it in the post.
+
+Write to the desk at *desk@strikeandrule.shop*. We answer in the order letters arrive, on the second Friday of each month, in handwriting.

--- a/examples/typesetter-strike/content/index.md
+++ b/examples/typesetter-strike/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "STRIKE & RULE — a one-person wood-type letterpress shop on Lot 4. Show posters, broadsides, and broadcasts pulled by hand on a Vandercook 219."
+template = "index"
++++

--- a/examples/typesetter-strike/static/css/style.css
+++ b/examples/typesetter-strike/static/css/style.css
@@ -1,0 +1,979 @@
+/* STRIKE & RULE — wood-type letterpress, vermilion & black on cream rag */
+
+:root {
+  --rag: #ece2cf;
+  --rag-deep: #d9caac;
+  --rag-edge: #c9b690;
+  --ink: #111111;
+  --ink-soft: #2a2522;
+  --red: #c1311b;
+  --red-deep: #8e2010;
+  --blue: #1f3a6a;
+  --rule: #111111;
+
+  --face-rye: "Rye", "Rockwell", "Georgia", serif;
+  --face-bowlby: "Bowlby One SC", "Impact", "Arial Black", sans-serif;
+  --face-ultra: "Ultra", "Bodoni 72", "Times New Roman", serif;
+  --face-dm: "DM Serif Display", "Bodoni 72", Georgia, serif;
+  --face-mono: "IBM Plex Mono", "Courier New", ui-monospace, monospace;
+  --face-text: "DM Serif Display", Georgia, "Times New Roman", serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--rag);
+  color: var(--ink);
+  overflow-x: hidden;
+}
+
+body {
+  font-family: var(--face-text);
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  /* paper grain — tiled SVG speckle, no gradient */
+  background-color: var(--rag);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12'><circle cx='1.5' cy='2.5' r='0.6' fill='rgba(17,17,17,0.1)'/><circle cx='8' cy='5' r='0.5' fill='rgba(193,49,27,0.08)'/><circle cx='4.5' cy='9' r='0.5' fill='rgba(17,17,17,0.08)'/></svg>");
+  background-size: 12px 12px;
+}
+
+a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 2px solid var(--red);
+  font-weight: 500;
+}
+
+a:hover { color: var(--red); border-bottom-color: var(--ink); }
+
+::selection { background: var(--red); color: var(--rag); }
+
+/* ============================ TOP STRIP ============================ */
+.topstrip {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 24px;
+  align-items: center;
+  padding: 14px 28px;
+  border-bottom: 4px double var(--ink);
+  background: var(--rag);
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.topstrip .mark {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border: 2px solid var(--ink);
+}
+
+.topstrip .mark .amp {
+  font-family: var(--face-ultra);
+  font-size: 26px;
+  line-height: 1;
+  color: var(--red);
+  margin-right: 2px;
+}
+
+.topstrip .mark .mk-text {
+  font-family: var(--face-bowlby);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: var(--ink);
+}
+
+.topstrip .strapline { color: var(--ink-soft); }
+.topstrip .strapline b { color: var(--ink); letter-spacing: 0.28em; }
+.topstrip .strapline .dot { color: var(--red); padding: 0 4px; }
+
+.topstrip .topnav { display: flex; gap: 22px; }
+.topstrip .topnav a { border-bottom: 1px solid var(--ink); padding-bottom: 2px; }
+.topstrip .topnav a:hover { color: var(--rag); background: var(--ink); border-bottom-color: var(--ink); }
+
+/* ============================ HERO ============================ */
+.hero {
+  position: relative;
+  padding: 100px 40px 80px;
+  border-bottom: 2px solid var(--ink);
+  min-height: 78vh;
+  overflow: hidden;
+}
+
+/* corner crop marks */
+.crop {
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  pointer-events: none;
+}
+.crop::before, .crop::after {
+  content: "";
+  position: absolute;
+  background: var(--ink);
+}
+.crop::before { width: 36px; height: 2px; }
+.crop::after { width: 2px; height: 36px; }
+.crop.tl { top: 24px; left: 24px; }
+.crop.tl::before { top: 0; left: 0; }
+.crop.tl::after { top: 0; left: 0; }
+.crop.tr { top: 24px; right: 24px; }
+.crop.tr::before { top: 0; right: 0; }
+.crop.tr::after { top: 0; right: 0; }
+.crop.bl { bottom: 24px; left: 24px; }
+.crop.bl::before { bottom: 0; left: 0; }
+.crop.bl::after { bottom: 0; left: 0; }
+.crop.br { bottom: 24px; right: 24px; }
+.crop.br::before { bottom: 0; right: 0; }
+.crop.br::after { bottom: 0; right: 0; }
+
+/* registration marks */
+.reg-marks .reg {
+  position: absolute;
+  font-family: var(--face-mono);
+  font-weight: 700;
+  font-size: 22px;
+  color: var(--red);
+  line-height: 1;
+}
+.reg-marks .reg::after {
+  content: "+";
+  position: absolute;
+  top: -2px;
+  left: 2px;
+  color: var(--ink);
+  mix-blend-mode: multiply;
+}
+.reg-marks .r1 { top: 80px; right: 80px; }
+.reg-marks .r2 { bottom: 80px; left: 80px; }
+.reg-marks .r3 { top: 50%; left: 50%; transform: translate(-50%, -50%); opacity: 0.4; }
+
+/* overprint wood-type words */
+.overprint {
+  position: relative;
+  margin: 40px auto 60px;
+  max-width: 1280px;
+  min-height: 38vw;
+}
+
+.word {
+  margin: 0;
+  font-family: var(--face-bowlby);
+  font-weight: 400;
+  font-size: 24vw;
+  line-height: 0.82;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  position: absolute;
+}
+
+.word-strike {
+  top: 0;
+  left: -1vw;
+  color: var(--red);
+  font-family: var(--face-ultra);
+  text-shadow:
+    4px -3px 0 var(--ink),
+    -1px 2px 0 var(--red-deep);
+  transform: rotate(-1.4deg);
+  z-index: 1;
+}
+
+/* misregistered red ghost behind */
+.word-strike::before {
+  content: attr(data-text);
+  position: absolute;
+  top: 4px;
+  left: -3px;
+  color: var(--red);
+  z-index: -1;
+  opacity: 0.6;
+}
+
+.word-rule {
+  top: 18vw;
+  left: 18vw;
+  color: var(--ink);
+  font-family: var(--face-bowlby);
+  letter-spacing: -0.04em;
+  mix-blend-mode: multiply;
+  text-shadow: -3px 2px 0 var(--red);
+  transform: rotate(0.8deg);
+  z-index: 2;
+}
+
+.hero-meta {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 60px;
+  align-items: start;
+  border-top: 2px solid var(--ink);
+  padding-top: 24px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.hero-meta-left {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  max-width: 320px;
+}
+
+.stamp {
+  display: inline-block;
+  padding: 6px 10px;
+  border: 2px solid var(--ink);
+  font-family: var(--face-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  background: var(--rag);
+  transform: rotate(-1deg);
+}
+.stamp.red {
+  border-color: var(--red);
+  color: var(--red);
+  transform: rotate(1.5deg);
+}
+
+.hero-meta-right {
+  font-family: var(--face-text);
+  font-size: 20px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  max-width: 560px;
+  justify-self: end;
+  text-align: right;
+}
+.hero-meta-right p { margin: 0; }
+
+/* ============================ SECTION HEADS ============================ */
+.wrap {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.press-head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 28px;
+  row-gap: 8px;
+  align-items: end;
+  padding: 56px 0 28px;
+  border-bottom: 4px double var(--ink);
+  margin-bottom: 48px;
+}
+
+.press-num {
+  grid-row: 1 / span 2;
+  font-family: var(--face-ultra);
+  font-size: 92px;
+  line-height: 0.85;
+  color: var(--red);
+  text-shadow: 2px -1px 0 var(--ink);
+}
+
+.sec-title {
+  grid-column: 2;
+  margin: 0;
+  font-family: var(--face-bowlby);
+  font-size: 86px;
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.sec-title i {
+  font-style: italic;
+  font-family: var(--face-dm);
+  font-weight: 400;
+  text-transform: none;
+  color: var(--red);
+  letter-spacing: -0.01em;
+}
+
+.press-sub {
+  grid-column: 2;
+  font-family: var(--face-mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+/* ============================ PRESS BODY ============================ */
+.press { padding: 0 0 80px; border-bottom: 2px solid var(--ink); }
+
+.press-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  margin-bottom: 56px;
+  align-items: start;
+}
+
+.press-body .lede {
+  font-family: var(--face-dm);
+  font-size: 26px;
+  line-height: 1.35;
+  margin: 0;
+  color: var(--ink);
+}
+.press-body .lede b {
+  font-weight: 400;
+  color: var(--red);
+  font-style: italic;
+}
+
+.press-body p:not(.lede) {
+  font-family: var(--face-text);
+  font-size: 17px;
+  line-height: 1.65;
+  margin: 0;
+  color: var(--ink-soft);
+  column-count: 1;
+  border-left: 3px solid var(--red);
+  padding-left: 20px;
+}
+
+/* specimen sheet */
+.specimen-sheet {
+  position: relative;
+  background: var(--rag-deep);
+  border: 3px solid var(--ink);
+  padding: 40px 48px 28px;
+}
+
+.specimen-corner {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--red);
+}
+.specimen-corner.tl { top: -3px; left: -3px; border-right: 0; border-bottom: 0; }
+.specimen-corner.tr { top: -3px; right: -3px; border-left: 0; border-bottom: 0; }
+.specimen-corner.bl { bottom: -3px; left: -3px; border-right: 0; border-top: 0; }
+.specimen-corner.br { bottom: -3px; right: -3px; border-left: 0; border-top: 0; }
+
+.specimen-head {
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink);
+  padding-bottom: 14px;
+  border-bottom: 2px solid var(--ink);
+  margin-bottom: 12px;
+}
+
+.specimen-row {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  align-items: center;
+  gap: 24px;
+  padding: 18px 0;
+  border-bottom: 1px dashed var(--ink);
+}
+.specimen-row.last { border-bottom: 0; }
+
+.specimen-label { display: flex; flex-direction: column; gap: 2px; }
+.sp-no {
+  font-family: var(--face-mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--red);
+  line-height: 1;
+}
+.sp-name {
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.sp-size {
+  font-family: var(--face-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.specimen-show {
+  font-size: 56px;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  text-align: right;
+}
+.face-rye   { font-family: var(--face-rye); color: var(--red); }
+.face-bowlby{ font-family: var(--face-bowlby); text-transform: uppercase; }
+.face-ultra { font-family: var(--face-ultra); }
+.face-dm    { font-family: var(--face-dm); font-style: italic; }
+
+/* ============================ RUNS GRID ============================ */
+.runs { padding: 0 0 80px; border-bottom: 2px solid var(--ink); }
+
+.runs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 28px;
+}
+
+.poster-card {
+  position: relative;
+  background: var(--rag-deep);
+  border: 2px solid var(--ink);
+  padding: 48px 32px 28px;
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-crop {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+}
+.card-crop::before, .card-crop::after {
+  content: "";
+  position: absolute;
+  background: var(--red);
+}
+.card-crop::before { width: 14px; height: 1px; }
+.card-crop::after { width: 1px; height: 14px; }
+.card-crop.tl { top: 6px; left: 6px; }
+.card-crop.tr { top: 6px; right: 6px; }
+.card-crop.tr::before { right: 0; }
+.card-crop.tr::after { right: 0; }
+.card-crop.bl { bottom: 6px; left: 6px; }
+.card-crop.bl::before { bottom: 0; }
+.card-crop.bl::after { bottom: 0; }
+.card-crop.br { bottom: 6px; right: 6px; }
+.card-crop.br::before { bottom: 0; right: 0; }
+.card-crop.br::after { bottom: 0; right: 0; }
+
+.card-stamp {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: var(--ink);
+  padding: 3px 7px;
+  border: 1.5px solid var(--ink);
+  background: var(--rag);
+  transform: rotate(2deg);
+}
+
+.card-title {
+  display: flex;
+  flex-direction: column;
+  font-size: 64px;
+  line-height: 0.86;
+  letter-spacing: -0.02em;
+  margin: 12px 0 28px;
+  text-transform: uppercase;
+}
+
+.card-title .ct-red {
+  color: var(--red);
+  position: relative;
+  text-shadow: 3px -2px 0 var(--ink);
+}
+.card-title .ct-red::before {
+  content: attr(data-text);
+  position: absolute;
+  top: 3px;
+  left: -3px;
+  color: var(--red-deep);
+  opacity: 0.5;
+  z-index: -1;
+}
+
+.card-title .ct-blk {
+  color: var(--ink);
+  text-shadow: -2px 2px 0 var(--red);
+  margin-left: 12px;
+}
+
+.card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-top: auto;
+  padding-top: 18px;
+  border-top: 1px solid var(--ink);
+}
+.card-meta .dot { color: var(--red); }
+
+.card-foot {
+  font-family: var(--face-dm);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--ink-soft);
+  margin-top: 8px;
+}
+
+/* ============================ TARIFF ============================ */
+.commission { padding: 0 0 80px; border-bottom: 2px solid var(--ink); }
+
+.tariff {
+  border: 3px solid var(--ink);
+  background: var(--rag-deep);
+  margin-bottom: 36px;
+}
+
+.tariff-row {
+  display: grid;
+  grid-template-columns: 56px 2fr 1.4fr 1.4fr 1fr;
+  align-items: baseline;
+  gap: 16px;
+  padding: 16px 24px;
+  border-bottom: 1px dashed var(--ink);
+}
+.tariff-row.last { border-bottom: 0; }
+.tariff-row.head {
+  background: var(--ink);
+  color: var(--rag);
+  font-family: var(--face-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  padding: 12px 24px;
+  border-bottom: 0;
+}
+
+.t-no {
+  font-family: var(--face-mono);
+  font-size: 22px;
+  color: var(--red);
+  font-weight: 700;
+}
+.tariff-row.head .t-no { color: var(--rag); font-size: 10px; }
+
+.t-name {
+  font-size: 28px;
+  line-height: 1;
+  color: var(--ink);
+}
+.tariff-row.head .t-name { font-size: 10px; }
+
+.t-dim, .t-ink {
+  font-family: var(--face-mono);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: var(--ink-soft);
+}
+.tariff-row.head .t-dim, .tariff-row.head .t-ink { font-size: 10px; letter-spacing: 0.28em; }
+
+.t-price {
+  font-family: var(--face-bowlby);
+  font-size: 24px;
+  color: var(--ink);
+  text-align: right;
+  letter-spacing: 0.02em;
+}
+.tariff-row.head .t-price { font-size: 10px; font-family: var(--face-mono); letter-spacing: 0.28em; color: var(--rag); }
+
+.commission-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.press-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 22px;
+  background: var(--ink);
+  color: var(--rag);
+  font-family: var(--face-mono);
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  border: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+  font-weight: 700;
+}
+.press-btn:hover {
+  background: var(--red);
+  border-color: var(--red);
+  color: var(--rag);
+}
+.press-btn.ghost {
+  background: var(--rag);
+  color: var(--ink);
+}
+.press-btn.ghost:hover { background: var(--ink); color: var(--rag); }
+.press-btn .arr { color: var(--red); }
+.press-btn:hover .arr { color: var(--rag); }
+
+/* ============================ BROADCAST ============================ */
+.broadcast {
+  padding: 100px 0 110px;
+  border-bottom: 2px solid var(--ink);
+  text-align: center;
+  background: var(--rag-deep);
+}
+
+.broadcast-stamp {
+  display: inline-block;
+  padding: 6px 14px;
+  margin-bottom: 30px;
+  border: 2px solid var(--ink);
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  color: var(--ink);
+  transform: rotate(-1deg);
+}
+
+.bc-line {
+  font-family: var(--face-bowlby);
+  font-size: 8vw;
+  line-height: 0.95;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.bc-line i {
+  font-family: var(--face-dm);
+  font-style: italic;
+  color: var(--red);
+  text-transform: none;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+
+.bc-line.red {
+  color: var(--red);
+  position: relative;
+  text-shadow: 4px -3px 0 var(--ink);
+}
+.bc-line.red::before {
+  content: attr(data-text);
+  position: absolute;
+  top: 4px;
+  left: -4px;
+  color: var(--red-deep);
+  opacity: 0.5;
+  z-index: -1;
+}
+
+.broadcast-sign {
+  margin-top: 36px;
+  font-family: var(--face-mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+/* ============================ PROSE / PAGE ============================ */
+.prose {
+  position: relative;
+  max-width: 760px;
+  margin: 60px auto 80px;
+  padding: 60px 56px 80px;
+  background: var(--rag-deep);
+  border: 3px solid var(--ink);
+}
+
+.prose-crop {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+}
+.prose-crop::before, .prose-crop::after { content: ""; position: absolute; background: var(--red); }
+.prose-crop::before { width: 22px; height: 2px; }
+.prose-crop::after { width: 2px; height: 22px; }
+.prose-crop.tl { top: -3px; left: -3px; }
+.prose-crop.tr { top: -3px; right: -3px; }
+.prose-crop.tr::before { right: 0; }
+.prose-crop.tr::after { right: 0; }
+.prose-crop.bl { bottom: -3px; left: -3px; }
+.prose-crop.bl::before { bottom: 0; }
+.prose-crop.bl::after { bottom: 0; }
+.prose-crop.br { bottom: -3px; right: -3px; }
+.prose-crop.br::before { bottom: 0; right: 0; }
+.prose-crop.br::after { bottom: 0; right: 0; }
+
+.prose-head {
+  border-bottom: 4px double var(--ink);
+  padding-bottom: 24px;
+  margin-bottom: 36px;
+}
+
+.prose-stamp {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1.5px solid var(--ink);
+  font-family: var(--face-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin-bottom: 16px;
+}
+
+.prose-title {
+  font-family: var(--face-bowlby);
+  font-size: 64px;
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--ink);
+  text-transform: uppercase;
+  text-shadow: 3px -2px 0 var(--red);
+}
+
+.prose h2 {
+  font-family: var(--face-ultra);
+  font-size: 36px;
+  line-height: 1.05;
+  margin: 48px 0 18px;
+  color: var(--red);
+  text-shadow: 2px -1px 0 var(--ink);
+}
+
+.prose h3 {
+  font-family: var(--face-bowlby);
+  font-size: 22px;
+  margin: 32px 0 12px;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.prose p {
+  font-family: var(--face-text);
+  font-size: 18px;
+  line-height: 1.65;
+  margin: 0 0 18px;
+  color: var(--ink-soft);
+}
+
+.prose p strong, .prose p b {
+  font-weight: 400;
+  font-style: italic;
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--red);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+}
+
+.prose ul, .prose ol { padding-left: 24px; margin: 0 0 18px; }
+.prose li {
+  font-family: var(--face-text);
+  font-size: 17px;
+  line-height: 1.6;
+  margin-bottom: 8px;
+  color: var(--ink-soft);
+}
+.prose li::marker { color: var(--red); }
+
+.prose a {
+  color: var(--red);
+  border-bottom: 2px solid var(--ink);
+  font-style: italic;
+}
+.prose a:hover { color: var(--ink); border-bottom-color: var(--red); }
+
+.prose code {
+  font-family: var(--face-mono);
+  font-size: 14px;
+  padding: 2px 6px;
+  background: var(--rag);
+  border: 1px solid var(--ink);
+  color: var(--ink);
+}
+
+.prose blockquote {
+  border-left: 4px solid var(--red);
+  padding: 8px 20px;
+  margin: 24px 0;
+  font-family: var(--face-dm);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink);
+}
+
+/* ============================ ARCHIVE ============================ */
+.archive { padding: 0 0 80px; border-bottom: 2px solid var(--ink); }
+.archive-list { display: flex; flex-direction: column; }
+.archive-row {
+  display: grid;
+  grid-template-columns: 140px 1fr auto;
+  align-items: baseline;
+  gap: 24px;
+  padding: 22px 0;
+  border-bottom: 1px dashed var(--ink);
+  border-left: 0;
+  border-right: 0;
+  border-top: 0;
+  font-family: var(--face-text);
+}
+.archive-row .ar-date {
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--red);
+}
+.archive-row .ar-title {
+  font-family: var(--face-bowlby);
+  font-size: 24px;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.archive-row .ar-arr { font-family: var(--face-mono); color: var(--ink); font-size: 18px; }
+.archive-row:hover .ar-title { color: var(--red); }
+.archive-row:hover .ar-arr { color: var(--red); }
+
+/* ============================ FOOTER ============================ */
+.foot {
+  padding: 60px 32px 36px;
+  background: var(--ink);
+  color: var(--rag);
+}
+
+.rule-ornament {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 0;
+  font-family: var(--face-mono);
+  color: var(--rag-deep);
+  font-size: 18px;
+  letter-spacing: 0.1em;
+}
+
+.foot-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 36px;
+  max-width: 1240px;
+  margin: 28px auto;
+  padding-bottom: 36px;
+}
+
+.foot-mark { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
+.big-amp {
+  font-family: var(--face-ultra);
+  font-size: 80px;
+  line-height: 0.8;
+  color: var(--red);
+  text-shadow: 3px -2px 0 var(--rag);
+}
+.big-mark {
+  font-family: var(--face-bowlby);
+  font-size: 38px;
+  line-height: 0.92;
+  color: var(--rag);
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+}
+
+.foot-col h4 {
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--red);
+  margin: 0 0 14px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--rag-deep);
+}
+.foot-col a {
+  display: block;
+  color: var(--rag);
+  font-family: var(--face-text);
+  font-size: 15px;
+  line-height: 1.5;
+  margin-bottom: 8px;
+  border-bottom: 0;
+  font-style: italic;
+}
+.foot-col a:hover { color: var(--red); }
+
+.colophon {
+  text-align: center;
+  margin-top: 28px;
+  padding-top: 24px;
+  border-top: 1px solid var(--rag-deep);
+  font-family: var(--face-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--rag-deep);
+}
+.colophon p { margin: 4px 0; }
+.colophon i {
+  font-family: var(--face-dm);
+  text-transform: none;
+  letter-spacing: 0;
+  font-style: italic;
+  font-size: 16px;
+  color: var(--rag);
+}
+
+/* ============================ RESPONSIVE ============================ */
+@media (max-width: 980px) {
+  .topstrip { grid-template-columns: auto auto; padding: 12px 18px; gap: 12px; }
+  .topstrip .strapline { display: none; }
+  .hero { padding: 60px 24px 50px; }
+  .word { font-size: 28vw; }
+  .word-rule { top: 22vw; left: 8vw; }
+  .hero-meta { grid-template-columns: 1fr; gap: 24px; }
+  .hero-meta-right { text-align: left; justify-self: start; font-size: 17px; }
+  .press-head { grid-template-columns: 1fr; }
+  .press-num { grid-row: auto; font-size: 64px; }
+  .sec-title { font-size: 54px; grid-column: 1; }
+  .press-sub { grid-column: 1; }
+  .press-body { grid-template-columns: 1fr; gap: 24px; }
+  .specimen-row { grid-template-columns: 1fr; gap: 8px; }
+  .specimen-show { text-align: left; font-size: 40px; }
+  .runs-grid { grid-template-columns: 1fr; }
+  .tariff-row { grid-template-columns: 40px 1fr 1fr; row-gap: 6px; }
+  .tariff-row.head { grid-template-columns: 40px 1fr 1fr; }
+  .t-ink, .t-dim { grid-column: span 1; }
+  .t-price { grid-column: 2 / span 2; text-align: left; }
+  .tariff-row.head .t-dim, .tariff-row.head .t-ink, .tariff-row.head .t-price { display: none; }
+  .bc-line { font-size: 12vw; }
+  .foot-grid { grid-template-columns: 1fr 1fr; }
+  .prose { padding: 40px 28px 60px; margin: 32px 18px; }
+  .prose-title { font-size: 44px; }
+  .archive-row { grid-template-columns: 1fr; gap: 4px; }
+}
+
+@media (max-width: 560px) {
+  .word { font-size: 32vw; }
+  .sec-title { font-size: 42px; }
+  .card-title { font-size: 44px; }
+  .foot-grid { grid-template-columns: 1fr; }
+  .bc-line { font-size: 14vw; }
+}

--- a/examples/typesetter-strike/static/favicon.svg
+++ b/examples/typesetter-strike/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#ece2cf"/>
+  <rect x="2" y="2" width="28" height="28" fill="none" stroke="#111111" stroke-width="2"/>
+  <path d="M6 8h7v3H9v2h4v8h-7v-3h4v-2H6z" fill="#c1311b"/>
+  <path d="M16 8h7v6l-3 1 3 5h-3l-3-5v5h-1z" fill="#111111"/>
+  <rect x="6" y="24" width="20" height="2" fill="#111111"/>
+</svg>

--- a/examples/typesetter-strike/templates/404.html
+++ b/examples/typesetter-strike/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-crop tl" aria-hidden="true"></div>
+  <div class="prose-crop tr" aria-hidden="true"></div>
+  <div class="prose-crop bl" aria-hidden="true"></div>
+  <div class="prose-crop br" aria-hidden="true"></div>
+  <div class="prose-head">
+    <div class="prose-stamp">404 &middot; OUT OF EDITION</div>
+    <h1 class="prose-title">This sheet did not make the run.</h1>
+  </div>
+  <p>The plate broke, the ink dried, or the page was never set. Either way, this address turns up no impression on the bed.</p>
+  <p>Try the <a href="{{ base_url }}/">front of the shop</a>, or write to the desk.</p>
+</article>
+{% include "footer.html" %}

--- a/examples/typesetter-strike/templates/footer.html
+++ b/examples/typesetter-strike/templates/footer.html
@@ -1,0 +1,40 @@
+  <footer class="foot">
+    <div class="rule-ornament" aria-hidden="true">
+      <span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span>
+    </div>
+    <div class="foot-grid">
+      <div class="foot-mark">
+        <div class="big-amp">&amp;</div>
+        <div class="big-mark">STRIKE<br>RULE</div>
+      </div>
+      <div class="foot-col">
+        <h4>THE SHOP</h4>
+        <a href="#">Lot 4, Old Print Row</a>
+        <a href="#">Open by appointment</a>
+        <a href="#">Fri &amp; Sat afternoons</a>
+      </div>
+      <div class="foot-col">
+        <h4>WORK</h4>
+        <a href="{{ base_url }}/about/">The Vandercook 219</a>
+        <a href="{{ base_url }}/tags/">Recent runs</a>
+        <a href="#">Out of season</a>
+      </div>
+      <div class="foot-col">
+        <h4>BY POST</h4>
+        <a href="#">desk@strikeandrule.shop</a>
+        <a href="#">Press inquiries</a>
+        <a href="#">Commissions</a>
+      </div>
+    </div>
+    <div class="rule-ornament" aria-hidden="true">
+      <span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span><span>&middot;</span><span>&mdash;</span>
+    </div>
+    <div class="colophon">
+      <p><i>Set in wood type. Printed on a Vandercook 219.</i></p>
+      <p>&copy; {{ current_year }} STRIKE &amp; RULE &middot; Lot 4 &middot; one-press shop &middot; built with Hwaro</p>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/typesetter-strike/templates/header.html
+++ b/examples/typesetter-strike/templates/header.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &mdash; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bowlby+One+SC&family=DM+Serif+Display:ital@0;1&family=IBM+Plex+Mono:wght@400;500;700&family=Rye&family=Ultra&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="topstrip">
+    <div class="mark">
+      <span class="amp">&amp;</span>
+      <span class="mk-text">S&amp;R</span>
+    </div>
+    <div class="strapline">
+      <b>STRIKE &amp; RULE</b>
+      <span class="dot">&middot;</span> LETTERPRESS
+      <span class="dot">&middot;</span> EST. 2018
+      <span class="dot">&middot;</span> LOT 4
+    </div>
+    <nav class="topnav">
+      <a href="{{ base_url }}/">shop</a>
+      <a href="{{ base_url }}/about/">press</a>
+      <a href="{{ base_url }}/tags/">archive</a>
+    </nav>
+  </header>

--- a/examples/typesetter-strike/templates/index.html
+++ b/examples/typesetter-strike/templates/index.html
@@ -1,0 +1,246 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="crop tl" aria-hidden="true"></div>
+  <div class="crop tr" aria-hidden="true"></div>
+  <div class="crop bl" aria-hidden="true"></div>
+  <div class="crop br" aria-hidden="true"></div>
+
+  <div class="reg-marks" aria-hidden="true">
+    <span class="reg r1">+</span>
+    <span class="reg r2">+</span>
+    <span class="reg r3">+</span>
+  </div>
+
+  <div class="overprint">
+    <h1 class="word word-strike" data-text="STRIKE">STRIKE</h1>
+    <h1 class="word word-rule" data-text="RULE">RULE</h1>
+  </div>
+
+  <div class="hero-meta">
+    <div class="hero-meta-left">
+      <span class="stamp">RUN N&deg; 047</span>
+      <span class="stamp red">VERMILION &amp; BLACK</span>
+      <span class="stamp">14 &times; 22 IN.</span>
+    </div>
+    <div class="hero-meta-right">
+      <p>A one-press shop on Lot 4. Wood-type show posters, broadsides, and the occasional broadcast &mdash; pulled by hand, two passes through a Vandercook 219.</p>
+    </div>
+  </div>
+</section>
+
+<section class="press" id="press">
+  <div class="wrap">
+    <div class="press-head">
+      <div class="press-num">N&deg; II</div>
+      <h2 class="sec-title">The <i>Press.</i></h2>
+      <div class="press-sub">A specimen sheet, set down in the cabinet faces presently in service at Lot 4.</div>
+    </div>
+
+    <div class="press-body">
+      <p class="lede">The shop runs on a single <b>Vandercook 219 proof press</b>, restored in 2018 from a closed newspaper plant in the next county over. Two-ink runs come off in roughly forty minutes per pull; a three-ink run is reserved for broadsides on commission, and rarely otherwise.</p>
+      <p>The cabinet holds eight faces of wood type, four faces of foundry metal, and a drawer of borders and printer&rsquo;s flowers. Letters above 72 point are cut from end-grain maple; smaller sorts are foundry lead. We do not set digital plates &mdash; if it isn&rsquo;t in the cabinet, the poster does without.</p>
+    </div>
+
+    <div class="specimen-sheet">
+      <div class="specimen-corner tl" aria-hidden="true"></div>
+      <div class="specimen-corner tr" aria-hidden="true"></div>
+      <div class="specimen-corner bl" aria-hidden="true"></div>
+      <div class="specimen-corner br" aria-hidden="true"></div>
+
+      <div class="specimen-head">SPECIMEN &mdash; CABINET FACES, LOT 4</div>
+
+      <div class="specimen-row">
+        <div class="specimen-label">
+          <span class="sp-no">01</span>
+          <span class="sp-name">ANTIQUE TUSCAN</span>
+          <span class="sp-size">10 line / end-grain maple</span>
+        </div>
+        <div class="specimen-show face-rye">Antique Tuscan</div>
+      </div>
+
+      <div class="specimen-row">
+        <div class="specimen-label">
+          <span class="sp-no">02</span>
+          <span class="sp-name">GOTHIC CONDENSED</span>
+          <span class="sp-size">12 line / pine</span>
+        </div>
+        <div class="specimen-show face-bowlby">GOTHIC CONDENSED</div>
+      </div>
+
+      <div class="specimen-row">
+        <div class="specimen-label">
+          <span class="sp-no">03</span>
+          <span class="sp-name">FRENCH CLARENDON</span>
+          <span class="sp-size">8 line / cherry</span>
+        </div>
+        <div class="specimen-show face-ultra">French Clarendon</div>
+      </div>
+
+      <div class="specimen-row last">
+        <div class="specimen-label">
+          <span class="sp-no">04</span>
+          <span class="sp-name">OLD STYLE No 7</span>
+          <span class="sp-size">36 pt / foundry lead</span>
+        </div>
+        <div class="specimen-show face-dm">Old Style N<sup>o</sup> 7</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="runs" id="runs">
+  <div class="wrap">
+    <div class="press-head">
+      <div class="press-num">N&deg; III</div>
+      <h2 class="sec-title">Recent <i>Runs.</i></h2>
+      <div class="press-sub">Selections from the past four pressings. Editions are numbered, signed in the margin, and shipped flat.</div>
+    </div>
+
+    <div class="runs-grid">
+      <article class="poster-card">
+        <div class="card-crop tl" aria-hidden="true"></div>
+        <div class="card-crop tr" aria-hidden="true"></div>
+        <div class="card-crop bl" aria-hidden="true"></div>
+        <div class="card-crop br" aria-hidden="true"></div>
+        <div class="card-stamp">N&deg; 047</div>
+        <div class="card-title face-bowlby">
+          <span class="ct-red" data-text="BLUES">BLUES</span>
+          <span class="ct-blk">NIGHT</span>
+        </div>
+        <div class="card-meta">
+          <span>14 &times; 22 IN.</span>
+          <span class="dot">&middot;</span>
+          <span>EDITION 100</span>
+        </div>
+        <div class="card-foot">2 ink &mdash; vermilion &amp; black &mdash; cream rag</div>
+      </article>
+
+      <article class="poster-card">
+        <div class="card-crop tl" aria-hidden="true"></div>
+        <div class="card-crop tr" aria-hidden="true"></div>
+        <div class="card-crop bl" aria-hidden="true"></div>
+        <div class="card-crop br" aria-hidden="true"></div>
+        <div class="card-stamp">N&deg; 046</div>
+        <div class="card-title face-rye">
+          <span class="ct-red" data-text="HARVEST">HARVEST</span>
+          <span class="ct-blk">FAIR</span>
+        </div>
+        <div class="card-meta">
+          <span>11 &times; 17 IN.</span>
+          <span class="dot">&middot;</span>
+          <span>EDITION 75</span>
+        </div>
+        <div class="card-foot">2 ink &mdash; vermilion &amp; black &mdash; oat rag</div>
+      </article>
+
+      <article class="poster-card">
+        <div class="card-crop tl" aria-hidden="true"></div>
+        <div class="card-crop tr" aria-hidden="true"></div>
+        <div class="card-crop bl" aria-hidden="true"></div>
+        <div class="card-crop br" aria-hidden="true"></div>
+        <div class="card-stamp">N&deg; 045</div>
+        <div class="card-title face-ultra">
+          <span class="ct-red" data-text="THE LATE">THE LATE</span>
+          <span class="ct-blk">ROOM</span>
+        </div>
+        <div class="card-meta">
+          <span>19 &times; 25 IN.</span>
+          <span class="dot">&middot;</span>
+          <span>EDITION 50</span>
+        </div>
+        <div class="card-foot">3 ink &mdash; vermilion, black &amp; blue &mdash; cream rag</div>
+      </article>
+
+      <article class="poster-card">
+        <div class="card-crop tl" aria-hidden="true"></div>
+        <div class="card-crop tr" aria-hidden="true"></div>
+        <div class="card-crop bl" aria-hidden="true"></div>
+        <div class="card-crop br" aria-hidden="true"></div>
+        <div class="card-stamp">N&deg; 044</div>
+        <div class="card-title face-bowlby">
+          <span class="ct-red" data-text="OPEN">OPEN</span>
+          <span class="ct-blk">CABINET</span>
+        </div>
+        <div class="card-meta">
+          <span>14 &times; 22 IN.</span>
+          <span class="dot">&middot;</span>
+          <span>EDITION 120</span>
+        </div>
+        <div class="card-foot">2 ink &mdash; vermilion &amp; black &mdash; cream rag</div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="commission" id="order">
+  <div class="wrap">
+    <div class="press-head">
+      <div class="press-num">N&deg; IV</div>
+      <h2 class="sec-title">Order a <i>Run.</i></h2>
+      <div class="press-sub">A short tariff. Plates set; ink mixed; rags folded. Quoted in editions of fifty unless noted.</div>
+    </div>
+
+    <div class="tariff">
+      <div class="tariff-row head">
+        <div class="t-no">N&deg;</div>
+        <div class="t-name">FORMAT</div>
+        <div class="t-dim">DIMENSION</div>
+        <div class="t-ink">INK</div>
+        <div class="t-price">FROM</div>
+      </div>
+      <div class="tariff-row">
+        <div class="t-no">i.</div>
+        <div class="t-name face-dm">Chap-book card</div>
+        <div class="t-dim">5 &times; 7 in.</div>
+        <div class="t-ink">2 colour</div>
+        <div class="t-price">$3 / ea.</div>
+      </div>
+      <div class="tariff-row">
+        <div class="t-no">ii.</div>
+        <div class="t-name face-dm">Handbill</div>
+        <div class="t-dim">8 &times; 10 in.</div>
+        <div class="t-ink">2 colour</div>
+        <div class="t-price">$8 / ea.</div>
+      </div>
+      <div class="tariff-row">
+        <div class="t-no">iii.</div>
+        <div class="t-name face-dm">Show poster</div>
+        <div class="t-dim">14 &times; 22 in.</div>
+        <div class="t-ink">2 colour</div>
+        <div class="t-price">$22 / ea.</div>
+      </div>
+      <div class="tariff-row">
+        <div class="t-no">iv.</div>
+        <div class="t-name face-dm">Broadside</div>
+        <div class="t-dim">19 &times; 25 in.</div>
+        <div class="t-ink">2 or 3 colour</div>
+        <div class="t-price">$45 / ea.</div>
+      </div>
+      <div class="tariff-row last">
+        <div class="t-no">v.</div>
+        <div class="t-name face-dm">Broadcast (large)</div>
+        <div class="t-dim">26 &times; 39 in.</div>
+        <div class="t-ink">2 or 3 colour</div>
+        <div class="t-price">on request</div>
+      </div>
+    </div>
+
+    <div class="commission-cta">
+      <a class="press-btn" href="#">WRITE THE DESK <span class="arr">&rarr;</span></a>
+      <a class="press-btn ghost" href="{{ base_url }}/about/">READ THE COLOPHON <span class="arr">&rarr;</span></a>
+    </div>
+  </div>
+</section>
+
+<section class="broadcast">
+  <div class="wrap">
+    <div class="broadcast-stamp">BROADCAST &mdash; LOT 4</div>
+    <p class="bc-line face-bowlby">A poster <i>worth printing</i></p>
+    <p class="bc-line face-bowlby red" data-text="is a poster">is a poster</p>
+    <p class="bc-line face-bowlby">worth <i>keeping.</i></p>
+    <div class="broadcast-sign">&mdash; the shop, lot 4 &middot; pressing N&deg; 047, {{ current_year }}</div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/typesetter-strike/templates/page.html
+++ b/examples/typesetter-strike/templates/page.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-crop tl" aria-hidden="true"></div>
+  <div class="prose-crop tr" aria-hidden="true"></div>
+  <div class="prose-crop bl" aria-hidden="true"></div>
+  <div class="prose-crop br" aria-hidden="true"></div>
+  {% if page.title is present %}
+  <div class="prose-head">
+    <div class="prose-stamp">LOT 4 &middot; N&deg; 047</div>
+    <h1 class="prose-title">{{ page.title | e }}</h1>
+  </div>
+  {% endif %}
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/typesetter-strike/templates/section.html
+++ b/examples/typesetter-strike/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<section class="archive">
+  <div class="wrap">
+    <div class="press-head">
+      <div class="press-num">ARCHIVE</div>
+      {% if page.title is present %}<h2 class="sec-title">{{ page.title | e }}</h2>{% endif %}
+      <div class="press-sub">Pulled from the cabinet drawers. Sorted by pressing date.</div>
+    </div>
+    {{ content | safe }}
+    <div class="archive-list">
+      {% for post in section.pages %}
+      <a class="archive-row" href="{{ post.url }}">
+        <span class="ar-date">{{ post.date | date(format="%Y &middot; %m") | safe }}</span>
+        <span class="ar-title">{{ post.title | e }}</span>
+        <span class="ar-arr">&rarr;</span>
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/typesetter-strike/templates/taxonomy.html
+++ b/examples/typesetter-strike/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-crop tl" aria-hidden="true"></div>
+  <div class="prose-crop tr" aria-hidden="true"></div>
+  <div class="prose-crop bl" aria-hidden="true"></div>
+  <div class="prose-crop br" aria-hidden="true"></div>
+  <div class="prose-head">
+    <div class="prose-stamp">INDEX &middot; CABINET</div>
+    <h1 class="prose-title">{{ page.title | e }}</h1>
+  </div>
+  <p><i>An index of subjects, stamped across the archive.</i></p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/typesetter-strike/templates/taxonomy_term.html
+++ b/examples/typesetter-strike/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-crop tl" aria-hidden="true"></div>
+  <div class="prose-crop tr" aria-hidden="true"></div>
+  <div class="prose-crop bl" aria-hidden="true"></div>
+  <div class="prose-crop br" aria-hidden="true"></div>
+  <div class="prose-head">
+    <div class="prose-stamp">DRAWER</div>
+    <h1 class="prose-title">{{ page.title | e }}</h1>
+  </div>
+  <p><i>Entries filed under this stamp.</i></p>
+  {{ content | safe }}
+</article>
+{% include "footer.html" %}

--- a/examples/whisper-courier/AGENTS.md
+++ b/examples/whisper-courier/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/whisper-courier/archetypes/default.md
+++ b/examples/whisper-courier/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/whisper-courier/config.toml
+++ b/examples/whisper-courier/config.toml
@@ -1,0 +1,387 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "WHISPER COURIER"
+description = "An encrypted physical-document courier for legal, journalism, and diplomatic clients. Sealed envelopes carried by hand."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing.
+# Page-level settings (front matter) override these defaults.
+# The runtime auto-emits og:type="website" for the homepage,
+# section indexes, taxonomy listings, and 404 page; the value
+# below applies to article-style content pages only.
+
+[og]
+# default_image = "/images/og-default.png" # Drop a 1200x630 image under static/ and uncomment
+type = "article"                           # OpenGraph type for content pages (website, article, …)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false             # If true, raw HTML in markdown is stripped (replaced by comments)
+lazy_loading = false     # If true, automatically add loading="lazy" to img tags
+emoji = false            # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+footnotes = true         # GitHub-flavored footnote syntax: [^1] / [^1]: definition
+task_lists = true        # Task list syntax: - [ ] todo / - [x] done
+definition_lists = true  # Definition list syntax (Term newline ": Definition")
+admonitions = true       # GitHub-style `> [!NOTE]` blockquotes render as admonition <div>s
+heading_ids = true       # `## Heading {#custom-id}` sets an explicit id
+mermaid = false          # Render ```mermaid code blocks as diagrams (loads mermaid.js)
+math = false             # Inline ($...$) and block ($$...$$) math (loads math_engine)
+math_engine = "katex"    # "katex" or "mathjax"
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Customize what `hwaro new <path>` writes when there's no archetype
+# match. Archetypes in `archetypes/` always take priority.
+
+# [content.new]
+# front_matter_format = "toml"        # "toml" (default), "yaml", or "json"
+# default_fields = ["description"]    # Extra fields beyond title/date/draft/tags
+# bundle = false                      # If true, create page bundles (foo/index.md) instead of foo.md
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+# cache_strategy = "cache-first"  # cache-first, network-first, stale-while-revalidate
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Doctor
+# =============================================================================
+# Configure doctor diagnostics behavior
+# Add rule IDs to the ignore list to suppress known issues
+# Run `hwaro doctor --json` to see rule IDs in the output
+
+[doctor]
+ignore = []
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/whisper-courier/content/about.md
+++ b/examples/whisper-courier/content/about.md
@@ -1,0 +1,29 @@
++++
+title = "About the Desk"
+description = "Whisper Courier — bonded carriers, sealed intake, chain-of-custody, destruction protocols, and how to reach Desk 09."
++++
+
+## Bonded couriers
+
+Every carrier on our roster is **bonded and credentialed** before they touch an envelope. Background checks, polygraph on annual review, and a sworn confidentiality clause that survives termination. We hire ex-archivists, ex-paralegals, and one retired diplomatic-pouch courier. We do not subcontract. We do not use rideshare.
+
+## Intake
+
+A courier comes to your office or a neutral location of your choosing. The document is **counted, weighed, and noted** in the intake log in your presence. You receive a triplicate receipt — pink copy to you, yellow copy in the pouch, white copy to Desk 09. No scans. No photographs.
+
+## Seal and chain-of-custody
+
+The envelope is **sealed in front of you** with a numbered wax seal and a tamper-evident foil strip. The seal number is logged against the intake. From that moment until the recipient breaks the seal, the envelope is in continuous physical custody of a named carrier. **Transit log** is timestamped at every handover.
+
+## Destruction
+
+For documents marked **DESTROY ON DELIVERY**, the carrier carries a portable cross-cut shredder and a sealed burn bag. Destruction happens in the recipient's presence; the ash is returned to the recipient. For routine carries, originals are returned to the sender after recipient signature.
+
+## Contact
+
+> Send the address. Do not send the document.
+
+- **Desk 09** — `desk09@whisper.courier`
+- **Bookings** — by telephone only, `+82-2-555-0904`
+- **Walk-in intake** — Tuesday and Friday, 09:00 to 16:00, by appointment
+- **After hours** — pager number on the receipt you were given at intake

--- a/examples/whisper-courier/content/index.md
+++ b/examples/whisper-courier/content/index.md
@@ -1,0 +1,5 @@
++++
+title = ""
+description = "WHISPER COURIER — encrypted physical-document courier for legal, journalism, and diplomatic clients."
+template = "index"
++++

--- a/examples/whisper-courier/static/css/style.css
+++ b/examples/whisper-courier/static/css/style.css
@@ -1,0 +1,740 @@
+/* =============================================================================
+   WHISPER COURIER — espionage-dossier aesthetic
+   Manila paper, typewriter ink, redaction bars, rubber stamps.
+   No gradients. No emoji. Solids only.
+   ============================================================================= */
+
+:root {
+  --manila: #d8c89a;
+  --manila-deep: #b89e6a;
+  --typewriter-ink: #1a1612;
+  --redaction: #050505;
+  --stamp-red: #b3251c;
+  --stamp-blue: #1c3a72;
+  --onion-cream: #f0e8c8;
+
+  --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  --font-typed: "Special Elite", "IBM Plex Mono", monospace;
+  --font-display: "DM Serif Display", "Times New Roman", serif;
+}
+
+* { box-sizing: border-box; }
+
+html { background: var(--manila); }
+
+body {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--typewriter-ink);
+  background-color: var(--manila);
+  /* Subtle horizontal dossier-paper rules via tiled SVG (no gradient) */
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='28' height='28'><line x1='0' y1='27.5' x2='28' y2='27.5' stroke='rgba(184,158,106,0.45)' stroke-width='1'/></svg>");
+  background-size: 28px 28px;
+}
+
+a { color: var(--typewriter-ink); text-decoration: underline; text-underline-offset: 3px; }
+a:hover { color: var(--stamp-red); }
+
+/* -------------------------- TOP STRIP -------------------------- */
+
+.strip-top {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 24px;
+  background: var(--typewriter-ink);
+  color: var(--manila);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  border-bottom: 3px double var(--manila-deep);
+}
+
+.strip-home {
+  color: var(--manila);
+  text-decoration: none;
+  font-weight: 700;
+}
+.strip-home:hover { color: var(--manila); text-decoration: underline; }
+
+.strip-nav { display: flex; gap: 22px; }
+.strip-nav a { color: var(--manila); text-decoration: none; }
+.strip-nav a:hover { color: var(--stamp-red); text-decoration: underline; }
+
+/* -------------------------- DOSSIER HERO -------------------------- */
+
+.dossier {
+  position: relative;
+  padding: 48px 24px 80px;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.folder-tab {
+  display: inline-block;
+  margin-left: 56px;
+  padding: 8px 28px 6px;
+  background: var(--manila-deep);
+  color: var(--typewriter-ink);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border: 2px solid var(--typewriter-ink);
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  position: relative;
+  top: 2px;
+}
+
+.folder {
+  position: relative;
+  background: var(--manila-deep);
+  border: 2px solid var(--typewriter-ink);
+  padding: 10px;
+}
+
+.folder-corner {
+  position: absolute;
+  top: 0; right: 0;
+  width: 56px; height: 56px;
+  background: var(--manila);
+  border-left: 2px solid var(--typewriter-ink);
+  border-bottom: 2px solid var(--typewriter-ink);
+}
+
+.folder-fold {
+  height: 18px;
+  background: var(--manila-deep);
+  border-top: 2px solid var(--typewriter-ink);
+  margin-top: 0;
+}
+
+.cover-letter {
+  position: relative;
+  background: var(--manila);
+  border: 1px solid var(--typewriter-ink);
+  padding: 56px 56px 64px;
+  min-height: 520px;
+}
+
+.letter-meta {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 6px 16px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  border-bottom: 2px dashed var(--typewriter-ink);
+  padding-bottom: 16px;
+  margin-bottom: 28px;
+  max-width: 560px;
+}
+.letter-meta span { color: var(--typewriter-ink); opacity: 0.75; }
+.letter-meta b { font-weight: 700; }
+
+.typed-head {
+  font-family: var(--font-typed);
+  font-weight: 400;
+  font-size: clamp(40px, 7vw, 92px);
+  line-height: 1.02;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  margin: 8px 0 28px;
+  color: var(--typewriter-ink);
+}
+.typed-head span {
+  display: inline-block;
+  margin-right: 0.18em;
+}
+.typed-head .last {
+  border-bottom: 4px solid var(--stamp-red);
+  padding-bottom: 4px;
+}
+
+.memo {
+  max-width: 640px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.7;
+}
+.memo p { margin: 0 0 14px; }
+.memo strong { font-weight: 700; }
+
+.redact-line { position: relative; }
+
+.redact-bar {
+  display: inline-block;
+  background: var(--redaction);
+  color: var(--redaction);
+  padding: 1px 8px;
+  letter-spacing: 0.2em;
+  user-select: none;
+  vertical-align: baseline;
+  position: relative;
+}
+.redact-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--redaction);
+}
+.redact-bar.inline { padding: 0 38px; }
+.redact-bar.small { padding: 0 26px; }
+
+/* -------------------------- STAMPS -------------------------- */
+
+.stamp-field {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.stamp {
+  position: absolute;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  padding: 10px 18px;
+  border: 4px double currentColor;
+  background: transparent;
+  text-align: center;
+  white-space: nowrap;
+  font-size: 18px;
+  opacity: 0.92;
+}
+.stamp::before, .stamp::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+}
+.stamp-red { color: var(--stamp-red); }
+.stamp-blue { color: var(--stamp-blue); }
+
+.stamp-classified {
+  top: 40px;
+  right: 48px;
+  transform: rotate(-8deg);
+  font-size: 26px;
+  padding: 14px 24px;
+}
+.stamp-verified {
+  top: 220px;
+  right: 80px;
+  transform: rotate(6deg);
+  font-size: 22px;
+  padding: 12px 22px;
+}
+.stamp-eyes {
+  bottom: 120px;
+  left: 36px;
+  transform: rotate(-4deg);
+  font-size: 24px;
+  padding: 14px 26px;
+}
+.stamp-received {
+  bottom: 60px;
+  right: 60px;
+  transform: rotate(-12deg);
+  font-size: 14px;
+  padding: 8px 14px;
+}
+.stamp-fixed {
+  position: static;
+  display: inline-block;
+  transform: rotate(-6deg);
+  margin: 8px 0 24px;
+  font-size: 22px;
+  padding: 12px 22px;
+}
+
+.sig-row {
+  position: absolute;
+  bottom: 32px;
+  left: 56px;
+  right: 56px;
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.sig-line {
+  flex: 1;
+  border-bottom: 1px solid var(--typewriter-ink);
+  height: 1.4em;
+  font-family: var(--font-typed);
+  font-size: 18px;
+  text-transform: none;
+  letter-spacing: 0;
+  text-align: center;
+  padding-bottom: 2px;
+}
+
+/* -------------------------- REDACTION TAPE DIVIDER -------------------------- */
+
+.redaction-tape {
+  display: flex;
+  gap: 4px;
+  padding: 22px 24px;
+  background: var(--manila-deep);
+  border-top: 2px solid var(--typewriter-ink);
+  border-bottom: 2px solid var(--typewriter-ink);
+}
+.redaction-tape span {
+  flex: 1;
+  height: 22px;
+  background: var(--redaction);
+}
+.redaction-tape span:nth-child(3n) { background: var(--typewriter-ink); }
+.redaction-tape span:nth-child(5n) { width: 8%; flex: none; background: var(--manila); border: 1px solid var(--typewriter-ink); }
+
+/* -------------------------- SECTIONS -------------------------- */
+
+.section-wrap {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 72px 24px;
+}
+
+.section-head { margin-bottom: 44px; max-width: 820px; }
+.section-tag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--typewriter-ink);
+  opacity: 0.7;
+  border-bottom: 2px dashed var(--typewriter-ink);
+  display: inline-block;
+  padding-bottom: 4px;
+  margin-bottom: 18px;
+}
+.section-head h2 {
+  font-family: var(--font-typed);
+  font-size: clamp(28px, 4.4vw, 52px);
+  line-height: 1.08;
+  text-transform: uppercase;
+  margin: 0 0 14px;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+}
+.section-lede {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  margin: 0;
+  max-width: 60ch;
+}
+
+/* -------------------------- TIERS -------------------------- */
+
+.tiers { background: var(--manila); }
+
+.tier-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 32px;
+}
+
+.tier {
+  position: relative;
+  background: var(--onion-cream);
+  border: 1.5px solid var(--typewriter-ink);
+  padding: 36px 28px 32px;
+  min-height: 480px;
+  box-shadow: 6px 6px 0 var(--manila-deep);
+}
+.tier-mid { transform: rotate(-0.6deg); }
+.tier:nth-child(1) { transform: rotate(0.4deg); }
+.tier:nth-child(3) { transform: rotate(-0.3deg); }
+
+.tier-clip {
+  position: absolute;
+  top: -14px;
+  left: 40px;
+  width: 28px;
+  height: 56px;
+}
+.tier-clip svg { width: 100%; height: 100%; }
+
+.tier-tag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--stamp-red);
+  border: 1.5px solid var(--stamp-red);
+  display: inline-block;
+  padding: 3px 10px;
+  margin-bottom: 12px;
+}
+.tier h3 {
+  font-family: var(--font-typed);
+  font-size: 38px;
+  font-weight: 400;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.tier-time {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+  padding-bottom: 12px;
+  border-bottom: 1px dashed var(--typewriter-ink);
+}
+.tier-price {
+  font-family: var(--font-display);
+  font-size: 30px;
+  margin-bottom: 22px;
+  color: var(--typewriter-ink);
+}
+.tier-price small {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+.tier-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+}
+.tier-list li {
+  padding-left: 22px;
+  position: relative;
+  margin-bottom: 6px;
+}
+.tier-list li::before {
+  content: "+";
+  position: absolute;
+  left: 0;
+  color: var(--stamp-red);
+  font-weight: 700;
+}
+
+/* -------------------------- CUSTODY RECEIPT -------------------------- */
+
+.custody { background: var(--manila); }
+
+.receipt {
+  background: var(--onion-cream);
+  border: 2px solid var(--typewriter-ink);
+  padding: 36px 40px;
+  max-width: 880px;
+  margin: 0 auto;
+  position: relative;
+}
+.receipt::before {
+  content: "";
+  position: absolute;
+  top: -2px; left: 24px; right: 24px;
+  height: 8px;
+  border-top: 2px dashed var(--typewriter-ink);
+}
+
+.receipt-head {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  border-bottom: 2px solid var(--typewriter-ink);
+  padding-bottom: 10px;
+  margin-bottom: 24px;
+}
+
+.custody-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px;
+  counter-reset: cust;
+}
+.custody-list li {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 18px;
+  padding: 18px 0;
+  border-bottom: 1px dashed var(--typewriter-ink);
+}
+.custody-list li:last-child { border-bottom: 2px solid var(--typewriter-ink); }
+.cust-num {
+  font-family: var(--font-display);
+  font-size: 40px;
+  line-height: 1;
+  color: var(--stamp-red);
+}
+.custody-list h4 {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin: 0 0 6px;
+}
+.custody-list p {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.receipt-sign {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding-top: 18px;
+}
+.receipt-sign em { font-style: normal; font-family: var(--font-typed); letter-spacing: 0; text-transform: none; }
+
+/* -------------------------- RECENT CARRIES LOG -------------------------- */
+
+.recent { background: var(--manila); }
+
+.log-onion {
+  background: var(--onion-cream);
+  border: 1.5px solid var(--typewriter-ink);
+  padding: 28px 32px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  max-width: 980px;
+  margin: 0 auto;
+}
+.log-head, .log-foot {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  border-bottom: 2px solid var(--typewriter-ink);
+  padding-bottom: 10px;
+  margin-bottom: 12px;
+}
+.log-foot {
+  border-bottom: none;
+  border-top: 2px solid var(--typewriter-ink);
+  padding: 12px 0 0;
+  margin-top: 12px;
+  margin-bottom: 0;
+  opacity: 0.75;
+}
+
+.log-line {
+  display: grid;
+  grid-template-columns: 110px 1fr 100px 220px;
+  gap: 18px;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px dashed var(--typewriter-ink);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+}
+.log-line:last-of-type { border-bottom: none; }
+.log-date { font-weight: 700; letter-spacing: 0.16em; }
+.log-pages { letter-spacing: 0.16em; text-transform: uppercase; opacity: 0.85; }
+.log-status {
+  text-align: right;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--stamp-blue);
+}
+
+/* -------------------------- FOOTER -------------------------- */
+
+.foot {
+  background: var(--typewriter-ink);
+  color: var(--manila);
+  padding: 72px 24px 40px;
+  border-top: 6px double var(--manila-deep);
+}
+.foot-inner { max-width: 1180px; margin: 0 auto; }
+
+.foot-colophon {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 24px;
+  align-items: start;
+  margin-bottom: 44px;
+  padding-bottom: 32px;
+  border-bottom: 1px dashed var(--manila-deep);
+}
+.paperclip-wrap { width: 60px; }
+.paperclip { width: 100%; height: auto; }
+.paperclip path { stroke: var(--manila); }
+.foot-colophon .typed {
+  font-family: var(--font-typed);
+  font-size: 16px;
+  line-height: 1.7;
+  margin: 0 0 18px;
+  max-width: 70ch;
+}
+.foot-colophon .bond {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  border-top: 1px solid var(--manila-deep);
+  padding-top: 12px;
+  margin: 0;
+}
+
+.foot-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px;
+}
+.foot-col h4 {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin: 0 0 14px;
+  color: var(--manila-deep);
+  border-bottom: 1px dashed var(--manila-deep);
+  padding-bottom: 6px;
+}
+.foot-col p {
+  margin: 4px 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--manila);
+  letter-spacing: 0.04em;
+}
+
+.foot-rule { height: 6px; background: var(--manila-deep); margin: 40px 0 16px; }
+
+.foot-meta {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--manila-deep);
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+/* -------------------------- PROSE (about, 404, etc.) -------------------------- */
+
+.prose {
+  max-width: 880px;
+  margin: 48px auto 80px;
+  padding: 0 24px;
+}
+.prose-tab {
+  display: inline-block;
+  margin-left: 40px;
+  padding: 8px 24px 6px;
+  background: var(--manila-deep);
+  color: var(--typewriter-ink);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border: 2px solid var(--typewriter-ink);
+  border-bottom: none;
+  position: relative;
+  top: 2px;
+}
+.prose-paper {
+  background: var(--onion-cream);
+  border: 2px solid var(--typewriter-ink);
+  padding: 48px 56px;
+  box-shadow: 8px 8px 0 var(--manila-deep);
+}
+.prose h1 {
+  font-family: var(--font-typed);
+  font-size: clamp(34px, 5vw, 56px);
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  margin: 0 0 28px;
+  padding-bottom: 16px;
+  border-bottom: 3px double var(--typewriter-ink);
+}
+.prose h2 {
+  font-family: var(--font-typed);
+  font-size: 26px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 36px 0 14px;
+}
+.prose p, .prose li {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.75;
+}
+.prose blockquote {
+  border-left: 4px solid var(--stamp-red);
+  margin: 24px 0;
+  padding: 8px 20px;
+  font-family: var(--font-typed);
+  font-size: 18px;
+  background: var(--manila);
+}
+.prose code {
+  font-family: var(--font-mono);
+  background: var(--manila);
+  padding: 2px 6px;
+  border: 1px solid var(--typewriter-ink);
+  font-size: 13px;
+}
+.prose a { color: var(--stamp-blue); }
+.prose a:hover { color: var(--stamp-red); }
+.prose ul, .prose ol { padding-left: 22px; }
+.prose strong { font-weight: 700; }
+
+/* -------------------------- RESPONSIVE -------------------------- */
+
+@media (max-width: 900px) {
+  .tier-grid { grid-template-columns: 1fr; }
+  .foot-grid { grid-template-columns: repeat(2, 1fr); }
+  .cover-letter { padding: 36px 28px 56px; }
+  .stamp-classified { right: 16px; top: 24px; font-size: 18px; }
+  .stamp-verified { right: 24px; top: 180px; font-size: 16px; }
+  .stamp-eyes { left: 16px; bottom: 90px; font-size: 17px; }
+  .stamp-received { right: 16px; bottom: 30px; font-size: 11px; }
+  .log-line { grid-template-columns: 1fr; gap: 4px; padding: 14px 0; }
+  .log-status { text-align: left; }
+  .sig-row { position: static; margin-top: 32px; }
+  .prose-paper { padding: 32px 24px; }
+}
+
+@media (max-width: 600px) {
+  .strip-top { flex-direction: column; align-items: flex-start; gap: 8px; padding: 10px 16px; }
+  .strip-nav { gap: 14px; flex-wrap: wrap; }
+  .dossier { padding: 32px 12px 56px; }
+  .section-wrap { padding: 56px 16px; }
+  .foot-grid { grid-template-columns: 1fr; }
+  .foot-colophon { grid-template-columns: 1fr; }
+  .foot-meta { flex-direction: column; }
+  .receipt-sign { flex-direction: column; gap: 12px; }
+  .custody-list li { grid-template-columns: 48px 1fr; gap: 12px; }
+  .cust-num { font-size: 28px; }
+}

--- a/examples/whisper-courier/static/favicon.svg
+++ b/examples/whisper-courier/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="2" fill="#d8c89a"/>
+  <rect x="4" y="14" width="24" height="4" fill="#050505"/>
+  <rect x="6" y="22" width="14" height="2" fill="#050505"/>
+  <rect x="6" y="7" width="10" height="2" fill="#1a1612"/>
+</svg>

--- a/examples/whisper-courier/templates/404.html
+++ b/examples/whisper-courier/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-tab">DOSSIER 04-{{ current_year }} &middot; FILE NOT ON DESK</div>
+  <div class="prose-paper">
+    <div class="stamp stamp-red stamp-fixed" aria-hidden="true">FILE MISSING</div>
+    <h1>404 // FILE NOT ON DESK.</h1>
+    <p>The file you requested is not in the cabinet. It may have been carried out, destroyed, or never opened. The desk chief has no record.</p>
+    <p>Return to the <a href="{{ base_url }}/">front desk</a> and present a different reference.</p>
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/whisper-courier/templates/footer.html
+++ b/examples/whisper-courier/templates/footer.html
@@ -1,0 +1,48 @@
+  <footer class="foot">
+    <div class="foot-inner">
+      <div class="foot-colophon">
+        <div class="paperclip-wrap" aria-hidden="true">
+          <svg class="paperclip" viewBox="0 0 40 80" xmlns="http://www.w3.org/2000/svg">
+            <path d="M28 8 C 34 8, 34 16, 28 16 L 14 16 C 8 16, 8 24, 14 24 L 28 24 C 22 24, 22 32, 28 32 L 14 32" fill="none" stroke="#1a1612" stroke-width="2.5"/>
+          </svg>
+        </div>
+        <p class="typed">A typed colophon. Set in IBM Plex Mono on manila stock. Pressed at Desk 09, filed under DOSSIER 04-{{ current_year }}. The envelope you are reading was sealed by hand and carried by a bonded human who knows your name only when required.</p>
+        <p class="bond">ALL CARRIERS BONDED &middot; {{ current_year }}</p>
+      </div>
+      <div class="foot-grid">
+        <div class="foot-col">
+          <h4>// DESK 09</h4>
+          <p>Office 904, 9th Floor</p>
+          <p>Hannam-daero 217</p>
+          <p>Yongsan-gu, Seoul</p>
+        </div>
+        <div class="foot-col">
+          <h4>// SUB-DESK 02</h4>
+          <p>Suite 1402</p>
+          <p>One Raffles Quay, North Tower</p>
+          <p>Singapore 048583</p>
+        </div>
+        <div class="foot-col">
+          <h4>// SUB-DESK 11</h4>
+          <p>Rue de la Confederation 8</p>
+          <p>1204 Geneva</p>
+          <p>Switzerland</p>
+        </div>
+        <div class="foot-col">
+          <h4>// REACH</h4>
+          <p>desk09@whisper.courier</p>
+          <p>+82-2-555-0904</p>
+          <p>Pager on receipt</p>
+        </div>
+      </div>
+      <div class="foot-rule"></div>
+      <div class="foot-meta">
+        <span>&copy; {{ current_year }} WHISPER COURIER &middot; DOSSIER 04-{{ current_year }}</span>
+        <span>FILE NO. WC-{{ current_year }}-0904 &middot; CARRIER ROSTER ON FILE</span>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/whisper-courier/templates/header.html
+++ b/examples/whisper-courier/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} // {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,700;1,400&family=Special+Elite&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ math_tags }}
+  {{ mermaid_tags }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <header class="strip-top">
+    <a class="strip-home" href="{{ base_url }}/">WHISPER COURIER &middot; SEALED &amp; CARRIED &middot; DESK 09</a>
+    <nav class="strip-nav">
+      <a href="#routes">Routes</a>
+      <a href="#custody">Custody</a>
+      <a href="#verification">Verification</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </nav>
+  </header>

--- a/examples/whisper-courier/templates/index.html
+++ b/examples/whisper-courier/templates/index.html
@@ -1,0 +1,235 @@
+{% include "header.html" %}
+
+<section class="dossier">
+  <div class="folder-tab">DOSSIER 04-{{ current_year }} &middot; FILE WC-0904</div>
+  <div class="folder">
+    <div class="folder-corner"></div>
+    <div class="cover-letter">
+      <div class="letter-meta">
+        <span>FROM:</span><b>DESK 09 &middot; WHISPER COURIER</b>
+        <span>TO:</span><b>BEARER OF THIS FILE</b>
+        <span>RE:</span><b>SERVICE ENGAGEMENT &middot; SEALED</b>
+        <span>DATE:</span><b>04 / {{ current_year }}</b>
+      </div>
+
+      <h1 class="typed-head">
+        <span>WE</span>
+        <span>CARRY</span>
+        <span>WHAT</span>
+        <span>CANNOT</span>
+        <span>BE</span>
+        <span class="last">EMAILED.</span>
+      </h1>
+
+      <div class="memo">
+        <p>The undersigned operates a manual courier service for documents that <strong>must not</strong> traverse a network, a cloud, or a third-party server. Sealed envelopes, hand to hand, between named persons.</p>
+        <p>Each carry is logged against a numbered seal. Each carrier is bonded, vetted, and personally known to the desk. We accept work on referral and on retainer.</p>
+        <p class="redact-line">The carrier assigned to your file last week was <span class="redact-bar" aria-label="redacted">REDACTED</span> and signed for the parcel at 14:32 local time.</p>
+      </div>
+
+      <div class="stamp-field" aria-hidden="true">
+        <div class="stamp stamp-red stamp-classified">CLASSIFIED</div>
+        <div class="stamp stamp-blue stamp-verified">VERIFIED</div>
+        <div class="stamp stamp-red stamp-eyes">EYES ONLY</div>
+        <div class="stamp stamp-blue stamp-received">RECEIVED 04/{{ current_year }}</div>
+      </div>
+
+      <div class="sig-row">
+        <span>SIGNED &mdash;</span>
+        <span class="sig-line">&nbsp;</span>
+        <span>DESK CHIEF, 09</span>
+      </div>
+    </div>
+    <div class="folder-fold"></div>
+  </div>
+</section>
+
+<div class="redaction-tape" aria-hidden="true">
+  <span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span>
+</div>
+
+<section class="tiers" id="routes">
+  <div class="section-wrap">
+    <div class="section-head">
+      <div class="section-tag">// SECTION I &middot; SERVICE TIERS</div>
+      <h2>THREE ROUTES. ONE STANDARD OF CUSTODY.</h2>
+      <p class="section-lede">Pick the tempo. The seal does not change.</p>
+    </div>
+    <div class="tier-grid">
+      <article class="tier">
+        <div class="tier-clip" aria-hidden="true">
+          <svg viewBox="0 0 40 80"><path d="M28 8 C 34 8, 34 16, 28 16 L 14 16 C 8 16, 8 24, 14 24 L 28 24 C 22 24, 22 32, 28 32 L 14 32" fill="none" stroke="#1a1612" stroke-width="2.5"/></svg>
+        </div>
+        <div class="tier-tag">TIER I</div>
+        <h3>ROUTINE</h3>
+        <div class="tier-time">24 HOUR WINDOW</div>
+        <div class="tier-price">&#8361; 480,000 <small>/ envelope</small></div>
+        <ul class="tier-list">
+          <li>Single bonded carrier</li>
+          <li>Numbered wax seal &amp; foil strip</li>
+          <li>Triplicate intake receipt</li>
+          <li>Recipient signature on file</li>
+          <li>Transit log &mdash; <span class="redact-bar small">REDACTED</span></li>
+          <li>Max 200 pages or 1.2 kg</li>
+        </ul>
+      </article>
+
+      <article class="tier tier-mid">
+        <div class="tier-clip" aria-hidden="true">
+          <svg viewBox="0 0 40 80"><path d="M28 8 C 34 8, 34 16, 28 16 L 14 16 C 8 16, 8 24, 14 24 L 28 24 C 22 24, 22 32, 28 32 L 14 32" fill="none" stroke="#1a1612" stroke-width="2.5"/></svg>
+        </div>
+        <div class="tier-tag">TIER II</div>
+        <h3>PRIORITY</h3>
+        <div class="tier-time">4 HOUR WINDOW</div>
+        <div class="tier-price">&#8361; 1,240,000 <small>/ envelope</small></div>
+        <ul class="tier-list">
+          <li>Two bonded carriers, staggered</li>
+          <li>Tamper-evident pouch &amp; wax</li>
+          <li>Live pager check-in every 30 min</li>
+          <li>Counter-signature at handover</li>
+          <li>Route <span class="redact-bar small">REDACTED</span> from log</li>
+          <li>Max 600 pages or 3 kg</li>
+        </ul>
+      </article>
+
+      <article class="tier">
+        <div class="tier-clip" aria-hidden="true">
+          <svg viewBox="0 0 40 80"><path d="M28 8 C 34 8, 34 16, 28 16 L 14 16 C 8 16, 8 24, 14 24 L 28 24 C 22 24, 22 32, 28 32 L 14 32" fill="none" stroke="#1a1612" stroke-width="2.5"/></svg>
+        </div>
+        <div class="tier-tag">TIER III</div>
+        <h3>DIPLOMATIC</h3>
+        <div class="tier-time">CHAIN OF CUSTODY</div>
+        <div class="tier-price">QUOTE <small>/ on request</small></div>
+        <ul class="tier-list">
+          <li>Pouch-class carrier, ex-credentialed</li>
+          <li>Diplomatic wax &amp; lead seal</li>
+          <li>Two-person rule at all handovers</li>
+          <li>Customs documentation prepared</li>
+          <li>Carrier identity <span class="redact-bar small">REDACTED</span></li>
+          <li>No weight or page cap</li>
+        </ul>
+      </article>
+    </div>
+  </div>
+</section>
+
+<div class="redaction-tape" aria-hidden="true">
+  <span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span>
+</div>
+
+<section class="custody" id="custody">
+  <div class="section-wrap">
+    <div class="section-head">
+      <div class="section-tag">// SECTION II &middot; CHAIN OF CUSTODY</div>
+      <h2>SIX STEPS. NO GAPS.</h2>
+      <p class="section-lede">Reproduced below as printed on the back of every intake receipt.</p>
+    </div>
+
+    <div class="receipt">
+      <div class="receipt-head">
+        <span>WHISPER COURIER &middot; INTAKE RECEIPT &middot; FORM 09-A</span>
+        <span>FILE: WC-{{ current_year }}-_____</span>
+      </div>
+
+      <ol class="custody-list">
+        <li>
+          <span class="cust-num">01</span>
+          <div>
+            <h4>INTAKE</h4>
+            <p>Document counted, weighed, and noted in your presence. You receive the pink copy of Form 09-A. No scans. No photographs.</p>
+          </div>
+        </li>
+        <li>
+          <span class="cust-num">02</span>
+          <div>
+            <h4>SEAL</h4>
+            <p>Envelope sealed with a numbered wax seal and tamper-evident foil. Seal number is logged against the intake.</p>
+          </div>
+        </li>
+        <li>
+          <span class="cust-num">03</span>
+          <div>
+            <h4>CARRIER SIGNS</h4>
+            <p>Named carrier signs for the parcel. From this moment until the seal is broken, the envelope is in continuous physical custody.</p>
+          </div>
+        </li>
+        <li>
+          <span class="cust-num">04</span>
+          <div>
+            <h4>TRANSIT LOG</h4>
+            <p>Timestamped entries at every handover. Photographs of the seal at each checkpoint, retained for thirty days then destroyed.</p>
+          </div>
+        </li>
+        <li>
+          <span class="cust-num">05</span>
+          <div>
+            <h4>RECIPIENT SIGNS</h4>
+            <p>Recipient verifies the seal number against the receipt before breaking it. Signature collected on the yellow copy.</p>
+          </div>
+        </li>
+        <li>
+          <span class="cust-num">06</span>
+          <div>
+            <h4>DESTRUCTION OR RETURN</h4>
+            <p>Originals are either returned to the sender under a fresh seal, or destroyed in the recipient's presence with the ash returned.</p>
+          </div>
+        </li>
+      </ol>
+
+      <div class="receipt-sign">
+        <span>Carrier: <em>_______________________</em></span>
+        <span>Date: <em>__________</em></span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="redaction-tape" aria-hidden="true">
+  <span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span>
+</div>
+
+<section class="recent" id="verification">
+  <div class="section-wrap">
+    <div class="section-head">
+      <div class="section-tag">// SECTION III &middot; RECENT CARRIES</div>
+      <h2>LOG EXCERPT. NAMES WITHHELD.</h2>
+      <p class="section-lede">Reproduced from the transit log of Desk 09. All identifying detail is redacted before release.</p>
+    </div>
+
+    <div class="log-onion">
+      <div class="log-head">
+        <span>WC TRANSIT LOG &middot; EXTRACT</span>
+        <span>PAGE 47 OF 312</span>
+      </div>
+      <div class="log-line">
+        <span class="log-date">04 / {{ current_year }}</span>
+        <span class="log-route"><span class="redact-bar inline">REDACTED</span> &rarr; <span class="redact-bar inline">REDACTED</span></span>
+        <span class="log-pages">47 PAGES</span>
+        <span class="log-status">SEALED INTACT</span>
+      </div>
+      <div class="log-line">
+        <span class="log-date">04 / {{ current_year }}</span>
+        <span class="log-route"><span class="redact-bar inline">REDACTED</span> &rarr; <span class="redact-bar inline">REDACTED</span></span>
+        <span class="log-pages">112 PAGES</span>
+        <span class="log-status">SEALED INTACT</span>
+      </div>
+      <div class="log-line">
+        <span class="log-date">03 / {{ current_year }}</span>
+        <span class="log-route"><span class="redact-bar inline">REDACTED</span> &rarr; <span class="redact-bar inline">REDACTED</span></span>
+        <span class="log-pages">9 PAGES</span>
+        <span class="log-status">DESTROYED ON DELIVERY</span>
+      </div>
+      <div class="log-line">
+        <span class="log-date">03 / {{ current_year }}</span>
+        <span class="log-route"><span class="redact-bar inline">REDACTED</span> &rarr; <span class="redact-bar inline">REDACTED</span></span>
+        <span class="log-pages">214 PAGES</span>
+        <span class="log-status">SEALED INTACT</span>
+      </div>
+      <div class="log-foot">
+        <span>EXTRACT ENDS &mdash; FULL LOG ON FILE AT DESK 09</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/whisper-courier/templates/page.html
+++ b/examples/whisper-courier/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-tab">DOSSIER 04-{{ current_year }} &middot; PAGE INSERT</div>
+  <div class="prose-paper">
+    {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/whisper-courier/templates/section.html
+++ b/examples/whisper-courier/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+<section class="section-listing">
+  <div class="section-wrap">
+    <div class="section-head">
+      <div class="section-tag">// SECTION INDEX</div>
+      {% if page.title is present %}<h2>{{ page.title | e | upper }}</h2>{% endif %}
+    </div>
+    <div class="prose-paper">
+      {{ content | safe }}
+    </div>
+    <div class="log-onion">
+      <div class="log-head">
+        <span>FILED ENTRIES</span>
+        <span>SORTED BY DATE</span>
+      </div>
+      {% for post in section.pages %}
+      <div class="log-line">
+        <span class="log-date">{{ post.date | date(format="%m / %Y") }}</span>
+        <span class="log-route"><a href="{{ post.url }}">{{ post.title | e | upper }}</a></span>
+        <span class="log-status">FILED</span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{{ pagination }}
+{% include "footer.html" %}

--- a/examples/whisper-courier/templates/shortcodes/alert.html
+++ b/examples/whisper-courier/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/whisper-courier/templates/taxonomy.html
+++ b/examples/whisper-courier/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-tab">DOSSIER 04-{{ current_year }} &middot; INDEX</div>
+  <div class="prose-paper">
+    <h1>{{ page.title | e | upper }}</h1>
+    <p>// Cross-reference index of filed entries.</p>
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/examples/whisper-courier/templates/taxonomy_term.html
+++ b/examples/whisper-courier/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<article class="prose">
+  <div class="prose-tab">DOSSIER 04-{{ current_year }} &middot; SUB-INDEX</div>
+  <div class="prose-paper">
+    <h1>{{ page.title | e | upper }}</h1>
+    <p>// Entries filed under this reference.</p>
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -326,6 +326,13 @@
     "docs",
     "git-workflow"
   ],
+  "arcade-token": [
+    "dark",
+    "landing",
+    "retro",
+    "arcade",
+    "pixel"
+  ],
   "archipelago": [
     "dark",
     "landing",
@@ -589,6 +596,13 @@
     "pass",
     "backstage",
     "credential"
+  ],
+  "balloon-mail": [
+    "light",
+    "landing",
+    "aeronautics",
+    "engraved",
+    "editorial"
   ],
   "bamboo": [
     "light",
@@ -1093,6 +1107,13 @@
     "dark",
     "gallery",
     "minimal"
+  ],
+  "carbon-press": [
+    "light",
+    "landing",
+    "form",
+    "editorial",
+    "typewriter"
   ],
   "carnival": [
     "dark",
@@ -2303,6 +2324,13 @@
     "personal",
     "journal"
   ],
+  "diner-counter": [
+    "light",
+    "landing",
+    "diner",
+    "chalkboard",
+    "retro"
+  ],
   "diorama": [
     "dark",
     "landing",
@@ -3425,6 +3453,13 @@
     "intimate",
     "green"
   ],
+  "gridfield-mfg": [
+    "dark",
+    "landing",
+    "blueprint",
+    "industrial",
+    "technical"
+  ],
   "grimoire": [
     "magical",
     "ancient-book",
@@ -3476,6 +3511,13 @@
     "elegant",
     "industrial",
     "metallic"
+  ],
+  "gymnasium-bell": [
+    "light",
+    "landing",
+    "bauhaus",
+    "athletics",
+    "geometric"
   ],
   "gyroscope": [
     "dark",
@@ -4105,6 +4147,13 @@
     "kintsugi",
     "gold-repair"
   ],
+  "knit-pattern": [
+    "light",
+    "landing",
+    "pattern",
+    "craft",
+    "editorial"
+  ],
   "lab": [
     "light",
     "blog",
@@ -4148,6 +4197,13 @@
     "closing",
     "final",
     "urgent"
+  ],
+  "late-broadcast": [
+    "dark",
+    "landing",
+    "retro",
+    "broadcast",
+    "vhs"
   ],
   "lattice": [
     "light",
@@ -4246,6 +4302,13 @@
     "light",
     "elegant",
     "baskerville"
+  ],
+  "library-card": [
+    "light",
+    "landing",
+    "library",
+    "typewriter",
+    "editorial"
   ],
   "libretto": [
     "light",
@@ -5160,6 +5223,13 @@
     "translucent",
     "venetian"
   ],
+  "museum-vitrine": [
+    "light",
+    "landing",
+    "editorial",
+    "museum",
+    "refined"
+  ],
   "music-box": [
     "nostalgic",
     "wooden-inspired",
@@ -5507,6 +5577,13 @@
     "blog",
     "minimal"
   ],
+  "night-pharmacy": [
+    "light",
+    "landing",
+    "apothecary",
+    "editorial",
+    "compounding"
+  ],
   "nimbus-cortex": [
     "dark",
     "dashboard",
@@ -5629,6 +5706,13 @@
     "dark",
     "blog",
     "space"
+  ],
+  "observatory-bureau": [
+    "light",
+    "landing",
+    "astronomy",
+    "editorial",
+    "data-dense"
   ],
   "obsidian": [
     "dark",
@@ -5898,6 +5982,13 @@
     "light",
     "readable",
     "baskerville"
+  ],
+  "paperfold-mag": [
+    "light",
+    "landing",
+    "paper",
+    "editorial",
+    "minimal"
   ],
   "papermod": [
     "light",
@@ -6258,6 +6349,13 @@
     "light",
     "blog",
     "postcard"
+  ],
+  "postcard-route": [
+    "light",
+    "landing",
+    "travel",
+    "postcard",
+    "handwritten"
   ],
   "powder-burn": [
     "event",
@@ -6648,6 +6746,13 @@
     "cyan",
     "minimalist"
   ],
+  "railway-flap": [
+    "dark",
+    "landing",
+    "signage",
+    "transit",
+    "industrial"
+  ],
   "rainbow-cascade": [
     "elegant",
     "glowing",
@@ -6861,6 +6966,13 @@
     "boxing",
     "fight",
     "intense"
+  ],
+  "rink-zamboni": [
+    "light",
+    "landing",
+    "scoreboard",
+    "sport",
+    "signage"
   ],
   "riot-act": [
     "radical",
@@ -7179,6 +7291,13 @@
     "blog",
     "sgraffito",
     "scratched"
+  ],
+  "shadow-puppet": [
+    "light",
+    "landing",
+    "theater",
+    "silhouette",
+    "wayang"
   ],
   "shockwave": [
     "radiant",
@@ -8192,6 +8311,13 @@
     "ocean",
     "wellness"
   ],
+  "tide-bureau": [
+    "light",
+    "landing",
+    "maritime",
+    "almanac",
+    "editorial"
+  ],
   "timber": [
     "light",
     "blog",
@@ -8344,6 +8470,13 @@
     "light",
     "typography",
     "minimal"
+  ],
+  "typesetter-strike": [
+    "light",
+    "landing",
+    "letterpress",
+    "bold",
+    "typography"
   ],
   "typewriter": [
     "light",
@@ -8700,6 +8833,13 @@
     "neon",
     "high-energy",
     "impact"
+  ],
+  "whisper-courier": [
+    "light",
+    "landing",
+    "dossier",
+    "typewriter",
+    "redacted"
   ],
   "white-cube": [
     "minimal",


### PR DESCRIPTION
## Summary

Twenty new landing examples, each with a distinct non-AI aesthetic. Zero CSS gradients, zero emoji anywhere.

**Batch one (paper / print / archive aesthetics):**
- **carbon-press** — NCR triplicate-form drafting co-op
- **typesetter-strike** — wood-type letterpress with simulated misregistration
- **postcard-route** — vintage airmail postcards, slow-travel itinerary platform
- **observatory-bureau** — 19th-century astronomical bulletin
- **railway-flap** — 1960s BR flap-board sleeper-train booking
- **paperfold-mag** — folded broadsheet newsletter, mountain/valley fold ticks
- **late-broadcast** — SMPTE colour bars, VHS digitization studio
- **museum-vitrine** — specimen-catalogue plates, curation CMS
- **gridfield-mfg** — blueprint isometric drawings, precision-parts catalog
- **whisper-courier** — manila-dossier with redaction bars, encrypted document courier

**Batch two (real-world domain aesthetics):**
- **tide-bureau** — admiralty tide-table almanac
- **arcade-token** — CSS-pixel marquee headlines, coin-op arcade repair shop
- **knit-pattern** — square-grid stitch chart, pattern-booklet publisher
- **gymnasium-bell** — 1920s Bauhaus athletics, indoor climbing hall
- **diner-counter** — chalkboard menu board, 24-hour diner
- **night-pharmacy** — 19c apothecary cabinet, late-night compounding chemist
- **shadow-puppet** — wayang kulit cutout silhouettes, touring puppet theatre
- **library-card** — manila card-catalogue with date-due stamps, lending library
- **balloon-mail** — engraved aeronautics manual, ballooning club
- **rink-zamboni** — hockey rink overhead + scoreboard, pickup ice league

Each site ships full templates (index/page/section/taxonomy/404), content (index + about), extracted CSS, an original favicon, and an entry in `tags.json`.

## Test plan

- [x] `hwaro doctor` passes on all 20 sites
- [x] `hwaro build` passes on all 20 sites
- [x] Repository-wide scan: zero `linear-gradient` / `radial-gradient` / `conic-gradient` / `repeating-*-gradient` occurrences
- [x] Repository-wide scan: zero emoji characters in templates/CSS/content
- [x] `tags.json` validated (1,453 entries, parses as JSON)
- [ ] Visual review of each site in the deployed preview