### PR TITLE
feat: add 5 sensational and trendy Hwaro dashboard examples

### DIFF
--- a/examples/bauhaus-dashboard/AGENTS.md
+++ b/examples/bauhaus-dashboard/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/bauhaus-dashboard/archetypes/default.md
+++ b/examples/bauhaus-dashboard/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/bauhaus-dashboard/config.toml
+++ b/examples/bauhaus-dashboard/config.toml
@@ -1,0 +1,194 @@
+title = "Bauhaus Dashboard"
+description = "A highly artistic, modular Bauhaus-themed dashboard featuring CSS-rendered geometric shape monitors and expressive Syne typography."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/bauhaus-dashboard/content/about.md
+++ b/examples/bauhaus-dashboard/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "The Architecture"
+description = "Specifications and layout guidelines of the Bauhaus Dashboard."
+tags = ["philosophy", "specs"]
+categories = ["meta"]
++++
+
+Bauhaus Dashboard is an expressive modular exploration translating classical modernist art principles into modern static build environments.
+
+We believe that form, structure, and solid primary color accents can present complex system metrics with absolute clarity.
+
+## the visual rules
+
+* **Color Space**: Bauhaus Cream `#FAF6EE` background, deep charcoal `#1E1E22` for borders and text, with flat primary red `#CC0000`, primary blue `#0F4C81`, and ochre yellow `#F3A322` accents.
+* **Geometric Monitors**: Flat visual indicators (CSS circles, rectangles, and bars) serve as status indicators instead of bloated dynamic charts.
+* **Expressive Fonts**: Geometric headlines (Syne) and clean modern body text (Outfit).
+
+## technical specifications
+
+- **Host Compiler**: Hwaro Engine statically compiled in Crystal.
+- **Visual Delivery**: Bespoke Vanilla CSS (under 280 lines).
+- **Compile Speed**: Stably compiles under 10 milliseconds.

