### PR TITLE
Fix 404 links in nexus-docs example

### DIFF
--- a/examples/nexus-docs/content/getting-started/configuration.md
+++ b/examples/nexus-docs/content/getting-started/configuration.md
@@ -33,4 +33,4 @@ enabled = true
 
 ## Full Reference
 
-See the [Configuration Reference](/reference/config.html) for all available options.
+See the [Configuration Reference](/reference/config/) for all available options.

--- a/examples/nexus-docs/content/getting-started/installation.md
+++ b/examples/nexus-docs/content/getting-started/installation.md
@@ -28,4 +28,4 @@ You should see the version number if Hwaro is installed correctly.
 
 ## Next Steps
 
-Once installed, proceed to the [Quick Start](/getting-started/quick-start.html) guide.
+Once installed, proceed to the [Quick Start](/getting-started/quick-start/) guide.

--- a/examples/nexus-docs/content/getting-started/quick-start.md
+++ b/examples/nexus-docs/content/getting-started/quick-start.md
@@ -42,5 +42,5 @@ Visit `http://localhost:3000` to see your site.
 
 ## Next Steps
 
-- Read about [Configuration](/getting-started/configuration.html)
-- Learn about [Content Management](/guide/content-management.html)
+- Read about [Configuration](/getting-started/configuration/)
+- Learn about [Content Management](/guide/content-management/)

--- a/examples/nexus-docs/content/guide/content-management.md
+++ b/examples/nexus-docs/content/guide/content-management.md
@@ -42,7 +42,7 @@ Sections are directories containing related content. Each section should have an
 Link to other pages using relative paths:
 
 ```markdown
-[Installation](/getting-started/installation.html)
+[Installation](/getting-started/installation/)
 ```
 
 ## Images


### PR DESCRIPTION
Fixes 404 broken links in the `nexus-docs` example site by updating markdown `.html` links to use proper directory-style trailing slashes.

---
*PR created automatically by Jules for task [2337798977420550141](https://jules.google.com/task/2337798977420550141) started by @hahwul*