### PR TITLE
Fix 404 taxonomy link in examples/polaroid

### DIFF
--- a/examples/polaroid/content/tags/_index.md
+++ b/examples/polaroid/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+description = "All tags"
++++


### PR DESCRIPTION
Fix 404 taxonomy link in examples/polaroid

Added the missing content/tags/_index.md file to the polaroid example, which resolves the 404 error when navigating to /tags/.

---
*PR created automatically by Jules for task [3695790875329480759](https://jules.google.com/task/3695790875329480759) started by @hahwul*