--- a/examples/bauhaus-dashboard/content/index.md
+++ b/examples/bauhaus-dashboard/content/index.md
@@ -1,0 +1,87 @@
++++
+title = "Modular Bauhaus Dashboard"
+description = "Artistic Bauhaus modular dashboard demonstrating compilation telemetry, active processes, and CSS-rendered shape monitors."
+tags = ["bauhaus", "modular", "telemetry"]
++++
+
+<div class="dashboard-grid">
+<div class="metric-card">
+<div class="card-header-bar"></div>
+<div class="metric-body">
+<div class="metric-label">Compile Overhead</div>
+<div class="metric-value">7.59<span>MS</span></div>
+<div class="bauhaus-chart-indicator">
+<div class="chart-dot dot-red"></div>
+<div class="chart-bar-bg"><div class="chart-bar-fill" style="width: 25%;"></div></div>
+</div>
+</div>
+</div>
+<div class="metric-card">
+<div class="card-header-bar"></div>
+<div class="metric-body">
+<div class="metric-label">Shape Monitors</div>
+<div class="metric-value">03<span>UNITS</span></div>
+<div class="bauhaus-chart-indicator">
+<div class="chart-dot dot-blue"></div>
+<div class="chart-bar-bg"><div class="chart-bar-fill" style="width: 50%;"></div></div>
+</div>
+</div>
+</div>
+<div class="metric-card">
+<div class="card-header-bar"></div>
+<div class="metric-body">
+<div class="metric-label">Static Build Ratio</div>
+<div class="metric-value">100%<span>YIELD</span></div>
+<div class="bauhaus-chart-indicator">
+<div class="chart-dot dot-ochre"></div>
+<div class="chart-bar-bg"><div class="chart-bar-fill" style="width: 100%;"></div></div>
+</div>
+</div>
+</div>
+</div>
+
+<div class="dashboard-panels">
+<div class="panel">
+<div class="panel-header">
+<h2 class="panel-title">Active Process Nodes <span>[BAUHAUS_GRID]</span></h2>
+<a href="posts/" class="panel-action">Access Logs</a>
+</div>
+
+<table class="bauhaus-table">
+<thead>
+<tr>
+<th>Process Module Name</th>
+<th>Physical RAM</th>
+<th>Visual Status</th>
+<th>Execution Integrity</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bauhaus-builder-daemon</td>
+<td>42.5 MB</td>
+<td><span class="geometric-status"><span class="status-shape shape-circle"></span>ACTIVE</span></td>
+</tr>
+<tr>
+<td>shape-rasterizer-cache</td>
+<td>128.0 MB</td>
+<td><span class="geometric-status"><span class="status-shape shape-square"></span>ACTIVE</span></td>
+</tr>
+</tbody>
+</table>
+
+Ongoing compilation diagnostics and process logs are actively cataloged under the [Intrusion Logs Section](posts/).
+</div>
+
+<div class="panel">
+<div class="panel-header">
+<h2 class="panel-title">Design Specs</h2>
+<span class="geometric-status" style="cursor: default;"><span class="status-shape shape-circle" style="background-color: var(--ochre);"></span>INFO</span>
+</div>
+
+- **Visual Base**: Bauhaus Cream (#FAF6EE)
+- **Active Accents**: Solid Red, Blue, Ochre
+- **Title typeface**: Syne (Geometric)
+- **Body typeface**: Outfit (Sans-serif)
+</div>
+</div>

--- a/examples/bauhaus-dashboard/content/posts/_index.md
+++ b/examples/bauhaus-dashboard/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Diagnostic Directory"
+sort_by = "date"
+reverse = true
+paginate = 6
+template = "section"
+generate_feeds = true
++++
+
+A timeline of diagnostic reports, modular compile analyses, and layout grid telemetry.

--- a/examples/bauhaus-dashboard/content/posts/geometric-ux-balance.md
+++ b/examples/bauhaus-dashboard/content/posts/geometric-ux-balance.md
@@ -1,0 +1,23 @@
++++
+title = "Geometric Balance in Telemetry Interfaces"
+date = "2026-05-16"
+draft = false
+description = "Translating early-20th-century geometric balance principles to web-based telemetry interfaces."
+tags = ["design", "performance", "lists"]
+categories = ["diagnostics"]
+reading_time = 3
++++
+
+Web performance is often measured at the browser layer. However, the user experience is heavily gated by **cognitive processing speed**.
+
+A confusing, overly decorated layout forces the reader to search for data, creating friction.
+
+## design values: typographic readability
+
+By adopting a strict typographic hierarchy, we make visual scanning near-instantaneous:
+
+1. **Giant Metric Headers**: Sizing key counters at extra-bold weights (`800`) and massive dimensions (`2.5rem`) commands focus.
+2. **Neutral Labeling**: Setting parameters in clean, sans-serif weights to let data stand out objectively.
+3. **Structured gut separators**: Dividing fields with solid, high-contrast borders instead of soft drop-shadow gradients.
+
+By channeling layout rules into pure structure, we elevate data into absolute clarity.

--- a/examples/bauhaus-dashboard/content/posts/modular-art-telemetry.md
+++ b/examples/bauhaus-dashboard/content/posts/modular-art-telemetry.md
@@ -1,0 +1,29 @@
++++
+title = "Architecting Modular Art Telemetry"
+date = "2026-05-23"
+draft = false
+description = "A thorough evaluation of modular compile blocks, grid-aligned layout speeds, and static build pipelines in Bauhaus aesthetics."
+tags = ["art", "compilation", "systems"]
+categories = ["diagnostics"]
+reading_time = 3
++++
+
+In structural design, a modular grid allows for infinite variations in layout while maintaining a consistent visual identity.
+
+How do we compile these modular panels at lightning speed?
+
+## grid alignment during compile loops
+
+The Hwaro compiler processes all modular layouts concurrently, ensuring that each grid item aligns perfectly to its vertical rhythms:
+
+* **Rigid Modules**: Ensuring line heights and margin blocks align to a strict vertical rhythm.
+* **Liquid guts**: Columns scale naturally based on fluid container parameters, preventing overlap.
+
+## local telemetry benchmarks
+
+During recent compilation diagnostics, the modular grid dashboard constructed all directories and assets inside single-digit millisecond ranges:
+
+- **Build Core Time**: 7.59ms
+- **Resource Footprint**: Minimal (zero dynamic database calls)
+
+Purity in static structure ensures absolute delivery speed.

--- a/examples/bauhaus-dashboard/static/css/style.css
+++ b/examples/bauhaus-dashboard/static/css/style.css
@@ -1,0 +1,575 @@
+@import url('https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=Outfit:wght@300;400;500;600&display=swap');
+
+:root {
+  --bg: #FAF6EE;             /* Bauhaus Cream */
+  --panel: #FFFFFF;
+  --text: #1E1E22;           /* Stark Dark Grey */
+  --red: #CC0000;            /* Bauhaus Red */
+  --blue: #0F4C81;           /* Bauhaus Blue */
+  --ochre: #F3A322;          /* Bauhaus Ochre */
+  --border: 2px solid var(--text);
+  --border-thick: 4px solid var(--text);
+  --font-title: 'Syne', sans-serif;
+  --font-body: 'Outfit', sans-serif;
+  --transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Bauhaus Layout */
+.site-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+}
+
+.site-header {
+  border-bottom: var(--border-thick);
+  padding-bottom: 2.5rem;
+  margin-bottom: 4rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+}
+
+.site-logo {
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 2.2rem;
+  color: var(--text);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: -2px;
+  line-height: 0.9;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.site-logo::after {
+  content: '';
+  display: inline-block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: var(--red);
+  border-radius: 50%;
+  border: var(--border);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.site-header nav a {
+  font-family: var(--font-title);
+  font-weight: 700;
+  font-size: 1rem;
+  text-transform: uppercase;
+  color: var(--text);
+  text-decoration: none;
+  padding: 0.3rem 0.8rem;
+  border: var(--border);
+  background-color: var(--panel);
+  transition: var(--transition);
+  box-shadow: 3px 3px 0px var(--text);
+}
+
+.site-header nav a:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 5px 5px 0px var(--text);
+  background-color: var(--ochre);
+}
+
+.site-main {
+  min-height: 60vh;
+}
+
+.site-footer {
+  margin-top: 6rem;
+  border-top: var(--border-thick);
+  padding-top: 3rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.site-footer p {
+  margin: 0;
+  font-family: var(--font-title);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+}
+
+.site-footer a {
+  color: var(--blue);
+  text-decoration: none;
+  border-bottom: 2px solid var(--blue);
+}
+
+.site-footer a:hover {
+  background-color: var(--blue);
+  color: var(--white);
+}
+
+/* Dashboard Grid */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  margin-bottom: 4rem;
+}
+
+.metric-card {
+  background-color: var(--panel);
+  border: var(--border);
+  box-shadow: 5px 5px 0px var(--text);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.metric-card:hover {
+  transform: translate(-3px, -3px);
+  box-shadow: 8px 8px 0px var(--text);
+}
+
+.card-header-bar {
+  height: 12px;
+  background-color: var(--red);
+  border-bottom: var(--border);
+}
+
+.metric-card:nth-child(2n) .card-header-bar {
+  background-color: var(--blue);
+}
+
+.metric-card:nth-child(3n) .card-header-bar {
+  background-color: var(--ochre);
+}
+
+.metric-body {
+  padding: 2rem;
+}
+
+.metric-label {
+  font-family: var(--font-title);
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--text);
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.05em;
+}
+
+.metric-value {
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 2.5rem;
+  line-height: 1.1;
+  color: var(--text);
+  margin-bottom: 1rem;
+}
+
+.metric-value span {
+  font-size: 1rem;
+  font-family: var(--font-body);
+  font-weight: 500;
+  color: #666;
+  margin-left: 0.25rem;
+}
+
+/* CSS Bauhaus Shape Indicators acting as live charts */
+.bauhaus-chart-indicator {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 1rem;
+}
+
+.chart-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid var(--text);
+}
+
+.chart-dot.dot-red { background-color: var(--red); }
+.chart-dot.dot-blue { background-color: var(--blue); }
+.chart-dot.dot-ochre { background-color: var(--ochre); }
+
+.chart-bar-bg {
+  flex-grow: 1;
+  height: 12px;
+  background-color: var(--bg);
+  border: 1px solid var(--text);
+}
+
+.chart-bar-fill {
+  height: 100%;
+  background-color: var(--text);
+}
+
+/* Asymmetric Panels */
+.dashboard-panels {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 3rem;
+  margin-bottom: 4rem;
+}
+
+.panel {
+  background-color: var(--panel);
+  border: var(--border);
+  box-shadow: 6px 6px 0px var(--text);
+  padding: 3rem;
+}
+
+.panel-header {
+  border-bottom: var(--border);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-title {
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 1.8rem;
+  text-transform: uppercase;
+  margin: 0;
+  letter-spacing: -0.5px;
+}
+
+.panel-title span {
+  color: var(--blue);
+}
+
+.panel-action {
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  color: var(--text);
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  border: var(--border);
+  background-color: var(--panel);
+  transition: var(--transition);
+  box-shadow: 3px 3px 0px var(--text);
+}
+
+.panel-action:hover {
+  background-color: var(--ochre);
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0px var(--text);
+}
+
+/* Bauhaus Table */
+.bauhaus-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+}
+
+.bauhaus-table th, .bauhaus-table td {
+  border: var(--border);
+  padding: 0.9rem 1.25rem;
+  text-align: left;
+}
+
+.bauhaus-table th {
+  background-color: var(--ochre);
+  font-family: var(--font-title);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.bauhaus-table tr:nth-child(even) {
+  background-color: var(--bg);
+}
+
+.geometric-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-title);
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.status-shape {
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--text);
+}
+
+.status-shape.shape-circle { border-radius: 50%; background-color: var(--red); }
+.status-shape.shape-square { background-color: var(--blue); }
+
+/* Log Panel list */
+.log-item {
+  border-bottom: var(--border);
+  padding: 1.5rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.log-item:last-child {
+  border-bottom: none;
+}
+
+.log-info a {
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 1.3rem;
+  text-transform: uppercase;
+  letter-spacing: -0.5px;
+  color: var(--text);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.log-info a:hover {
+  color: var(--blue);
+}
+
+.log-meta {
+  font-family: var(--font-title);
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.log-action {
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 2px solid var(--text);
+  padding-bottom: 0.15rem;
+  transition: var(--transition);
+}
+
+.log-action:hover {
+  color: var(--red);
+  border-bottom-color: var(--red);
+}
+
+/* Post Detail */
+.post-wrapper {
+  background-color: var(--panel);
+  border: var(--border-thick);
+  box-shadow: 7px 7px 0px var(--text);
+  padding: 3.5rem;
+  margin-bottom: 4rem;
+}
+
+.post-title {
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 3rem;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: -2px;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+}
+
+.post-meta {
+  font-family: var(--font-title);
+  font-weight: 700;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  border-bottom: var(--border);
+  padding-bottom: 1.25rem;
+  margin-bottom: 2.5rem;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.prose {
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.prose p {
+  margin-bottom: 1.5rem;
+}
+
+.prose strong {
+  font-weight: 800;
+}
+
+.prose h1, .prose h2, .prose h3 {
+  font-family: var(--font-title);
+  font-weight: 800;
+  text-transform: uppercase;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  letter-spacing: -1px;
+}
+
+.prose h1 { font-size: 2.2rem; }
+.prose h2 { font-size: 1.7rem; border-bottom: var(--border); padding-bottom: 0.4rem; }
+.prose h3 { font-size: 1.3rem; }
+
+.prose a {
+  color: var(--blue);
+  text-decoration: none;
+  font-weight: 800;
+  border-bottom: 2px dashed var(--blue);
+}
+
+.prose a:hover {
+  border-bottom-style: solid;
+  background-color: var(--blue);
+  color: var(--white);
+}
+
+.prose blockquote {
+  margin: 2.5rem 0;
+  padding: 1.5rem 2rem;
+  background-color: var(--bg);
+  border: var(--border);
+  border-left: 8px solid var(--ochre);
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 1.25rem;
+  text-transform: uppercase;
+}
+
+.prose pre {
+  background-color: var(--bg);
+  border: var(--border);
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 2.5rem 0;
+}
+
+.prose code {
+  font-family: monospace;
+  background-color: var(--bg);
+  border: 1px solid rgba(0,0,0,0.1);
+  padding: 0.1rem 0.3rem;
+  font-size: 0.9em;
+}
+
+/* Badge/Taxonomy */
+.badge-container {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-family: var(--font-title);
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  background-color: var(--panel);
+  border: var(--border);
+  padding: 0.2rem 0.6rem;
+  color: var(--text);
+  text-decoration: none;
+  transition: var(--transition);
+  box-shadow: 2px 2px 0px var(--text);
+}
+
+.badge:hover {
+  background-color: var(--blue);
+  color: var(--white);
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0px var(--text);
+}
+
+/* Buttons */
+.btn-main {
+  font-family: var(--font-title);
+  font-weight: 800;
+  font-size: 1rem;
+  text-transform: uppercase;
+  color: var(--text);
+  background-color: var(--ochre);
+  border: var(--border);
+  box-shadow: 5px 5px 0px var(--text);
+  padding: 0.75rem 1.75rem;
+  cursor: pointer;
+  display: inline-block;
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.btn-main:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 7px 7px 0px var(--text);
+  background-color: var(--red);
+  color: var(--white);
+}
+
+/* Responsive grid */
+@media (max-width: 992px) {
+  .dashboard-panels {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-wrapper {
+    padding: 1.5rem 1rem;
+  }
+  .site-header {
+    flex-direction: column;
+    gap: 1.5rem;
+    padding-bottom: 2rem;
+  }
+  .site-header nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .hero-title {
+    font-size: 2.6rem;
+  }
+  .post-title {
+    font-size: 2.2rem;
+  }
+  .post-wrapper {
+    padding: 1.5rem;
+  }
+  .site-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}

--- a/examples/bauhaus-dashboard/static/favicon.svg
+++ b/examples/bauhaus-dashboard/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/bauhaus-dashboard/templates/404.html
+++ b/examples/bauhaus-dashboard/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main" style="display: flex; align-items: center; justify-content: center; min-height: 50vh;">
+    <div class="panel" style="text-align: center; max-width: 550px; width: 100%;">
+      <div class="panel-header" style="justify-content: center;">
+        <h1 class="panel-title" style="font-size: 4rem; color: var(--red);">404</h1>
+      </div>
+      <h2 style="font-family: var(--font-title); font-size: 1.4rem; text-transform: uppercase; margin-bottom: 1.5rem;">GEOMETRIC ERROR: FOLDER NOT LOCATED</h2>
+      <p style="margin-bottom: 2rem; font-size: 0.9rem;">The specific coordinate requested is not mapped within our design canvas.</p>
+      <a href="{{ base_url }}/" class="btn-main" style="box-shadow: 3px 3px 0px var(--text);">Return to Center Overview</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/bauhaus-dashboard/templates/footer.html
+++ b/examples/bauhaus-dashboard/templates/footer.html
@@ -1,0 +1,9 @@
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} Bauhaus Design Board.</p>
+      <p style="text-align: right;">Compiled with <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/bauhaus-dashboard/templates/header.html
+++ b/examples/bauhaus-dashboard/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+
+  <!-- Bespoke Bauhaus Dashboard stylesheet -->
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">BAUHAUS</a>
+      <nav>
+        <a href="{{ base_url }}/">Overview</a>
+        <a href="{{ base_url }}/posts/">Diagnostics</a>
+        <a href="{{ base_url }}/about/">Manifesto</a>
+      </nav>
+    </header>

--- a/examples/bauhaus-dashboard/templates/page.html
+++ b/examples/bauhaus-dashboard/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="post-wrapper">
+      {% if page.title is present %}
+        <h1 class="post-title">{{ page.title | e }}</h1>
+      {% endif %}
+      
+      <div class="post-meta">
+        {% if page.date is present %}
+          <span>DATED: {{ page.date | date("%Y-%m-%d") }}</span>
+        {% endif %}
+        <span>SECTOR: BAUHAUS_LOG</span>
+      </div>
+
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+
+      {% if page.tags is present %}
+        <div class="badge-container" style="margin-top: 4rem; border-top: var(--border); padding-top: 2rem;">
+          {% for tag in page.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="badge">#{{ tag }}</a>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/bauhaus-dashboard/templates/section.html
+++ b/examples/bauhaus-dashboard/templates/section.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Diagnostic Reports & <span>Telemetry Logs</span></h1>
+        <a href="{{ base_url }}/" class="panel-action" style="cursor: default;">MONITOR_LOGS</a>
+      </div>
+      
+      {% if page.description is present %}
+        <p style="margin-bottom: 3rem; font-weight: 400;">{{ page.description | e }}</p>
+      {% endif %}
+
+      <div class="log-list">
+        {% for post in section.pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>DATE: {{ post.date | date("%Y-%m-%d") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— CLASSIFICATION: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">Access Report</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/bauhaus-dashboard/templates/shortcodes/alert.html
+++ b/examples/bauhaus-dashboard/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/bauhaus-dashboard/templates/taxonomy.html
+++ b/examples/bauhaus-dashboard/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">System Taxonomy Registers: {{ taxonomy_name | e }}</h1>
+        <span class="panel-action" style="cursor: default;">INDEX_REGISTRY</span>
+      </div>
+
+      <div class="badge-container" style="gap: 1.5rem; padding: 1.5rem 0;">
+        {% for term in taxonomy_terms %}
+          <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term.name | slugify }}/" class="badge" style="font-size: 1.1rem; padding: 0.5rem 1rem;">
+            #{{ term.name | upper }} ({{ term.pages | length }})
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/bauhaus-dashboard/templates/taxonomy_term.html
+++ b/examples/bauhaus-dashboard/templates/taxonomy_term.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Buffer Archive: <span>#{{ taxonomy_term | e }}</span></h1>
+        <span class="panel-action" style="cursor: default;">FILTERED_CHANNEL</span>
+      </div>
+
+      <div class="log-list">
+        {% for post in taxonomy_pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>DATE: {{ post.date | date("%Y-%m-%d") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— CLASSIFICATION: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">Access Report</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/brutal-dashboard/AGENTS.md
+++ b/examples/brutal-dashboard/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/brutal-dashboard/archetypes/default.md
+++ b/examples/brutal-dashboard/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/brutal-dashboard/config.toml
+++ b/examples/brutal-dashboard/config.toml
@@ -1,0 +1,194 @@
+title = "Brutal Dashboard"
+description = "A bold, blocky Neo-Brutalist dashboard displaying system telemetry, network latency, and rigid performance logs."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/brutal-dashboard/content/about.md
+++ b/examples/brutal-dashboard/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "Telemetry Spec Sheet"
+description = "Specifications and layout details of the Brutal Dashboard telemetry console."
+tags = ["monitors", "specs"]
+categories = ["meta"]
++++
+
+The Brutal Dashboard telemetry console is designed to showcase metric card components and structured data tables.
+
+## telemetry capabilities
+
+- **Responsive Grid Cards**: Status counters resize based on viewport width, using fluid CSS margins.
+- **Visual Alert States**: Important markers toggle to deep Safety Orange (`#FF5E00`) blockages during spikes.
+- **Zero Decors**: Zero color gradients and zero emojis are used to guarantee high data processing speed and clean reading flow.
+
+## system specs
+
+- **Host Engine**: Hwaro SSG compiled in Crystal.
+- **Style Delivery**: Raw Vanilla CSS (under 250 lines).
+- **Page Compilation Speed**: Under 10 milliseconds.

--- a/examples/brutal-dashboard/content/index.md
+++ b/examples/brutal-dashboard/content/index.md
@@ -1,0 +1,83 @@
++++
+title = "Telemetry Dashboard"
+description = "System telemetry console presenting network parameters, latency spike monitors, and server resource metrics."
+tags = ["telemetry", "monitors", "networks"]
++++
+
+<div class="dashboard-grid">
+<div class="metric-card">
+<div class="metric-label">System Uptime</div>
+<div class="metric-value">99.98%</div>
+<div class="metric-status-bar">
+<div class="metric-status-fill" style="width: 99%;"></div>
+</div>
+</div>
+<div class="metric-card">
+<div class="metric-label">Network Latency</div>
+<div class="metric-value">14.2ms</div>
+<div class="metric-status-bar">
+<div class="metric-status-fill" style="width: 14%;"></div>
+</div>
+</div>
+<div class="metric-card alert-state">
+<div class="metric-label">CPU LOAD (CORE_0)</div>
+<div class="metric-value">87.4%</div>
+<div class="metric-status-bar">
+<div class="metric-status-fill" style="width: 87%;"></div>
+</div>
+</div>
+</div>
+
+<div class="dashboard-panels">
+<div class="panel">
+<div class="panel-header">
+<h2 class="panel-title">Active Server Telemetry</h2>
+<span class="status-badge status-ok">LIVE_METRICS</span>
+</div>
+
+<table class="telemetry-table">
+<thead>
+<tr>
+<th>Service Name</th>
+<th>Port</th>
+<th>Memory Use</th>
+<th>Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>hwaro-builder-daemon</td>
+<td>:3000</td>
+<td>42.5 MB</td>
+<td><span class="status-badge status-ok">ACTIVE</span></td>
+</tr>
+<tr>
+<td>crystal-compiler-cache</td>
+<td>:9000</td>
+<td>128.0 MB</td>
+<td><span class="status-badge status-ok">ACTIVE</span></td>
+</tr>
+<tr>
+<td>latency-telemetry-db</td>
+<td>:5432</td>
+<td>312.4 MB</td>
+<td><span class="status-badge status-warning">HIGH_LOAD</span></td>
+</tr>
+</tbody>
+</table>
+
+For full detail regarding ongoing latency logs, access our [Latest Status Logs](posts/).
+</div>
+
+<div class="panel">
+<div class="panel-header">
+<h2 class="panel-title">Hardware Specs</h2>
+<span class="status-badge status-ok">HARDWARE_INFO</span>
+</div>
+
+- **CPU Architecture**: ARM64v8 (10 Cores)
+- **Physical RAM**: 32.0 GB LPDDR5
+- **SSD Cache**: 1.0 TB NVMe PCIe Gen4
+- **Primary Gateway**: static.hwaro.internal
+</div>
+</div>

--- a/examples/brutal-dashboard/content/posts/_index.md
+++ b/examples/brutal-dashboard/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "System Logs"
+sort_by = "date"
+reverse = true
+paginate = 6
+template = "section"
+generate_feeds = true
++++
+
+A timeline of network telemetry status logs, traffic spike warnings, and diagnostic notes compiled directly from our static metrics.

--- a/examples/brutal-dashboard/content/posts/bandwidth-spike-diagnostic.md
+++ b/examples/brutal-dashboard/content/posts/bandwidth-spike-diagnostic.md
@@ -1,0 +1,27 @@
++++
+title = "Diagnostic: Bandwidth Peak during Site Build"
+date = "2026-05-21"
+draft = false
+description = "Analyzing high bandwidth telemetry peaks during massive site assets bundle deployments."
+tags = ["performance", "bandwidth", "assets"]
+categories = ["diagnostics"]
+reading_time = 3
++++
+
+During the static asset pipeline compilation, we recorded a significant bandwidth peak on our primary static gateway (`static.hwaro.internal`).
+
+Bandwidth utilization rose to `850 Mbps` during the minified stylesheet asset bundles generation.
+
+## peak parameters
+
+1. **Staged Assets Bundle**: The builder processed all static style and layout assets, merging them into unified directories.
+2. **Instant Delivery**: The assets were copied to target staging outputs inside single-digit millisecond ranges.
+3. **Zero telemetries overhead**: The asset packaging was completed entirely without dynamic network requests, saving external bandwidth allocation.
+
+## compilation specs
+
+- **Build Core Time**: 9.49ms
+- **Asset footprint**: 12.5 KB minified Vanilla CSS
+- **Network Cost**: Negligible (due to pure static compilation)
+
+Our tests confirm that static asset compiles dramatically minimize active network bandwidth overhead.

--- a/examples/brutal-dashboard/content/posts/telemetry-latency-report.md
+++ b/examples/brutal-dashboard/content/posts/telemetry-latency-report.md
@@ -1,0 +1,25 @@
++++
+title = "Diagnostic: Latency Spike in Port 5432"
+date = "2026-05-23"
+draft = false
+description = "Analyzing high latency issues inside postgres database gateway port 5432 during static site compilation loops."
+tags = ["latency", "database", "postgres"]
+categories = ["diagnostics"]
+reading_time = 3
++++
+
+We recorded an unexpected network latency spike on the database gateway (`:5432`) during our scheduled compiling run.
+
+Average response times escalated from `14.2ms` to `124.8ms` over a period of 45 seconds.
+
+## latency telemetry timeline
+
+* **08:14:02Z** - Initial compile loop triggered. Memory usage registers normal values.
+* **08:14:15Z** - Latency spikes to `124.8ms`. Thread pool capacity reaches limit state.
+* **08:14:47Z** - Cache sweep executed. Memory usage clears, latency returns to `14.2ms`.
+
+## structural solutions
+
+To prevent future latency spikes during rapid compile runs, we suggest implementing absolute static page caches. This eliminates the need for dynamic query queries, keeping gateways clear.
+
+The static architecture must remain pure to ensure continuous, high-speed delivery.

--- a/examples/brutal-dashboard/static/css/style.css
+++ b/examples/brutal-dashboard/static/css/style.css
@@ -1,0 +1,511 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:root {
+  --primary: #FFE600;        /* Canary Yellow */
+  --accent: #FF5E00;         /* Safety Orange */
+  --text: #0C0C0C;
+  --bg: #F7F7F2;             /* Off-white */
+  --white: #FFFFFF;
+  --border: 3px solid var(--text);
+  --border-thin: 1.5px solid var(--text);
+  --shadow: 6px 6px 0px var(--text);
+  --shadow-sm: 4px 4px 0px var(--text);
+  --shadow-hover: 2px 2px 0px var(--text);
+  --transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'JetBrains Mono', monospace;
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Dashboard Shell */
+.site-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.site-header {
+  background-color: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  padding: 1.25rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2.5rem;
+}
+
+.site-logo {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  font-size: 1.8rem;
+  color: var(--text);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: -1.5px;
+}
+
+.site-logo span {
+  background-color: var(--primary);
+  padding: 0.1rem 0.5rem;
+  border: var(--border-thin);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.site-header nav a {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  color: var(--text);
+  text-decoration: none;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  padding: 0.3rem 0.6rem;
+  border: var(--border-thin);
+  background-color: var(--white);
+  box-shadow: var(--shadow-sm);
+  transition: var(--transition);
+}
+
+.site-header nav a:hover {
+  transform: translate(2px, 2px);
+  box-shadow: var(--shadow-hover);
+  background-color: var(--accent);
+  color: var(--white);
+}
+
+.site-main {
+  min-height: 60vh;
+}
+
+.site-footer {
+  margin-top: 5rem;
+  padding: 2rem;
+  background-color: var(--text);
+  color: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.site-footer p {
+  margin: 0;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.site-footer a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  text-decoration: underline;
+}
+
+/* Brutal Grid Dashboard Layout */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  margin-bottom: 3.5rem;
+}
+
+/* Metric Display Panels */
+.metric-card {
+  background-color: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+  transition: var(--transition);
+}
+
+.metric-card:hover {
+  transform: translate(4px, 4px);
+  box-shadow: var(--shadow-hover);
+}
+
+.metric-card.alert-state {
+  background-color: var(--accent);
+  color: var(--white);
+}
+
+.metric-card.alert-state .metric-value,
+.metric-card.alert-state .metric-label {
+  color: var(--white);
+}
+
+.metric-label {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.metric-card.alert-state .metric-label {
+  color: rgba(255,255,255,0.8);
+}
+
+.metric-value {
+  font-size: 2.8rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--text);
+  margin-bottom: 1rem;
+}
+
+.metric-status-bar {
+  height: 8px;
+  background-color: var(--text);
+  border-top: var(--border-thin);
+  margin-top: 1rem;
+}
+
+.metric-card.alert-state .metric-status-bar {
+  background-color: var(--white);
+}
+
+.metric-status-fill {
+  height: 100%;
+  background-color: var(--primary);
+}
+
+.metric-card.alert-state .metric-status-fill {
+  background-color: var(--text);
+}
+
+/* Layout Panels */
+.dashboard-panels {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 3rem;
+  margin-bottom: 4rem;
+}
+
+.panel {
+  background-color: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  padding: 2.5rem;
+}
+
+.panel-header {
+  border-bottom: var(--border);
+  padding-bottom: 1rem;
+  margin-bottom: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  font-size: 1.8rem;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+/* Monospace Telemetry Tables */
+.telemetry-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+}
+
+.telemetry-table th, .telemetry-table td {
+  border-bottom: var(--border-thin);
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+.telemetry-table th {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  text-transform: uppercase;
+  background-color: var(--primary);
+  border: var(--border-thin);
+}
+
+.telemetry-table tr:hover {
+  background-color: var(--bg);
+}
+
+.status-badge {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border: var(--border-thin);
+  display: inline-block;
+}
+
+.status-badge.status-ok {
+  background-color: var(--primary);
+}
+
+.status-badge.status-warning {
+  background-color: var(--accent);
+  color: var(--white);
+}
+
+/* Post list / card detail inside dashboards */
+.log-item {
+  border-bottom: var(--border-thin);
+  padding: 1.25rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.log-item:last-child {
+  border-bottom: none;
+}
+
+.log-info a {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  text-transform: uppercase;
+  font-size: 1.15rem;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.log-info a:hover {
+  background-color: var(--primary);
+}
+
+.log-meta {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #666;
+  text-transform: uppercase;
+  margin-top: 0.25rem;
+}
+
+.log-action {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: var(--text);
+  border: var(--border-thin);
+  padding: 0.3rem 0.6rem;
+  background-color: var(--white);
+  box-shadow: 2px 2px 0px var(--text);
+  text-decoration: none;
+  font-size: 0.8rem;
+  transition: var(--transition);
+}
+
+.log-action:hover {
+  transform: translate(1px, 1px);
+  box-shadow: 1px 1px 0px var(--text);
+  background-color: var(--primary);
+}
+
+/* Articles and Prose detail */
+.post-wrapper {
+  background-color: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  padding: 3rem;
+  margin-bottom: 3rem;
+}
+
+.post-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  font-size: 2.8rem;
+  text-transform: uppercase;
+  letter-spacing: -1px;
+  line-height: 1.1;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+}
+
+.post-meta {
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  border-bottom: var(--border-thin);
+  padding-bottom: 1rem;
+  margin-bottom: 2rem;
+  display: flex;
+  gap: 2rem;
+}
+
+.prose {
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.prose h1, .prose h2, .prose h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  text-transform: uppercase;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.prose h1 { font-size: 2rem; }
+.prose h2 { font-size: 1.6rem; border-bottom: var(--border-thin); padding-bottom: 0.4rem; }
+.prose h3 { font-size: 1.25rem; }
+
+.prose p {
+  margin-bottom: 1.25rem;
+}
+
+.prose a {
+  color: var(--text);
+  text-decoration: underline;
+  text-decoration-thickness: 3px;
+  text-decoration-color: var(--primary);
+  font-weight: 700;
+}
+
+.prose a:hover {
+  background-color: var(--primary);
+}
+
+.prose blockquote {
+  margin: 2rem 0;
+  padding: 1rem 1.5rem;
+  background-color: var(--bg);
+  border: var(--border);
+  box-shadow: var(--shadow-sm);
+  font-style: italic;
+}
+
+.prose pre {
+  background-color: var(--bg);
+  border: var(--border);
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 2rem 0;
+}
+
+.prose code {
+  font-family: monospace;
+  background-color: var(--bg);
+  border: var(--border-thin);
+  padding: 0.1rem 0.3rem;
+  font-size: 0.9em;
+  font-weight: 700;
+}
+
+.prose pre code {
+  border: none;
+  background-color: transparent;
+  padding: 0;
+  font-weight: 400;
+}
+
+/* Badge/Taxonomy */
+.badge-container {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  background-color: var(--white);
+  border: var(--border-thin);
+  padding: 0.2rem 0.5rem;
+  box-shadow: 2px 2px 0px var(--text);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.badge:hover {
+  background-color: var(--primary);
+  transform: translate(1px, 1px);
+  box-shadow: 1px 1px 0px var(--text);
+}
+
+/* Buttons */
+.btn-main {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 800;
+  font-size: 1rem;
+  text-transform: uppercase;
+  color: var(--text);
+  background-color: var(--primary);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  display: inline-block;
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.btn-main:hover {
+  transform: translate(3px, 3px);
+  box-shadow: var(--shadow-sm);
+  background-color: var(--white);
+}
+
+/* Responsive grid */
+@media (max-width: 992px) {
+  .dashboard-panels {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-wrapper {
+    padding: 1.5rem 1rem;
+  }
+  .site-header {
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: flex-start;
+    padding: 1.25rem;
+  }
+  .site-header nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .metric-value {
+    font-size: 2.2rem;
+  }
+  .post-title {
+    font-size: 2rem;
+  }
+  .site-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}

--- a/examples/brutal-dashboard/static/favicon.svg
+++ b/examples/brutal-dashboard/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/brutal-dashboard/templates/404.html
+++ b/examples/brutal-dashboard/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main" style="display: flex; align-items: center; justify-content: center; min-height: 50vh;">
+    <div class="panel" style="text-align: center; max-width: 550px; width: 100%;">
+      <div class="panel-header" style="justify-content: center;">
+        <h1 class="panel-title" style="font-size: 4rem; color: var(--accent);">404</h1>
+      </div>
+      <h2 style="font-family: 'Space Grotesk', sans-serif; font-size: 1.4rem; text-transform: uppercase; margin-bottom: 1.5rem;">FATAL_ERROR: INDEX_PATH_INVALID</h2>
+      <p style="margin-bottom: 2rem; font-size: 0.9rem;">The sector coordinate requested was not registered in our static dashboard index files.</p>
+      <a href="{{ base_url }}/" class="btn-main">Reset Dashboard</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/brutal-dashboard/templates/footer.html
+++ b/examples/brutal-dashboard/templates/footer.html
@@ -1,0 +1,9 @@
+    <footer class="site-footer">
+      <p>SYSTEM TELEMETRY STATUS: OK // YEAR: {{ current_year }}</p>
+      <p>Compiled with <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/brutal-dashboard/templates/header.html
+++ b/examples/brutal-dashboard/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+
+  <!-- Bespoke Brutal Dashboard stylesheet -->
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">BRUTAL<span>.db</span></a>
+      <nav>
+        <a href="{{ base_url }}/">Dashboard</a>
+        <a href="{{ base_url }}/posts/">Logs</a>
+        <a href="{{ base_url }}/about/">Specs</a>
+      </nav>
+    </header>

--- a/examples/brutal-dashboard/templates/page.html
+++ b/examples/brutal-dashboard/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="post-wrapper">
+      {% if page.title is present %}
+        <h1 class="post-title">{{ page.title | e }}</h1>
+      {% endif %}
+      
+      <div class="post-meta">
+        {% if page.date is present %}
+          <span>TIMESTAMP: {{ page.date | date("%Y-%m-%d %H:%M") }}</span>
+        {% endif %}
+        <span>SECTOR: SYSTEM_LOG</span>
+      </div>
+
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+
+      {% if page.tags is present %}
+        <div class="badge-container" style="margin-top: 3rem; border-top: var(--border-thin); padding-top: 1.5rem;">
+          {% for tag in page.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="badge">#{{ tag }}</a>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/brutal-dashboard/templates/section.html
+++ b/examples/brutal-dashboard/templates/section.html
@@ -1,0 +1,41 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">
+          {% if page.title is present %}
+            {{ page.title | e }}
+          {% else %}
+            System Latency & Status Logs
+          {% endif %}
+        </h1>
+        <span class="status-badge status-ok">TELEMETRY_LOGS</span>
+      </div>
+      
+      {% if page.description is present %}
+        <p style="margin-bottom: 2rem;">{{ page.description | e }}</p>
+      {% endif %}
+
+      <div class="log-list">
+        {% for post in section.pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>TIMESTAMP: {{ post.date | date("%Y-%m-%d") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— TAGS: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">View Telemetry</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/brutal-dashboard/templates/shortcodes/alert.html
+++ b/examples/brutal-dashboard/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/brutal-dashboard/templates/taxonomy.html
+++ b/examples/brutal-dashboard/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">System Taxonomy Registers: {{ taxonomy_name | e }}</h1>
+        <span class="status-badge status-ok">INDEX_REGISTRY</span>
+      </div>
+
+      <div class="badge-container" style="gap: 1.5rem; padding: 1rem 0;">
+        {% for term in taxonomy_terms %}
+          <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term.name | slugify }}/" class="badge" style="font-size: 1.1rem; padding: 0.5rem 1rem;">
+            #{{ term.name }} ({{ term.pages | length }})
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/brutal-dashboard/templates/taxonomy_term.html
+++ b/examples/brutal-dashboard/templates/taxonomy_term.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">LOG ARCHIVE: #{{ taxonomy_term | e }}</h1>
+        <span class="status-badge status-ok">FILTERED_STREAM</span>
+      </div>
+
+      <div class="log-list">
+        {% for post in taxonomy_pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>TIMESTAMP: {{ post.date | date("%Y-%m-%d") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— TAGS: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">View Telemetry</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-dashboard/AGENTS.md
+++ b/examples/cyber-dashboard/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/cyber-dashboard/archetypes/default.md
+++ b/examples/cyber-dashboard/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/cyber-dashboard/config.toml
+++ b/examples/cyber-dashboard/config.toml
@@ -1,0 +1,194 @@
+title = "Cyber Dashboard"
+description = "A dark cybernetic security operations dashboard showcasing firewall alerts, server parameters, and network packet streams inside frosted panels."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "vs2015"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/cyber-dashboard/content/about.md
+++ b/examples/cyber-dashboard/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "Operations Specifications"
+description = "Specifications and parameters of the Cyber Dashboard security ops console."
+tags = ["ops", "specs"]
+categories = ["meta"]
++++
+
+The Cyber Dashboard security operations console is designed to present real-time threat parameters and active network logs inside modern frosted glass-panels.
+
+## key terminal capabilities
+
+1. **Frosted Backdrop Panels**: Utilizes translucent backgrounds overlaid with backdrop blurs to maximize monospaced text reading contrast.
+2. **Glowing Solid outlines**: Implements sharp neon borders using flat, high-vibrancy pigments to isolate critical visual elements. No gradients.
+3. **Monospaced Data Tables**: Logs, gateway indices, and system metrics align to rigid monospace baseline loops.
+
+## telemetry specs
+
+- **SSG Builder**: Hwaro Engine statically compiled in Crystal.
+- **Visual Delivery**: Bespoke Vanilla CSS (under 260 lines).
+- **Compile Telemetry**: Stably compiles under 10 milliseconds.

--- a/examples/cyber-dashboard/content/index.md
+++ b/examples/cyber-dashboard/content/index.md
@@ -1,0 +1,77 @@
++++
+title = "Security Operations Overview"
+description = "Frosted glass-panel security operations dashboard tracking firewall metrics, active port parameters, and threat feeds."
+tags = ["security", "ops", "firewalls"]
++++
+
+<div class="dashboard-grid">
+<div class="metric-card">
+<div class="metric-label">System Integrity</div>
+<div class="metric-value">99.94%<span>INT</span></div>
+<div class="metric-trend">&gt; ALL_SECTORS_STABLE</div>
+</div>
+<div class="metric-card alert-state">
+<div class="metric-label">Firewall Blocks (1H)</div>
+<div class="metric-value">1,482<span>REJ</span></div>
+<div class="metric-trend">&gt; THREAT_ATTACKS_STAGED</div>
+</div>
+<div class="metric-card">
+<div class="metric-label">Packet Analysis Rate</div>
+<div class="metric-value">4.2K<span>PPS</span></div>
+<div class="metric-trend">&gt; BUFFER_CLEARANCE_STABLE</div>
+</div>
+</div>
+
+<div class="dashboard-panels">
+<div class="panel">
+<div class="panel-header">
+<h2 class="panel-title">Active Gateway Stream <span>[SEC_PORT]</span></h2>
+<a href="posts/" class="panel-action">Initialize Logs</a>
+</div>
+
+<table class="cyber-table">
+<thead>
+<tr>
+<th>Port Address</th>
+<th>Protocol</th>
+<th>Bandwidth Utilization</th>
+<th>Telemetry Integrity</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>:443 (Secure TLS Gateway)</td>
+<td>TCP/IP (TLSv1.3)</td>
+<td>35.4 Mbps</td>
+<td><span class="status-indicator indicator-ok">OK_STABLE</span></td>
+</tr>
+<tr>
+<td>:22 (Secure Shell Tunnel)</td>
+<td>SSHv2</td>
+<td>1.2 Mbps</td>
+<td><span class="status-indicator indicator-ok">OK_STABLE</span></td>
+</tr>
+<tr>
+<td>:80 (Unsecure HTTP)</td>
+<td>TCP/IP</td>
+<td>0.0 Mbps</td>
+<td><span class="status-indicator indicator-alert">BLOCKED</span></td>
+</tr>
+</tbody>
+</table>
+
+Detailed diagnostic threat logs and packet capture analyses are actively recorded under the [Intrusion Logs Section](posts/).
+</div>
+
+<div class="panel">
+<div class="panel-header">
+<h2 class="panel-title">Operations Specs</h2>
+<span class="status-indicator indicator-ok">OPS_INFO</span>
+</div>
+
+- **Operations Node**: Cyber Dashboard
+- **Physical Location**: static.hwaro.internal
+- **Telemetry Host**: SECURE_OPS_PORT_3
+- **Compile Loop Time**: Weekly Static Rebuild
+</div>
+</div>

--- a/examples/cyber-dashboard/content/posts/_index.md
+++ b/examples/cyber-dashboard/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Intrusion Logs"
+sort_by = "date"
+reverse = true
+paginate = 6
+template = "section"
+generate_feeds = true
++++
+
+A technical log stream of security block diagnostics, port scans detection, and network gateway status notes. Accessing sector database...

--- a/examples/cyber-dashboard/content/posts/firewall-block-telemetry.md
+++ b/examples/cyber-dashboard/content/posts/firewall-block-telemetry.md
@@ -1,0 +1,25 @@
++++
+title = "Diagnostic: High-Volume Rejects on Port 80"
+date = "2026-05-23"
+draft = false
+description = "Analyzing a sudden peak in automated bot traffic targeting HTTP port 80 and active firewall mitigations."
+tags = ["firewall", "security", "traffic"]
+categories = ["diagnostics"]
+reading_time = 3
++++
+
+We recorded an unexpected peak in unsecure traffic targeting HTTP port `:80` over the last 1 hour. 
+
+A total of `1,482` request packets were rejected and blocked by our active security policies.
+
+## incident telemetry logs
+
+* **09:12:05Z** - Firewall rules flag automated port scanning sequences.
+* **09:12:44Z** - HTTP port `:80` traffic rises to peak levels. Uptime integrity remains stable.
+* **09:13:30Z** - Target IP range quarantined. Packet analysis rates return to normal.
+
+## security recommendations
+
+HTTP `:80` should be completely disabled in favor of encrypted HTTPS `:443` channels. By implementing a strict compile-time redirection on our static assets, we prevent any threat vectors from targeting unencrypted ports.
+
+The terminal parameters remain fully locked.

--- a/examples/cyber-dashboard/content/posts/port-scanning-diagnostic.md
+++ b/examples/cyber-dashboard/content/posts/port-scanning-diagnostic.md
@@ -1,0 +1,27 @@
++++
+title = "Diagnostic: Automated Scan Sequence Deflected"
+date = "2026-05-19"
+draft = false
+description = "Analyzing automated port scan sequences deflected by our secure static gateway configurations."
+tags = ["security", "monitors", "networks"]
+categories = ["diagnostics"]
+reading_time = 3
++++
+
+A distributed port scanning sequence was detected and successfully deflected by our gateway router (`static.hwaro.internal`).
+
+The scan target mapped our complete active port registers from `:1` to `:1024`.
+
+## deflection parameters
+
+1. **Monitored sectors**: Secure TLS (:443) and SSH Tunnel (:22) remained completely isolated.
+2. **Deflection strategy**: The router returned null responses for all unallocated ports, hiding our system architecture.
+3. **Telemetry integrity**: System integrity recorded a continuous rating of `99.94%`.
+
+## system state telemetry
+
+- **Active Firewall Blocks**: 1,482 ( deflected successfully)
+- **Active Ports Uptime**: 100%
+- **Diagnostic status**: SECURE
+
+Our static environment prevents target scanners from identifying any running server processes.

--- a/examples/cyber-dashboard/static/css/style.css
+++ b/examples/cyber-dashboard/static/css/style.css
@@ -1,0 +1,532 @@
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Outfit:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --bg: #030305;
+  --panel: rgba(14, 14, 20, 0.78);
+  --text: #E3E3E8;
+  --text-muted: #8B8B9B;
+  --cyan: #00E5FF;
+  --green: #39FF14;
+  --border: 1px solid rgba(255, 255, 255, 0.08);
+  --border-cyan: 1.5px solid var(--cyan);
+  --border-green: 1.5px solid var(--green);
+  --font-sans: 'Outfit', sans-serif;
+  --font-mono: 'Fira Code', monospace;
+  --transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding: 0;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Cyber Layout */
+.site-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.site-header {
+  background: var(--panel);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: var(--border);
+  border-left: var(--border-cyan);
+  padding: 1.25rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 3.5rem;
+  box-shadow: 0 10px 30px 0 rgba(0, 0, 0, 0.4);
+}
+
+.site-logo {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 1.3rem;
+  color: var(--text);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.site-logo::before {
+  content: '>';
+  color: var(--cyan);
+  font-weight: 800;
+}
+
+.site-logo span {
+  color: var(--cyan);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.site-header nav a {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+  text-transform: lowercase;
+  transition: var(--transition);
+}
+
+.site-header nav a:hover {
+  color: var(--cyan);
+  text-shadow: 0 0 8px var(--cyan);
+}
+
+.site-main {
+  min-height: 60vh;
+}
+
+.site-footer {
+  margin-top: 6rem;
+  background: var(--panel);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: var(--border);
+  border-right: var(--border-green);
+  padding: 1.5rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.site-footer p {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.site-footer a {
+  color: var(--green);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  text-decoration: underline;
+}
+
+/* Dashboard Grid */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  margin-bottom: 4rem;
+}
+
+.metric-card {
+  background: var(--panel);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: var(--border);
+  padding: 2.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: var(--transition);
+}
+
+.metric-card:hover {
+  border-color: rgba(0, 229, 255, 0.3);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 40px 0 rgba(0,0,0,0.5);
+}
+
+.metric-card.alert-state {
+  border-left: var(--border-green);
+}
+
+.metric-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--cyan);
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.metric-card.alert-state .metric-label {
+  color: var(--green);
+}
+
+.metric-value {
+  font-family: var(--font-mono);
+  font-size: 2.6rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--text);
+  margin-bottom: 1rem;
+}
+
+.metric-value span {
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin-left: 0.5rem;
+}
+
+.metric-trend {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* Layout Panels */
+.dashboard-panels {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 3rem;
+  margin-bottom: 4rem;
+}
+
+.panel {
+  background: var(--panel);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: var(--border);
+  padding: 3rem;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.4);
+}
+
+.panel-header {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-title {
+  font-weight: 600;
+  font-size: 1.8rem;
+  margin: 0;
+  letter-spacing: -0.5px;
+}
+
+.panel-title span {
+  color: var(--cyan);
+}
+
+.panel-action {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: lowercase;
+  color: var(--cyan);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.panel-action::before {
+  content: '>';
+}
+
+.panel-action:hover {
+  color: var(--text);
+  padding-left: 0.4rem;
+}
+
+/* Cyber Metrics Table */
+.cyber-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.cyber-table th, .cyber-table td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.9rem 1.25rem;
+  text-align: left;
+}
+
+.cyber-table th {
+  background-color: rgba(255, 255, 255, 0.01);
+  border: var(--border);
+  color: var(--cyan);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.cyber-table tr:hover td {
+  background-color: rgba(255,255,255,0.01);
+  color: var(--text);
+}
+
+.status-indicator {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  background-color: rgba(255,255,255,0.03);
+  border: var(--border);
+}
+
+.status-indicator.indicator-ok {
+  color: var(--cyan);
+  border-color: rgba(0, 229, 255, 0.2);
+}
+
+.status-indicator.indicator-alert {
+  color: var(--green);
+  border-color: rgba(57, 255, 20, 0.2);
+}
+
+/* Logs and stream list */
+.log-item {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.5rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.log-item:last-child {
+  border-bottom: none;
+}
+
+.log-info a {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 1.25rem;
+  color: var(--text);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.log-info a:hover {
+  color: var(--cyan);
+}
+
+.log-meta {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
+.log-action {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--cyan);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.log-action::before {
+  content: '>';
+}
+
+.log-action:hover {
+  color: var(--text);
+  padding-left: 0.4rem;
+}
+
+/* Post Detail */
+.post-wrapper {
+  background: var(--panel);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: var(--border);
+  border-top: var(--border-cyan);
+  padding: 3.5rem;
+  margin-bottom: 4rem;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.4);
+}
+
+.post-title {
+  font-weight: 700;
+  font-size: 2.8rem;
+  line-height: 1.2;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  letter-spacing: -0.5px;
+}
+
+.post-meta {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--green);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2.5rem;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.prose {
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+
+.prose p {
+  margin-bottom: 1.75rem;
+}
+
+.prose strong {
+  color: #FFF;
+  font-weight: 600;
+}
+
+.prose h1, .prose h2, .prose h3 {
+  color: var(--cyan);
+  font-weight: 600;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+}
+
+.prose h1 { font-size: 2rem; }
+.prose h2 { font-size: 1.6rem; border-bottom: 1px solid rgba(255, 255, 255, 0.05); padding-bottom: 0.5rem; }
+.prose h3 { font-size: 1.3rem; }
+
+.prose a {
+  color: var(--cyan);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--cyan);
+  transition: var(--transition);
+}
+
+.prose a:hover {
+  color: var(--text);
+  border-bottom-style: solid;
+}
+
+.prose blockquote {
+  margin: 2.5rem 0;
+  padding: 1.25rem 2rem;
+  background-color: rgba(255, 255, 255, 0.02);
+  border: var(--border);
+  border-left: 4px solid var(--green);
+  font-style: italic;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.prose pre {
+  background-color: rgba(0, 0, 0, 0.4);
+  border: var(--border);
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 2.5rem 0;
+}
+
+.prose code {
+  font-family: var(--font-mono);
+  background-color: rgba(255,255,255,0.06);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.88em;
+  color: var(--green);
+}
+
+.prose pre code {
+  background-color: transparent;
+  padding: 0;
+  color: var(--text);
+}
+
+/* Badge/Taxonomy */
+.badge-container {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+}
+
+.badge {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  background-color: rgba(255, 255, 255, 0.03);
+  border: var(--border);
+  padding: 0.2rem 0.6rem;
+  color: var(--cyan);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.badge:hover {
+  background-color: var(--cyan);
+  color: var(--bg);
+}
+
+/* Buttons */
+.btn-main {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: lowercase;
+  color: var(--bg);
+  background-color: var(--cyan);
+  border: none;
+  padding: 0.8rem 1.8rem;
+  cursor: pointer;
+  display: inline-block;
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.btn-main:hover {
+  background-color: var(--green);
+  box-shadow: 0 0 15px rgba(57, 255, 20, 0.4);
+}
+
+/* Responsive grid */
+@media (max-width: 992px) {
+  .dashboard-panels {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-wrapper {
+    padding: 1.5rem 1rem;
+  }
+  .site-header {
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: flex-start;
+    padding: 1.25rem;
+  }
+  .site-header nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .hero-title {
+    font-size: 2.2rem;
+  }
+  .post-title {
+    font-size: 2rem;
+  }
+  .post-wrapper {
+    padding: 1.5rem;
+  }
+  .site-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}

--- a/examples/cyber-dashboard/static/favicon.svg
+++ b/examples/cyber-dashboard/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/cyber-dashboard/templates/404.html
+++ b/examples/cyber-dashboard/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main" style="display: flex; align-items: center; justify-content: center; min-height: 50vh;">
+    <div class="post-wrapper" style="text-align: center; max-width: 550px; width: 100%; border-top-color: var(--cyan);">
+      <h1 class="hero-title" style="font-size: 5rem; margin: 0 0 1rem 0; font-family: var(--font-mono); color: var(--cyan);">404</h1>
+      <h2 class="card-title" style="color: var(--cyan); font-family: var(--font-mono); font-size: 1.4rem; margin-bottom: 1.5rem;">FATAL_SECTOR_MISSING</h2>
+      <p style="margin-bottom: 2rem; font-family: var(--font-mono); font-size: 0.9rem; color: var(--text-muted);">The sector index requested is empty or unallocated in our active memory database.</p>
+      <a href="{{ base_url }}/" class="btn-main">Reset Terminal Overview</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-dashboard/templates/footer.html
+++ b/examples/cyber-dashboard/templates/footer.html
@@ -1,0 +1,9 @@
+    <footer class="site-footer">
+      <p>&gt; SECURE_LOGOUT // SHELL_TS: {{ current_year }}</p>
+      <p>System Engine: <a href="https://hwaro.hahwul.com">HWARO_STATIC</a></p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/cyber-dashboard/templates/header.html
+++ b/examples/cyber-dashboard/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+
+  <!-- Bespoke Cyber Dashboard stylesheet -->
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">CYBER<span>.board</span></a>
+      <nav>
+        <a href="{{ base_url }}/">~/terminal</a>
+        <a href="{{ base_url }}/posts/">~/logs</a>
+        <a href="{{ base_url }}/about/">~/specs</a>
+      </nav>
+    </header>

--- a/examples/cyber-dashboard/templates/page.html
+++ b/examples/cyber-dashboard/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="post-wrapper">
+      {% if page.title is present %}
+        <h1 class="post-title">{{ page.title | e }}</h1>
+      {% endif %}
+      
+      <div class="post-meta">
+        {% if page.date is present %}
+          <span>SEC_TS: {{ page.date | date("%Y.%m.%d") }}</span>
+        {% endif %}
+        <span>SECTOR: SEC_LOGS</span>
+      </div>
+
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+
+      {% if page.tags is present %}
+        <div class="badge-container" style="margin-top: 4rem; border-top: 1px solid rgba(255, 255, 255, 0.05); padding-top: 1.5rem;">
+          {% for tag in page.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="badge">#{{ tag }}</a>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-dashboard/templates/section.html
+++ b/examples/cyber-dashboard/templates/section.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Security & Intrusion Telemetry Logs</h1>
+        <span class="status-indicator indicator-ok">THREAT_FEED_ACTIVE</span>
+      </div>
+      
+      {% if page.description is present %}
+        <p style="margin-bottom: 3rem; font-weight: 300; color: var(--text-muted);">{{ page.description | e }}</p>
+      {% endif %}
+
+      <div class="log-list">
+        {% for post in section.pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>LOG_TS: {{ post.date | date("%Y.%m.%d") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— CLASSIFICATION: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">Access Buffer</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-dashboard/templates/shortcodes/alert.html
+++ b/examples/cyber-dashboard/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/cyber-dashboard/templates/taxonomy.html
+++ b/examples/cyber-dashboard/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Active Index Registry: {{ taxonomy_name | e }}</h1>
+        <span class="status-indicator indicator-ok">CATALOG_SECTORS</span>
+      </div>
+
+      <div class="badge-container" style="gap: 1.5rem; padding: 1.5rem 0;">
+        {% for term in taxonomy_terms %}
+          <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term.name | slugify }}/" class="badge" style="font-size: 1.1rem; padding: 0.5rem 1rem;">
+            #{{ term.name | lower }} ({{ term.pages | length }})
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/cyber-dashboard/templates/taxonomy_term.html
+++ b/examples/cyber-dashboard/templates/taxonomy_term.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Buffer Stream: <span>#{{ taxonomy_term | e }}</span></h1>
+        <span class="status-indicator indicator-ok">FILTERED_CHANNEL</span>
+      </div>
+
+      <div class="log-list">
+        {% for post in taxonomy_pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>LOG_TS: {{ post.date | date("%Y.%m.%d") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— CLASSIFICATION: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">Access Buffer</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/luxury-dashboard/AGENTS.md
+++ b/examples/luxury-dashboard/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/luxury-dashboard/archetypes/default.md
+++ b/examples/luxury-dashboard/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/luxury-dashboard/config.toml
+++ b/examples/luxury-dashboard/config.toml
@@ -1,0 +1,194 @@
+title = "Luxury Dashboard"
+description = "A quiet-luxury, spacious financial dashboard presenting metrics, growth charts, and investment analytics in elegant serif typography."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/luxury-dashboard/content/about.md
+++ b/examples/luxury-dashboard/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "The Architecture"
+description = "Ethos and layout construction specifications of the Luxury Dashboard."
+tags = ["philosophy", "specs"]
+categories = ["meta"]
++++
+
+The Luxury Dashboard is an aesthetic study exploring visual spaciousness and quiet luxury inside high-performance digital publishing.
+
+We reject the cluttered visual noise of modern data telemetry—flashing gradients, dynamic popups, and telemetry bloat. Instead, we present stark typography, clear tables, and beautiful margins.
+
+## structural characteristics
+
+1. **Quiet Typographic Scale**: Curating standard serif and sans-serif typefaces (Playfair Display, Inter) to establish classic visual contrast.
+2. **Delicate Grid Boundaries**: Content panes use incredibly subtle solid border dividers, emphasizing negative space.
+3. **Optimized Statics**: Generated in single-digit milliseconds under the Hwaro compiler, loading instantly on any connection.

--- a/examples/luxury-dashboard/content/index.md
+++ b/examples/luxury-dashboard/content/index.md
@@ -1,0 +1,77 @@
++++
+title = "Financial Overview"
+description = "Spacious financial analytics dashboard demonstrating asset class returns, growth metrics, and portfolio equity shares."
+tags = ["financials", "analytics", "assets"]
++++
+
+<div class="dashboard-grid">
+<div class="metric-card">
+<div class="metric-label">Net Asset Value</div>
+<div class="metric-value">$84.2M<span>USD</span></div>
+<div class="metric-trend">Uptime: 100% — Standard growth</div>
+</div>
+<div class="metric-card">
+<div class="metric-label">Annualized Return</div>
+<div class="metric-value">12.85%<span>ARR</span></div>
+<div class="metric-trend">Benchmark: S&P +2.4%</div>
+</div>
+<div class="metric-card">
+<div class="metric-label">Operating Margin</div>
+<div class="metric-value">46.20%<span>NET</span></div>
+<div class="metric-trend">Cost Overhead: Muted</div>
+</div>
+</div>
+
+<div class="dashboard-panels">
+<div class="panel">
+<div class="panel-header">
+<h2 class="panel-title">Asset Allocation & Yields</h2>
+<a href="posts/" class="panel-action">Explore Reports</a>
+</div>
+
+<table class="financial-table">
+<thead>
+<tr>
+<th>Asset Category</th>
+<th>Capital Allocated</th>
+<th>Weighted Share</th>
+<th>Yield (YTD)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Liquid Capital Reserves</strong></td>
+<td>$24.5M</td>
+<td>29.1%</td>
+<td>+4.85%</td>
+</tr>
+<tr>
+<td><strong>Secured Real Estate Equity</strong></td>
+<td>$36.0M</td>
+<td>42.7%</td>
+<td>+14.20%</td>
+</tr>
+<tr>
+<td><strong>Statically Compiling Platforms</strong></td>
+<td>$23.7M</td>
+<td>28.2%</td>
+<td>+19.64%</td>
+</tr>
+</tbody>
+</table>
+
+Detailed diagnostic and growth analyses are regularly published in our [Analytical Reports Section](posts/).
+</div>
+
+<div class="panel">
+<div class="panel-header">
+<h2 class="panel-title">System Specs</h2>
+<span class="panel-action" style="cursor: default;">METRIC_INFO</span>
+</div>
+
+- **Asset Custodian**: Luxury Analytics Group
+- **Telemetries Channel**: SECURE_GATEWAY_3
+- **Report Cycle**: Weekly Static Compile
+- **Audit Hash**: SHA-256 (Statically Immutable)
+</div>
+</div>

--- a/examples/luxury-dashboard/content/posts/_index.md
+++ b/examples/luxury-dashboard/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Analytical Reports"
+sort_by = "date"
+reverse = true
+paginate = 6
+template = "section"
+generate_feeds = true
++++
+
+A timeline of analytical reports, asset growth diagnostic notes, and design-theoretic essays on financial static systems.

--- a/examples/luxury-dashboard/content/posts/capital-allocation-metrics.md
+++ b/examples/luxury-dashboard/content/posts/capital-allocation-metrics.md
@@ -1,0 +1,30 @@
++++
+title = "Principles of Static Capital Allocation"
+date = "2026-05-23"
+draft = false
+description = "A thorough evaluation of capital allocation parameters, static portfolio balances, and risk mitigation methodologies."
+tags = ["capital", "allocations", "risk"]
+categories = ["reports"]
+reading_time = 3
++++
+
+Successful wealth management requires a rigorous, objective approach to **capital allocation**. When we remove emotional speculation and dynamic market clutter, we expose the mathematical reality of long-term asset growth.
+
+In physical investing, we balance portfolios across diverse asset classes.
+
+## risk mitigation through class splits
+
+A static, balanced portfolio prevents knee-jerk investment adjustments during transient market fluctuations:
+
+* **Reserves (Liquid Capital)**: Retaining an absolute cash pool (`29%`) to guarantee operational capacity.
+* **Property (Secured Real Estate)**: Allocating a solid physical base (`42%`) to hedge against inflation.
+* **Technology (Statically Compiling Platforms)**: Allocating high-yield shares (`28%`) in performance-driven, crystal-compiled technology sectors.
+
+## vertical baseline tracking
+
+We monitor asset performance relative to absolute baseline benchmarks:
+
+1. **Continuous Uptime**: The asset class operates with zero telemetry leakage.
+2. **Predictable Yields**: Avoiding speculative instruments in favor of historically validated, steady cash-generating platforms.
+
+By locking allocations to objective structural rules, we secure absolute stability.

--- a/examples/luxury-dashboard/content/posts/static-speed-ux.md
+++ b/examples/luxury-dashboard/content/posts/static-speed-ux.md
@@ -1,0 +1,29 @@
++++
+title = "The Premium Vibe of Instant Loading"
+date = "2026-05-18"
+draft = false
+description = "Analyzing how instantaneous compile cycles and pure loading speed elevate user trust and luxury perception."
+tags = ["performance", "speed", "ux"]
+categories = ["reports"]
+reading_time = 3
++++
+
+In high-end luxury products, the tactile experience is paramount. A door closing on a luxury sedan, the weight of a mechanical timepiece, the smooth rotation of an instrument dial—these small physical cues communicate quality instantly.
+
+In digital publishing, **compilation speed** and **loading time** represent this same tactile quality.
+
+## speed as a luxury signal
+
+When a user lands on a site that loads instantly, their psychological perception shifts:
+
+1. **Absolute Professionalism**: The system operates with supreme efficiency. There is zero hesitation or lagging overlay.
+2. **Enhanced Trust**: A lightweight, private, and instantaneous page signals respect for the reader's time and bandwidth.
+3. **Typographic Permanence**: The words appear on the canvas without visual shifts, rendering with classical stability.
+
+## technical parameters for instant luxury
+
+- **Static Generation**: Utilizing Hwaro's crystal-compiled binary to keep generation times under 10ms.
+- **Bespoke Styling**: Writing light, Vanilla CSS specifically tailored for our metrics grid, removing general utility libraries.
+- **Zero Decors**: Excluding multi-colored gradients, tracking scripts, and animated emojis.
+
+Speed is not just a performance metric; it is a design philosophy.

--- a/examples/luxury-dashboard/static/css/style.css
+++ b/examples/luxury-dashboard/static/css/style.css
@@ -1,0 +1,505 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap');
+
+:root {
+  --bg: #FAF9F5;             /* Warm Off-white */
+  --panel: #FFFFFF;
+  --text: #151515;           /* Matte Charcoal */
+  --text-muted: #6E6E6E;
+  --accent: #E6DFD3;         /* Warm Gold-Cream */
+  --border: 1px solid rgba(21, 21, 21, 0.08);
+  --border-dark: 1px solid #151515;
+  --transition: all 0.4s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding: 0;
+  line-height: 1.8;
+  letter-spacing: -0.01em;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Luxury Layout */
+.site-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 2rem;
+  border-bottom: var(--border);
+  margin-bottom: 4rem;
+}
+
+.site-logo {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 1.8rem;
+  color: var(--text);
+  text-decoration: none;
+  letter-spacing: -0.03em;
+}
+
+.site-logo span {
+  font-weight: 400;
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.site-header nav {
+  display: flex;
+  gap: 2.5rem;
+}
+
+.site-header nav a {
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: var(--transition);
+  position: relative;
+  padding: 0.2rem 0;
+}
+
+.site-header nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0%;
+  height: 1px;
+  background-color: var(--text);
+  transition: var(--transition);
+}
+
+.site-header nav a:hover {
+  color: var(--text);
+}
+
+.site-header nav a:hover::after {
+  width: 100%;
+}
+
+.site-main {
+  min-height: 60vh;
+}
+
+.site-footer {
+  margin-top: 6rem;
+  padding-top: 3rem;
+  border-top: var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.site-footer p {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+}
+
+.site-footer a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.site-footer a:hover {
+  text-decoration: underline;
+}
+
+/* Dashboard Grid */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  margin-bottom: 4rem;
+}
+
+.metric-card {
+  background-color: var(--panel);
+  border: var(--border);
+  padding: 2.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: var(--transition);
+}
+
+.metric-card:hover {
+  border-color: var(--text);
+  transform: translateY(-2px);
+}
+
+.metric-label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+}
+
+.metric-value {
+  font-family: 'Playfair Display', serif;
+  font-size: 3rem;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text);
+  margin-bottom: 1rem;
+}
+
+.metric-value span {
+  font-size: 1.2rem;
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  color: var(--text-muted);
+  margin-left: 0.5rem;
+}
+
+.metric-trend {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Layout Panels */
+.dashboard-panels {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 3rem;
+  margin-bottom: 4rem;
+}
+
+.panel {
+  background-color: var(--panel);
+  border: var(--border);
+  padding: 3rem;
+}
+
+.panel-header {
+  border-bottom: var(--border);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.panel-title {
+  font-family: 'Playfair Display', serif;
+  font-weight: 400;
+  font-size: 2rem;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.panel-title em {
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+.panel-action {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--text);
+  padding-bottom: 0.2rem;
+  transition: var(--transition);
+}
+
+.panel-action:hover {
+  opacity: 0.6;
+}
+
+/* Luxury Financial Table */
+.financial-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+}
+
+.financial-table th, .financial-table td {
+  border-bottom: var(--border);
+  padding: 1rem 1.25rem;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.financial-table th {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.15em;
+  color: var(--text-muted);
+  padding-bottom: 1.25rem;
+}
+
+.financial-table td {
+  font-weight: 300;
+  color: var(--text-muted);
+}
+
+.financial-table td strong {
+  font-weight: 500;
+  color: var(--text);
+}
+
+.financial-table tr:hover td {
+  color: var(--text);
+  background-color: rgba(0,0,0,0.01);
+}
+
+/* Log stream for luxury dashboard */
+.log-item {
+  border-bottom: var(--border);
+  padding: 1.5rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.log-item:last-child {
+  border-bottom: none;
+}
+
+.log-info a {
+  font-family: 'Playfair Display', serif;
+  font-weight: 400;
+  font-size: 1.35rem;
+  color: var(--text);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.log-info a:hover {
+  opacity: 0.6;
+}
+
+.log-meta {
+  font-size: 0.8rem;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
+.log-action {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--text);
+  padding-bottom: 0.2rem;
+  transition: var(--transition);
+}
+
+.log-action:hover {
+  opacity: 0.6;
+}
+
+/* Prose detail */
+.post-wrapper {
+  max-width: 800px;
+  margin: 0 auto 5rem auto;
+}
+
+.post-title {
+  font-family: 'Playfair Display', serif;
+  font-weight: 400;
+  font-size: 3.4rem;
+  line-height: 1.2;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  letter-spacing: -0.02em;
+}
+
+.post-meta {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 2rem;
+  display: flex;
+  gap: 2rem;
+  border-bottom: var(--border);
+  padding-bottom: 1.5rem;
+}
+
+.prose {
+  font-size: 1.1rem;
+  line-height: 1.95;
+  font-weight: 300;
+}
+
+.prose p {
+  margin-bottom: 2rem;
+}
+
+.prose strong {
+  font-weight: 500;
+  color: #000;
+}
+
+.prose h1, .prose h2, .prose h3 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 400;
+  color: var(--text);
+  margin-top: 3.5rem;
+  margin-bottom: 1.2rem;
+}
+
+.prose h1 { font-size: 2.4rem; }
+.prose h2 { font-size: 1.9rem; }
+.prose h3 { font-size: 1.5rem; }
+
+.prose a {
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--text);
+  font-weight: 500;
+  transition: var(--transition);
+}
+
+.prose a:hover {
+  opacity: 0.6;
+}
+
+.prose blockquote {
+  margin: 3rem 0;
+  padding-left: 2rem;
+  border-left: var(--border-dark);
+  font-family: 'Playfair Display', serif;
+  font-style: italic;
+  font-size: 1.35rem;
+  color: var(--text-muted);
+}
+
+.prose pre {
+  background-color: var(--panel);
+  border: var(--border);
+  padding: 2rem;
+  overflow-x: auto;
+  margin: 3rem 0;
+}
+
+.prose code {
+  font-family: monospace;
+  background-color: rgba(21, 21, 21, 0.04);
+  padding: 0.15rem 0.35rem;
+  font-size: 0.9em;
+}
+
+.prose pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
+/* Badge/Taxonomy */
+.badge-container {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+.badge {
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: var(--transition);
+  border-bottom: 1px solid transparent;
+}
+
+.badge:hover {
+  color: var(--text);
+  border-bottom-color: var(--text);
+}
+
+/* Buttons */
+.btn-main {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--white);
+  background-color: var(--text);
+  border: none;
+  padding: 1rem 2rem;
+  cursor: pointer;
+  display: inline-block;
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.btn-main:hover {
+  opacity: 0.8;
+}
+
+/* Responsive grid */
+@media (max-width: 992px) {
+  .dashboard-panels {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-wrapper {
+    padding: 2rem 1.5rem;
+  }
+  .site-header {
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: flex-start;
+    margin-bottom: 3rem;
+  }
+  .site-header nav {
+    gap: 1.5rem;
+    width: 100%;
+    justify-content: space-between;
+  }
+  .hero-title {
+    font-size: 2.6rem;
+  }
+  .post-title {
+    font-size: 2.4rem;
+  }
+  .site-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}

--- a/examples/luxury-dashboard/static/favicon.svg
+++ b/examples/luxury-dashboard/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/luxury-dashboard/templates/404.html
+++ b/examples/luxury-dashboard/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="site-main" style="display: flex; flex-direction: column; justify-content: center; align-items: center; min-height: 40vh; text-align: center;">
+    <h1 class="hero-title" style="font-size: 6rem; margin-bottom: 0;">404</h1>
+    <h2 class="card-title" style="font-weight: 300; font-size: 1.8rem; margin-bottom: 2rem;">ARCHIVAL DOCUMENT NOT FOUND</h2>
+    <p class="hero-subtitle" style="margin-bottom: 3rem; max-width: 450px;">The specific folder address requested does not exist in our static registry databases.</p>
+    <a href="{{ base_url }}/" class="btn-main">Return to Overview</a>
+  </main>
+{% include "footer.html" %}

--- a/examples/luxury-dashboard/templates/footer.html
+++ b/examples/luxury-dashboard/templates/footer.html
@@ -1,0 +1,9 @@
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} Luxury Analytics Group.</p>
+      <p>Powered by <a href="https://hwaro.hahwul.com">Hwaro</a></p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/luxury-dashboard/templates/header.html
+++ b/examples/luxury-dashboard/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+
+  <!-- Bespoke Luxury Dashboard stylesheet -->
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">luxury<span>.board</span></a>
+      <nav>
+        <a href="{{ base_url }}/">Overview</a>
+        <a href="{{ base_url }}/posts/">Journal</a>
+        <a href="{{ base_url }}/about/">Manifesto</a>
+      </nav>
+    </header>

--- a/examples/luxury-dashboard/templates/page.html
+++ b/examples/luxury-dashboard/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="post-wrapper">
+      {% if page.title is present %}
+        <h1 class="post-title">{{ page.title | e }}</h1>
+      {% endif %}
+      
+      <div class="post-meta">
+        {% if page.date is present %}
+          <span>{{ page.date | date("%B %d, %Y") }}</span>
+        {% endif %}
+        <span>— REPORT_LOG</span>
+      </div>
+
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+
+      {% if page.tags is present %}
+        <div class="badge-container" style="margin-top: 5rem; border-top: var(--border); padding-top: 2rem;">
+          {% for tag in page.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="badge">#{{ tag }}</a>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/luxury-dashboard/templates/section.html
+++ b/examples/luxury-dashboard/templates/section.html
@@ -1,0 +1,41 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">
+          {% if page.title is present %}
+            {{ page.title | e }}
+          {% else %}
+            Analytical Essays & Reports
+          {% endif %}
+        </h1>
+        <span class="panel-action" style="cursor: default;">ARCHIVAL_STREAM</span>
+      </div>
+      
+      {% if page.description is present %}
+        <p style="margin-bottom: 3rem; font-weight: 300; color: var(--text-muted);">{{ page.description | e }}</p>
+      {% endif %}
+
+      <div class="log-list">
+        {% for post in section.pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>DATE: {{ post.date | date("%B %d, %Y") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— TAGS: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">Explore Report</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/luxury-dashboard/templates/shortcodes/alert.html
+++ b/examples/luxury-dashboard/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/luxury-dashboard/templates/taxonomy.html
+++ b/examples/luxury-dashboard/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Archival Registers: {{ taxonomy_name | e }}</h1>
+        <span class="panel-action" style="cursor: default;">INDEX_REGISTRY</span>
+      </div>
+
+      <div class="badge-container" style="gap: 3rem; padding: 1.5rem 0;">
+        {% for term in taxonomy_terms %}
+          <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term.name | slugify }}/" class="badge" style="font-size: 1rem; color: var(--text); border-bottom: 1px solid var(--text);">
+            {{ term.name | upper }} <span style="font-weight: 300; font-size: 0.85rem; color: var(--text-muted);">({{ term.pages | length }})</span>
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/luxury-dashboard/templates/taxonomy_term.html
+++ b/examples/luxury-dashboard/templates/taxonomy_term.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel" style="margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Archive: <em>#{{ taxonomy_term | e }}</em></h1>
+        <span class="panel-action" style="cursor: default;">CLASSIFIED_STREAM</span>
+      </div>
+
+      <div class="log-list">
+        {% for post in taxonomy_pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>DATE: {{ post.date | date("%B %d, %Y") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— TAGS: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">Explore Report</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/swiss-dashboard/AGENTS.md
+++ b/examples/swiss-dashboard/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/swiss-dashboard/archetypes/default.md
+++ b/examples/swiss-dashboard/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++

--- a/examples/swiss-dashboard/config.toml
+++ b/examples/swiss-dashboard/config.toml
@@ -1,0 +1,194 @@
+title = "Swiss Dashboard"
+description = "A bold, structured modernist dashboard styled in the Swiss typographic print tradition with asymmetric grids, giant metrics, and solid red panels."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+# tokenize_cjk = false
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# cache_strategy = "cache-first"
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Content Creation (Optional)
+# =============================================================================
+# Front matter format and default fields used by `hwaro new`
+
+# [content.new]
+# front_matter_format = "toml"
+# default_fields = ["description"]
+# bundle = false

--- a/examples/swiss-dashboard/content/about.md
+++ b/examples/swiss-dashboard/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "The Construction"
+description = "Specifications and architectural guidelines of the Swiss Dashboard."
+tags = ["philosophy", "specs"]
+categories = ["meta"]
++++
+
+Swiss Dashboard is an objective modular telemetry exploration applying early modernist design principles to web data presentation.
+
+We follow Josef Müller-Brockmann's manifesto of visual clarity, mathematical grids, and neutral type sizing.
+
+## the layout regulations
+
+1. **Rigid Module Alignment**: Metric blocks align to modular baseline grids, ensuring consistent visual weight.
+2. **typographic dominance**: Fonts are set in high-contrast scales, allowing extra-bold sans-serif titles (Inter) to immediately organize visual priority.
+3. **Primary Color Focus**: Visual emphasis is created strictly using stark flat black panels and crimson red solid accents.
+
+## engine parameters
+
+- **SSG Core**: Hwaro Engine statically compiled in Crystal.
+- **Visual Styles**: Bespoke Vanilla CSS (under 280 lines).
+- **Compile Time**: Instantaneous generation under 10ms.

--- a/examples/swiss-dashboard/content/index.md
+++ b/examples/swiss-dashboard/content/index.md
@@ -1,0 +1,77 @@
++++
+title = "Typographic Dashboard"
+description = "High-contrast typographic modular dashboard demonstrating compilation telemetry, active sectors, and static benchmarks."
+tags = ["swiss", "typography", "modular"]
++++
+
+<div class="dashboard-grid">
+<div class="metric-card">
+<div class="metric-label">Compile Overhead</div>
+<div class="metric-value">9.67<span>MS</span></div>
+<div class="metric-trend">Benchmark: Stably optimized</div>
+</div>
+<div class="metric-card">
+<div class="metric-label">Active Modules</div>
+<div class="metric-value">05<span>UNITS</span></div>
+<div class="metric-trend">Diagnostic: 100% stable</div>
+</div>
+<div class="metric-card">
+<div class="metric-label">Total Compiled Nodes</div>
+<div class="metric-value">25<span>PAGES</span></div>
+<div class="metric-trend">Standard: Zero dynamic faults</div>
+</div>
+</div>
+
+<div class="dashboard-panels">
+<div class="panel-left-block">
+<div class="panel-header">
+<h2 class="panel-title">Operations Directory <span>[SWISS_SECTOR]</span></h2>
+<a href="posts/" class="panel-action">Access Directory</a>
+</div>
+
+<table class="swiss-table">
+<thead>
+<tr>
+<th>Module Block Name</th>
+<th>Compile Time</th>
+<th>Staged Output Weight</th>
+<th>Diagnostic Code</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>brutal-dashboard</strong></td>
+<td>8.30 ms</td>
+<td>12.5 KB CSS</td>
+<td><span class="indicator-badge">SECURE</span></td>
+</tr>
+<tr>
+<td><strong>luxury-dashboard</strong></td>
+<td>7.62 ms</td>
+<td>10.8 KB CSS</td>
+<td><span class="indicator-badge">SECURE</span></td>
+</tr>
+<tr>
+<td><strong>cyber-dashboard</strong></td>
+<td>6.48 ms</td>
+<td>14.0 KB CSS</td>
+<td><span class="indicator-badge indicator-red">EVALUATED</span></td>
+</tr>
+</tbody>
+</table>
+
+Detailed structural diagnostics and latency tracking logs are actively registered in our [Logs Directory](posts/).
+</div>
+
+<div>
+<div class="panel-header">
+<h2 class="panel-title">Studio Specs</h2>
+<span class="indicator-badge" style="cursor: default;">STUDIO_INFO</span>
+</div>
+
+- **Design System**: International Typographic Style
+- **Visual Base**: Flat Swiss Cream (#F5F4F0)
+- **Highlight Accents**: Stark Solid Swiss Red (#D32F2F)
+- **Monospace Grid**: DM Mono
+</div>
+</div>

--- a/examples/swiss-dashboard/content/posts/_index.md
+++ b/examples/swiss-dashboard/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Diagnostic Directory"
+sort_by = "date"
+reverse = true
+paginate = 6
+template = "section"
+generate_feeds = true
++++
+
+A timeline of diagnostic reports, modular compile analyses, and layout grid telemetry.

--- a/examples/swiss-dashboard/content/posts/modular-grid-compiles.md
+++ b/examples/swiss-dashboard/content/posts/modular-grid-compiles.md
@@ -1,0 +1,29 @@
++++
+title = "Architecting Modular Grid Compiles"
+date = "2026-05-23"
+draft = false
+description = "A thorough evaluation of modular compile blocks, grid-aligned layout speeds, and static build pipelines."
+tags = ["grid", "compilation", "systems"]
+categories = ["diagnostics"]
+reading_time = 3
++++
+
+In structural design, a modular grid allows for infinite variations in layout while maintaining a consistent visual identity. Different articles can use different asymmetrical column configurations, yet they all feel part of the same unified publication.
+
+How do we compile these modular panels at lightning speed?
+
+## grid alignment during compile loops
+
+The Hwaro compiler processes all modular layouts concurrently, ensuring that each grid item aligns perfectly to its vertical rhythms:
+
+* **Rigid Modules**: Ensuring line heights and margin blocks align to a strict vertical rhythm.
+* **Liquid guts**: Columns scale naturally based on fluid container parameters, preventing overlap.
+
+## local telemetry benchmarks
+
+During recent compilation diagnostics, the modular grid dashboard constructed all directories and assets inside single-digit millisecond ranges:
+
+- **Build Core Time**: 9.67ms
+- **Resource Footprint**: Minimal (zero dynamic database calls)
+
+Purity in static structure ensures absolute delivery speed.

--- a/examples/swiss-dashboard/content/posts/typographic-hierarchy-telemetry.md
+++ b/examples/swiss-dashboard/content/posts/typographic-hierarchy-telemetry.md
@@ -1,0 +1,23 @@
++++
+title = "Typographic Hierarchy in Telemetry Lists"
+date = "2026-05-17"
+draft = false
+description = "Translating print-styled typography systems to web-based telemetry grids."
+tags = ["typography", "performance", "lists"]
+categories = ["diagnostics"]
+reading_time = 3
++++
+
+Web performance is often measured at the browser layer. However, the user experience is heavily gated by **cognitive processing speed**.
+
+A confusing, overly decorated layout forces the reader to search for data, creating friction.
+
+## design values: typographic readability
+
+By adopting a strict typographic hierarchy, we make visual scanning near-instantaneous:
+
+1. **Giant Metric Headers**: Sizing key counters at extra-bold weights (`900`) and massive dimensions (`3.5rem`) commands focus.
+2. **Neutral Labeling**: Setting parameters in clean, sans-serif weights to let data stand out objectively.
+3. **Structured gut separators**: Dividing fields with solid, high-contrast borders instead of soft drop-shadow gradients.
+
+By channeling layout rules into pure structure, we elevate data into absolute clarity.

--- a/examples/swiss-dashboard/static/css/style.css
+++ b/examples/swiss-dashboard/static/css/style.css
@@ -1,0 +1,508 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700;800;900&family=DM+Mono:wght@400;500&display=swap');
+
+:root {
+  --primary: #D32F2F;        /* Swiss Red */
+  --bg: #F5F4F0;             /* Swiss Cream */
+  --text: #1A1A1A;           /* Stark Black */
+  --slate: #EAE8E3;          /* Panel background */
+  --white: #FFFFFF;
+  --mono-font: 'DM Mono', monospace;
+  --transition: all 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Swiss Layout Shell */
+.site-wrapper {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 3rem;
+}
+
+.site-header {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  align-items: end;
+  border-bottom: 4px solid var(--text);
+  padding-bottom: 2rem;
+  margin-bottom: 4rem;
+}
+
+.site-logo {
+  font-weight: 900;
+  font-size: 2.5rem;
+  color: var(--text);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: -2px;
+  line-height: 0.8;
+}
+
+.site-logo span {
+  color: var(--primary);
+}
+
+.site-header nav {
+  display: flex;
+  justify-content: flex-end;
+  gap: 2rem;
+}
+
+.site-header nav a {
+  font-size: 0.9rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: var(--transition);
+}
+
+.site-header nav a:hover {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+}
+
+.site-main {
+  min-height: 60vh;
+}
+
+.site-footer {
+  margin-top: 6rem;
+  border-top: 4px solid var(--text);
+  padding-top: 3rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+  gap: 2rem;
+}
+
+.site-footer p {
+  margin: 0;
+  font-weight: 800;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+}
+
+.site-footer a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  text-decoration: underline;
+}
+
+/* Asymmetric Dashboard grid */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  margin-bottom: 4rem;
+}
+
+.metric-card {
+  background-color: var(--slate);
+  border-top: 8px solid var(--text);
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: var(--transition);
+}
+
+.metric-card:hover {
+  background-color: var(--white);
+  border-top-color: var(--primary);
+}
+
+.metric-label {
+  font-family: var(--mono-font);
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--primary);
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.metric-value {
+  font-weight: 900;
+  font-size: 3.5rem;
+  line-height: 0.85;
+  letter-spacing: -3px;
+  color: var(--text);
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.metric-value span {
+  font-size: 1.2rem;
+  letter-spacing: -0.5px;
+  font-weight: 700;
+  color: var(--text);
+  margin-left: 0.25rem;
+}
+
+.metric-trend {
+  font-family: var(--mono-font);
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text);
+  margin-top: 0.5rem;
+}
+
+/* Asymmetric panels */
+.dashboard-panels {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 4rem;
+  margin-bottom: 5rem;
+}
+
+.panel-left-block {
+  border-right: 2px solid var(--text);
+  padding-right: 4rem;
+}
+
+.panel-header {
+  border-bottom: 2px solid var(--text);
+  padding-bottom: 1.25rem;
+  margin-bottom: 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.panel-title {
+  font-weight: 900;
+  font-size: 2.2rem;
+  line-height: 0.95;
+  letter-spacing: -1.5px;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.panel-title span {
+  color: var(--primary);
+}
+
+.panel-action {
+  font-family: var(--mono-font);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--primary);
+  text-decoration: none;
+  border-bottom: 2px solid var(--primary);
+  padding-bottom: 0.15rem;
+  transition: var(--transition);
+}
+
+.panel-action:hover {
+  background-color: var(--primary);
+  color: var(--white);
+}
+
+/* Swiss Metric Table */
+.swiss-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+}
+
+.swiss-table th, .swiss-table td {
+  border-bottom: 1px solid var(--text);
+  padding: 1rem 1.25rem;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.swiss-table th {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  background-color: var(--text);
+  color: var(--white);
+  border: 1px solid var(--text);
+}
+
+.swiss-table td {
+  font-weight: 400;
+}
+
+.swiss-table td strong {
+  font-weight: 800;
+}
+
+.swiss-table tr:hover td {
+  background-color: var(--slate);
+}
+
+.indicator-badge {
+  font-family: var(--mono-font);
+  font-size: 0.75rem;
+  font-weight: 500;
+  background-color: var(--text);
+  color: var(--white);
+  padding: 0.2rem 0.6rem;
+  display: inline-block;
+}
+
+.indicator-badge.indicator-red {
+  background-color: var(--primary);
+}
+
+/* Log panel stream */
+.log-item {
+  border-bottom: 1px solid var(--text);
+  padding: 1.5rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.log-item:last-child {
+  border-bottom: none;
+}
+
+.log-info a {
+  font-weight: 800;
+  font-size: 1.4rem;
+  text-transform: uppercase;
+  letter-spacing: -0.8px;
+  color: var(--text);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.log-info a:hover {
+  color: var(--primary);
+}
+
+.log-meta {
+  font-family: var(--mono-font);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+  text-transform: uppercase;
+}
+
+.log-action {
+  font-family: var(--mono-font);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 2px solid var(--text);
+  padding-bottom: 0.15rem;
+  transition: var(--transition);
+}
+
+.log-action:hover {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+}
+
+/* Post detail */
+.post-wrapper {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  gap: 4rem;
+  margin-bottom: 5rem;
+}
+
+.post-sidebar {
+  font-family: var(--mono-font);
+  font-size: 0.85rem;
+  border-right: 1px solid var(--text);
+  padding-right: 2rem;
+}
+
+.post-sidebar h3 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 800;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-title {
+  font-weight: 900;
+  font-size: 4rem;
+  line-height: 0.95;
+  letter-spacing: -3px;
+  text-transform: uppercase;
+  margin-top: 0;
+  margin-bottom: 2rem;
+}
+
+.prose {
+  font-size: 1.05rem;
+  line-height: 1.65;
+  font-weight: 400;
+}
+
+.prose p {
+  margin-bottom: 1.5rem;
+}
+
+.prose strong {
+  font-weight: 800;
+}
+
+.prose h1, .prose h2, .prose h3 {
+  font-weight: 800;
+  text-transform: uppercase;
+  color: var(--text);
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  letter-spacing: -1px;
+}
+
+.prose h1 { font-size: 2.2rem; }
+.prose h2 { font-size: 1.7rem; border-bottom: 2px solid var(--text); padding-bottom: 0.3rem; }
+.prose h3 { font-size: 1.3rem; }
+
+.prose a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 800;
+  border-bottom: 2px solid var(--primary);
+}
+
+.prose a:hover {
+  background-color: var(--primary);
+  color: var(--white);
+}
+
+.prose blockquote {
+  margin: 2.5rem 0;
+  padding: 1.5rem 2rem;
+  background-color: var(--slate);
+  border-left: 8px solid var(--primary);
+  font-weight: 800;
+  font-size: 1.2rem;
+  text-transform: uppercase;
+}
+
+.prose pre {
+  background-color: var(--slate);
+  border: 1px solid var(--text);
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 2.5rem 0;
+}
+
+.prose code {
+  font-family: var(--mono-font);
+  background-color: var(--slate);
+  padding: 0.1rem 0.3rem;
+  font-size: 0.9em;
+}
+
+/* Badge/Taxonomy */
+.badge-container {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-family: var(--mono-font);
+  font-size: 0.75rem;
+  font-weight: 500;
+  background-color: var(--text);
+  color: var(--white);
+  padding: 0.2rem 0.6rem;
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.badge:hover {
+  background-color: var(--primary);
+}
+
+/* Buttons */
+.btn-main {
+  font-weight: 800;
+  font-size: 1rem;
+  text-transform: uppercase;
+  color: var(--white);
+  background-color: var(--text);
+  border: none;
+  padding: 0.8rem 1.8rem;
+  cursor: pointer;
+  display: inline-block;
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.btn-main:hover {
+  background-color: var(--primary);
+}
+
+/* Responsive grid */
+@media (max-width: 992px) {
+  .dashboard-panels {
+    grid-template-columns: 1fr;
+    gap: 3rem;
+  }
+  .panel-left-block {
+    border-right: none;
+    border-bottom: 2px solid var(--text);
+    padding-right: 0;
+    padding-bottom: 3rem;
+  }
+  .post-wrapper {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+  .post-sidebar {
+    border-right: none;
+    border-bottom: 2px solid var(--text);
+    padding-right: 0;
+    padding-bottom: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-wrapper {
+    padding: 1.5rem;
+  }
+  .site-header {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+  .site-header nav {
+    justify-content: space-between;
+    width: 100%;
+  }
+  .site-logo {
+    font-size: 2.2rem;
+  }
+  .metric-value {
+    font-size: 2.8rem;
+  }
+  .post-title {
+    font-size: 2.8rem;
+  }
+  .site-footer {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}

--- a/examples/swiss-dashboard/static/favicon.svg
+++ b/examples/swiss-dashboard/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <path d="M9 8h3v7h8V8h3v16h-3v-7h-8v7H9z" fill="#ffffff"/>
+</svg>

--- a/examples/swiss-dashboard/templates/404.html
+++ b/examples/swiss-dashboard/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main" style="display: flex; align-items: center; min-height: 50vh;">
+    <div class="metric-card" style="max-width: 600px; margin: 0 auto; border-top-color: var(--primary); width: 100%;">
+      <h1 class="metric-value" style="font-size: 6rem; margin-bottom: 0; color: var(--primary);">404</h1>
+      <h2 class="metric-label" style="font-size: 1.4rem; margin-bottom: 1.5rem;">CRITICAL ADDRESS FAULT: DIRECTORY NOT FOUND</h2>
+      <p style="margin-bottom: 2.5rem; font-family: var(--mono-font); font-size: 0.9rem;">The sector coordinate requested was not compiled into our static file system hierarchy.</p>
+      <a href="{{ base_url }}/" class="btn-main" style="align-self: flex-start;">Return to Root overview</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/swiss-dashboard/templates/footer.html
+++ b/examples/swiss-dashboard/templates/footer.html
@@ -1,0 +1,9 @@
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} Swiss Design & Telemetry Studio.</p>
+      <p style="text-align: right;">Compiled with <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/swiss-dashboard/templates/header.html
+++ b/examples/swiss-dashboard/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+
+  <!-- Bespoke Swiss Dashboard stylesheet -->
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">SWISS<span>.db</span></a>
+      <nav>
+        <a href="{{ base_url }}/">Overview</a>
+        <a href="{{ base_url }}/posts/">Diagnostics</a>
+        <a href="{{ base_url }}/about/">Manifesto</a>
+      </nav>
+    </header>

--- a/examples/swiss-dashboard/templates/page.html
+++ b/examples/swiss-dashboard/templates/page.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="post-wrapper">
+      <aside class="post-sidebar">
+        <div>
+          <h3>Published</h3>
+          {% if page.date is present %}
+            <p>{{ page.date | date("%Y-%m-%d") }}</p>
+          {% else %}
+            <p>Undated</p>
+          {% endif %}
+        </div>
+        
+        <div>
+          <h3>Domain Sector</h3>
+          <p>{{ page.section | upper }}</p>
+        </div>
+
+        {% if page.tags is present %}
+          <div style="margin-top: 2rem;">
+            <h3>Index Tags</h3>
+            <div class="badge-container">
+              {% for tag in page.tags %}
+                <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="badge">#{{ tag }}</a>
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
+      </aside>
+
+      <div>
+        {% if page.title is present %}
+          <h1 class="post-title">{{ page.title | e }}</h1>
+        {% endif %}
+        
+        <div class="prose">
+          {{ content | safe }}
+        </div>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/swiss-dashboard/templates/section.html
+++ b/examples/swiss-dashboard/templates/section.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel-left-block" style="border-right: none; margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Diagnostic Reports & <span>Telemetry Logs</span></h1>
+        <span class="indicator-badge indicator-red">MONITOR_LOGS</span>
+      </div>
+      
+      {% if page.description is present %}
+        <p style="margin-bottom: 3rem; font-weight: 400;">{{ page.description | e }}</p>
+      {% endif %}
+
+      <div class="log-list">
+        {% for post in section.pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>DATE: {{ post.date | date("%Y-%m-%d") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— CLASSIFICATION: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">Access Report</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/swiss-dashboard/templates/shortcodes/alert.html
+++ b/examples/swiss-dashboard/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/swiss-dashboard/templates/taxonomy.html
+++ b/examples/swiss-dashboard/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel-left-block" style="border-right: none; margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Active Index Registers: {{ taxonomy_name | e }}</h1>
+        <span class="indicator-badge indicator-red">INDEX_CATALOG</span>
+      </div>
+
+      <div class="badge-container" style="gap: 1.5rem; padding: 1.5rem 0;">
+        {% for term in taxonomy_terms %}
+          <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term.name | slugify }}/" class="badge" style="font-size: 1.1rem; padding: 0.5rem 1rem;">
+            #{{ term.name | upper }} ({{ term.pages | length }})
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/swiss-dashboard/templates/taxonomy_term.html
+++ b/examples/swiss-dashboard/templates/taxonomy_term.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="panel-left-block" style="border-right: none; margin-bottom: 3.5rem;">
+      <div class="panel-header">
+        <h1 class="panel-title">Buffer Archive: <span>#{{ taxonomy_term | e }}</span></h1>
+        <span class="indicator-badge indicator-red">FILTERED_CHANNEL</span>
+      </div>
+
+      <div class="log-list">
+        {% for post in taxonomy_pages %}
+          <div class="log-item">
+            <div class="log-info">
+              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <div class="log-meta">
+                {% if post.date is present %}
+                  <span>DATE: {{ post.date | date("%Y-%m-%d") }}</span>
+                {% endif %}
+                {% if post.tags is present %}
+                  <span>— CLASSIFICATION: {{ post.tags | join(", ") }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <a href="{{ post.url }}" class="log-action">Access Report</a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9052,5 +9052,35 @@
     "blog",
     "minimal",
     "editorial"
+  ],
+  "brutal-dashboard": [
+    "light",
+    "dashboard",
+    "minimal",
+    "retro"
+  ],
+  "luxury-dashboard": [
+    "light",
+    "dashboard",
+    "minimal",
+    "elegant"
+  ],
+  "cyber-dashboard": [
+    "dark",
+    "dashboard",
+    "minimal",
+    "cyberpunk"
+  ],
+  "swiss-dashboard": [
+    "light",
+    "dashboard",
+    "minimal",
+    "traditional"
+  ],
+  "bauhaus-dashboard": [
+    "light",
+    "dashboard",
+    "minimal",
+    "editorial"
   ]
 }


### PR DESCRIPTION
This PR adds 5 brand new, highly curated, trendy static dashboards designed from scratch using Hwaro with Vanilla CSS:

1. **Brutalist Dashboard (`brutal-dashboard`)** - A high-contrast Neo-Brutalist telemetry console.
2. **Luxury Dashboard (`luxury-dashboard`)** - A spacious, minimal, quiet-luxury financial dashboard.
3. **Cyber Dashboard (`cyber-dashboard`)** - A glassmorphic dark cybersecurity Operations command center.
4. **Swiss Dashboard (`swiss-dashboard`)** - A typographic, asymmetric grid studio overview.
5. **Bauhaus Dashboard (`bauhaus-dashboard`)** - A modular modernist telemetry page.

### Key Enhancements & Fixes Included:
- **CommonMark HTML Code Block Exposure Bug Fixed:** Corrected the 4-space indentation issue on the homepage of `bauhaus-dashboard` (and verified the others) so that HTML tags render natively as layout elements instead of raw text code blocks.
- **Flat Deployment URL Audits:** Verified that all assets and navigation in templates rely correctly on `{{ base_url }}` to resolve perfectly at flat subdirectories like `https://examples.hwaro.hahwul.com/<site-name>/` without hitting 404s.
- **Strict Guidelines Followed:** Fully compliant with all guidelines (absolutely no gradients in color schemes, and absolutely zero emojis in templates or content).