### PR TITLE
Add 10 bold, original documentation themes

### DIFF
--- a/examples/card-catalog/AGENTS.md
+++ b/examples/card-catalog/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for the Card Catalog theme (Hwaro Site)
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/card-catalog/archetypes/default.md
+++ b/examples/card-catalog/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/card-catalog/config.toml
+++ b/examples/card-catalog/config.toml
@@ -1,0 +1,197 @@
+title = "Card Catalog"
+description = "A mid-century library card-catalog documentation theme. Manila cards, oak drawers, brass pulls, and a rubber stamp for the date."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/card-catalog/content/about.md
+++ b/examples/card-catalog/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "About"
+description = "About Card Catalog, the choices behind it, and where to file your suggestions."
+date = "2026-04-01"
++++
+
+Card Catalog is a documentation theme that borrows its look from a mid-century reference room and its information architecture from the people who actually ran one. Every page is an index card. Every section is a drawer. The cabinet is oak, the cards are manila, and the date in the corner was applied with a rubber stamp.
+
+It is unapologetically tactile. The grain is faint but present, the brass pulls catch a hint of light, and the headings are typed, not set. The goal is documentation that feels like something you can hold.
+
+## The choices we have made
+
+- Manila card stock, oak-brown frames, typewriter ink, and one oxblood stamp. Four colors, no more.
+- Solid fills only. Every surface is a flat color, a border, or a soft shadow.
+- A typewriter mono for catalog metadata and a workhorse serif for the prose you actually read.
+- Two font families, both served from Google Fonts, both legible at small sizes.
+
+## What this is not
+
+This is not a marketing theme. There is no carousel, no testimonial wall, and no animation that fires on scroll. The drawers do not bounce. The cards do not flip. They sit where you filed them.
+
+## License
+
+MIT. Use it, fork it, refile it, and send improvements upstream.

--- a/examples/card-catalog/content/docs/_index.md
+++ b/examples/card-catalog/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The reference drawer: installation, configuration, and the day-to-day workflow, each filed on its own card."
+sort_by = "weight"
++++

--- a/examples/card-catalog/content/docs/cli.md
+++ b/examples/card-catalog/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "Every command, every flag, and the one or two you actually need every day."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose. Install it once with `brew install hahwul/hwaro/hwaro`, then everything below is a single subcommand away.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name> --scaffold docs` | Scaffold a new documentation site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/card-catalog/content/docs/configuration.md
+++ b/examples/card-catalog/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "Every setting in config.toml, what it does, and the smallest sensible default."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/card-catalog/content/docs/installation.md
+++ b/examples/card-catalog/content/docs/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
+description = "Three commands from an empty folder to a live preview. Pick how strict you want the config and pull the drawer."
+weight = 1
+date = "2026-05-01"
++++
+
+Card Catalog runs on the Hwaro static site generator. You can install it from Homebrew, run it under Docker, or build it from source.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve --open
+```
+
+The dev server will open `http://localhost:3000` in your browser. Any edit to `content/`, `templates/`, or `static/` reloads in under 50ms.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.0 or newer
+```
+
+If you see anything older, your package manager has cached an old version. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Move on to **Your first page**, where you will type up a single card, give it a template, and watch it file itself into the drawer.

--- a/examples/card-catalog/content/docs/sections-and-pages.md
+++ b/examples/card-catalog/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "How content is organized, how sections behave, and why _index.md is doing more than it looks."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/card-catalog/content/docs/taxonomies.md
+++ b/examples/card-catalog/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Tags, categories, and the occasional custom one. How to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/card-catalog/content/docs/template-filters.md
+++ b/examples/card-catalog/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A reference of the most useful template filters, with examples you can paste."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/card-catalog/content/docs/templates.md
+++ b/examples/card-catalog/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Jinja-flavored templates, where to put them, and the small set of globals you can count on."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/card-catalog/content/docs/your-first-page.md
+++ b/examples/card-catalog/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "A small walkthrough that ends with a rendered page and the satisfaction of a green build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/card-catalog/content/guides/_index.md
+++ b/examples/card-catalog/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "The recipe drawer: longer walkthroughs for real situations and the occasional misfiled edge case."
+sort_by = "weight"
++++

--- a/examples/card-catalog/content/guides/build-pipeline.md
+++ b/examples/card-catalog/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "What happens between hwaro build and public/, in seven readable phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/card-catalog/content/guides/deploying.md
+++ b/examples/card-catalog/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Cookbook entries for GitHub Pages, Cloudflare Pages, and a Bash script for the rest of you."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/card-catalog/content/guides/i18n.md
+++ b/examples/card-catalog/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/card-catalog/content/index.md
+++ b/examples/card-catalog/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Card Catalog"
+description = "A mid-century library card-catalog documentation theme. Manila cards, oak drawers, brass pulls, and a rubber stamp for the date."
+template = "home"
++++

--- a/examples/card-catalog/static/css/style.css
+++ b/examples/card-catalog/static/css/style.css
@@ -1,0 +1,935 @@
+/* =============================================================================
+   CARD CATALOG — a mid-century library card-catalog documentation theme.
+   Browsing docs like wooden drawers of index cards.
+   Palette: manila/buff card stock, oak-brown frame, typewriter ink, oxblood.
+   Solid fills only: flat color, borders, box-shadow, outline, solid-color SVG.
+   ========================================================================== */
+
+:root {
+  /* --- palette ------------------------------------------------------------ */
+  --card:        #efe7d6;   /* manila / buff card stock */
+  --card-edge:   #e3d8bf;   /* darker stock for ruled lines & shadows */
+  --card-aged:   #e7ddc6;   /* slightly aged stock */
+  --oak:         #5b4a32;   /* oak-brown cabinet frame */
+  --oak-dark:    #3f3220;   /* deep grain shadow */
+  --oak-light:   #6f5a3c;   /* lighter oak edge */
+  --ink:         #2b2620;   /* typewriter ink */
+  --ink-soft:    #5b5244;   /* faded carbon impression */
+  --oxblood:     #9c3b2e;   /* rubber-stamp oxblood red */
+  --oxblood-dk:  #7c2c20;
+  --brass:       #b08a3e;   /* drawer pull plate */
+  --brass-dk:    #8a6a28;
+  --brass-lt:    #c8a558;
+  --paper-bg:    #ddd0b4;   /* cabinet backing / wall */
+  --label-cream: #f6f0e2;   /* engraved label cream */
+
+  /* --- type --------------------------------------------------------------- */
+  --mono: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  --serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+
+  /* --- spacing ------------------------------------------------------------ */
+  --u: 8px;
+  --radius: 3px;
+  --maxw: 1180px;
+
+  /* --- shadow ------------------------------------------------------------- */
+  --lift: 0 2px 0 var(--card-edge), 0 6px 14px rgba(43, 38, 32, 0.16);
+  --lift-hi: 0 3px 0 var(--brass-dk), 0 12px 26px rgba(43, 38, 32, 0.26);
+  --inset: inset 0 0 0 1px rgba(91, 74, 50, 0.25);
+}
+
+/* =============================================================================
+   RESET & BASE
+   ========================================================================== */
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.7;
+  color: var(--ink);
+  background-color: var(--paper-bg);
+  /* faint cabinet wood dot texture, solid-color SVG tile */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Crect width='40' height='40' fill='%23ddd0b4'/%3E%3Ccircle cx='6' cy='6' r='1' fill='%23cdbf9e'/%3E%3Ccircle cx='26' cy='22' r='1' fill='%23cdbf9e'/%3E%3C/svg%3E");
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--oxblood); text-decoration: none; }
+a:hover { color: var(--oxblood-dk); }
+
+img { max-width: 100%; height: auto; }
+
+::selection { background: var(--oxblood); color: var(--label-cream); }
+
+:focus-visible {
+  outline: 3px solid var(--oxblood);
+  outline-offset: 2px;
+}
+
+/* =============================================================================
+   TYPEWRITER HEADINGS — tracked letter-spacing + faint ink-impression shadow
+   ========================================================================== */
+
+h1, h2, h3, h4, h5 {
+  font-family: var(--mono);
+  color: var(--ink);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.25;
+  text-shadow: 0.5px 0.5px 0 rgba(43, 38, 32, 0.18);
+}
+
+/* =============================================================================
+   TOP BAR — the cabinet header rail
+   ========================================================================== */
+
+.bar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--oak);
+  border-bottom: 4px solid var(--oak-dark);
+  box-shadow: 0 2px 0 var(--oak-light) inset, 0 4px 10px rgba(43, 38, 32, 0.3);
+}
+
+.bar-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 24px;
+  height: 66px;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 0.06em;
+  color: var(--label-cream);
+  text-transform: uppercase;
+}
+.brand:hover { color: #fff; }
+
+/* punched-card hole mark next to brand */
+.brand .mark {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--oak-dark);
+  border: 2px solid var(--brass-lt);
+  box-shadow: inset 0 0 0 2px var(--oak);
+  flex: 0 0 auto;
+}
+
+.search {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--card);
+  border: 2px solid var(--oak-dark);
+  border-radius: var(--radius);
+  padding: 5px 10px;
+  box-shadow: var(--inset);
+}
+.search input {
+  border: 0;
+  background: transparent;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--ink);
+  width: 180px;
+  outline: none;
+}
+.search input::placeholder { color: #8a7f6c; }
+.search .kbd {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--oak);
+  border: 1px solid var(--oak);
+  border-radius: 2px;
+  padding: 1px 5px;
+}
+
+.bar nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.bar nav a {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: var(--label-cream);
+  padding: 7px 12px;
+  border-radius: 2px;
+  text-transform: uppercase;
+}
+.bar nav a:hover { background: var(--oak-dark); color: #fff; }
+.bar nav a.cta {
+  background: var(--brass);
+  color: var(--oak-dark);
+  border: 2px solid var(--brass-dk);
+  font-weight: 600;
+  box-shadow: inset 0 1px 0 var(--brass-lt);
+}
+.bar nav a.cta:hover { background: var(--brass-lt); color: var(--oak-dark); }
+
+/* =============================================================================
+   HOMEPAGE HERO — the catalog plate
+   ========================================================================== */
+
+.hero {
+  max-width: var(--maxw);
+  margin: 44px auto 0;
+  padding: 0 24px;
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 40px;
+  align-items: start;
+}
+
+.hero .copy {
+  background: var(--card);
+  border: 3px solid var(--oak);
+  border-radius: var(--radius);
+  padding: 38px 36px;
+  box-shadow: var(--lift);
+  position: relative;
+}
+/* stamped corner index tab */
+.hero .copy::before {
+  content: "Nº 000.1";
+  position: absolute;
+  top: -14px;
+  left: 28px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--label-cream);
+  background: var(--oxblood);
+  border: 2px solid var(--oxblood-dk);
+  padding: 3px 10px;
+  border-radius: 2px;
+  box-shadow: 0 2px 0 var(--oxblood-dk);
+}
+
+.hero h1 {
+  font-size: clamp(30px, 4.2vw, 46px);
+  margin: 6px 0 16px;
+  letter-spacing: 0.01em;
+}
+.hero h1 .stamp {
+  color: var(--oxblood);
+  text-shadow: 0.5px 0.5px 0 rgba(124, 44, 32, 0.3);
+}
+
+.hero .deck {
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.65;
+  color: #4a4236;
+  margin: 0 0 24px;
+}
+
+.cta-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+.cta-row a {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  padding: 11px 18px;
+  border-radius: var(--radius);
+  border: 2px solid var(--oak);
+  color: var(--ink);
+  background: var(--card-aged);
+}
+.cta-row a:hover { background: var(--card-edge); }
+.cta-row a.primary {
+  background: var(--oxblood);
+  color: var(--label-cream);
+  border-color: var(--oxblood-dk);
+  box-shadow: 0 2px 0 var(--oxblood-dk);
+}
+.cta-row a.primary:hover { background: var(--oxblood-dk); color: #fff; }
+.cta-row a.kbd {
+  border-style: dashed;
+  color: var(--oak);
+  background: transparent;
+}
+
+/* --- the drawer wall ----------------------------------------------------- */
+.drawers {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  background: var(--oak);
+  border: 4px solid var(--oak-dark);
+  border-radius: 4px;
+  padding: 14px;
+  box-shadow: var(--lift), inset 0 0 0 2px var(--oak-light);
+}
+
+.drawer {
+  background: var(--card-aged);
+  border: 2px solid var(--oak-dark);
+  border-radius: var(--radius);
+  padding: 16px 14px 38px;
+  position: relative;
+  min-height: 92px;
+  box-shadow: inset 0 2px 0 #f7f0df, inset 0 -3px 0 var(--card-edge);
+}
+.drawer .face {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--oak);
+}
+.drawer .range {
+  font-family: var(--mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: 0.06em;
+  margin-top: 2px;
+}
+/* brass drawer pull — solid color plate + inset border */
+.drawer .pull {
+  position: absolute;
+  left: 50%;
+  bottom: 9px;
+  transform: translateX(-50%);
+  width: 46px;
+  height: 16px;
+  background: var(--brass);
+  border: 2px solid var(--brass-dk);
+  border-radius: 8px;
+  box-shadow: inset 0 1px 0 var(--brass-lt), inset 0 -2px 0 var(--brass-dk);
+}
+.drawer .pull::after {
+  content: "";
+  position: absolute;
+  inset: 4px 12px;
+  border: 1px solid var(--brass-dk);
+  border-radius: 3px;
+}
+
+/* =============================================================================
+   HOMEPAGE CATALOG ROWS — section shortcuts as catalog cards
+   ========================================================================== */
+
+.cats {
+  max-width: var(--maxw);
+  margin: 56px auto 0;
+  padding: 0 24px;
+}
+.cats-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  border-bottom: 3px double var(--oak);
+  padding-bottom: 10px;
+  margin-bottom: 22px;
+}
+.cats-head h2 {
+  font-size: 16px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin: 0;
+  color: var(--oak);
+}
+.cats-head .note {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: #8a7f6c;
+  margin-left: auto;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 22px;
+}
+
+/* =============================================================================
+   THE CATALOG CARD — signature component
+   ruled lines (solid-color SVG bg), call number, punched hole, stamp label
+   ========================================================================== */
+
+.cat {
+  display: block;
+  position: relative;
+  background-color: var(--card);
+  /* faint ruled lines — solid-color SVG tile, one hairline per row */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='30'%3E%3Crect width='4' height='30' fill='%23efe7d6'/%3E%3Crect y='29' width='4' height='1' fill='%23d8cbac'/%3E%3C/svg%3E");
+  background-position: 0 64px;
+  border: 2px solid var(--oak);
+  border-radius: var(--radius);
+  padding: 22px 24px 46px;
+  min-height: 200px;
+  color: var(--ink);
+  box-shadow: var(--lift);
+  transition: transform 0.13s ease, box-shadow 0.13s ease, border-color 0.13s ease;
+}
+.cat:hover {
+  transform: translateY(-4px) rotate(-0.4deg);
+  box-shadow: var(--lift-hi);
+  border-color: var(--oxblood);
+  color: var(--ink);
+}
+.cat:focus-visible { transform: translateY(-4px); }
+
+/* Dewey-style call number, top-left, mono */
+.cat .call {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--oak);
+  border: 1.5px solid var(--oak);
+  border-radius: 2px;
+  padding: 2px 7px;
+  display: inline-block;
+  background: var(--card-aged);
+}
+
+.cat h3 {
+  font-size: 19px;
+  margin: 16px 0 8px;
+  letter-spacing: 0.02em;
+}
+.cat p {
+  font-family: var(--serif);
+  font-size: 15.5px;
+  line-height: 1.6;
+  color: #4a4236;
+  margin: 0;
+}
+.cat .read {
+  position: absolute;
+  left: 24px;
+  bottom: 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--oxblood);
+  text-transform: uppercase;
+}
+.cat:hover .read { color: var(--oxblood-dk); }
+
+/* punched hole — bordered circle, bottom-center */
+.cat::after {
+  content: "";
+  position: absolute;
+  bottom: 9px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--paper-bg);
+  border: 2px solid var(--oak);
+  box-shadow: inset 0 1px 2px rgba(43, 38, 32, 0.4);
+}
+
+/* rotated rubber-stamp category/date label — oxblood, double-bordered */
+.stamp-label {
+  position: absolute;
+  top: 16px;
+  right: 14px;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  border: 2px solid var(--oxblood);
+  outline: 1px solid var(--oxblood);
+  outline-offset: 2px;
+  padding: 4px 9px;
+  border-radius: 2px;
+  transform: rotate(-7deg);
+  background: transparent;
+  opacity: 0.85;
+}
+
+/* =============================================================================
+   HOMEPAGE METRICS — catalog stat cards
+   ========================================================================== */
+
+.metrics {
+  max-width: var(--maxw);
+  margin: 56px auto 70px;
+  padding: 0 24px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+}
+.m {
+  background: var(--card);
+  border: 2px solid var(--oak);
+  border-radius: var(--radius);
+  padding: 20px;
+  text-align: center;
+  box-shadow: var(--lift);
+}
+.m .v {
+  font-family: var(--mono);
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+}
+.m .v.red { color: var(--oxblood); }
+.m .v.brass { color: var(--brass-dk); }
+.m .k {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a7f6c;
+  margin-top: 6px;
+}
+
+/* =============================================================================
+   DOC SHELL — sidebar + main + toc
+   ========================================================================== */
+
+.shell {
+  max-width: var(--maxw);
+  margin: 32px auto 70px;
+  padding: 0 24px;
+  display: grid;
+  grid-template-columns: 248px minmax(0, 1fr) 200px;
+  gap: 36px;
+  align-items: start;
+}
+
+/* =============================================================================
+   SIDEBAR — a stack of drawer labels with brass pull plates
+   ========================================================================== */
+
+.sidebar {
+  position: sticky;
+  top: 90px;
+  background: var(--oak);
+  border: 3px solid var(--oak-dark);
+  border-radius: 4px;
+  padding: 14px 12px;
+  box-shadow: var(--lift), inset 0 0 0 2px var(--oak-light);
+}
+
+.sidebar h4 {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--oak-dark);
+  margin: 0;
+  padding: 9px 12px;
+  background: var(--brass);
+  border: 2px solid var(--brass-dk);
+  border-radius: var(--radius);
+  box-shadow: inset 0 1px 0 var(--brass-lt), inset 0 -2px 0 var(--brass-dk);
+  text-shadow: none;
+  position: relative;
+}
+/* small drawer-pull notch on each label */
+.sidebar h4::after {
+  content: "";
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 8px;
+  border: 1.5px solid var(--brass-dk);
+  border-radius: 4px;
+  background: var(--brass-lt);
+}
+.sidebar h4:not(:first-child) { margin-top: 14px; }
+
+.sidebar ul {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 6px 4px;
+  background: var(--card-aged);
+  border: 2px solid var(--oak-dark);
+  border-top: 0;
+  border-radius: 0 0 var(--radius) var(--radius);
+}
+.sidebar li { margin: 0; }
+.sidebar li a {
+  display: block;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  padding: 6px 10px;
+  border-left: 3px solid transparent;
+  border-radius: 2px;
+}
+.sidebar li a:hover {
+  background: var(--card-edge);
+  border-left-color: var(--oxblood);
+  color: var(--oxblood-dk);
+}
+
+/* =============================================================================
+   MAIN COLUMN
+   ========================================================================== */
+
+.main {
+  background: var(--card);
+  border: 3px solid var(--oak);
+  border-radius: var(--radius);
+  padding: 36px 40px 44px;
+  box-shadow: var(--lift);
+  min-width: 0;
+}
+
+.crumb {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: #8a7f6c;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--card-edge);
+  padding-bottom: 12px;
+}
+.crumb .accent { color: var(--oxblood); font-weight: 700; }
+.crumb a { color: var(--oak); }
+.crumb a:hover { color: var(--oxblood); }
+.crumb span { color: var(--ink); }
+
+.main > h1 {
+  font-size: clamp(26px, 3.4vw, 36px);
+  margin: 0 0 10px;
+  letter-spacing: 0.01em;
+}
+.main > .deck {
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.6;
+  color: #4a4236;
+  margin: 0 0 26px;
+  padding-left: 14px;
+  border-left: 3px solid var(--oxblood);
+}
+
+/* =============================================================================
+   .content — PROSE (style EVERYTHING)
+   ========================================================================== */
+
+.content { font-family: var(--serif); }
+
+.content h2 {
+  font-size: 24px;
+  margin: 38px 0 14px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--oak);
+  letter-spacing: 0.02em;
+}
+.content h2::before {
+  content: "\00A7 ";
+  color: var(--oxblood);
+  font-weight: 700;
+}
+.content h3 {
+  font-size: 19px;
+  margin: 28px 0 10px;
+  color: var(--oak-dark);
+}
+.content h4 {
+  font-size: 16px;
+  margin: 22px 0 8px;
+  color: var(--oak);
+}
+
+.content p { margin: 0 0 16px; }
+
+.content a {
+  color: var(--oxblood);
+  border-bottom: 1px solid var(--oxblood);
+  font-weight: 500;
+}
+.content a:hover {
+  color: var(--oxblood-dk);
+  border-bottom-width: 2px;
+}
+
+.content strong { color: var(--ink); font-weight: 700; }
+.content em { color: var(--oak-dark); }
+
+.content ul, .content ol { margin: 0 0 18px; padding-left: 22px; }
+.content li { margin: 6px 0; }
+.content ul li::marker { color: var(--oxblood); }
+.content ol li::marker { color: var(--oak); font-family: var(--mono); }
+
+/* blockquote — a clipped reference slip */
+.content blockquote {
+  margin: 22px 0;
+  padding: 14px 20px;
+  background: var(--card-aged);
+  border: 1px solid var(--card-edge);
+  border-left: 4px solid var(--oxblood);
+  border-radius: var(--radius);
+  font-style: italic;
+  color: #4a4236;
+}
+.content blockquote p:last-child { margin-bottom: 0; }
+
+/* inline code — a little typewriter chip */
+.content code {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--card-aged);
+  border: 1px solid var(--card-edge);
+  border-radius: 2px;
+  padding: 1px 5px;
+  color: var(--oxblood-dk);
+}
+
+/* code blocks — carbon-copy slip */
+.content pre {
+  margin: 22px 0;
+  padding: 18px 20px;
+  background: var(--ink);
+  border: 2px solid var(--oak-dark);
+  border-radius: var(--radius);
+  overflow-x: auto;
+  box-shadow: inset 0 0 0 1px rgba(176, 138, 62, 0.25), 0 3px 0 var(--oak-dark);
+}
+.content pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: #e7ddc6;
+  font-size: 13.5px;
+  line-height: 1.7;
+}
+
+/* tables — a ledger */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 22px 0;
+  font-size: 15px;
+  border: 2px solid var(--oak);
+}
+.content th {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-align: left;
+  background: var(--oak);
+  color: var(--label-cream);
+  padding: 10px 14px;
+}
+.content td {
+  padding: 10px 14px;
+  border-top: 1px solid var(--card-edge);
+  vertical-align: top;
+}
+.content tbody tr:nth-child(even) { background: var(--card-aged); }
+.content td code { white-space: nowrap; }
+
+.content hr {
+  border: 0;
+  border-top: 2px dashed var(--oak);
+  margin: 34px 0;
+}
+
+.content img {
+  border: 2px solid var(--oak);
+  border-radius: var(--radius);
+  box-shadow: var(--lift);
+}
+
+/* =============================================================================
+   PAGER — two filing cards
+   ========================================================================== */
+
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 42px;
+  padding-top: 24px;
+  border-top: 3px double var(--oak);
+}
+.pager .b {
+  display: block;
+  background: var(--card-aged);
+  border: 2px solid var(--oak);
+  border-radius: var(--radius);
+  padding: 14px 18px;
+  color: var(--ink);
+  box-shadow: var(--lift);
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+.pager .b:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--lift-hi);
+  border-color: var(--oxblood);
+}
+.pager .b.next { text-align: right; }
+.pager .k {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+}
+.pager .t {
+  font-family: var(--mono);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+  margin-top: 4px;
+}
+
+/* =============================================================================
+   TOC — index tab rail
+   ========================================================================== */
+
+.toc {
+  position: sticky;
+  top: 90px;
+  font-size: 13px;
+}
+.toc h5 {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--oak);
+  margin: 0 0 10px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--oak);
+}
+.toc ul { list-style: none; margin: 0; padding: 0; }
+.toc li { margin: 0; }
+.toc a {
+  display: block;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: #6b6151;
+  padding: 4px 0 4px 12px;
+  border-left: 2px solid var(--card-edge);
+}
+.toc a:hover {
+  color: var(--oxblood);
+  border-left-color: var(--oxblood);
+}
+.toc ul ul { padding-left: 12px; }
+
+/* =============================================================================
+   404
+   ========================================================================== */
+
+.notfound {
+  max-width: 720px;
+  margin: 70px auto;
+  padding: 0 24px;
+  text-align: center;
+}
+.notfound .plate {
+  background: var(--card);
+  border: 3px solid var(--oak);
+  border-radius: var(--radius);
+  padding: 50px 40px;
+  box-shadow: var(--lift);
+  position: relative;
+}
+.notfound .miss {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  border: 2px solid var(--oxblood);
+  outline: 1px solid var(--oxblood);
+  outline-offset: 3px;
+  padding: 6px 14px;
+  transform: rotate(-5deg);
+  margin-bottom: 26px;
+}
+.notfound h1 { font-size: 64px; margin: 0 0 12px; letter-spacing: 0.06em; }
+.notfound .deck { font-size: 18px; color: #4a4236; }
+.notfound .deck a {
+  color: var(--oxblood);
+  border-bottom: 1px solid var(--oxblood);
+}
+
+/* =============================================================================
+   FOOTER — the cabinet plinth
+   ========================================================================== */
+
+.foot {
+  background: var(--oak);
+  border-top: 4px solid var(--oak-dark);
+  box-shadow: 0 2px 0 var(--oak-light) inset;
+  color: var(--card-aged);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.03em;
+  padding: 26px 24px;
+  text-align: center;
+}
+.foot div { margin: 3px 0; }
+.foot strong { color: var(--label-cream); letter-spacing: 0.06em; }
+.foot a { color: var(--brass-lt); }
+.foot a:hover { color: #fff; }
+
+/* =============================================================================
+   RESPONSIVE — one column under ~860px
+   ========================================================================== */
+
+@media (max-width: 1040px) {
+  .shell { grid-template-columns: 220px minmax(0, 1fr); }
+  .toc { display: none; }
+}
+
+@media (max-width: 860px) {
+  body { font-size: 16px; }
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 26px;
+    margin-top: 28px;
+  }
+  .hero .copy { padding: 30px 24px; }
+  .shell {
+    grid-template-columns: 1fr;
+    gap: 22px;
+    margin-top: 22px;
+  }
+  .sidebar { position: static; top: auto; }
+  .main { padding: 26px 22px 32px; }
+  .metrics { grid-template-columns: repeat(2, 1fr); }
+  .card-grid { grid-template-columns: 1fr; }
+  .bar-inner { gap: 12px; }
+  .search { display: none; }
+  .bar nav a { padding: 6px 9px; font-size: 12px; }
+  .pager { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 520px) {
+  .bar-inner { height: 58px; }
+  .brand { font-size: 15px; }
+  .drawers { grid-template-columns: 1fr; }
+  .metrics { grid-template-columns: 1fr; }
+  .cta-row a { width: 100%; text-align: center; }
+}

--- a/examples/card-catalog/templates/404.html
+++ b/examples/card-catalog/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+<section class="notfound">
+  <div class="plate">
+    <span class="miss">Card not in file</span>
+    <h1>404</h1>
+    <p class="deck">This card was misfiled, weeded, or never typed up. Pull a drawer from the <a href="{{ base_url }}/docs/">documentation</a> or return to the <a href="{{ base_url }}/">card catalog</a>.</p>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/card-catalog/templates/_sidebar.html
+++ b/examples/card-catalog/templates/_sidebar.html
@@ -1,0 +1,28 @@
+<aside class="sidebar">
+  <h4>Drawer 001 &middot; Start Here</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+    <li><a href="{{ base_url }}/docs/your-first-page/">Your first page</a></li>
+    <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+  </ul>
+
+  <h4>Drawer 120 &middot; Concepts</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a></li>
+    <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+    <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+  </ul>
+
+  <h4>Drawer 410 &middot; Guides</h4>
+  <ul>
+    <li><a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a></li>
+    <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+    <li><a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a></li>
+  </ul>
+
+  <h4>Drawer 900 &middot; Reference</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/cli/">CLI reference</a></li>
+    <li><a href="{{ base_url }}/docs/template-filters/">Template filters</a></li>
+  </ul>
+</aside>

--- a/examples/card-catalog/templates/footer.html
+++ b/examples/card-catalog/templates/footer.html
@@ -1,0 +1,6 @@
+<footer class="foot">
+  <div><strong>{{ site.title }}</strong> &mdash; {{ site.description }}</div>
+  <div>(c) {{ current_year }} &middot; Filed under Hwaro &middot; Set in JetBrains Mono &amp; Source Serif 4</div>
+</footer>
+</body>
+</html>

--- a/examples/card-catalog/templates/header.html
+++ b/examples/card-catalog/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="mark"></span>{{ site.title }}</a>
+    <div class="search">
+      <input type="text" placeholder="Search the catalog..." />
+      <span class="kbd">Cmd K</span>
+    </div>
+    <nav>
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/guides/">Guides</a>
+      <a href="{{ base_url }}/about/">About</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/examples/card-catalog/templates/home.html
+++ b/examples/card-catalog/templates/home.html
@@ -1,0 +1,95 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <h1>Your docs, filed like a <span class="stamp">card catalog</span>.</h1>
+    <p class="deck">Card Catalog is a documentation theme that reads like a mid-century library: manila index cards, oak drawers, brass pulls, and a rubber stamp for the date. Every page is a card. Every section is a drawer. Pull one open and start browsing.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/installation/" class="primary">Open the cabinet</a>
+      <a href="{{ base_url }}/docs/">Browse the drawers</a>
+      <a class="kbd">$ brew install hahwul/hwaro/hwaro</a>
+    </div>
+  </div>
+  <div class="drawers">
+    <div class="drawer">
+      <div class="face">Drawer A&ndash;C</div>
+      <div class="range">001&ndash;099</div>
+      <div class="pull"></div>
+    </div>
+    <div class="drawer">
+      <div class="face">Drawer D&ndash;F</div>
+      <div class="range">100&ndash;199</div>
+      <div class="pull"></div>
+    </div>
+    <div class="drawer">
+      <div class="face">Drawer G&ndash;M</div>
+      <div class="range">200&ndash;399</div>
+      <div class="pull"></div>
+    </div>
+    <div class="drawer">
+      <div class="face">Drawer N&ndash;Z</div>
+      <div class="range">400&ndash;999</div>
+      <div class="pull"></div>
+    </div>
+  </div>
+</section>
+
+<section class="cats">
+  <div class="cats-head">
+    <h2>Most-requested cards</h2>
+    <span class="note">Sorted by circulation</span>
+  </div>
+  <div class="card-grid">
+    <a href="{{ base_url }}/docs/installation/" class="cat">
+      <span class="call">001.1 / INS</span>
+      <span class="stamp-label">Start here</span>
+      <h3>Installation</h3>
+      <p>Three commands from an empty folder to a live preview. Homebrew, source, or container &mdash; pick one and pull the drawer.</p>
+      <span class="read">Pull card</span>
+    </a>
+    <a href="{{ base_url }}/docs/sections-and-pages/" class="cat">
+      <span class="call">120.4 / SEC</span>
+      <span class="stamp-label">Concepts</span>
+      <h3>Sections &amp; pages</h3>
+      <p>How drawers and cards are organized, why <code>_index.md</code> earns its keep, and where each file lands in the cabinet.</p>
+      <span class="read">Pull card</span>
+    </a>
+    <a href="{{ base_url }}/docs/templates/" class="cat">
+      <span class="call">240.7 / TPL</span>
+      <span class="stamp-label">Concepts</span>
+      <h3>Templates</h3>
+      <p>Crinja templates, where they live, and the small set of globals you can always count on when typing up a card.</p>
+      <span class="read">Pull card</span>
+    </a>
+    <a href="{{ base_url }}/guides/build-pipeline/" class="cat">
+      <span class="call">410.2 / BLD</span>
+      <span class="stamp-label">Guide</span>
+      <h3>The build pipeline</h3>
+      <p>What happens between <code>hwaro build</code> and a finished <code>public/</code> drawer, walked through one readable phase at a time.</p>
+      <span class="read">Pull card</span>
+    </a>
+    <a href="{{ base_url }}/guides/i18n/" class="cat">
+      <span class="call">430.9 / I18</span>
+      <span class="stamp-label">Guide</span>
+      <h3>Internationalization</h3>
+      <p>Run the same cabinet in several languages. One default locale, one rule for fallbacks, no missing-card surprises.</p>
+      <span class="read">Pull card</span>
+    </a>
+    <a href="{{ base_url }}/guides/deploying/" class="cat">
+      <span class="call">450.5 / DEP</span>
+      <span class="stamp-label">Guide</span>
+      <h3>Deploying</h3>
+      <p>Catalog entries for GitHub Pages, Cloudflare Pages, and a plain shell script for everyone who keeps it simple.</p>
+      <span class="read">Pull card</span>
+    </a>
+  </div>
+</section>
+
+<section class="metrics">
+  <div class="m"><div class="v red">11</div><div class="k">Reference cards</div></div>
+  <div class="m"><div class="v">3</div><div class="k">Drawers filed</div></div>
+  <div class="m"><div class="v brass">2</div><div class="k">Type families</div></div>
+  <div class="m"><div class="v">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/card-catalog/templates/page.html
+++ b/examples/card-catalog/templates/page.html
@@ -1,0 +1,45 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb">
+      <span class="accent">&#9670;</span> Catalog /
+      {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a> /{% endif %}
+      <span>{{ page.title }}</span>
+    </div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b">
+        <div class="k">&larr; Previous card</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">Next card &rarr;</div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+  </main>
+  <aside class="toc">
+    <h5>On this card</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top of card</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/card-catalog/templates/section.html
+++ b/examples/card-catalog/templates/section.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">&#9670;</span> Catalog / <span>{{ section.title }}</span></div>
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+
+    <div class="cats-head" style="margin-top:24px;">
+      <h2>{{ section.pages | length }} cards on file</h2>
+      <span class="note">Drawer: {{ section.title }}</span>
+    </div>
+    <div class="card-grid">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <span class="call">{% if loop.index < 10 %}00{% else %}0{% endif %}{{ loop.index }}.{{ loop.index }} / CRD</span>
+        <span class="stamp-label">{{ section.title }}</span>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Pull card</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5>{{ section.pages | length }} cards filed</h5>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/card-catalog/templates/taxonomy.html
+++ b/examples/card-catalog/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">&#9670;</span> Catalog / <span>{{ taxonomy_name }}</span></div>
+    <h1>Subject index: {{ taxonomy_name }}</h1>
+    <div class="content">
+      <ul>
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term }}</a> &middot; {{ term.pages | length }} cards</li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/card-catalog/templates/taxonomy_term.html
+++ b/examples/card-catalog/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">&#9670;</span> Catalog / <a href="{{ base_url }}/tags/">tags</a> / <span>{{ taxonomy_term }}</span></div>
+    <h1>Subject: {{ taxonomy_term }}</h1>
+    <div class="card-grid" style="margin-top:24px;">
+    {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <span class="call">{% if loop.index < 10 %}00{% else %}0{% endif %}{{ loop.index }}.{{ loop.index }} / TAG</span>
+        <span class="stamp-label">{{ taxonomy_term }}</span>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Pull card</span>
+      </a>
+    {% endfor %}
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/constructivist/AGENTS.md
+++ b/examples/constructivist/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - Constructivist documentation theme (Hwaro)
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/constructivist/archetypes/default.md
+++ b/examples/constructivist/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/constructivist/config.toml
+++ b/examples/constructivist/config.toml
@@ -1,0 +1,197 @@
+title = "Constructivist"
+description = "A Russian Constructivist documentation theme — diagonal red bands, heavy condensed caps, and giant agitprop numerals over a calm reading column."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/constructivist/content/about.md
+++ b/examples/constructivist/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "About"
+description = "The thinking behind Constructivist — why the chrome shouts and the reading column stays calm."
+date = "2026-04-01"
++++
+
+Constructivist borrows the visual language of the Soviet avant-garde — Rodchenko's photomontage angles, El Lissitzky's red wedge, the heavy condensed lettering of the agitprop poster — and points it at a technical manual. The result is loud where it should be loud and quiet where it counts.
+
+## The idea
+
+A documentation theme has two competing jobs. It has to look like something — to have a point of view a reader remembers. And it has to disappear the moment someone is actually reading a paragraph about config files. Constructivist resolves that tension by putting all the energy in the chrome: the slanted red band across the hero, the giant rotated numerals bleeding off the page edge, the offset solid tabs in the sidebar. The reading column itself stays upright, generously spaced, and easy on the eye.
+
+## The choices we have made
+
+- One dominant red, used as a flat solid block — never blended, never a tint ramp.
+- Diagonals built from real rotation and clip-paths on solid shapes, so the angles are honest geometry, not a trick of shading.
+- Heavy condensed caps for display type, set at deliberate angles. Plain humanist body type for everything you actually read.
+- Hard black rules at full weight, because a Constructivist composition lives on its lines.
+
+## What this is not
+
+This is not a poster you stare at; it is a manual you work from. There is no scroll-jacking, no parallax, no animation that fires as you read. The kinetic tension is composed once, in CSS, and then it holds still so you can think.
+
+## License
+
+MIT. Use it, fork it, tilt it further, send improvements.

--- a/examples/constructivist/content/docs/_index.md
+++ b/examples/constructivist/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The working manual. Install the toolchain, write your first page, wire up the config, and learn the moving parts that turn markdown into a built site."
+sort_by = "weight"
++++

--- a/examples/constructivist/content/docs/cli.md
+++ b/examples/constructivist/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "The whole hwaro command surface — the four you run daily, the few you reach for occasionally, and the flags worth memorizing."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name>` | Scaffold a new site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/constructivist/content/docs/configuration.md
+++ b/examples/constructivist/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "The shape of config.toml — the minimum that gets you running, the handful of blocks you will actually add, and why base_url belongs in CI."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/constructivist/content/docs/installation.md
+++ b/examples/constructivist/content/docs/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
+description = "Get the toolchain on your machine and a running site in front of you in under a minute — Homebrew in, scaffold out, dev server live."
+weight = 1
+date = "2026-05-01"
++++
+
+Constructivist is a theme for the Hwaro static site generator. Install Hwaro from Homebrew, scaffold a docs site, and you are editing in seconds.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve --open
+```
+
+The dev server will open `http://localhost:3000` in your browser. Any edit to `content/`, `templates/`, or `static/` reloads in under 50ms.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.0 or newer
+```
+
+If you see anything older, your package manager has cached an old version. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Move on to **Your first page**, where you will write a single piece of content, give it a template, and watch it render.

--- a/examples/constructivist/content/docs/sections-and-pages.md
+++ b/examples/constructivist/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "The two-shape content model — sections and pages — how the tree maps to URLs, and the quiet power of _index.md."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/constructivist/content/docs/taxonomies.md
+++ b/examples/constructivist/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Group pages by a shared field — tags, authors, anything you name. How to declare a taxonomy and how to render its terms."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/constructivist/content/docs/template-filters.md
+++ b/examples/constructivist/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A paste-ready reference to the filters you reach for most — formatting single values and reshaping whole collections."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/constructivist/content/docs/templates.md
+++ b/examples/constructivist/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Where templates live, which ones Hwaro expects, and the small, dependable set of globals every template can reach for."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/constructivist/content/docs/your-first-page.md
+++ b/examples/constructivist/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "Author one markdown file, give it front matter, and run a build — from blank directory to rendered page in a single sitting."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/constructivist/content/guides/_index.md
+++ b/examples/constructivist/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "Worked procedures for the jobs that come up once the basics are behind you — the build pipeline end to end, multilingual content, and shipping to a real host."
+sort_by = "weight"
++++

--- a/examples/constructivist/content/guides/build-pipeline.md
+++ b/examples/constructivist/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "Follow a build all the way through — the seven ordered phases that turn a content tree into the files under public/."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/constructivist/content/guides/deploying.md
+++ b/examples/constructivist/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Ship the built output anywhere static files live — recipes for GitHub Pages, Cloudflare Pages, and a plain rsync script."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/constructivist/content/guides/i18n.md
+++ b/examples/constructivist/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Run a site in several languages without the usual traps — one default locale, one honest fallback rule, one naming convention."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/constructivist/content/index.md
+++ b/examples/constructivist/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Constructivist"
+description = "A Russian Constructivist documentation theme — diagonal red bands, heavy condensed caps, and giant agitprop numerals over a calm reading column."
+template = "home"
++++

--- a/examples/constructivist/static/css/style.css
+++ b/examples/constructivist/static/css/style.css
@@ -1,0 +1,955 @@
+/* =========================================================================
+   CONSTRUCTIVIST — a Russian Constructivist / agitprop documentation theme.
+   Solid blocks only. Diagonals come from transform:rotate and clip-path on
+   solid shapes — flat fills exclusively. Energy lives in the chrome; the
+   reading column stays upright and calm.
+   ========================================================================= */
+
+:root {
+  --paper:   #efe9df;   /* warm poster paper */
+  --paper-2: #e6dfd1;   /* deeper paper, panels */
+  --ink:     #141414;   /* heavy black */
+  --ink-2:   #2b2b2b;   /* soft black for body text */
+  --red:     #d51f1f;   /* the single dominant solid red */
+  --red-ink: #a81616;   /* darker red for hover states */
+  --steel:   #7d8895;   /* optional third — steel grey */
+  --steel-d: #5c6671;
+  --knock:   #f4efe6;   /* knockout white-ish on dark blocks */
+  --mute:    #6a6359;   /* muted label text on paper */
+  --line:    #141414;   /* hard rule color */
+  --code-bg: #e2dbcb;
+
+  --rule:    3px;       /* heavy rule weight */
+  --display: "Oswald", "Arial Narrow", sans-serif;
+  --black:   "Archivo Black", "Oswald", sans-serif;
+  --body:    "Inter", system-ui, sans-serif;
+  --mono:    "Space Mono", ui-monospace, monospace;
+
+  --maxcol:  74ch;      /* calm reading measure */
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink-2);
+  font-family: var(--body);
+  font-size: 16px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+a { color: inherit; text-decoration: none; }
+
+::selection { background: var(--red); color: var(--knock); }
+
+/* =========================================================================
+   TOP BAR
+   ========================================================================= */
+.bar {
+  border-bottom: var(--rule) solid var(--ink);
+  background: var(--paper);
+  position: sticky; top: 0; z-index: 40;
+}
+.bar-inner {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 26px;
+  border-right: var(--rule) solid var(--ink);
+}
+.brand .mark {
+  position: relative;
+  width: 26px; height: 26px;
+  background: var(--red);
+  transform: rotate(-12deg);
+  flex: none;
+}
+.brand .mark::after {
+  content: ""; position: absolute; inset: 0;
+  background: var(--ink);
+  clip-path: polygon(0 0, 100% 0, 0 100%);
+}
+.brand-name {
+  font-family: var(--black);
+  font-weight: 400;
+  font-size: 20px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.bar-nav { display: flex; }
+.bar-nav a {
+  display: flex; align-items: center;
+  padding: 0 24px;
+  border-left: var(--rule) solid var(--ink);
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink);
+  transition: background 110ms linear, color 110ms linear;
+}
+.bar-nav a:hover { background: var(--ink); color: var(--knock); }
+.bar-nav a.cta { background: var(--red); color: var(--knock); }
+.bar-nav a.cta:hover { background: var(--ink); color: var(--knock); }
+
+/* =========================================================================
+   HERO — diagonal red band + heavy caps + giant numeral
+   ========================================================================= */
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-bottom: var(--rule) solid var(--ink);
+  padding: 96px 56px 84px;
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+}
+/* slanted red band — a solid block rotated across the hero */
+.hero-band {
+  position: absolute;
+  left: -12%; right: -12%;
+  top: 50%;
+  height: 132px;
+  background: var(--red);
+  transform: rotate(-7deg);
+  transform-origin: center;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  border-top: var(--rule) solid var(--ink);
+  border-bottom: var(--rule) solid var(--ink);
+  pointer-events: none;
+}
+.hero-band-text {
+  font-family: var(--black);
+  font-size: 64px;
+  line-height: 1;
+  color: var(--ink);
+  white-space: nowrap;
+  letter-spacing: 0.04em;
+  opacity: 0.9;
+  padding-left: 4vw;
+}
+/* giant rotated numeral bleeding off the right edge */
+.hero-numeral {
+  position: absolute;
+  right: -3%; top: -8%;
+  font-family: var(--black);
+  font-size: clamp(200px, 34vw, 460px);
+  line-height: 0.8;
+  color: var(--ink);
+  opacity: 0.08;
+  transform: rotate(8deg);
+  z-index: 0;
+  pointer-events: none;
+  user-select: none;
+}
+.hero-copy {
+  position: relative;
+  z-index: 3;
+  max-width: 760px;
+}
+.hero-eyebrow {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 0 0 20px;
+  display: inline-block;
+  background: var(--paper);
+  padding: 4px 10px;
+  border: 2px solid var(--ink);
+}
+.hero-title {
+  font-family: var(--black);
+  font-weight: 400;
+  font-size: clamp(56px, 11vw, 150px);
+  line-height: 0.86;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  margin: 0 0 28px;
+  color: var(--ink);
+}
+.hero-title .line { display: block; }
+.hero-title .line.red {
+  color: var(--knock);
+  background: var(--red);
+  display: inline-block;
+  padding: 0 0.12em;
+  transform: rotate(-2deg);
+  border: var(--rule) solid var(--ink);
+}
+.hero-title .line.calm {
+  color: var(--red);
+  -webkit-text-stroke: 2px var(--ink);
+}
+.hero-deck {
+  font-family: var(--body);
+  font-size: 19px;
+  line-height: 1.6;
+  color: var(--ink-2);
+  max-width: 56ch;
+  margin: 0 0 34px;
+  background: var(--paper);
+  padding: 4px 0;
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+.btn-solid, .btn-ghost {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 15px 26px;
+  border: var(--rule) solid var(--ink);
+  transition: transform 110ms ease, background 110ms linear, color 110ms linear;
+}
+.btn-solid {
+  background: var(--ink);
+  color: var(--knock);
+  box-shadow: 6px 6px 0 var(--red);
+}
+.btn-solid:hover { background: var(--red); color: var(--knock); transform: translate(-2px, -2px); box-shadow: 8px 8px 0 var(--ink); }
+.btn-ghost {
+  background: var(--paper);
+  color: var(--ink);
+}
+.btn-ghost:hover { background: var(--ink); color: var(--knock); transform: translate(-2px, -2px); }
+.hero-cmd {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--knock);
+  background: var(--ink);
+  padding: 14px 18px;
+  border: var(--rule) solid var(--ink);
+}
+
+/* =========================================================================
+   INDEX STRIP — running ticker of numbered steps
+   ========================================================================= */
+.index-strip {
+  display: flex;
+  flex-wrap: wrap;
+  background: var(--ink);
+  border-bottom: var(--rule) solid var(--ink);
+}
+.index-strip span {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--knock);
+  padding: 14px 26px;
+  border-right: 2px solid #333;
+}
+.index-strip span:first-child { color: var(--red); }
+
+/* =========================================================================
+   CARDS — asymmetric grid, giant numerals
+   ========================================================================= */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: var(--rule) solid var(--ink);
+}
+.card {
+  position: relative;
+  overflow: hidden;
+  padding: 40px 34px 34px;
+  border-right: var(--rule) solid var(--ink);
+  border-bottom: var(--rule) solid var(--ink);
+  background: var(--paper);
+  transition: background 120ms linear;
+}
+.cards .card:nth-child(3n) { border-right: 0; }
+.cards .card:nth-last-child(-n+3) { border-bottom: 0; }
+.card-num {
+  position: absolute;
+  right: -10px; bottom: -28px;
+  font-family: var(--black);
+  font-size: 150px;
+  line-height: 0.7;
+  color: var(--ink);
+  opacity: 0.07;
+  transform: rotate(-8deg);
+  pointer-events: none;
+  user-select: none;
+  transition: color 120ms linear, opacity 120ms linear;
+}
+.card h3 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 0 0 12px;
+  position: relative; z-index: 2;
+}
+.card p {
+  font-size: 15px;
+  color: var(--ink-2);
+  line-height: 1.6;
+  margin: 0 0 18px;
+  position: relative; z-index: 2;
+}
+.card code { font-family: var(--mono); font-size: 0.88em; background: var(--code-bg); padding: 1px 5px; }
+.card-go {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink);
+  border-bottom: 3px solid var(--red);
+  padding-bottom: 2px;
+  position: relative; z-index: 2;
+}
+.card:hover { background: var(--red); }
+.card:hover h3, .card:hover p, .card:hover .card-go { color: var(--knock); }
+.card:hover .card-go { border-bottom-color: var(--ink); }
+.card:hover .card-num { color: var(--ink); opacity: 0.18; }
+.card:hover code { background: var(--red-ink); color: var(--knock); }
+
+/* =========================================================================
+   SLOGAN BLOCK — knockout red panel
+   ========================================================================= */
+.slogan {
+  position: relative;
+  overflow: hidden;
+  background: var(--red);
+  border-bottom: var(--rule) solid var(--ink);
+  padding: 72px 56px;
+}
+.slogan-num {
+  position: absolute;
+  left: 2%; top: 50%;
+  transform: translateY(-50%) rotate(-10deg);
+  font-family: var(--black);
+  font-size: clamp(180px, 26vw, 360px);
+  line-height: 0.7;
+  color: var(--ink);
+  opacity: 0.14;
+  pointer-events: none;
+  user-select: none;
+}
+.slogan blockquote {
+  position: relative; z-index: 2;
+  margin: 0;
+  text-align: right;
+  font-family: var(--black);
+  font-size: clamp(34px, 6vw, 78px);
+  line-height: 0.95;
+  text-transform: uppercase;
+  color: var(--knock);
+}
+.slogan blockquote .line { display: block; }
+.slogan blockquote .line.red {
+  color: var(--ink);
+}
+
+/* =========================================================================
+   STATS
+   ========================================================================= */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  background: var(--ink);
+  border-bottom: var(--rule) solid var(--ink);
+}
+.stat { padding: 30px 30px; border-right: 2px solid #333; }
+.stat:last-child { border-right: 0; }
+.stat-v {
+  font-family: var(--black);
+  font-size: 44px;
+  line-height: 1;
+  color: var(--knock);
+}
+.stat-v.red { color: var(--red); }
+.stat-k {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #a9a299;
+  margin-top: 10px;
+}
+
+/* =========================================================================
+   DOC SHELL — sidebar / main / toc
+   ========================================================================= */
+.shell {
+  display: grid;
+  grid-template-columns: 288px minmax(0, 1fr) 234px;
+  align-items: start;
+}
+.sidebar {
+  border-right: var(--rule) solid var(--ink);
+  padding: 40px 22px 60px 30px;
+  position: sticky; top: 64px;
+  align-self: start;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+}
+
+/* sidebar nav — stack of angled / offset solid tabs */
+.nav-stack { display: flex; flex-direction: column; gap: 22px; }
+.nav-group { position: relative; }
+.nav-head {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--knock);
+  margin: 0 0 12px;
+  padding: 8px 16px;
+  border: var(--rule) solid var(--ink);
+  display: inline-block;
+  background: var(--ink);
+}
+.nav-head.tab-a { background: var(--red); color: var(--knock); transform: rotate(-2deg); margin-left: -4px; }
+.nav-head.tab-b { background: var(--ink); color: var(--knock); transform: rotate(1.5deg); margin-left: 8px; }
+.nav-head.tab-c { background: var(--steel); color: var(--ink); transform: rotate(-1.5deg); margin-left: -2px; }
+.nav-head.tab-d { background: var(--paper); color: var(--ink); transform: rotate(2deg); margin-left: 10px; }
+
+.nav-group ul { list-style: none; padding: 0; margin: 0; }
+.nav-group li { margin: 0; }
+.nav-group a {
+  display: block;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--ink-2);
+  padding: 6px 12px;
+  border-left: 3px solid transparent;
+  transition: border-color 100ms linear, background 100ms linear, color 100ms linear;
+}
+.nav-group a:hover {
+  border-left-color: var(--red);
+  background: var(--paper-2);
+  color: var(--ink);
+}
+.nav-group a.active {
+  border-left-color: var(--red);
+  color: var(--ink);
+  font-weight: 700;
+  background: var(--paper-2);
+}
+
+/* main reading column — upright and calm */
+.main {
+  padding: 64px 72px;
+  min-width: 0;
+}
+.article { max-width: var(--maxcol); }
+
+.toc {
+  border-left: var(--rule) solid var(--ink);
+  padding: 64px 22px;
+  position: sticky; top: 64px;
+  align-self: start;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+  font-size: 14px;
+}
+.toc-head {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin: 0 0 16px;
+  border-bottom: 2px solid var(--ink);
+  padding-bottom: 8px;
+}
+.toc ul { list-style: none; padding: 0; margin: 0; }
+.toc li { padding: 5px 0; }
+.toc a { color: var(--ink-2); border-left: 0; }
+.toc a:hover { color: var(--red); }
+
+/* =========================================================================
+   ARTICLE HEAD
+   ========================================================================= */
+.crumb {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--mute);
+  margin-bottom: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  text-transform: uppercase;
+}
+.crumb-mark { color: var(--red); font-weight: 700; }
+.crumb a { color: var(--ink-2); border-bottom: 1px solid var(--ink); }
+.crumb a:hover { color: var(--red); border-bottom-color: var(--red); }
+.crumb-here { color: var(--ink); }
+
+.article-head { margin-bottom: 14px; }
+.article-title {
+  font-family: var(--black);
+  font-weight: 400;
+  font-size: clamp(40px, 6vw, 66px);
+  line-height: 0.92;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 0 0 20px;
+  position: relative;
+  padding-bottom: 22px;
+}
+.article-title::after {
+  content: "";
+  position: absolute;
+  left: 0; bottom: 0;
+  width: 120px; height: 8px;
+  background: var(--red);
+  transform: skewX(-24deg);
+}
+.deck {
+  font-family: var(--body);
+  font-size: 20px;
+  line-height: 1.55;
+  color: var(--ink);
+  max-width: 60ch;
+  margin: 0 0 40px;
+  font-weight: 500;
+}
+
+/* =========================================================================
+   ARTICLE BODY — calm, upright, readable
+   ========================================================================= */
+.content { color: var(--ink-2); }
+.content > *:first-child { margin-top: 0; }
+
+.content h2 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 30px;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 52px 0 18px;
+  padding-left: 18px;
+  position: relative;
+}
+.content h2::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 6px; bottom: 6px;
+  width: 7px;
+  background: var(--red);
+}
+.content h3 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 21px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 36px 0 12px;
+}
+.content h4 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 17px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+  margin: 28px 0 10px;
+}
+.content p { margin: 0 0 18px; max-width: var(--maxcol); }
+.content strong { color: var(--ink); font-weight: 700; }
+.content a {
+  color: var(--red-ink);
+  border-bottom: 2px solid var(--red);
+  font-weight: 500;
+  transition: background 100ms linear, color 100ms linear;
+}
+.content a:hover { background: var(--red); color: var(--knock); border-bottom-color: var(--ink); }
+
+.content ul, .content ol { padding-left: 26px; max-width: var(--maxcol); }
+.content li { margin-bottom: 8px; }
+.content ul li::marker { color: var(--red); }
+.content ol li::marker { font-family: var(--mono); color: var(--red); font-weight: 700; }
+
+/* inline + block code */
+.content code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  background: var(--code-bg);
+  padding: 2px 6px;
+  border: 1px solid #cfc7b6;
+}
+.content pre {
+  background: var(--ink);
+  color: var(--knock);
+  border: var(--rule) solid var(--ink);
+  padding: 22px 24px;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 13.5px;
+  line-height: 1.6;
+  margin: 26px 0;
+  position: relative;
+  box-shadow: 7px 7px 0 var(--red);
+}
+.content pre code { background: transparent; border: 0; padding: 0; color: inherit; font-size: 13.5px; }
+.content pre::before {
+  content: "CODE";
+  position: absolute;
+  top: 0; right: 0;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--ink);
+  background: var(--red);
+  padding: 3px 9px;
+}
+
+/* blockquote — solid red callout with knockout white text */
+.content blockquote {
+  position: relative;
+  background: var(--red);
+  color: var(--knock);
+  border: var(--rule) solid var(--ink);
+  padding: 20px 26px 20px 28px;
+  margin: 28px 0;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 17px;
+  line-height: 1.55;
+  box-shadow: 7px 7px 0 var(--ink);
+}
+.content blockquote::before {
+  content: "!";
+  position: absolute;
+  left: -3px; top: -22px;
+  font-family: var(--black);
+  font-size: 40px;
+  color: var(--ink);
+  background: var(--red);
+  border: var(--rule) solid var(--ink);
+  width: 44px; height: 44px;
+  display: grid; place-items: center;
+  transform: rotate(-6deg);
+}
+.content blockquote p { margin: 0; max-width: none; }
+.content blockquote a { color: var(--knock); border-bottom-color: var(--knock); }
+.content blockquote a:hover { background: var(--ink); color: var(--knock); }
+
+/* tables — hard ruled */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 28px 0;
+  border: var(--rule) solid var(--ink);
+  font-size: 14.5px;
+}
+.content th {
+  font-family: var(--display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  text-align: left;
+  background: var(--ink);
+  color: var(--knock);
+  padding: 11px 16px;
+}
+.content td {
+  padding: 11px 16px;
+  border-top: 2px solid var(--ink);
+  vertical-align: top;
+}
+.content tbody tr:nth-child(even) { background: var(--paper-2); }
+.content td code { background: var(--paper); }
+
+.content hr {
+  border: 0;
+  height: var(--rule);
+  background: var(--ink);
+  margin: 40px 0;
+}
+
+.content img { max-width: 100%; height: auto; border: var(--rule) solid var(--ink); }
+
+/* =========================================================================
+   PAGER
+   ========================================================================= */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  margin-top: 60px;
+  border: var(--rule) solid var(--ink);
+}
+.pager-b {
+  display: block;
+  padding: 22px 24px;
+  background: var(--paper);
+  transition: background 110ms linear, color 110ms linear;
+}
+.pager .prev { border-right: var(--rule) solid var(--ink); }
+.pager .next { text-align: right; }
+.pager-k {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+.pager-t {
+  display: block;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 19px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  margin-top: 6px;
+}
+.pager-b:hover { background: var(--ink); }
+.pager-b:hover .pager-k { color: var(--red); }
+.pager-b:hover .pager-t { color: var(--knock); }
+
+/* =========================================================================
+   SECTION / TAXONOMY INDEX LIST — giant numerals, hard rules
+   ========================================================================= */
+.index-list {
+  margin-top: 36px;
+  border-top: var(--rule) solid var(--ink);
+}
+.index-item {
+  display: grid;
+  grid-template-columns: 130px 1fr auto;
+  align-items: center;
+  gap: 24px;
+  padding: 26px 20px 26px 8px;
+  border-bottom: var(--rule) solid var(--ink);
+  background: var(--paper);
+  transition: background 120ms linear, color 120ms linear;
+}
+.index-num {
+  font-family: var(--black);
+  font-size: 76px;
+  line-height: 0.8;
+  color: var(--ink);
+  opacity: 0.16;
+  transform: rotate(-6deg);
+  transition: opacity 120ms linear, color 120ms linear;
+  user-select: none;
+}
+.index-body h3 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 0 0 6px;
+}
+.index-body p { margin: 0; font-size: 15px; color: var(--ink-2); line-height: 1.55; max-width: 62ch; }
+.index-go {
+  font-family: var(--black);
+  font-size: 30px;
+  color: var(--red);
+  transition: transform 120ms ease, color 120ms linear;
+}
+.index-item:hover { background: var(--ink); }
+.index-item:hover .index-num { color: var(--red); opacity: 1; }
+.index-item:hover .index-body h3 { color: var(--knock); }
+.index-item:hover .index-body p { color: #c8c1b6; }
+.index-item:hover .index-go { color: var(--knock); transform: translateX(8px); }
+
+/* =========================================================================
+   404
+   ========================================================================= */
+.error {
+  position: relative;
+  overflow: hidden;
+  padding: 110px 56px;
+  min-height: 64vh;
+  display: flex;
+  align-items: center;
+}
+.error-numeral {
+  position: absolute;
+  right: -4%; top: 50%;
+  transform: translateY(-50%) rotate(-9deg);
+  font-family: var(--black);
+  font-size: clamp(180px, 36vw, 520px);
+  line-height: 0.7;
+  color: var(--red);
+  opacity: 0.16;
+  pointer-events: none;
+  user-select: none;
+}
+.error-copy { position: relative; z-index: 2; max-width: 640px; }
+.error-title {
+  font-family: var(--black);
+  font-weight: 400;
+  font-size: clamp(44px, 8vw, 96px);
+  line-height: 0.9;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 0 0 22px;
+}
+.error-title .red { color: var(--red); }
+.error-deck {
+  font-size: 19px;
+  color: var(--ink-2);
+  max-width: 52ch;
+  margin: 0 0 32px;
+}
+
+/* =========================================================================
+   FOOTER
+   ========================================================================= */
+.foot {
+  border-top: var(--rule) solid var(--ink);
+  background: var(--ink);
+  color: var(--knock);
+  padding: 44px 32px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 28px;
+}
+.foot-mark {
+  width: 40px; height: 40px;
+  background: var(--red);
+  transform: rotate(-12deg);
+  position: relative;
+}
+.foot-mark::after {
+  content: ""; position: absolute; inset: 0;
+  background: var(--knock);
+  clip-path: polygon(0 0, 100% 0, 0 100%);
+}
+.foot-title {
+  font-family: var(--black);
+  font-size: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--knock);
+}
+.foot-desc { font-size: 13px; color: #a9a299; margin-top: 2px; max-width: 60ch; }
+.foot-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #a9a299;
+  text-align: right;
+}
+
+/* =========================================================================
+   RESPONSIVE — collapse to one column under ~860px, tame the angles
+   ========================================================================= */
+@media (max-width: 1180px) {
+  .shell { grid-template-columns: 252px minmax(0, 1fr); }
+  .toc { display: none; }
+  .cards { grid-template-columns: 1fr 1fr; }
+  .cards .card:nth-child(3n) { border-right: var(--rule) solid var(--ink); }
+  .cards .card:nth-child(2n) { border-right: 0; }
+  .cards .card:nth-last-child(-n+3) { border-bottom: var(--rule) solid var(--ink); }
+  .cards .card:nth-last-child(-n+2) { border-bottom: 0; }
+}
+
+@media (max-width: 860px) {
+  body { font-size: 15.5px; }
+
+  .bar-inner { flex-direction: column; align-items: stretch; }
+  .brand { border-right: 0; border-bottom: var(--rule) solid var(--ink); }
+  .bar-nav a:first-child { border-left: 0; }
+
+  .hero { padding: 64px 26px 56px; min-height: auto; }
+  .hero-band { transform: rotate(-5deg); height: 96px; }
+  .hero-band-text { font-size: 40px; }
+  .hero-numeral { font-size: 200px; opacity: 0.06; }
+  .hero-title .line.red { transform: rotate(-1deg); }
+
+  .shell { grid-template-columns: 1fr; }
+  /* sidebar moves inline, tabs straighten so text stays readable */
+  .sidebar {
+    position: static;
+    max-height: none;
+    border-right: 0;
+    border-bottom: var(--rule) solid var(--ink);
+    padding: 28px 24px;
+  }
+  .nav-head.tab-a, .nav-head.tab-b, .nav-head.tab-c, .nav-head.tab-d {
+    transform: none;
+    margin-left: 0;
+  }
+  .main { padding: 40px 24px; }
+  .article { max-width: none; }
+
+  .cards { grid-template-columns: 1fr; }
+  .cards .card,
+  .cards .card:nth-child(2n) { border-right: 0; }
+  .cards .card { border-bottom: var(--rule) solid var(--ink); }
+  .cards .card:last-child { border-bottom: 0; }
+  .card-num { font-size: 120px; opacity: 0.06; }
+
+  .slogan { padding: 48px 26px; }
+  .slogan blockquote { text-align: left; }
+  .slogan-num { opacity: 0.1; }
+
+  .stats { grid-template-columns: 1fr 1fr; }
+  .stat:nth-child(2n) { border-right: 0; }
+  .stat:nth-child(-n+2) { border-bottom: 2px solid #333; }
+
+  /* index list — straighten the numerals, keep them legible */
+  .index-item { grid-template-columns: 70px 1fr auto; gap: 16px; padding: 20px 12px 20px 6px; }
+  .index-num { font-size: 48px; transform: none; opacity: 0.22; }
+
+  .pager { grid-template-columns: 1fr; }
+  .pager .prev { border-right: 0; border-bottom: var(--rule) solid var(--ink); }
+  .pager .next { text-align: left; }
+
+  .error { padding: 64px 26px; }
+  .error-numeral { opacity: 0.1; }
+
+  .foot { grid-template-columns: 1fr; gap: 16px; }
+  .foot-meta { align-items: flex-start; text-align: left; }
+
+  .content pre, .content blockquote { box-shadow: 4px 4px 0 var(--ink); }
+  .content blockquote { box-shadow: 4px 4px 0 var(--ink); }
+}
+
+@media (max-width: 480px) {
+  .hero-title { font-size: clamp(44px, 16vw, 72px); }
+  .hero-cmd { font-size: 11.5px; word-break: break-all; }
+  .btn-solid, .btn-ghost { font-size: 13px; padding: 13px 18px; }
+}
+
+/* respect reduced motion — disable transform shifts on hover */
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
+  .btn-solid:hover, .btn-ghost:hover, .index-item:hover .index-go { transform: none; }
+}

--- a/examples/constructivist/templates/404.html
+++ b/examples/constructivist/templates/404.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<section class="error">
+  <div class="error-numeral" aria-hidden="true">404</div>
+  <div class="error-copy">
+    <p class="hero-eyebrow">Off the grid</p>
+    <h1 class="error-title">This page is<br><span class="red">not in the index.</span></h1>
+    <p class="error-deck">The URL you followed does not resolve to a page in this site. Head back to the documentation or the front page and pick up the thread.</p>
+    <div class="hero-actions">
+      <a href="{{ base_url }}/docs/" class="btn-solid">Open the docs</a>
+      <a href="{{ base_url }}/" class="btn-ghost">Front page</a>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/constructivist/templates/_sidebar.html
+++ b/examples/constructivist/templates/_sidebar.html
@@ -1,0 +1,38 @@
+<aside class="sidebar">
+  <nav class="nav-stack">
+    <div class="nav-group">
+      <h4 class="nav-head tab-a">Start here</h4>
+      <ul>
+        <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+        <li><a href="{{ base_url }}/docs/your-first-page/">Your first page</a></li>
+        <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+      </ul>
+    </div>
+
+    <div class="nav-group">
+      <h4 class="nav-head tab-b">Concepts</h4>
+      <ul>
+        <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a></li>
+        <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+        <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+      </ul>
+    </div>
+
+    <div class="nav-group">
+      <h4 class="nav-head tab-c">Guides</h4>
+      <ul>
+        <li><a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a></li>
+        <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+        <li><a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a></li>
+      </ul>
+    </div>
+
+    <div class="nav-group">
+      <h4 class="nav-head tab-d">Reference</h4>
+      <ul>
+        <li><a href="{{ base_url }}/docs/cli/">CLI reference</a></li>
+        <li><a href="{{ base_url }}/docs/template-filters/">Template filters</a></li>
+      </ul>
+    </div>
+  </nav>
+</aside>

--- a/examples/constructivist/templates/footer.html
+++ b/examples/constructivist/templates/footer.html
@@ -1,0 +1,14 @@
+<footer class="foot">
+  <div class="foot-mark" aria-hidden="true"></div>
+  <div class="foot-lines">
+    <div class="foot-title">{{ site.title }}</div>
+    <div class="foot-desc">{{ site.description }}</div>
+  </div>
+  <div class="foot-meta">
+    <span>© {{ current_year }}</span>
+    <span>Built with Hwaro</span>
+    <span>Set in Oswald &amp; Inter</span>
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/constructivist/templates/header.html
+++ b/examples/constructivist/templates/header.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@500;600;700&family=Archivo+Black&family=Inter:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand">
+      <span class="mark" aria-hidden="true"></span>
+      <span class="brand-name">{{ site.title }}</span>
+    </a>
+    <nav class="bar-nav">
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/guides/">Guides</a>
+      <a href="{{ base_url }}/about/">About</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/examples/constructivist/templates/home.html
+++ b/examples/constructivist/templates/home.html
@@ -1,0 +1,87 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="hero-band" aria-hidden="true">
+    <span class="hero-band-text">МАНИФЕСТ · MANIFEST · МАНИФЕСТ · MANIFEST ·</span>
+  </div>
+  <div class="hero-numeral" aria-hidden="true">00</div>
+  <div class="hero-copy">
+    <p class="hero-eyebrow">A documentation theme</p>
+    <h1 class="hero-title">
+      <span class="line">BUILD</span>
+      <span class="line red">LOUD</span>
+      <span class="line">READ</span>
+      <span class="line calm">CALM.</span>
+    </h1>
+    <p class="hero-deck">Constructivist points the visual grammar of the Soviet avant-garde — the red wedge, the diagonal, the heavy condensed cap — at a technical manual. The chrome shouts so the reading column does not have to.</p>
+    <div class="hero-actions">
+      <a href="{{ base_url }}/docs/installation/" class="btn-solid">Get started</a>
+      <a href="{{ base_url }}/docs/" class="btn-ghost">Browse the docs</a>
+      <code class="hero-cmd">brew install hahwul/hwaro/hwaro</code>
+    </div>
+  </div>
+</section>
+
+<section class="index-strip">
+  <span>01 Install</span>
+  <span>02 Author</span>
+  <span>03 Configure</span>
+  <span>04 Build</span>
+  <span>05 Ship</span>
+</section>
+
+<section class="cards">
+  <a href="{{ base_url }}/docs/installation/" class="card">
+    <div class="card-num" aria-hidden="true">01</div>
+    <h3>Installation</h3>
+    <p>One Homebrew line, one scaffold command, and a live dev server. The fastest path from nothing to a rendered page.</p>
+    <span class="card-go">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/sections-and-pages/" class="card">
+    <div class="card-num" aria-hidden="true">02</div>
+    <h3>Sections &amp; pages</h3>
+    <p>The two-shape content model. How the tree maps to URLs and why <code>_index.md</code> does more than it looks.</p>
+    <span class="card-go">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/templates/" class="card">
+    <div class="card-num" aria-hidden="true">03</div>
+    <h3>Templates</h3>
+    <p>Crinja templates, where they live, and the small dependable set of globals every template can count on.</p>
+    <span class="card-go">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/build-pipeline/" class="card">
+    <div class="card-num" aria-hidden="true">04</div>
+    <h3>Build pipeline</h3>
+    <p>What happens between <code>hwaro build</code> and <code>public/</code>, traced through seven readable phases.</p>
+    <span class="card-go">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/i18n/" class="card">
+    <div class="card-num" aria-hidden="true">05</div>
+    <h3>Internationalization</h3>
+    <p>Multilingual content without the traps. One default locale, one honest fallback rule, one naming convention.</p>
+    <span class="card-go">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/deploying/" class="card">
+    <div class="card-num" aria-hidden="true">06</div>
+    <h3>Deploying</h3>
+    <p>Recipes for GitHub Pages, Cloudflare Pages, and a plain rsync script for everything else.</p>
+    <span class="card-go">Read →</span>
+  </a>
+</section>
+
+<section class="slogan">
+  <div class="slogan-num" aria-hidden="true">!</div>
+  <blockquote>
+    <span class="line">Energy in the chrome.</span>
+    <span class="line red">Stillness in the page.</span>
+  </blockquote>
+</section>
+
+<section class="stats">
+  <div class="stat"><div class="stat-v red">0.14</div><div class="stat-k">Hwaro release line</div></div>
+  <div class="stat"><div class="stat-v">12</div><div class="stat-k">Pages in this site</div></div>
+  <div class="stat"><div class="stat-v">3</div><div class="stat-k">Type families</div></div>
+  <div class="stat"><div class="stat-v">MIT</div><div class="stat-k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/constructivist/templates/page.html
+++ b/examples/constructivist/templates/page.html
@@ -1,0 +1,47 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <article class="article">
+      <header class="article-head">
+        <nav class="crumb">
+          <span class="crumb-mark">/</span>
+          {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a> <span class="crumb-sep">/</span>{% endif %}
+          <span class="crumb-here">{{ page.title }}</span>
+        </nav>
+        <h1 class="article-title">{{ page.title }}</h1>
+        {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+      </header>
+
+      <div class="content">{{ content | safe }}</div>
+
+      {% if page.lower or page.higher %}
+      <nav class="pager">
+        {% if page.lower %}
+        <a href="{{ base_url }}{{ page.lower.url }}" class="pager-b prev">
+          <span class="pager-k">← Previous</span>
+          <span class="pager-t">{{ page.lower.title }}</span>
+        </a>
+        {% else %}<span></span>{% endif %}
+        {% if page.higher %}
+        <a href="{{ base_url }}{{ page.higher.url }}" class="pager-b next">
+          <span class="pager-k">Next →</span>
+          <span class="pager-t">{{ page.higher.title }}</span>
+        </a>
+        {% endif %}
+      </nav>
+      {% endif %}
+    </article>
+  </main>
+  <aside class="toc">
+    <div class="toc-head">On this page</div>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul><li><a href="#">Top</a></li></ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/constructivist/templates/section.html
+++ b/examples/constructivist/templates/section.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <header class="article-head">
+      <nav class="crumb">
+        <span class="crumb-mark">/</span>
+        <span class="crumb-here">{{ section.title }}</span>
+      </nav>
+      <h1 class="article-title">{{ section.title }}</h1>
+      {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+    </header>
+
+    <div class="index-list">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="index-item">
+        <div class="index-num" aria-hidden="true">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+        <div class="index-body">
+          <h3>{{ post.title }}</h3>
+          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        </div>
+        <span class="index-go">→</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <div class="toc-head">{{ section.pages | length }} entries</div>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/constructivist/templates/taxonomy.html
+++ b/examples/constructivist/templates/taxonomy.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <header class="article-head">
+      <nav class="crumb">
+        <span class="crumb-mark">/</span>
+        <span class="crumb-here">{{ taxonomy_name }}</span>
+      </nav>
+      <h1 class="article-title">All {{ taxonomy_name }}</h1>
+    </header>
+
+    <div class="index-list">
+      {% for term in taxonomy_terms %}
+      <a href="{{ base_url }}{{ term.url }}" class="index-item">
+        <div class="index-num" aria-hidden="true">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+        <div class="index-body">
+          <h3>#{{ term }}</h3>
+          <p>{{ term.pages | length }} entries</p>
+        </div>
+        <span class="index-go">→</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <div class="toc-head">{{ taxonomy_terms | length }} terms</div>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/constructivist/templates/taxonomy_term.html
+++ b/examples/constructivist/templates/taxonomy_term.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <header class="article-head">
+      <nav class="crumb">
+        <span class="crumb-mark">/</span>
+        <a href="{{ base_url }}/tags/">tags</a> <span class="crumb-sep">/</span>
+        <span class="crumb-here">{{ taxonomy_term }}</span>
+      </nav>
+      <h1 class="article-title">#{{ taxonomy_term }}</h1>
+    </header>
+
+    <div class="index-list">
+      {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="index-item">
+        <div class="index-num" aria-hidden="true">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+        <div class="index-body">
+          <h3>{{ post.title }}</h3>
+          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        </div>
+        <span class="index-go">→</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <div class="toc-head">{{ taxonomy_pages | length }} entries</div>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/datasheet/AGENTS.md
+++ b/examples/datasheet/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for the Datasheet theme (Hwaro site)
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/datasheet/archetypes/default.md
+++ b/examples/datasheet/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/datasheet/config.toml
+++ b/examples/datasheet/config.toml
@@ -1,0 +1,197 @@
+title = "Datasheet"
+description = "A documentation theme that presents your docs as a semiconductor datasheet — part-number headers, pinouts, and electrical-characteristics tables."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/datasheet/content/about.md
+++ b/examples/datasheet/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "About"
+description = "What Datasheet is, the decisions behind the part, and the conditions under which it is guaranteed to operate."
+date = "2026-04-01"
++++
+
+Datasheet is a documentation theme that borrows its entire visual language from the electronic component datasheet: the part-number header, the FEATURES column, the absolute-maximum-ratings box, the numbered sections, and the electrical-characteristics table. It is built for technical reference docs where tables carry as much weight as prose.
+
+## The decisions behind the part
+
+- A dark PCB-charcoal substrate with silkscreen-white text and a single phosphor-green data accent. Amber is reserved for caution.
+- Monospace for every piece of data, a tight grotesk for prose paragraphs. The two never trade jobs.
+- Solid fills and hairline borders only. The stylesheet uses flat colors, box-shadow, and SVG strokes — nothing blended.
+- Tables are first-class. Each markdown table renders as an electrical-characteristics block with a tinted unit column and zebra rows.
+
+## Functional description
+
+The homepage carries a pinout diagram: a rectangular IC body with numbered pins on both sides, each pin wired to a documentation section. Every doc page opens with a component header block — a part number, a FEATURES list, and an ABSOLUTE MAXIMUM RATINGS table. Headings are numbered like real datasheet sections, `1.0`, `1.1`, `2.0`.
+
+## Operating conditions
+
+This is a reference theme, not a marketing page. There is no carousel, no testimonial block, and no scroll-triggered motion. It is meant to be read at a workbench.
+
+## License
+
+MIT. Take it, fork it, and send a pull request if you improve the part.

--- a/examples/datasheet/content/docs/_index.md
+++ b/examples/datasheet/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The core reference. Bring-up, configuration, and the day-to-day operating procedure — pins 1 through 8 of the package."
+sort_by = "weight"
++++

--- a/examples/datasheet/content/docs/cli.md
+++ b/examples/datasheet/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "Pin 8 — control interface. Every command, every flag, and the two or three you reach for daily."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name>` | Scaffold a new site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/datasheet/content/docs/configuration.md
+++ b/examples/datasheet/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "Pin 3 — configuration register. Every setting in config.toml, its function, and the smallest safe default value."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/datasheet/content/docs/installation.md
+++ b/examples/datasheet/content/docs/installation.md
@@ -1,0 +1,42 @@
++++
+title = "Installation"
+description = "Pin 1 — board bring-up. Install the toolchain, scaffold a docs site, and bring the dev server online."
+weight = 1
+date = "2026-05-01"
++++
+
+The Datasheet theme runs on the Hwaro static site generator. Install it from Homebrew, then scaffold a site with the docs layout and power up the dev server.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs
+hwaro serve
+```
+
+The dev server listens on `http://localhost:3000`. Any edit to `content/`, `templates/`, or `static/` reloads the page within a few milliseconds.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.0 or newer
+```
+
+If you see an older build, your package manager has cached a stale bottle. Run `brew upgrade hwaro` and check again.
+
+## Power-on test
+
+The following table is the minimum confirmation that the part is alive on the bench.
+
+| Check | Command | Expected |
+| --- | --- | --- |
+| Toolchain present | `hwaro --version` | prints a version |
+| Site scaffolded | `ls content/` | shows `_index.md` |
+| Server responds | `hwaro serve` | serves on `:3000` |
+
+## Where to next
+
+Continue to **Your first page**, where you write one piece of content, give it a template, and watch the build go green.

--- a/examples/datasheet/content/docs/sections-and-pages.md
+++ b/examples/datasheet/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "Pin 4 — content bus. How the tree is wired, how sections behave, and why _index.md carries more current than it looks."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/datasheet/content/docs/taxonomies.md
+++ b/examples/datasheet/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Pin 6 — cross-reference. Tags, categories, and custom groupings: how to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/datasheet/content/docs/template-filters.md
+++ b/examples/datasheet/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "Pin 7 — filter reference. The most useful template filters, each with a paste-ready example."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/datasheet/content/docs/templates.md
+++ b/examples/datasheet/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Pin 5 — template interface. Crinja templates, where they live, and the small set of globals guaranteed at the pins."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/datasheet/content/docs/your-first-page.md
+++ b/examples/datasheet/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "Pin 2 — application example. Write one markdown page, wire its front matter, and confirm a clean build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/datasheet/content/guides/_index.md
+++ b/examples/datasheet/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "Application notes — longer procedures for the build pipeline, multilingual content, and shipping the static output to a host."
+sort_by = "weight"
++++

--- a/examples/datasheet/content/guides/build-pipeline.md
+++ b/examples/datasheet/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "Application note G1 — timing diagram. What happens between hwaro build and public/, traced as seven phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/datasheet/content/guides/deploying.md
+++ b/examples/datasheet/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Application note G3 — output stage. Ship the static build to GitHub Pages, Cloudflare Pages, or any plain file host."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/datasheet/content/guides/i18n.md
+++ b/examples/datasheet/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Application note G2 — multi-locale operation. One default language, one fallback rule, and no undefined behavior."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/datasheet/content/index.md
+++ b/examples/datasheet/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Datasheet"
+description = "A documentation theme that presents your docs as a semiconductor datasheet — part-number headers, pinouts, and electrical-characteristics tables."
+template = "home"
++++

--- a/examples/datasheet/static/css/style.css
+++ b/examples/datasheet/static/css/style.css
@@ -1,0 +1,877 @@
+/* =============================================================================
+   DATASHEET — a semiconductor / IC datasheet documentation theme
+   Dark PCB charcoal panels on near-black, phosphor-green data accent,
+   caution-amber, hairline solder-mask borders. Monospace for data,
+   tight grotesk for prose. Solid fills and hairline borders only.
+   ============================================================================= */
+
+:root {
+  /* Substrate */
+  --pcb:        #0b0e10;   /* near-black board */
+  --panel:      #101417;   /* charcoal component panel */
+  --panel-2:    #161b1f;   /* raised panel / zebra row B */
+  --panel-3:    #1b2227;   /* hovered panel */
+
+  /* Silkscreen */
+  --silk:       #e9edf0;   /* primary text */
+  --silk-dim:   #aab4ba;   /* secondary text */
+  --silk-faint: #6c7a82;   /* tertiary / captions */
+
+  /* Signals */
+  --phos:       #3fbf6a;   /* phosphor-green data accent */
+  --phos-deep:  #1f6e3c;   /* darkened green for borders */
+  --amber:      #e0a32a;   /* caution amber */
+  --amber-tint: rgba(224, 163, 42, 0.06);
+
+  /* Solder mask hairlines */
+  --hair:       #243038;
+  --hair-soft:  #1a2126;
+  --hair-bright:#33454f;
+
+  /* Typography */
+  --mono: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace;
+  --sans: "Inter", system-ui, -apple-system, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--pcb);
+  color: var(--silk);
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.62;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: inherit; text-decoration: none; }
+
+::selection { background: var(--phos); color: var(--pcb); }
+
+:focus-visible { outline: 2px solid var(--phos); outline-offset: 2px; }
+
+/* =============================================================================
+   1.0  TOP BAR — instrument header
+   ============================================================================= */
+.bar {
+  border-bottom: 1px solid var(--hair-bright);
+  background: var(--panel);
+  position: sticky; top: 0; z-index: 40;
+}
+.bar-inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: stretch;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 22px;
+  border-right: 1px solid var(--hair);
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.02em;
+  color: var(--silk);
+}
+.brand .mark {
+  position: relative;
+  width: 22px; height: 22px;
+  border: 1.5px solid var(--phos);
+  background: var(--pcb);
+  flex: none;
+}
+/* notched DIP-package dot on the chip mark */
+.brand .mark::before {
+  content: "";
+  position: absolute;
+  top: -1.5px; left: 50%;
+  width: 8px; height: 4px;
+  border: 1.5px solid var(--phos);
+  border-top: 0;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  transform: translateX(-50%);
+  background: var(--panel);
+}
+.brand .mark::after {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  background: var(--phos);
+}
+
+.search {
+  padding: 0 22px;
+  display: flex;
+  align-items: center;
+  border-right: 1px solid var(--hair);
+}
+.search input {
+  border: 0; background: transparent;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--silk);
+  padding: 14px 0;
+  width: 100%;
+  outline: none;
+}
+.search input::placeholder { color: var(--silk-faint); }
+.search .kbd {
+  font-family: var(--mono); font-size: 10px;
+  padding: 3px 7px; border: 1px solid var(--hair-bright);
+  color: var(--silk-dim); white-space: nowrap;
+}
+
+.bar nav { display: flex; }
+.bar nav a {
+  padding: 0 20px;
+  display: flex; align-items: center;
+  border-left: 1px solid var(--hair);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--silk-dim);
+  transition: color 120ms, background 120ms;
+}
+.bar nav a:hover { background: var(--panel-2); color: var(--silk); }
+.bar nav a.cta { color: var(--phos); }
+.bar nav a.cta:hover { background: var(--phos); color: var(--pcb); }
+
+/* =============================================================================
+   2.0  LAYOUT SHELL
+   ============================================================================= */
+.shell {
+  display: grid;
+  grid-template-columns: 268px 1fr 232px;
+  min-height: calc(100vh - 49px);
+}
+
+/* ---- 2.1 Sidebar — pin index ---- */
+.sidebar {
+  border-right: 1px solid var(--hair);
+  padding: 28px 20px 48px;
+  position: sticky; top: 49px;
+  height: calc(100vh - 49px);
+  overflow-y: auto;
+  background: var(--panel);
+}
+.sidebar h4 {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--silk-faint);
+  margin: 26px 0 10px;
+  padding-left: 16px;
+  position: relative;
+}
+.sidebar h4:first-child { margin-top: 4px; }
+.sidebar h4::before {
+  content: "";
+  position: absolute; left: 0; top: 4px;
+  width: 7px; height: 7px;
+  background: var(--phos);
+}
+.sidebar h4.bank-b::before { background: var(--amber); }
+.sidebar h4.bank-c::before { background: var(--silk-dim); }
+.sidebar h4.bank-d::before { border: 1.5px solid var(--phos); background: transparent; }
+
+.sidebar ul { list-style: none; padding: 0; margin: 0; }
+.sidebar li { font-size: 13.5px; }
+.sidebar a {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  padding: 6px 12px 6px 16px;
+  border-left: 2px solid transparent;
+  color: var(--silk-dim);
+  font-family: var(--sans);
+}
+.sidebar a .num {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--silk-faint);
+  letter-spacing: 0.05em;
+  flex: none;
+}
+.sidebar a:hover { background: var(--panel-2); color: var(--silk); }
+.sidebar a:hover .num { color: var(--phos); }
+.sidebar a.active {
+  border-left-color: var(--phos);
+  background: var(--panel-2);
+  color: var(--silk);
+  font-weight: 500;
+}
+
+/* ---- 2.2 Main column ---- */
+.main { padding: 44px 56px 72px; max-width: 900px; }
+
+/* ---- 2.3 TOC — register map ---- */
+.toc {
+  border-left: 1px solid var(--hair);
+  padding: 44px 20px;
+  position: sticky; top: 49px;
+  height: calc(100vh - 49px);
+  overflow-y: auto;
+  font-size: 12.5px;
+  background: var(--panel);
+}
+.toc h5 {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--silk-faint);
+  margin: 0 0 14px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--hair);
+}
+.toc ul { list-style: none; padding: 0; margin: 0; }
+.toc li { padding: 0; }
+.toc a {
+  display: block;
+  padding: 5px 0 5px 12px;
+  border-left: 1px solid var(--hair);
+  color: var(--silk-dim);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+.toc a:hover { color: var(--phos); border-left-color: var(--phos); }
+.toc ul ul a { padding-left: 24px; color: var(--silk-faint); }
+
+/* =============================================================================
+   3.0  ARTICLE HEAD — breadcrumb + part header block
+   ============================================================================= */
+.crumb {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--silk-faint);
+  margin-bottom: 20px;
+  display: flex;
+  gap: 7px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.crumb a { color: var(--silk-dim); }
+.crumb a:hover { color: var(--phos); }
+.crumb .accent { color: var(--phos); }
+
+/* SIGNATURE COMPONENT (a): component header block */
+.partblock {
+  border: 1px solid var(--hair-bright);
+  background: var(--panel);
+  margin: 0 0 36px;
+}
+.partblock .ph {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--hair);
+  background: var(--panel-2);
+}
+.partblock .partno {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--phos);
+  text-transform: uppercase;
+}
+.partblock .rev {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--silk-faint);
+  text-transform: uppercase;
+}
+.partblock .pbody {
+  display: grid;
+  grid-template-columns: 1fr 250px;
+}
+.partblock .pmain {
+  padding: 22px 24px 24px;
+  border-right: 1px solid var(--hair);
+}
+.main h1 {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 1.08;
+  letter-spacing: -0.01em;
+  margin: 0 0 14px;
+  color: var(--silk);
+}
+.partblock .deck {
+  font-size: 15px;
+  color: var(--silk-dim);
+  margin: 0;
+  max-width: 56ch;
+  line-height: 1.55;
+}
+/* FEATURES bullet column */
+.partblock .feat { padding: 18px 20px; }
+.partblock .feat .ft {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--silk-faint);
+  margin: 0 0 12px;
+}
+.partblock .feat ul { list-style: none; margin: 0; padding: 0; }
+.partblock .feat li {
+  position: relative;
+  padding: 3px 0 3px 18px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--silk-dim);
+  line-height: 1.5;
+}
+.partblock .feat li::before {
+  content: "";
+  position: absolute; left: 0; top: 8px;
+  width: 7px; height: 7px;
+  background: var(--phos);
+}
+
+/* SIGNATURE COMPONENT (a, cont): ABSOLUTE MAXIMUM RATINGS box */
+.ratings {
+  border: 1px solid var(--hair-bright);
+  margin: 0 0 36px;
+}
+.ratings .rt {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--amber);
+  padding: 11px 18px;
+  border-bottom: 1px solid var(--hair);
+  background: var(--panel-2);
+  display: flex; align-items: center; gap: 9px;
+}
+.ratings .rt::before {
+  content: "";
+  width: 10px; height: 10px;
+  border: 1.5px solid var(--amber);
+  transform: rotate(45deg);
+  flex: none;
+}
+.ratings .rtable { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 12.5px; }
+.ratings .rtable th {
+  text-align: left;
+  color: var(--silk-faint);
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 9px 18px;
+  border-bottom: 1px solid var(--hair);
+  background: var(--panel);
+}
+.ratings .rtable td {
+  padding: 9px 18px;
+  border-bottom: 1px solid var(--hair-soft);
+  color: var(--silk);
+}
+.ratings .rtable tr:last-child td { border-bottom: 0; }
+.ratings .rtable td.sym { color: var(--phos); }
+.ratings .rtable td.unit { color: var(--amber); background: var(--amber-tint); width: 64px; }
+.ratings .rtable tr:nth-child(even) td { background: var(--panel-2); }
+.ratings .rtable tr:nth-child(even) td.unit { background: var(--amber-tint); }
+
+/* =============================================================================
+   4.0  .content — markdown body, datasheet styling
+   ============================================================================= */
+.content { font-size: 15px; counter-reset: sec; }
+
+/* Numbered datasheet section headings: 1.0 / 1.1 / 2.0 */
+.content h2 {
+  counter-increment: sec;
+  counter-reset: subsec;
+  font-family: var(--mono);
+  font-size: 19px;
+  font-weight: 600;
+  margin: 46px 0 16px;
+  padding-bottom: 9px;
+  border-bottom: 1px solid var(--hair);
+  letter-spacing: -0.005em;
+  color: var(--silk);
+}
+.content h2::before {
+  content: counter(sec) ".0  ";
+  color: var(--phos);
+  font-weight: 600;
+}
+.content h3 {
+  counter-increment: subsec;
+  font-family: var(--mono);
+  font-size: 15px;
+  font-weight: 600;
+  margin: 30px 0 10px;
+  color: var(--silk);
+}
+.content h3::before {
+  content: counter(sec) "." counter(subsec) "  ";
+  color: var(--amber);
+}
+.content h4 {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--silk-faint);
+  margin: 26px 0 8px;
+}
+
+.content p { margin: 0 0 16px; max-width: 72ch; color: var(--silk); }
+
+.content a {
+  color: var(--phos);
+  border-bottom: 1px solid var(--phos-deep);
+}
+.content a:hover { border-bottom-color: var(--phos); }
+
+.content strong { color: var(--silk); font-weight: 600; }
+
+.content code {
+  font-family: var(--mono);
+  background: var(--panel-2);
+  border: 1px solid var(--hair);
+  padding: 1px 6px;
+  font-size: 0.86em;
+  color: var(--phos);
+}
+
+.content pre {
+  background: var(--panel);
+  border: 1px solid var(--hair-bright);
+  border-left: 3px solid var(--phos);
+  padding: 18px 20px 18px 22px;
+  overflow-x: auto;
+  font-size: 13px;
+  font-family: var(--mono);
+  line-height: 1.6;
+  margin: 22px 0;
+  position: relative;
+}
+.content pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--silk);
+  font-size: 13px;
+}
+.content pre::before {
+  content: "// LISTING";
+  position: absolute; top: 8px; right: 14px;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  color: var(--silk-faint);
+}
+
+.content blockquote {
+  border: 1px solid var(--hair);
+  border-left: 3px solid var(--amber);
+  background: var(--panel);
+  padding: 14px 20px;
+  margin: 22px 0;
+  color: var(--silk-dim);
+}
+.content blockquote::before {
+  content: "NOTE";
+  display: block;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  color: var(--amber);
+  margin-bottom: 6px;
+}
+.content blockquote p:last-child { margin-bottom: 0; }
+
+.content ul, .content ol { padding-left: 22px; margin: 0 0 16px; max-width: 72ch; }
+.content li { margin-bottom: 5px; color: var(--silk); }
+.content ul li::marker { color: var(--phos); }
+.content ol li::marker { color: var(--phos); font-family: var(--mono); }
+
+.content hr {
+  border: 0;
+  border-top: 1px solid var(--hair);
+  margin: 36px 0;
+}
+
+/* SIGNATURE COMPONENT (c): electrical-characteristics tables.
+   Every markdown table reads as a MIN/TYP/MAX spec table. */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 24px 0;
+  font-size: 13px;
+  border: 1px solid var(--hair-bright);
+  font-family: var(--mono);
+}
+.content table thead th {
+  background: var(--panel-2);
+  color: var(--phos);
+  text-align: left;
+  font-weight: 600;
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--hair-bright);
+  border-right: 1px solid var(--hair);
+  white-space: nowrap;
+}
+.content table thead th:last-child { border-right: 0; }
+.content table tbody td {
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--hair-soft);
+  border-right: 1px solid var(--hair-soft);
+  color: var(--silk);
+  vertical-align: top;
+}
+.content table tbody td:last-child { border-right: 0; }
+.content table tbody tr:nth-child(odd)  { background: var(--panel); }
+.content table tbody tr:nth-child(even) { background: var(--panel-2); }
+.content table tbody tr:hover { background: var(--panel-3); }
+.content table tbody tr:last-child td { border-bottom: 0; }
+/* unit-column tint on the rightmost column */
+.content table tbody td:last-child {
+  color: var(--amber);
+  background: var(--amber-tint);
+}
+.content table code { background: transparent; border: 0; padding: 0; color: var(--phos); }
+
+/* =============================================================================
+   5.0  PAGER — adjacent registers
+   ============================================================================= */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-top: 52px;
+  padding-top: 28px;
+  border-top: 1px solid var(--hair);
+}
+.pager .b {
+  border: 1px solid var(--hair-bright);
+  padding: 16px 18px;
+  background: var(--panel);
+  transition: border-color 120ms, background 120ms;
+}
+.pager .b:hover { border-color: var(--phos); background: var(--panel-2); }
+.pager .b .k {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--silk-faint);
+}
+.pager .b .t {
+  font-family: var(--mono); font-weight: 600;
+  font-size: 14px; margin-top: 5px; color: var(--silk);
+}
+.pager .next { text-align: right; }
+.pager .b:hover .k { color: var(--phos); }
+
+/* =============================================================================
+   6.0  HOME — hero + pinout
+   ============================================================================= */
+.hero {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  border-bottom: 1px solid var(--hair);
+}
+.hero .copy { padding: 56px 52px; border-right: 1px solid var(--hair); }
+.hero .stamp {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--phos);
+  margin: 0 0 18px;
+  display: flex; align-items: center; gap: 10px;
+}
+.hero .stamp::after {
+  content: "";
+  flex: 1; height: 1px; background: var(--hair);
+}
+.hero h1 {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: clamp(30px, 4.4vw, 52px);
+  line-height: 1.04;
+  letter-spacing: -0.015em;
+  margin: 0 0 22px;
+  color: var(--silk);
+}
+.hero h1 .phos { color: var(--phos); }
+.hero h1 .amber { color: var(--amber); }
+.hero .deck {
+  font-family: var(--sans);
+  font-size: 16px; color: var(--silk-dim);
+  max-width: 48ch; margin: 0 0 28px; line-height: 1.6;
+}
+.hero .cta-row { display: flex; flex-wrap: wrap; gap: 0; }
+.hero .cta-row a {
+  border: 1px solid var(--hair-bright);
+  padding: 12px 20px;
+  font-family: var(--mono);
+  font-weight: 500;
+  font-size: 12.5px;
+  letter-spacing: 0.03em;
+  color: var(--silk);
+  transition: background 120ms, color 120ms, border-color 120ms;
+}
+.hero .cta-row a + a { border-left: 0; }
+.hero .cta-row a.primary { background: var(--phos); color: var(--pcb); border-color: var(--phos); font-weight: 600; }
+.hero .cta-row a.primary:hover { background: var(--silk); border-color: var(--silk); }
+.hero .cta-row a:hover { background: var(--panel-2); color: var(--phos); }
+.hero .cta-row a.kbd:hover { color: var(--amber); }
+
+/* SIGNATURE COMPONENT (b): PINOUT diagram — IC body w/ numbered pins */
+.pinout {
+  padding: 40px 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--pcb);
+}
+.chip {
+  display: grid;
+  grid-template-columns: 1fr 130px 1fr;
+  align-items: stretch;
+  width: 100%;
+  max-width: 380px;
+}
+.chip .pins {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+}
+.chip .pin {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  height: 42px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--silk-dim);
+  letter-spacing: 0.03em;
+  transition: color 120ms;
+}
+.chip .pins.right .pin { flex-direction: row-reverse; text-align: right; }
+.chip .pin .lead { flex: 1; height: 2px; background: var(--silk-faint); transition: background 120ms; }
+.chip .pin .pn {
+  width: 16px; height: 16px;
+  border: 1px solid var(--hair-bright);
+  display: grid; place-items: center;
+  font-size: 8px; color: var(--silk-faint);
+  flex: none;
+  background: var(--panel);
+  transition: border-color 120ms, color 120ms;
+}
+.chip .pin .pl { white-space: nowrap; }
+.chip a.pin:hover { color: var(--phos); }
+.chip a.pin:hover .lead { background: var(--phos); }
+.chip a.pin:hover .pn { border-color: var(--phos); color: var(--phos); }
+
+.chip .body {
+  border: 1.5px solid var(--hair-bright);
+  background: var(--panel);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 30px 12px;
+  text-align: center;
+}
+/* pin-1 notch */
+.chip .body::before {
+  content: "";
+  position: absolute; top: -1px; left: 50%;
+  width: 26px; height: 13px;
+  border: 1.5px solid var(--hair-bright);
+  border-top: 0;
+  border-bottom-left-radius: 26px;
+  border-bottom-right-radius: 26px;
+  transform: translateX(-50%);
+  background: var(--pcb);
+}
+/* pin-1 dot */
+.chip .body::after {
+  content: "";
+  position: absolute; bottom: 12px; left: 12px;
+  width: 8px; height: 8px;
+  border: 1.5px solid var(--phos);
+  border-radius: 50%;
+}
+.chip .body .label {
+  font-family: var(--mono);
+  font-size: 15px;
+  letter-spacing: 0.06em;
+  color: var(--silk);
+}
+.chip .body .sub {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  color: var(--silk-faint);
+  margin-top: 6px;
+  text-transform: uppercase;
+}
+
+/* ---- 6.1 Home: section cards ---- */
+.cats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.cat {
+  border-right: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+  padding: 28px 26px;
+  background: var(--panel);
+  transition: background 120ms;
+  display: block;
+}
+.cat:nth-child(3n) { border-right: 0; }
+.cat:hover { background: var(--panel-2); }
+.cat .icon {
+  width: 34px; height: 34px; margin-bottom: 16px;
+  border: 1px solid var(--hair-bright);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-weight: 600; font-size: 13px;
+  color: var(--phos);
+  background: var(--pcb);
+}
+.cat .icon.b { color: var(--amber); }
+.cat .icon.c { color: var(--silk); }
+.cat:hover .icon { border-color: var(--phos); }
+.cat h3 {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 16px;
+  margin: 0 0 7px;
+  color: var(--silk);
+}
+.cat p { color: var(--silk-dim); font-size: 13.5px; line-height: 1.55; margin: 0 0 14px; }
+.cat p code { font-family: var(--mono); background: var(--panel-2); border: 1px solid var(--hair); padding: 1px 5px; font-size: 0.85em; color: var(--phos); }
+.cat .read {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--phos);
+}
+.cat:hover .read { color: var(--silk); }
+
+/* ---- 6.2 Home: characteristics strip ---- */
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--hair);
+  background: var(--panel);
+}
+.metrics .m { padding: 22px 26px; border-right: 1px solid var(--hair); }
+.metrics .m:last-child { border-right: 0; }
+.metrics .v {
+  font-family: var(--mono); font-weight: 600; font-size: 26px;
+  letter-spacing: -0.01em; color: var(--silk);
+}
+.metrics .v.phos { color: var(--phos); }
+.metrics .v.amber { color: var(--amber); }
+.metrics .v small { font-size: 14px; color: var(--silk-faint); }
+.metrics .k {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--silk-faint); margin-top: 6px;
+}
+
+/* =============================================================================
+   7.0  FOOTER — revision history + ordering information
+   ============================================================================= */
+.foot {
+  border-top: 1px solid var(--hair-bright);
+  background: var(--panel);
+}
+.foot .foot-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+}
+.foot .col { padding: 26px 28px; }
+.foot .col + .col { border-left: 1px solid var(--hair); }
+.foot .ft {
+  font-family: var(--mono);
+  font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase;
+  color: var(--silk-faint); margin: 0 0 12px;
+}
+.foot .rev {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 5px 16px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--silk-dim);
+}
+.foot .rev .r { color: var(--phos); }
+.foot .order {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--silk-dim);
+  line-height: 1.85;
+}
+.foot .order b { color: var(--silk); font-weight: 600; }
+.foot .order .pn { color: var(--phos); }
+.foot .baseline {
+  border-top: 1px solid var(--hair);
+  padding: 14px 28px;
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px;
+  font-family: var(--mono);
+  font-size: 10px; letter-spacing: 0.06em;
+  color: var(--silk-faint);
+  text-transform: uppercase;
+}
+
+/* =============================================================================
+   8.0  RESPONSIVE — collapse to one column under ~860px
+   ============================================================================= */
+@media (max-width: 1080px) {
+  .shell { grid-template-columns: 240px 1fr; }
+  .toc { display: none; }
+  .partblock .pbody { grid-template-columns: 1fr; }
+  .partblock .pmain { border-right: 0; border-bottom: 1px solid var(--hair); }
+}
+@media (max-width: 980px) {
+  .hero { grid-template-columns: 1fr; }
+  .hero .copy { border-right: 0; border-bottom: 1px solid var(--hair); }
+  .cats { grid-template-columns: 1fr 1fr; }
+  .cat:nth-child(3n) { border-right: 1px solid var(--hair); }
+  .cat:nth-child(2n) { border-right: 0; }
+}
+@media (max-width: 860px) {
+  .shell { grid-template-columns: 1fr; }
+  .sidebar { display: none; }
+  .main { padding: 32px 22px 56px; }
+  .cats { grid-template-columns: 1fr; }
+  .cat { border-right: 0 !important; }
+  .metrics { grid-template-columns: 1fr 1fr; }
+  .metrics .m:nth-child(2n) { border-right: 0; }
+  .bar-inner { grid-template-columns: 1fr auto; }
+  .search { display: none; }
+  .pager { grid-template-columns: 1fr; }
+  .foot .foot-grid { grid-template-columns: 1fr; }
+  .foot .col + .col { border-left: 0; border-top: 1px solid var(--hair); }
+  .main h1 { font-size: 27px; }
+}
+@media (max-width: 520px) {
+  .metrics { grid-template-columns: 1fr; }
+  .metrics .m { border-right: 0; border-bottom: 1px solid var(--hair); }
+  .bar nav a { padding: 0 14px; }
+  .content table { font-size: 12px; }
+}

--- a/examples/datasheet/templates/404.html
+++ b/examples/datasheet/templates/404.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <p class="stamp">Fault · NO CONNECT</p>
+    <h1><span class="amber">404</span> — pin floating, no signal.</h1>
+    <p class="deck">This address is not bonded to any die. The trace you followed leads to an unrouted net. Return to a known-good reference and try a documented pin.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/" class="primary">OPEN DOCS →</a>
+      <a href="{{ base_url }}/">HOME</a>
+    </div>
+  </div>
+  <div class="pinout">
+    <div class="chip">
+      <div class="pins left">
+        <span class="pin"><span class="pn">N</span><span class="lead"></span><span class="pl">NC</span></span>
+        <span class="pin"><span class="pn">N</span><span class="lead"></span><span class="pl">NC</span></span>
+        <span class="pin"><span class="pn">N</span><span class="lead"></span><span class="pl">NC</span></span>
+      </div>
+      <div class="body">
+        <span class="label">— —</span>
+        <span class="sub">NO DEVICE</span>
+      </div>
+      <div class="pins right">
+        <span class="pin"><span class="pn">N</span><span class="lead"></span><span class="pl">NC</span></span>
+        <span class="pin"><span class="pn">N</span><span class="lead"></span><span class="pl">NC</span></span>
+        <span class="pin"><span class="pn">N</span><span class="lead"></span><span class="pl">NC</span></span>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/datasheet/templates/_sidebar.html
+++ b/examples/datasheet/templates/_sidebar.html
@@ -1,0 +1,28 @@
+<aside class="sidebar">
+  <h4>Bank A · Start Here</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/installation/"><span class="num">1</span>Installation</a></li>
+    <li><a href="{{ base_url }}/docs/your-first-page/"><span class="num">2</span>Your first page</a></li>
+    <li><a href="{{ base_url }}/docs/configuration/"><span class="num">3</span>Configuration</a></li>
+  </ul>
+
+  <h4 class="bank-b">Bank B · Concepts</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/sections-and-pages/"><span class="num">4</span>Sections &amp; pages</a></li>
+    <li><a href="{{ base_url }}/docs/templates/"><span class="num">5</span>Templates</a></li>
+    <li><a href="{{ base_url }}/docs/taxonomies/"><span class="num">6</span>Taxonomies</a></li>
+  </ul>
+
+  <h4 class="bank-d">Bank C · Reference</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/template-filters/"><span class="num">7</span>Template filters</a></li>
+    <li><a href="{{ base_url }}/docs/cli/"><span class="num">8</span>CLI reference</a></li>
+  </ul>
+
+  <h4 class="bank-c">Bank G · Guides</h4>
+  <ul>
+    <li><a href="{{ base_url }}/guides/build-pipeline/"><span class="num">G1</span>The build pipeline</a></li>
+    <li><a href="{{ base_url }}/guides/i18n/"><span class="num">G2</span>Internationalization</a></li>
+    <li><a href="{{ base_url }}/guides/deploying/"><span class="num">G3</span>Deploying to a CDN</a></li>
+  </ul>
+</aside>

--- a/examples/datasheet/templates/footer.html
+++ b/examples/datasheet/templates/footer.html
@@ -1,0 +1,28 @@
+<footer class="foot">
+  <div class="foot-grid">
+    <div class="col">
+      <p class="ft">Revision History</p>
+      <div class="rev">
+        <span class="r">REV D</span><span>{{ current_year }}-05</span><span>Pinout map + electrical-characteristics tables finalized.</span>
+        <span class="r">REV C</span><span>{{ current_year }}-03</span><span>Added guides bank; expanded ratings block.</span>
+        <span class="r">REV B</span><span>{{ current_year }}-01</span><span>Numbered section scheme; absolute-maximum ratings.</span>
+        <span class="r">REV A</span><span>{{ current_year }}-01</span><span>Initial release of the {{ site.title }} reference.</span>
+      </div>
+    </div>
+    <div class="col">
+      <p class="ft">Ordering Information</p>
+      <div class="order">
+        <div>PART NO. — <span class="pn">DS-HWARO-{{ current_year }}</span></div>
+        <div>PACKAGE — <b>STATIC / HTML</b></div>
+        <div>TOOLCHAIN — <b>hwaro build</b></div>
+        <div>LICENSE — <b>MIT</b></div>
+      </div>
+    </div>
+  </div>
+  <div class="baseline">
+    <span>{{ site.title }} — {{ site.description }}</span>
+    <span>© {{ current_year }} · DOC REV D · NO WARRANTY IMPLIED</span>
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/datasheet/templates/header.html
+++ b/examples/datasheet/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="mark"></span>{{ site.title }}</a>
+    <div class="search">
+      <input type="text" placeholder="grep the datasheet…" aria-label="Search" />
+      <span class="kbd">/ FIND</span>
+    </div>
+    <nav>
+      <a href="{{ base_url }}/docs/">DOCS</a>
+      <a href="{{ base_url }}/guides/">GUIDES</a>
+      <a href="{{ base_url }}/about/">ABOUT</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">SOURCE</a>
+    </nav>
+  </div>
+</header>

--- a/examples/datasheet/templates/home.html
+++ b/examples/datasheet/templates/home.html
@@ -1,0 +1,82 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <p class="stamp">Datasheet · Rev D · {{ current_year }}</p>
+    <h1>Docs that read like a <span class="phos">component</span> <span class="amber">datasheet</span>.</h1>
+    <p class="deck">{{ site.description }} Every page opens with a part-number header, a FEATURES column, and an absolute-maximum-ratings box. Tables read like electrical characteristics. Headings are numbered like sections of a real datasheet.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/installation/" class="primary">GET STARTED →</a>
+      <a href="{{ base_url }}/docs/">BROWSE DOCS</a>
+      <a class="kbd">$ brew install hahwul/hwaro/hwaro</a>
+    </div>
+  </div>
+  <div class="pinout">
+    <div class="chip" aria-label="Pinout: pins map to documentation sections">
+      <div class="pins left">
+        <a class="pin" href="{{ base_url }}/docs/installation/"><span class="pn">1</span><span class="lead"></span><span class="pl">INSTALL</span></a>
+        <a class="pin" href="{{ base_url }}/docs/your-first-page/"><span class="pn">2</span><span class="lead"></span><span class="pl">FIRST_PG</span></a>
+        <a class="pin" href="{{ base_url }}/docs/configuration/"><span class="pn">3</span><span class="lead"></span><span class="pl">CONFIG</span></a>
+        <a class="pin" href="{{ base_url }}/docs/sections-and-pages/"><span class="pn">4</span><span class="lead"></span><span class="pl">SECTIONS</span></a>
+      </div>
+      <div class="body">
+        <span class="label">HWARO</span>
+        <span class="sub">SSG · DIP-16</span>
+      </div>
+      <div class="pins right">
+        <a class="pin" href="{{ base_url }}/docs/cli/"><span class="pn">8</span><span class="lead"></span><span class="pl">CLI</span></a>
+        <a class="pin" href="{{ base_url }}/docs/template-filters/"><span class="pn">7</span><span class="lead"></span><span class="pl">FILTERS</span></a>
+        <a class="pin" href="{{ base_url }}/docs/taxonomies/"><span class="pn">6</span><span class="lead"></span><span class="pl">TAXONOMY</span></a>
+        <a class="pin" href="{{ base_url }}/docs/templates/"><span class="pn">5</span><span class="lead"></span><span class="pl">TEMPLATES</span></a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="cats">
+  <a href="{{ base_url }}/docs/installation/" class="cat">
+    <div class="icon">01</div>
+    <h3>Installation</h3>
+    <p>One <code>brew install</code>, one <code>hwaro init</code>, and a live dev server. Pin 1 of the package.</p>
+    <span class="read">READ →</span>
+  </a>
+  <a href="{{ base_url }}/docs/sections-and-pages/" class="cat">
+    <div class="icon">04</div>
+    <h3>Sections &amp; pages</h3>
+    <p>How the content tree is wired, and why <code>_index.md</code> carries more current than it looks.</p>
+    <span class="read">READ →</span>
+  </a>
+  <a href="{{ base_url }}/docs/templates/" class="cat">
+    <div class="icon">05</div>
+    <h3>Templates</h3>
+    <p>Crinja templates, the globals you can count on, and the body pattern <code>content | safe</code>.</p>
+    <span class="read">READ →</span>
+  </a>
+  <a href="{{ base_url }}/guides/build-pipeline/" class="cat">
+    <div class="icon b">G1</div>
+    <h3>Build pipeline</h3>
+    <p>What happens between <code>hwaro build</code> and <code>public/</code>, traced as seven phases.</p>
+    <span class="read">READ →</span>
+  </a>
+  <a href="{{ base_url }}/guides/i18n/" class="cat">
+    <div class="icon b">G2</div>
+    <h3>Internationalization</h3>
+    <p>Multilingual content with one default locale and exactly one fallback rule. No surprises.</p>
+    <span class="read">READ →</span>
+  </a>
+  <a href="{{ base_url }}/guides/deploying/" class="cat">
+    <div class="icon c">G3</div>
+    <h3>Deploying</h3>
+    <p>Ship the static output to GitHub Pages, Cloudflare Pages, or any box that serves files.</p>
+    <span class="read">READ →</span>
+  </a>
+</section>
+
+<section class="metrics">
+  <div class="m"><div class="v phos">REV D</div><div class="k">Current document</div></div>
+  <div class="m"><div class="v">12<small> pp</small></div><div class="k">Documented pages</div></div>
+  <div class="m"><div class="v amber">DIP-16</div><div class="k">Pinout package</div></div>
+  <div class="m"><div class="v">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/datasheet/templates/page.html
+++ b/examples/datasheet/templates/page.html
@@ -1,0 +1,77 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb">
+      <span class="accent">DS</span> /
+      {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a> /{% endif %}
+      <span>{{ page.title }}</span>
+    </div>
+
+    <div class="partblock">
+      <div class="ph">
+        <span class="partno">PART NO. DS-{{ page.title | upper | truncate(length=14, end="") }}</span>
+        <span class="rev">{% if page.date %}DATED {{ page.date }}{% else %}REV D{% endif %}</span>
+      </div>
+      <div class="pbody">
+        <div class="pmain">
+          <h1>{{ page.title }}</h1>
+          {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+        </div>
+        <div class="feat">
+          <p class="ft">Features</p>
+          <ul>
+            <li>Section: {% if page.section %}{{ page.section }}{% else %}root{% endif %}</li>
+            {% if page.lower %}<li>Prev: {{ page.lower.title | truncate(length=16) }}</li>{% endif %}
+            {% if page.higher %}<li>Next: {{ page.higher.title | truncate(length=16) }}</li>{% endif %}
+            <li>Format: Markdown</li>
+            <li>Output: Static HTML</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="ratings">
+      <div class="rt">Absolute Maximum Ratings</div>
+      <table class="rtable">
+        <tr><th>Parameter</th><th>Symbol</th><th>Value</th><th>Unit</th></tr>
+        <tr><td>Document section</td><td class="sym">SEC</td><td>{% if page.section %}{{ page.section }}{% else %}root{% endif %}</td><td class="unit">—</td></tr>
+        <tr><td>Build toolchain</td><td class="sym">CLI</td><td>hwaro build</td><td class="unit">cmd</td></tr>
+        <tr><td>Template engine</td><td class="sym">TPL</td><td>Crinja / Jinja2</td><td class="unit">—</td></tr>
+        <tr><td>Markdown processor</td><td class="sym">MD</td><td>enabled</td><td class="unit">bit</td></tr>
+      </table>
+    </div>
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b">
+        <div class="k">◄ PREV PIN</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">NEXT PIN ►</div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+  </main>
+  <aside class="toc">
+    <h5>Register Map</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top of page</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/datasheet/templates/section.html
+++ b/examples/datasheet/templates/section.html
@@ -1,0 +1,51 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">DS</span> / <span>{{ section.title }}</span></div>
+
+    <div class="partblock">
+      <div class="ph">
+        <span class="partno">BANK · {{ section.title | upper }}</span>
+        <span class="rev">{{ section.pages | length }} ENTRIES</span>
+      </div>
+      <div class="pbody">
+        <div class="pmain">
+          <h1>{{ section.title }}</h1>
+          {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+        </div>
+        <div class="feat">
+          <p class="ft">Bank Info</p>
+          <ul>
+            <li>Entries: {{ section.pages | length }}</li>
+            <li>Sort: weight</li>
+            <li>Format: Markdown</li>
+            <li>Engine: Crinja</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="cats" style="border-top:1px solid var(--hair);border-left:1px solid var(--hair);">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 3 == 2 %}b{% elif loop.index % 3 == 0 %}c{% endif %}">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">READ →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5>{{ section.pages | length }} Entries</h5>
+    <ul>
+      {% for post in section.pages %}
+      <li><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></li>
+      {% endfor %}
+    </ul>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/datasheet/templates/taxonomy.html
+++ b/examples/datasheet/templates/taxonomy.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">DS</span> / <span>{{ taxonomy_name }}</span></div>
+
+    <div class="partblock">
+      <div class="ph">
+        <span class="partno">INDEX · {{ taxonomy_name | upper }}</span>
+        <span class="rev">{{ taxonomy_terms | length }} TERMS</span>
+      </div>
+      <div class="pbody">
+        <div class="pmain">
+          <h1>{{ taxonomy_name }}</h1>
+          <p class="deck">Cross-reference index. Each term groups the pages that share it.</p>
+        </div>
+        <div class="feat">
+          <p class="ft">Index Info</p>
+          <ul>
+            <li>Terms: {{ taxonomy_terms | length }}</li>
+            <li>Type: {{ taxonomy_name }}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="content">
+      <table>
+        <thead><tr><th>Term</th><th>Entries</th></tr></thead>
+        <tbody>
+        {% for term in taxonomy_terms %}
+          <tr><td><a href="{{ base_url }}{{ term.url }}">{{ term }}</a></td><td>{{ term.pages | length }}</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/datasheet/templates/taxonomy_term.html
+++ b/examples/datasheet/templates/taxonomy_term.html
@@ -1,0 +1,41 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">DS</span> / <a href="{{ base_url }}/tags/">tags</a> / <span>{{ taxonomy_term }}</span></div>
+
+    <div class="partblock">
+      <div class="ph">
+        <span class="partno">TAG · {{ taxonomy_term | upper }}</span>
+        <span class="rev">{{ taxonomy_pages | length }} ENTRIES</span>
+      </div>
+      <div class="pbody">
+        <div class="pmain">
+          <h1>{{ taxonomy_term }}</h1>
+          <p class="deck">All pages tagged with this term.</p>
+        </div>
+        <div class="feat">
+          <p class="ft">Tag Info</p>
+          <ul>
+            <li>Entries: {{ taxonomy_pages | length }}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="cats" style="border-top:1px solid var(--hair);border-left:1px solid var(--hair);">
+    {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 3 == 2 %}b{% elif loop.index % 3 == 0 %}c{% endif %}">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">READ →</span>
+      </a>
+    {% endfor %}
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/deco/AGENTS.md
+++ b/examples/deco/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - Deco (Art Deco docs theme) — AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/deco/archetypes/default.md
+++ b/examples/deco/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/deco/config.toml
+++ b/examples/deco/config.toml
@@ -1,0 +1,197 @@
+title = "Deco"
+description = "An Art Deco documentation theme — the lobby of a Chrysler-era skyscraper, rendered as docs. Brass, charcoal, and stepped ornament."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/deco/content/about.md
+++ b/examples/deco/content/about.md
@@ -1,0 +1,38 @@
++++
+title = "About"
+description = "Why Deco looks the way it does — the palette, the ornament, and the things it deliberately refuses to do."
+date = "2026-04-01"
++++
+
+Deco is a documentation theme that borrows from the architecture of the 1920s and 1930s: the stepped towers, the brass fixtures, the fluted columns, and the wide-tracked capitals carved above a marble entrance. The idea is simple. A good reference manual is a building you return to often, so it may as well have a memorable lobby.
+
+It is intentionally opulent but restrained. The brass does the talking; everything else stays out of its way.
+
+## The palette
+
+Four colours carry the whole theme, all declared as CSS variables.
+
+- **Charcoal black-green** (`#13171c`) — the deep ground the type sits on.
+- **Warm cream** (`#ece3cf`) — the reading colour, chosen for contrast that stays comfortable over long pages.
+- **Brass / champagne** (`#b9975b`) — the single accent. It is a flat, solid colour. The metal never fades from one tone to another; the shine is implied entirely by typography and proportion, not by a colour blend.
+- **Deep emerald and oxblood** (`#1f5d4c`, `#7a2c25`) — secondary tones, used sparingly for quotes and emphasis.
+
+## The ornament
+
+Three motifs do the decorative work, and all of them are drawn with solid fills, borders, and box-shadows:
+
+- **Stepped corners** on cards — short brass brackets that echo a ziggurat setback.
+- **The deco rule** — a thin brass line interrupted by a single rotated diamond, used as a section divider.
+- **The sunburst** — solid radiating brass spokes, drawn as SVG lines, never as a radial blend.
+
+## What this is not
+
+This is not a marketing theme. There is no carousel, no testimonial wall, and no animation that fires on scroll. The motion budget is spent entirely on small, deliberate hover states.
+
+## Built on Hwaro
+
+Deco runs on [Hwaro](https://github.com/hahwul/hwaro), a fast static site generator written in Crystal. Scaffold a copy with `hwaro init my-docs --scaffold docs`, preview it with `hwaro serve`, and ship it with `hwaro build`.
+
+## License
+
+MIT. Use it, fork it, and send improvements.

--- a/examples/deco/content/docs/_index.md
+++ b/examples/deco/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The core reference. Installation, configuration, content structure, templates, and the daily workflow — floor by floor."
+sort_by = "weight"
++++

--- a/examples/deco/content/docs/cli.md
+++ b/examples/deco/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "Every command, every flag, and the one or two you actually need every day."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name>` | Scaffold a new site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/deco/content/docs/configuration.md
+++ b/examples/deco/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "Every setting in config.toml, what it does, and the smallest sensible default."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/deco/content/docs/installation.md
+++ b/examples/deco/content/docs/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
+description = "Three commands from an empty directory to a running dev server. The lobby is open; walk in."
+weight = 1
+date = "2026-05-01"
++++
+
+Deco runs on the Hwaro static site generator. The fastest way in is Homebrew, but you can equally run Hwaro under Docker or build it from source.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve --open
+```
+
+The dev server opens `http://localhost:3000` in your browser. Any edit to `content/`, `templates/`, or `static/` reloads almost instantly.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.0 or newer
+```
+
+If you see something older, your package manager has cached an out-of-date build. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Move on to **Your first page**, where you write a single piece of content, give it a template, and watch it render.

--- a/examples/deco/content/docs/sections-and-pages.md
+++ b/examples/deco/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "How content is organized, how sections behave, and why _index.md is doing more than it looks."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/deco/content/docs/taxonomies.md
+++ b/examples/deco/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Tags, categories, and the occasional custom one. How to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/deco/content/docs/template-filters.md
+++ b/examples/deco/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A reference of the most useful template filters, with examples you can paste."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/deco/content/docs/templates.md
+++ b/examples/deco/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Jinja-flavored templates, where to put them, and the small set of globals you can count on."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/deco/content/docs/your-first-page.md
+++ b/examples/deco/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "A small walkthrough that ends with a rendered page and the satisfaction of a green build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/deco/content/guides/_index.md
+++ b/examples/deco/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "Longer walk-throughs for the situations the reference pages only mention in passing — the build pipeline, languages, and shipping the finished site."
+sort_by = "weight"
++++

--- a/examples/deco/content/guides/build-pipeline.md
+++ b/examples/deco/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "What happens between hwaro build and public/, in seven readable phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/deco/content/guides/deploying.md
+++ b/examples/deco/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Cookbook entries for GitHub Pages, Cloudflare Pages, and a Bash script for the rest of you."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/deco/content/guides/i18n.md
+++ b/examples/deco/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/deco/content/index.md
+++ b/examples/deco/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Deco"
+description = "An Art Deco documentation theme for Hwaro — charcoal, solid brass, and stepped ornament. The lobby of a Chrysler-era skyscraper, rendered as docs."
+template = "home"
++++

--- a/examples/deco/static/css/style.css
+++ b/examples/deco/static/css/style.css
@@ -1,0 +1,580 @@
+/* ============================================================================
+   DECO — an Art Deco documentation theme for Hwaro
+   The lobby of a Chrysler-era skyscraper, rendered as docs.
+   Brass is a FLAT, SOLID color (#b9975b). Solid fills, borders, shadows only.
+   ========================================================================== */
+
+:root {
+  /* Palette — deep charcoal / black-green, warm cream, solid brass, emerald */
+  --bg:        #13171c;   /* deep charcoal black-green */
+  --bg-2:      #181d23;   /* raised panel */
+  --bg-3:      #1d242b;   /* card / inset */
+  --ink:       #ece3cf;   /* warm cream type */
+  --ink-soft:  #b9b09a;   /* muted cream */
+  --ink-faint: #7d7866;   /* faint cream */
+  --brass:     #b9975b;   /* SOLID brass / champagne accent */
+  --brass-dim: #8c7444;   /* darker brass for borders/hover */
+  --emerald:   #1f5d4c;   /* deep emerald secondary */
+  --oxblood:   #7a2c25;   /* deep oxblood, used sparingly */
+  --line:      #2c343d;   /* hairline on charcoal */
+  --line-2:    #39424c;
+
+  --ff-display: "Cinzel", "Marcellus", Georgia, serif;
+  --ff-alt:     "Marcellus", Georgia, serif;
+  --ff-body:    "EB Garamond", Georgia, serif;
+  --ff-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --maxw: 1200px;
+  --rad: 0;            /* Deco favours sharp corners */
+  --shadow: 0 18px 40px rgba(0,0,0,.45);
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--ff-body);
+  font-size: 19px;
+  line-height: 1.72;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::selection { background: var(--brass); color: var(--bg); }
+
+a { color: var(--brass); text-decoration: none; }
+
+/* ---------------------------------------------------------------- Top bar */
+.bar {
+  position: sticky; top: 0; z-index: 50;
+  background: var(--bg);
+  border-bottom: 1px solid var(--brass-dim);
+  box-shadow: 0 1px 0 rgba(185,151,91,.18);
+}
+.bar-inner {
+  max-width: var(--maxw); margin: 0 auto;
+  padding: 14px 28px;
+  display: flex; align-items: center; gap: 28px;
+}
+.brand {
+  display: flex; align-items: center; gap: 12px;
+  margin-right: auto;
+}
+.brand .mark { display: inline-flex; }
+.brand .mark svg { display: block; }
+.brand-word {
+  font-family: var(--ff-display);
+  font-weight: 600;
+  font-size: 22px;
+  letter-spacing: .26em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.bar nav { display: flex; align-items: center; gap: 30px; }
+.bar nav a {
+  font-family: var(--ff-alt);
+  font-size: 14px;
+  letter-spacing: .22em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  padding-bottom: 4px;
+  border-bottom: 1px solid transparent;
+  transition: color .15s ease, border-color .15s ease;
+}
+.bar nav a:hover,
+.bar nav a:focus-visible { color: var(--ink); border-bottom-color: var(--brass); outline: none; }
+.bar nav a.cta {
+  color: var(--bg);
+  background: var(--brass);
+  padding: 7px 16px;
+  border: 1px solid var(--brass);
+  letter-spacing: .18em;
+}
+.bar nav a.cta:hover { background: var(--bg); color: var(--brass); }
+
+/* ---------------------------------------------------------- Deco rule line */
+.deco-rule {
+  position: relative;
+  height: 1px; background: var(--brass-dim);
+  margin: 30px auto;
+  max-width: 460px;
+}
+.deco-rule.wide { max-width: var(--maxw); margin: 8px auto 40px; }
+.deco-rule.small { max-width: 100%; margin: 18px 0 30px; }
+.deco-rule .lozenge {
+  position: absolute; top: 50%; left: 50%;
+  width: 12px; height: 12px;
+  background: var(--brass);
+  transform: translate(-50%, -50%) rotate(45deg);
+  box-shadow: 0 0 0 5px var(--bg), 0 0 0 6px var(--brass-dim);
+}
+
+/* --------------------------------------------------------------- Hero */
+.hero {
+  max-width: 880px; margin: 0 auto;
+  padding: 76px 28px 44px;
+  text-align: center;
+}
+.hero-emblem {
+  position: relative;
+  width: 320px; height: 320px;
+  margin: 0 auto 26px;
+  display: flex; align-items: center; justify-content: center;
+}
+.hero.notfound .hero-emblem { width: 260px; height: 260px; }
+.sunburst { position: absolute; inset: 0; margin: auto; opacity: .55; }
+.tower { position: relative; z-index: 1; }
+.emblem-number {
+  position: relative; z-index: 1;
+  font-family: var(--ff-display);
+  font-weight: 700; font-size: 76px;
+  letter-spacing: .08em; color: var(--brass);
+}
+.hero-kicker {
+  font-family: var(--ff-alt);
+  text-transform: uppercase;
+  letter-spacing: .42em;
+  font-size: 13px;
+  color: var(--brass);
+  margin: 0 0 14px;
+}
+.hero-title {
+  font-family: var(--ff-display);
+  font-weight: 700;
+  font-size: clamp(48px, 9vw, 96px);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  margin: 0;
+  color: var(--ink);
+  line-height: 1.05;
+}
+.hero-title.small { font-size: clamp(38px, 6vw, 62px); }
+.hero-sub {
+  font-family: var(--ff-alt);
+  font-size: 22px;
+  color: var(--ink-soft);
+  margin: 16px 0 0;
+  font-style: italic;
+}
+.hero-deck { margin: 0 auto; max-width: 620px; }
+.notfound .hero-deck a { border-bottom: 1px solid var(--brass-dim); }
+.notfound .hero-deck a:hover { border-bottom-color: var(--brass); }
+
+.deck {
+  font-size: 21px;
+  color: var(--ink-soft);
+  line-height: 1.6;
+}
+
+.cta-row {
+  display: flex; flex-wrap: wrap; align-items: center; justify-content: center;
+  gap: 14px; margin-top: 30px;
+}
+.cta-row .primary,
+.cta-row .ghost {
+  font-family: var(--ff-alt);
+  text-transform: uppercase;
+  letter-spacing: .18em;
+  font-size: 14px;
+  padding: 13px 26px;
+  border: 1px solid var(--brass);
+  transition: background .15s ease, color .15s ease;
+}
+.cta-row .primary { background: var(--brass); color: var(--bg); }
+.cta-row .primary:hover { background: var(--bg); color: var(--brass); }
+.cta-row .ghost { background: transparent; color: var(--brass); }
+.cta-row .ghost:hover { background: var(--brass); color: var(--bg); }
+.kbd {
+  font-family: var(--ff-mono);
+  font-size: 13px;
+  letter-spacing: 0;
+  color: var(--ink-soft);
+  background: var(--bg-3);
+  border: 1px solid var(--line-2);
+  padding: 11px 16px;
+}
+
+/* --------------------------------------------------- Category cards (cats) */
+.cats {
+  max-width: var(--maxw); margin: 0 auto; padding: 0 28px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px;
+}
+.section-cats { padding: 0; margin-top: 10px; }
+.section-cats { grid-template-columns: repeat(2, 1fr); }
+
+/* Stepped / ziggurat ornament frame — built from borders + pseudo-elements */
+.cat {
+  position: relative;
+  display: flex; flex-direction: column;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  padding: 30px 26px 24px;
+  transition: border-color .18s ease, background .18s ease, transform .18s ease;
+}
+.cat::before,
+.cat::after {
+  content: ""; position: absolute; width: 16px; height: 16px;
+  border-color: var(--brass); border-style: solid; border-width: 0;
+  transition: border-color .18s ease;
+}
+.cat::before { top: 8px; left: 8px; border-top-width: 2px; border-left-width: 2px; }
+.cat::after  { bottom: 8px; right: 8px; border-bottom-width: 2px; border-right-width: 2px; }
+.cat:hover {
+  border-color: var(--brass-dim);
+  background: var(--bg-3);
+  transform: translateY(-3px);
+}
+.cat:hover::before, .cat:hover::after { border-color: var(--ink); }
+.cat .numeral {
+  font-family: var(--ff-display);
+  font-weight: 600;
+  font-size: 26px;
+  letter-spacing: .12em;
+  color: var(--brass);
+  border-bottom: 1px solid var(--brass-dim);
+  padding-bottom: 10px; margin-bottom: 14px;
+  width: fit-content;
+  min-width: 44px;
+}
+.cat h3 {
+  font-family: var(--ff-alt);
+  font-size: 22px;
+  letter-spacing: .04em;
+  margin: 0 0 8px;
+  color: var(--ink);
+}
+.cat p { margin: 0 0 18px; color: var(--ink-soft); font-size: 17px; line-height: 1.55; }
+.cat p code, .deck code {
+  font-family: var(--ff-mono); font-size: .82em;
+  background: var(--bg); border: 1px solid var(--line-2);
+  padding: 1px 6px; color: var(--brass);
+}
+.cat .read {
+  margin-top: auto;
+  font-family: var(--ff-alt);
+  text-transform: uppercase;
+  letter-spacing: .2em;
+  font-size: 12px;
+  color: var(--brass);
+}
+.cat:hover .read { color: var(--ink); }
+
+/* ------------------------------------------------------------- Metrics */
+.metrics {
+  max-width: var(--maxw); margin: 0 auto 70px; padding: 0 28px;
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+  border: 1px solid var(--line-2);
+}
+.metrics .m {
+  text-align: center;
+  padding: 30px 16px;
+  border-right: 1px solid var(--line-2);
+}
+.metrics .m:last-child { border-right: 0; }
+.metrics .v {
+  font-family: var(--ff-display);
+  font-weight: 700; font-size: 34px;
+  letter-spacing: .08em; color: var(--brass);
+}
+.metrics .k {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .18em;
+  font-size: 12px; color: var(--ink-faint);
+  margin-top: 8px;
+}
+
+/* ----------------------------------------------------- Docs shell layout */
+.shell {
+  max-width: var(--maxw); margin: 0 auto; padding: 40px 28px 60px;
+  display: grid; grid-template-columns: 240px minmax(0,1fr) 200px; gap: 40px;
+  align-items: start;
+}
+
+/* Sidebar with fluting — twin vertical brass hairlines drawn as a pseudo-element */
+.sidebar {
+  position: sticky; top: 88px;
+  padding-left: 18px;
+  border-left: 1px solid var(--line-2);
+}
+.sidebar::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 7px;
+  border-left: 1px solid var(--brass-dim);
+  border-right: 1px solid var(--line);
+  margin-left: -18px;
+}
+.sidebar h4 {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .24em;
+  font-size: 12px; color: var(--brass);
+  margin: 26px 0 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--line-2);
+}
+.sidebar h4:first-child { margin-top: 0; }
+.sidebar ul { list-style: none; margin: 0; padding: 0; }
+.sidebar li { margin: 0; }
+.sidebar a {
+  display: block;
+  font-size: 16px;
+  color: var(--ink-soft);
+  padding: 5px 0 5px 12px;
+  border-left: 2px solid transparent;
+  transition: color .15s ease, border-color .15s ease;
+}
+.sidebar a:hover, .sidebar a:focus-visible {
+  color: var(--ink); border-left-color: var(--brass); outline: none;
+}
+
+/* Main column */
+.main { min-width: 0; }
+.crumb {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .16em;
+  font-size: 12px; color: var(--ink-faint);
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+.crumb a { color: var(--ink-soft); }
+.crumb a:hover { color: var(--brass); }
+.crumb .sep { color: var(--brass); font-size: 8px; }
+.crumb .here { color: var(--brass); }
+
+.main h1 {
+  font-family: var(--ff-display);
+  font-weight: 700;
+  font-size: clamp(34px, 5vw, 50px);
+  letter-spacing: .06em;
+  line-height: 1.12;
+  margin: 0 0 10px;
+  color: var(--ink);
+}
+
+/* TOC column */
+.toc { position: sticky; top: 88px; }
+.toc h5 {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .2em;
+  font-size: 11px; color: var(--brass);
+  margin: 0 0 12px; padding-bottom: 6px;
+  border-bottom: 1px solid var(--line-2);
+}
+.toc ul { list-style: none; margin: 0; padding: 0; }
+.toc li { margin: 0; }
+.toc a {
+  display: block; font-size: 14px; color: var(--ink-faint);
+  padding: 4px 0 4px 10px; border-left: 1px solid var(--line-2);
+  transition: color .15s ease, border-color .15s ease;
+}
+.toc a:hover { color: var(--brass); border-left-color: var(--brass); }
+.toc ul ul a { padding-left: 22px; }
+
+/* ----------------------------------------------- CONTENT prose styling */
+.content { font-size: 19px; color: var(--ink); }
+.content > *:first-child { margin-top: 0; }
+
+.content h2 {
+  font-family: var(--ff-display);
+  font-weight: 600; font-size: 28px;
+  letter-spacing: .04em;
+  margin: 48px 0 16px;
+  padding-bottom: 10px;
+  color: var(--ink);
+  border-bottom: 1px solid var(--line-2);
+  position: relative;
+}
+.content h2::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 56px; height: 3px; background: var(--brass);
+}
+.content h3 {
+  font-family: var(--ff-alt);
+  font-size: 22px; letter-spacing: .03em;
+  margin: 34px 0 12px; color: var(--ink);
+}
+.content h4 {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .16em;
+  font-size: 15px; color: var(--brass);
+  margin: 28px 0 10px;
+}
+.content p { margin: 0 0 18px; }
+.content a {
+  color: var(--brass);
+  border-bottom: 1px solid var(--brass-dim);
+  transition: border-color .15s ease, color .15s ease;
+}
+.content a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+
+.content strong { color: var(--ink); font-weight: 600; }
+.content em { color: var(--ink-soft); }
+
+.content ul, .content ol { margin: 0 0 18px; padding-left: 26px; }
+.content li { margin: 6px 0; }
+.content ul li::marker { color: var(--brass); }
+.content ol li::marker { color: var(--brass); font-family: var(--ff-display); }
+
+/* Inline + block code */
+.content code {
+  font-family: var(--ff-mono); font-size: .82em;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  padding: 1px 6px; color: var(--brass);
+}
+.content pre {
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-left: 3px solid var(--brass);
+  padding: 20px 22px;
+  overflow-x: auto;
+  margin: 0 0 22px;
+  font-size: 15px; line-height: 1.6;
+}
+.content pre code {
+  background: none; border: 0; padding: 0; color: var(--ink);
+  font-size: 14.5px;
+}
+
+/* Blockquote — stepped brass frame */
+.content blockquote {
+  margin: 0 0 22px;
+  padding: 16px 22px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-left: 4px solid var(--emerald);
+  color: var(--ink-soft);
+  font-style: italic;
+}
+.content blockquote p:last-child { margin-bottom: 0; }
+
+/* Tables — deco ledger */
+.content table {
+  width: 100%; border-collapse: collapse; margin: 0 0 24px;
+  font-size: 16px;
+  border: 1px solid var(--line-2);
+}
+.content th {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .14em;
+  font-size: 12px; text-align: left;
+  background: var(--bg-3); color: var(--brass);
+  padding: 12px 16px;
+  border-bottom: 2px solid var(--brass-dim);
+}
+.content td {
+  padding: 11px 16px; border-bottom: 1px solid var(--line);
+  color: var(--ink-soft);
+}
+.content tr:last-child td { border-bottom: 0; }
+.content td code { font-size: .8em; }
+
+.content hr {
+  border: 0; height: 1px; background: var(--line-2);
+  margin: 36px 0; position: relative;
+}
+.content img { max-width: 100%; height: auto; border: 1px solid var(--line-2); }
+
+/* ------------------------------------------------------------- Pager */
+.pager {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 18px;
+  margin-top: 50px; padding-top: 30px;
+  border-top: 1px solid var(--line-2);
+}
+.pager .b {
+  display: block; padding: 18px 20px;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  transition: border-color .15s ease, background .15s ease;
+}
+.pager .b.next { text-align: right; }
+.pager .b:hover { border-color: var(--brass-dim); background: var(--bg-3); }
+.pager .k {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .18em;
+  font-size: 11px; color: var(--brass); margin-bottom: 6px;
+}
+.pager .t { font-family: var(--ff-alt); font-size: 18px; color: var(--ink); }
+
+/* --------------------------------------------------------- Taxonomy list */
+.term-list { list-style: none; padding: 0; }
+.term-list li {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 12px 0; border-bottom: 1px solid var(--line);
+}
+.term-list a {
+  font-family: var(--ff-alt); font-size: 20px;
+  border-bottom: 0; color: var(--brass);
+}
+.term-list a:hover { color: var(--ink); }
+.term-count {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .14em;
+  font-size: 12px; color: var(--ink-faint);
+}
+
+/* ------------------------------------------------------------- Footer */
+.foot { margin-top: 40px; }
+.foot-rule {
+  position: relative; height: 1px; background: var(--brass-dim);
+  max-width: var(--maxw); margin: 0 auto;
+}
+.foot-rule .lozenge {
+  position: absolute; top: 50%; left: 50%;
+  width: 12px; height: 12px; background: var(--brass);
+  transform: translate(-50%, -50%) rotate(45deg);
+  box-shadow: 0 0 0 5px var(--bg), 0 0 0 6px var(--brass-dim);
+}
+.foot-inner {
+  max-width: var(--maxw); margin: 0 auto;
+  padding: 34px 28px 48px;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 20px; flex-wrap: wrap;
+}
+.foot-mark { display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+.foot-mark .brand-word { font-size: 18px; }
+.foot-desc { color: var(--ink-faint); font-size: 16px; font-style: italic; max-width: 520px; }
+.foot-meta {
+  font-family: var(--ff-alt);
+  text-transform: uppercase; letter-spacing: .14em;
+  font-size: 12px; color: var(--ink-faint);
+}
+
+/* ------------------------------------------------------------- Responsive */
+@media (max-width: 1040px) {
+  .shell { grid-template-columns: 220px minmax(0,1fr); }
+  .toc { display: none; }
+}
+
+@media (max-width: 860px) {
+  body { font-size: 18px; }
+  .bar-inner { gap: 16px; }
+  .bar nav { gap: 18px; }
+  .bar nav a:not(.cta) { display: none; }
+  .bar nav a.cta { display: inline-block; }
+
+  .shell { grid-template-columns: 1fr; gap: 28px; padding: 28px 20px 50px; }
+  .sidebar {
+    position: static; top: auto;
+    border-left: 0; padding-left: 0;
+    border-bottom: 1px solid var(--line-2); padding-bottom: 20px;
+  }
+  .sidebar::before { display: none; }
+
+  .cats { grid-template-columns: 1fr; padding: 0 20px; }
+  .section-cats { grid-template-columns: 1fr; }
+  .metrics { grid-template-columns: 1fr 1fr; margin-left: 20px; margin-right: 20px; }
+  .metrics .m:nth-child(2) { border-right: 0; }
+  .metrics .m:nth-child(1), .metrics .m:nth-child(2) { border-bottom: 1px solid var(--line-2); }
+
+  .hero { padding: 50px 20px 30px; }
+  .hero-emblem, .hero.notfound .hero-emblem { width: 240px; height: 240px; }
+  .pager { grid-template-columns: 1fr; }
+  .foot-inner { flex-direction: column; align-items: flex-start; }
+}
+
+@media (max-width: 460px) {
+  .metrics { grid-template-columns: 1fr; }
+  .metrics .m { border-right: 0; border-bottom: 1px solid var(--line-2); }
+  .metrics .m:last-child { border-bottom: 0; }
+}

--- a/examples/deco/templates/404.html
+++ b/examples/deco/templates/404.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+
+<section class="hero notfound">
+  <div class="hero-emblem" aria-hidden="true">
+    <svg class="sunburst" viewBox="0 0 320 320" width="260" height="260">
+      <g stroke="#b9975b" stroke-width="2">
+        <line x1="160" y1="160" x2="160" y2="0"/>
+        <line x1="160" y1="160" x2="220" y2="6"/>
+        <line x1="160" y1="160" x2="274" y2="46"/>
+        <line x1="160" y1="160" x2="314" y2="100"/>
+        <line x1="160" y1="160" x2="320" y2="160"/>
+        <line x1="160" y1="160" x2="314" y2="220"/>
+        <line x1="160" y1="160" x2="274" y2="274"/>
+        <line x1="160" y1="160" x2="220" y2="314"/>
+        <line x1="160" y1="160" x2="160" y2="320"/>
+        <line x1="160" y1="160" x2="100" y2="314"/>
+        <line x1="160" y1="160" x2="46"  y2="274"/>
+        <line x1="160" y1="160" x2="6"   y2="220"/>
+        <line x1="160" y1="160" x2="0"   y2="160"/>
+        <line x1="160" y1="160" x2="6"   y2="100"/>
+        <line x1="160" y1="160" x2="46"  y2="46"/>
+        <line x1="160" y1="160" x2="100" y2="6"/>
+      </g>
+    </svg>
+    <div class="emblem-number">404</div>
+  </div>
+  <p class="hero-kicker">Off the floor plan</p>
+  <h1 class="hero-title small">Not found</h1>
+  <div class="deco-rule"><span class="lozenge"></span></div>
+  <p class="deck hero-deck">This room is not on the directory board. Take the elevator back to the
+    <a href="{{ base_url }}/docs/">documentation</a> or return to the
+    <a href="{{ base_url }}/">lobby</a>.</p>
+</section>
+
+{% include "footer.html" %}

--- a/examples/deco/templates/_sidebar.html
+++ b/examples/deco/templates/_sidebar.html
@@ -1,0 +1,28 @@
+<aside class="sidebar">
+  <h4>Start here</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+    <li><a href="{{ base_url }}/docs/your-first-page/">Your first page</a></li>
+    <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+  </ul>
+
+  <h4>Concepts</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a></li>
+    <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+    <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+  </ul>
+
+  <h4>Guides</h4>
+  <ul>
+    <li><a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a></li>
+    <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+    <li><a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a></li>
+  </ul>
+
+  <h4>Reference</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/cli/">CLI reference</a></li>
+    <li><a href="{{ base_url }}/docs/template-filters/">Template filters</a></li>
+  </ul>
+</aside>

--- a/examples/deco/templates/footer.html
+++ b/examples/deco/templates/footer.html
@@ -1,0 +1,12 @@
+<footer class="foot">
+  <div class="foot-rule" aria-hidden="true"><span class="lozenge"></span></div>
+  <div class="foot-inner">
+    <div class="foot-mark">
+      <span class="brand-word">{{ site.title }}</span>
+      <span class="foot-desc">{{ site.description }}</span>
+    </div>
+    <div class="foot-meta">© {{ current_year }} · Edition I · Set in Cinzel &amp; EB Garamond</div>
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/deco/templates/header.html
+++ b/examples/deco/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Marcellus&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand">
+      <span class="mark" aria-hidden="true">
+        <svg viewBox="0 0 40 40" width="34" height="34">
+          <rect x="18" y="3"  width="4"  height="34" fill="#b9975b"/>
+          <rect x="13" y="9"  width="14" height="3"  fill="#b9975b"/>
+          <rect x="9"  y="17" width="22" height="3"  fill="#b9975b"/>
+          <rect x="5"  y="25" width="30" height="3"  fill="#b9975b"/>
+          <rect x="2"  y="33" width="36" height="3"  fill="#b9975b"/>
+        </svg>
+      </span>
+      <span class="brand-word">{{ site.title }}</span>
+    </a>
+    <nav aria-label="Primary">
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/guides/">Guides</a>
+      <a href="{{ base_url }}/about/">About</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/examples/deco/templates/home.html
+++ b/examples/deco/templates/home.html
@@ -1,0 +1,104 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="hero-emblem" aria-hidden="true">
+    <svg class="sunburst" viewBox="0 0 320 320" width="320" height="320">
+      <g stroke="#b9975b" stroke-width="2">
+        <line x1="160" y1="160" x2="160" y2="0"/>
+        <line x1="160" y1="160" x2="220" y2="6"/>
+        <line x1="160" y1="160" x2="274" y2="46"/>
+        <line x1="160" y1="160" x2="314" y2="100"/>
+        <line x1="160" y1="160" x2="320" y2="160"/>
+        <line x1="160" y1="160" x2="314" y2="220"/>
+        <line x1="160" y1="160" x2="274" y2="274"/>
+        <line x1="160" y1="160" x2="220" y2="314"/>
+        <line x1="160" y1="160" x2="160" y2="320"/>
+        <line x1="160" y1="160" x2="100" y2="314"/>
+        <line x1="160" y1="160" x2="46"  y2="274"/>
+        <line x1="160" y1="160" x2="6"   y2="220"/>
+        <line x1="160" y1="160" x2="0"   y2="160"/>
+        <line x1="160" y1="160" x2="6"   y2="100"/>
+        <line x1="160" y1="160" x2="46"  y2="46"/>
+        <line x1="160" y1="160" x2="100" y2="6"/>
+      </g>
+    </svg>
+    <svg class="tower" viewBox="0 0 120 160" width="120" height="160">
+      <g fill="#b9975b">
+        <rect x="56" y="2"   width="8"  height="158"/>
+        <rect x="48" y="28"  width="24" height="132"/>
+        <rect x="38" y="58"  width="44" height="102"/>
+        <rect x="26" y="92"  width="68" height="68"/>
+        <rect x="12" y="126" width="96" height="34"/>
+      </g>
+      <g fill="#13171c">
+        <rect x="44" y="100" width="6" height="60"/>
+        <rect x="58" y="100" width="6" height="60"/>
+        <rect x="72" y="100" width="6" height="60"/>
+        <rect x="30" y="134" width="6" height="26"/>
+        <rect x="86" y="134" width="6" height="26"/>
+      </g>
+    </svg>
+  </div>
+  <p class="hero-kicker">A Hwaro documentation theme</p>
+  <h1 class="hero-title">Deco</h1>
+  <p class="hero-sub">The lobby of a Chrysler-era skyscraper, rendered as documentation.</p>
+  <div class="deco-rule"><span class="lozenge"></span></div>
+  <p class="deck hero-deck">Charcoal and brass. Stepped ziggurat frames, fluted rules, and wide-tracked capitals — built for projects that want their reference manual to feel like an entrance hall, not a spreadsheet.</p>
+  <div class="cta-row">
+    <a href="{{ base_url }}/docs/installation/" class="primary">Enter the lobby →</a>
+    <a href="{{ base_url }}/docs/" class="ghost">Browse the docs</a>
+    <code class="kbd">brew install hahwul/hwaro/hwaro</code>
+  </div>
+</section>
+
+<div class="deco-rule wide"><span class="lozenge"></span></div>
+
+<section class="cats">
+  <a href="{{ base_url }}/docs/installation/" class="cat">
+    <div class="numeral">I</div>
+    <h3>Installation</h3>
+    <p>Three commands from an empty directory to a running dev server. Homebrew, then a scaffold.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/sections-and-pages/" class="cat">
+    <div class="numeral">II</div>
+    <h3>Sections &amp; pages</h3>
+    <p>How content is arranged, how sections behave, and why <code>_index.md</code> is doing more than it looks.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/templates/" class="cat">
+    <div class="numeral">III</div>
+    <h3>Templates</h3>
+    <p>Crinja templates, where they live, and the small set of globals you are allowed to count on.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/build-pipeline/" class="cat">
+    <div class="numeral">IV</div>
+    <h3>The build pipeline</h3>
+    <p>What happens between <code>hwaro build</code> and <code>public/</code>, laid out in seven readable phases.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/i18n/" class="cat">
+    <div class="numeral">V</div>
+    <h3>Internationalization</h3>
+    <p>Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/deploying/" class="cat">
+    <div class="numeral">VI</div>
+    <h3>Deploying</h3>
+    <p>Cookbook entries for GitHub Pages, Cloudflare Pages, and a plain rsync script for the rest of us.</p>
+    <span class="read">Read →</span>
+  </a>
+</section>
+
+<div class="deco-rule wide"><span class="lozenge"></span></div>
+
+<section class="metrics">
+  <div class="m"><div class="v">XI</div><div class="k">Documentation pages</div></div>
+  <div class="m"><div class="v">II</div><div class="k">Signature fonts</div></div>
+  <div class="m"><div class="v">#b9975b</div><div class="k">Brass, flat &amp; solid</div></div>
+  <div class="m"><div class="v">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/deco/templates/page.html
+++ b/examples/deco/templates/page.html
@@ -1,0 +1,47 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb">
+      <a href="{{ base_url }}/">Lobby</a>
+      <span class="sep">◆</span>
+      {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a><span class="sep">◆</span>{% endif %}
+      <span class="here">{{ page.title }}</span>
+    </div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+    <div class="deco-rule small"><span class="lozenge"></span></div>
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b">
+        <div class="k">← Previous</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">Next →</div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+  </main>
+  <aside class="toc">
+    <h5>On this floor</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/deco/templates/section.html
+++ b/examples/deco/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><a href="{{ base_url }}/">Lobby</a><span class="sep">◆</span><span class="here">{{ section.title }}</span></div>
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+    <div class="deco-rule small"><span class="lozenge"></span></div>
+
+    <div class="cats section-cats">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="numeral">{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5>{{ section.pages | length }} entries</h5>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/deco/templates/taxonomy.html
+++ b/examples/deco/templates/taxonomy.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><a href="{{ base_url }}/">Lobby</a><span class="sep">◆</span><span class="here">{{ taxonomy_name }}</span></div>
+    <h1>All {{ taxonomy_name }}</h1>
+    <div class="deco-rule small"><span class="lozenge"></span></div>
+    <div class="content">
+      <ul class="term-list">
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term }}</a> <span class="term-count">{{ term.pages | length }} entries</span></li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/deco/templates/taxonomy_term.html
+++ b/examples/deco/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><a href="{{ base_url }}/">Lobby</a><span class="sep">◆</span><a href="{{ base_url }}/tags/">tags</a><span class="sep">◆</span><span class="here">{{ taxonomy_term }}</span></div>
+    <h1>#{{ taxonomy_term }}</h1>
+    <div class="deco-rule small"><span class="lozenge"></span></div>
+    <div class="cats section-cats">
+    {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="numeral">{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read →</span>
+      </a>
+    {% endfor %}
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/letterpress/AGENTS.md
+++ b/examples/letterpress/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - Letterpress, a refined classic letterpress-print documentation theme for Hwaro
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/letterpress/archetypes/default.md
+++ b/examples/letterpress/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/letterpress/config.toml
+++ b/examples/letterpress/config.toml
@@ -1,0 +1,197 @@
+title = "Letterpress"
+description = "A refined classic letterpress-print documentation theme, ink pressed into cotton paper."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/letterpress/content/about.md
+++ b/examples/letterpress/content/about.md
@@ -1,0 +1,30 @@
++++
+title = "Colophon"
+description = "About Letterpress, the typographic choices behind it, and where the credit is due."
+date = "2026-04-01"
++++
+
+Letterpress is a documentation theme that borrows from the craft of the print shop: type set by hand, ink pressed into cotton stock, and margins ruled with hairlines you can feel. It is unapologetically quiet. The goal is a page that rewards slow reading rather than a quick scroll.
+
+## The choices we have made
+
+- A serif display face, Spectral, for headings and titles, given a faint inked impression with layered text-shadow.
+- Source Serif 4 for the body, set generously so long passages stay comfortable.
+- IBM Plex Mono for kickers, labels, and code, always in small caps.
+- One accent only: an oxblood vermilion, used sparingly the way a second ink would cost a second pass through the press.
+- Solid fills and debossed hairlines instead of color blocks. No blended washes, ever.
+
+## Signature impressions
+
+- Headings and section labels carry a subtle pressed-into-paper shadow.
+- Every documentation page opens with a true drop-cap.
+- A printer's fleuron ornament closes each entry before the pager.
+- The footer is set as a colophon: the edition, the typeface, and the press that made it.
+
+## What this is not
+
+This is not a marketing theme. There is no carousel, no testimonial wall, and no animation that fires on scroll. It is a reading surface, set with intent.
+
+## License
+
+MIT. Use it, fork it, send improvements.

--- a/examples/letterpress/content/docs/_index.md
+++ b/examples/letterpress/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The core text. Installation, configuration, and the daily composition workflow."
+sort_by = "weight"
++++

--- a/examples/letterpress/content/docs/cli.md
+++ b/examples/letterpress/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "Every command, every flag, and the one or two you actually need every day."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name>` | Scaffold a new site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/letterpress/content/docs/configuration.md
+++ b/examples/letterpress/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "Every setting in config.toml, what it does, and the smallest sensible default."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/letterpress/content/docs/installation.md
+++ b/examples/letterpress/content/docs/installation.md
@@ -1,0 +1,32 @@
++++
+title = "Installation"
+description = "Three commands and the press is running. Then a few pages on how strict you want your composition to be."
+weight = 1
+date = "2026-05-01"
++++
+
+Letterpress runs on the Hwaro static site generator. You can install it from Homebrew, run it under Docker, or build it from source.
+
+## Quickstart
+
+```sh
+brew tap hahwul/hwaro
+brew install hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve --open
+```
+
+The dev server will open `http://localhost:3000` in your browser. Any edit to `content/`, `templates/`, or `static/` reloads in under 50ms.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.2 or newer
+```
+
+If you see anything older, your package manager has cached an old version. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Move on to **Your first page**, where you will write a single piece of content, give it a template, and watch it render.

--- a/examples/letterpress/content/docs/sections-and-pages.md
+++ b/examples/letterpress/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "How content is organized, how sections behave, and why _index.md is doing more than it looks."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/letterpress/content/docs/taxonomies.md
+++ b/examples/letterpress/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Tags, categories, and the occasional custom one. How to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/letterpress/content/docs/template-filters.md
+++ b/examples/letterpress/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A reference of the most useful template filters, with examples you can paste."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/letterpress/content/docs/templates.md
+++ b/examples/letterpress/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Jinja-flavored templates, where to put them, and the small set of globals you can count on."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/letterpress/content/docs/your-first-page.md
+++ b/examples/letterpress/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "A short walkthrough that ends with a rendered leaf and the quiet satisfaction of a clean build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/letterpress/content/guides/_index.md
+++ b/examples/letterpress/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "Longer recipes for common runs and the occasional awkward edge case."
+sort_by = "weight"
++++

--- a/examples/letterpress/content/guides/build-pipeline.md
+++ b/examples/letterpress/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "What happens between hwaro build and public/, in seven readable phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/letterpress/content/guides/deploying.md
+++ b/examples/letterpress/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Cookbook entries for GitHub Pages, Cloudflare Pages, and a Bash script for the rest of the run."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/letterpress/content/guides/i18n.md
+++ b/examples/letterpress/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/letterpress/content/index.md
+++ b/examples/letterpress/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Letterpress"
+description = "A refined classic letterpress-print documentation theme, ink pressed into cotton paper."
+template = "home"
++++

--- a/examples/letterpress/static/css/style.css
+++ b/examples/letterpress/static/css/style.css
@@ -1,0 +1,745 @@
+/* =============================================================================
+   LETTERPRESS — a refined classic letterpress-print documentation theme.
+   Concept: ink pressed into cotton paper. Warm cream, near-black ink,
+   oxblood/vermilion accent, debossed hairlines, pressed/inked type.
+   No blended fills anywhere. Solid colors, borders, inset box-shadow, text-shadow.
+   ============================================================================= */
+
+:root {
+  /* Palette — warm cream paper, near-black ink, oxblood accent */
+  --paper:      #f7f3ea;   /* cotton paper */
+  --paper-deep: #efe9dc;   /* shadowed fold of the sheet */
+  --paper-card: #fcfaf3;   /* lightest leaf */
+  --ink:        #1a1714;   /* near-black ink */
+  --ink-soft:   #423a32;   /* lighter impression */
+  --mute:       #877c6c;   /* faded margin note */
+  --accent:     #9c2f23;   /* oxblood / vermilion */
+  --accent-dk:  #75201a;   /* dried oxblood */
+  --hair:       #d8cfbd;   /* deboss hairline */
+  --hair-soft:  #e6dfd0;   /* faintest rule */
+  --code-bg:    #efe8d8;   /* ink slab for code */
+
+  /* Type system */
+  --serif-display: "Spectral", Georgia, "Times New Roman", serif;
+  --serif-body:    "Source Serif 4", Georgia, serif;
+  --mono:          "IBM Plex Mono", "SFMono-Regular", Menlo, monospace;
+
+  /* Spacing scale (8px base) */
+  --s1: 4px;  --s2: 8px;  --s3: 12px; --s4: 16px;
+  --s5: 24px; --s6: 32px; --s7: 48px; --s8: 64px; --s9: 96px;
+
+  /* The signature "press" — a pale highlight + an ink-dark deboss */
+  --press: inset 0 1px 0 rgba(255,255,255,0.7), inset 0 -1px 0 rgba(26,23,20,0.10);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--serif-body);
+  font-size: 17px;
+  line-height: 1.7;
+  font-feature-settings: "liga" 1, "onum" 1, "kern" 1;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* ---- Inked / pressed type helpers ---- */
+.pressed {
+  color: var(--ink);
+  text-shadow:
+    0 1px 0 rgba(255,255,255,0.65),
+    0 -1px 1px rgba(26,23,20,0.18);
+}
+.pressed-accent {
+  color: var(--accent);
+  text-shadow:
+    0 1px 0 rgba(255,255,255,0.55),
+    0 -1px 1px rgba(117,32,26,0.28);
+}
+
+/* ---- Small-caps mono kicker / label ---- */
+.kicker {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: inline-block;
+}
+
+/* =============================================================================
+   Masthead (top bar)
+   ============================================================================= */
+.bar {
+  background: var(--paper);
+  border-bottom: 1px solid var(--ink);
+  box-shadow: 0 1px 0 var(--hair);
+  position: sticky; top: 0; z-index: 30;
+}
+.bar-inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: stretch;
+  max-width: 1320px;
+  margin: 0 auto;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+  padding: var(--s4) var(--s5);
+  border-right: 1px solid var(--hair);
+  font-family: var(--serif-display);
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: 0.01em;
+}
+.brand .mark {
+  position: relative;
+  width: 30px; height: 30px;
+  border: 1.5px solid var(--ink);
+  display: grid; place-items: center;
+  box-shadow: var(--press);
+  background: var(--paper-card);
+}
+.brand .mark::after {
+  content: "L";
+  font-family: var(--serif-display);
+  font-weight: 700;
+  font-size: 17px;
+  color: var(--accent);
+  line-height: 1;
+  text-shadow: 0 1px 0 rgba(255,255,255,0.6);
+}
+
+.search {
+  padding: 0 var(--s5);
+  display: flex;
+  align-items: center;
+  border-right: 1px solid var(--hair);
+}
+.search input {
+  border: 0; background: transparent;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink);
+  padding: var(--s3) 0;
+  width: 100%;
+  outline: none;
+  letter-spacing: 0.04em;
+}
+.search input::placeholder { color: var(--mute); }
+.search .kbd {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 3px 7px;
+  border: 1px solid var(--hair);
+  color: var(--mute);
+  box-shadow: var(--press);
+  background: var(--paper-card);
+}
+
+.bar nav { display: flex; }
+.bar nav a {
+  padding: var(--s4) var(--s5);
+  border-left: 1px solid var(--hair);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  display: flex; align-items: center;
+  transition: color 120ms ease, background 120ms ease;
+}
+.bar nav a:hover { background: var(--ink); color: var(--paper); }
+.bar nav a.cta { color: var(--accent); }
+.bar nav a.cta:hover { background: var(--accent); color: var(--paper); }
+
+/* =============================================================================
+   Document shell (sidebar / main / toc)
+   ============================================================================= */
+.shell {
+  display: grid;
+  grid-template-columns: 264px 1fr 232px;
+  max-width: 1320px;
+  margin: 0 auto;
+  min-height: calc(100vh - 64px);
+}
+
+.sidebar {
+  border-right: 1px solid var(--hair);
+  padding: var(--s7) var(--s5);
+  position: sticky; top: 64px;
+  height: calc(100vh - 64px);
+  overflow-y: auto;
+}
+.sidebar h4 {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: var(--s6) 0 var(--s3);
+  padding-bottom: var(--s2);
+  border-bottom: 1px solid var(--hair);
+}
+.sidebar h4:first-child { margin-top: 0; }
+.sidebar ul { list-style: none; padding: 0; margin: 0; }
+.sidebar li { font-size: 15px; }
+.sidebar a {
+  display: block;
+  padding: var(--s2) var(--s3);
+  border-left: 2px solid transparent;
+  color: var(--ink-soft);
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+.sidebar a:hover { color: var(--ink); border-left-color: var(--hair); background: var(--paper-deep); }
+.sidebar a.active {
+  border-left-color: var(--accent);
+  color: var(--ink);
+  font-weight: 600;
+  background: var(--paper-deep);
+}
+
+.main { padding: var(--s8) var(--s8); max-width: 820px; }
+
+.toc {
+  border-left: 1px solid var(--hair);
+  padding: var(--s8) var(--s5);
+  position: sticky; top: 64px;
+  height: calc(100vh - 64px);
+  overflow-y: auto;
+  font-size: 14px;
+}
+.toc h5 {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--s4);
+  padding-bottom: var(--s2);
+  border-bottom: 1px solid var(--hair);
+}
+.toc ul { list-style: none; padding: 0; margin: 0; }
+.toc li { padding: var(--s1) 0; line-height: 1.4; }
+.toc a { color: var(--mute); border-bottom: 1px solid transparent; }
+.toc a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* =============================================================================
+   Article head
+   ============================================================================= */
+.crumb {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--mute);
+  margin-bottom: var(--s5);
+  display: flex;
+  gap: var(--s2);
+  align-items: center;
+  text-transform: uppercase;
+}
+.crumb .accent { color: var(--accent); }
+.crumb a { border-bottom: 1px solid var(--hair); }
+.crumb a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+.main h1 {
+  font-family: var(--serif-display);
+  font-weight: 800;
+  font-size: clamp(38px, 5vw, 56px);
+  line-height: 1.04;
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--s4);
+  color: var(--ink);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.6), 0 -1px 1px rgba(26,23,20,0.16);
+  padding-bottom: var(--s5);
+  position: relative;
+}
+/* Ornamental hairline rule under the title, with a pressed accent tick */
+.main h1::after {
+  content: "";
+  position: absolute; left: 0; bottom: 0;
+  width: 100%; height: 0;
+  border-bottom: 1px solid var(--ink);
+  box-shadow: 0 2px 0 var(--hair);
+}
+.main h1::before {
+  content: "";
+  position: absolute; left: 0; bottom: -1px;
+  width: 72px; height: 3px;
+  background: var(--accent);
+  z-index: 1;
+}
+.main .deck {
+  font-family: var(--serif-display);
+  font-weight: 300;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink-soft);
+  margin: 0 0 var(--s7);
+  max-width: 56ch;
+  line-height: 1.5;
+}
+
+/* =============================================================================
+   .content — the printed body
+   ============================================================================= */
+.content { font-size: 17px; }
+
+.content h2 {
+  font-family: var(--serif-display);
+  font-size: 30px;
+  font-weight: 700;
+  margin: var(--s8) 0 var(--s4);
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.55);
+  padding-bottom: var(--s2);
+  border-bottom: 1px solid var(--hair);
+}
+.content h3 {
+  font-family: var(--serif-display);
+  font-size: 22px;
+  font-weight: 700;
+  margin: var(--s6) 0 var(--s3);
+  color: var(--ink);
+}
+.content h4 {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: var(--s5) 0 var(--s3);
+}
+.content p { margin: 0 0 var(--s4); max-width: 68ch; }
+
+/* True drop-cap on the first paragraph of a doc page */
+.content > p:first-of-type::first-letter {
+  font-family: var(--serif-display);
+  font-weight: 800;
+  float: left;
+  font-size: 4.6em;
+  line-height: 0.78;
+  padding: 6px 12px 0 0;
+  margin-top: 4px;
+  color: var(--accent);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.6), 0 -1px 1px rgba(117,32,26,0.22);
+}
+
+.content a {
+  color: var(--accent);
+  border-bottom: 1px solid var(--hair);
+  transition: border-color 120ms ease, color 120ms ease;
+}
+.content a:hover { color: var(--accent-dk); border-bottom-color: var(--accent); }
+
+.content strong { font-weight: 700; color: var(--ink); }
+.content em { font-style: italic; }
+
+.content ul, .content ol { padding-left: var(--s6); margin: 0 0 var(--s4); max-width: 68ch; }
+.content li { margin-bottom: var(--s2); }
+.content ul li::marker { color: var(--accent); }
+.content ol li::marker { color: var(--accent); font-family: var(--mono); font-size: 0.85em; }
+
+/* Inline code */
+.content code {
+  font-family: var(--mono);
+  background: var(--code-bg);
+  padding: 2px 6px;
+  font-size: 0.84em;
+  color: var(--accent-dk);
+  border: 1px solid var(--hair);
+  border-radius: 2px;
+}
+
+/* Code blocks — an inked slab debossed into the page */
+.content pre {
+  background: var(--paper-card);
+  border: 1px solid var(--ink);
+  box-shadow: var(--press), 0 1px 0 var(--hair);
+  padding: var(--s5) var(--s6);
+  overflow-x: auto;
+  font-size: 13.5px;
+  line-height: 1.6;
+  font-family: var(--mono);
+  margin: var(--s5) 0;
+  position: relative;
+}
+.content pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--ink);
+  font-size: inherit;
+}
+.content pre::before {
+  content: "";
+  position: absolute; top: 0; left: 0;
+  width: 3px; height: 100%;
+  background: var(--accent);
+}
+
+/* Blockquotes — a margin note pressed in */
+.content blockquote {
+  border-left: 2px solid var(--accent);
+  padding: var(--s2) var(--s5);
+  margin: var(--s5) 0;
+  font-family: var(--serif-display);
+  font-style: italic;
+  font-size: 1.1em;
+  color: var(--ink-soft);
+}
+.content blockquote p:last-child { margin-bottom: 0; }
+
+/* Tables — a ledger ruled in hairlines */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--s5) 0;
+  font-size: 15px;
+  border: 1px solid var(--ink);
+  box-shadow: var(--press);
+}
+.content th {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-align: left;
+  padding: var(--s3) var(--s4);
+  background: var(--paper-deep);
+  border-bottom: 1px solid var(--ink);
+  color: var(--ink);
+}
+.content td {
+  padding: var(--s3) var(--s4);
+  border-bottom: 1px solid var(--hair);
+  vertical-align: top;
+}
+.content tr:last-child td { border-bottom: 0; }
+.content tbody tr:hover { background: var(--paper-deep); }
+
+.content hr {
+  border: 0;
+  height: 1px;
+  background: var(--hair);
+  margin: var(--s7) 0;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.6);
+}
+
+.content img { max-width: 100%; border: 1px solid var(--hair); box-shadow: var(--press); }
+
+/* =============================================================================
+   Fleuron — printer's ornament divider
+   ============================================================================= */
+.fleuron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s4);
+  margin: var(--s8) 0;
+  color: var(--accent);
+}
+.fleuron::before, .fleuron::after {
+  content: "";
+  flex: 1;
+  max-width: 180px;
+  height: 0;
+  border-bottom: 1px solid var(--hair);
+}
+.fleuron svg { display: block; }
+
+/* =============================================================================
+   Pager
+   ============================================================================= */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--s4);
+  margin-top: var(--s8);
+  border-top: 1px solid var(--hair);
+  padding-top: var(--s6);
+}
+.pager .b {
+  border: 1px solid var(--hair);
+  box-shadow: var(--press);
+  padding: var(--s4) var(--s5);
+  background: var(--paper-card);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.pager .b:hover { border-color: var(--ink); box-shadow: var(--press), 0 2px 0 var(--hair); }
+.pager .b .k {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.pager .b .t {
+  font-family: var(--serif-display);
+  font-weight: 700;
+  font-size: 19px;
+  margin-top: var(--s1);
+}
+.pager .next { text-align: right; }
+
+/* =============================================================================
+   Home — title page of the press
+   ============================================================================= */
+.hero {
+  max-width: 1320px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  border-bottom: 1px solid var(--hair);
+}
+.hero .copy {
+  padding: var(--s9) var(--s8);
+  border-right: 1px solid var(--hair);
+}
+.hero .copy .kicker { margin-bottom: var(--s5); }
+.hero h1 {
+  font-family: var(--serif-display);
+  font-weight: 800;
+  font-size: clamp(44px, 6vw, 84px);
+  line-height: 1.0;
+  letter-spacing: -0.015em;
+  margin: 0 0 var(--s5);
+  color: var(--ink);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.6), 0 -1px 1px rgba(26,23,20,0.16);
+}
+.hero h1 .accent { color: var(--accent); text-shadow: 0 1px 0 rgba(255,255,255,0.5), 0 -1px 1px rgba(117,32,26,0.26); }
+.hero h1 em { font-style: italic; font-weight: 400; }
+.hero .deck {
+  font-family: var(--serif-body);
+  font-size: 19px;
+  color: var(--ink-soft);
+  max-width: 52ch;
+  margin: 0 0 var(--s6);
+  line-height: 1.6;
+}
+.hero .cta-row { display: flex; flex-wrap: wrap; gap: var(--s3); align-items: center; }
+.hero .cta-row a {
+  border: 1px solid var(--ink);
+  padding: var(--s3) var(--s5);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: var(--press);
+  background: var(--paper-card);
+  transition: background 120ms ease, color 120ms ease;
+}
+.hero .cta-row a:hover { background: var(--paper-deep); }
+.hero .cta-row a.primary { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+.hero .cta-row a.primary:hover { background: var(--accent); border-color: var(--accent); }
+.hero .cta-row a.kbd {
+  border: 1px dashed var(--hair);
+  color: var(--mute);
+  box-shadow: none;
+  background: transparent;
+  text-transform: none;
+}
+
+/* Specimen plate — the right-hand panel as a printer's type specimen */
+.specimen {
+  padding: var(--s7) var(--s6);
+  display: grid;
+  align-content: center;
+  gap: var(--s4);
+}
+.specimen .plate {
+  border: 1px solid var(--ink);
+  box-shadow: var(--press), 0 2px 0 var(--hair);
+  background: var(--paper-card);
+  padding: var(--s6);
+  text-align: center;
+}
+.specimen .glyph {
+  font-family: var(--serif-display);
+  font-weight: 800;
+  font-size: 120px;
+  line-height: 1;
+  color: var(--accent);
+  text-shadow: 0 2px 0 rgba(255,255,255,0.6), 0 -2px 2px rgba(117,32,26,0.22);
+}
+.specimen .scale {
+  font-family: var(--serif-display);
+  font-size: 24px;
+  color: var(--ink-soft);
+  letter-spacing: 0.02em;
+}
+.specimen .meta {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin-top: var(--s4);
+  padding-top: var(--s3);
+  border-top: 1px solid var(--hair);
+}
+
+/* =============================================================================
+   Category cards (home + section listings)
+   ============================================================================= */
+.cats {
+  max-width: 1320px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.cat {
+  border-right: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+  padding: var(--s7) var(--s6);
+  transition: background 120ms ease;
+  position: relative;
+}
+.cat:nth-child(3n) { border-right: 0; }
+.cat:hover { background: var(--paper-deep); }
+.cat .icon {
+  width: 40px; height: 40px;
+  margin-bottom: var(--s4);
+  border: 1px solid var(--ink);
+  box-shadow: var(--press);
+  display: grid; place-items: center;
+  font-family: var(--serif-display);
+  font-weight: 700;
+  font-size: 18px;
+  background: var(--paper-card);
+  color: var(--ink);
+}
+.cat .icon.accent { background: var(--accent); color: var(--paper); border-color: var(--accent-dk); }
+.cat .icon.ink { background: var(--ink); color: var(--paper); }
+.cat h3 {
+  font-family: var(--serif-display);
+  font-weight: 700;
+  font-size: 24px;
+  margin: 0 0 var(--s2);
+  color: var(--ink);
+}
+.cat p { color: var(--ink-soft); font-size: 15px; line-height: 1.6; margin: 0 0 var(--s4); }
+.cat .read {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 1px;
+}
+
+/* =============================================================================
+   Colophon strip (metrics)
+   ============================================================================= */
+.metrics {
+  max-width: 1320px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--hair);
+  background: var(--ink);
+  color: var(--paper);
+}
+.metrics .m { padding: var(--s6) var(--s6); border-right: 1px solid #34302b; }
+.metrics .m:last-child { border-right: 0; }
+.metrics .v {
+  font-family: var(--serif-display);
+  font-weight: 800;
+  font-size: 38px;
+  letter-spacing: -0.01em;
+  color: var(--paper);
+}
+.metrics .v.accent { color: #e0897e; }
+.metrics .k {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #a89c8b;
+  margin-top: var(--s2);
+}
+
+/* =============================================================================
+   Footer — colophon
+   ============================================================================= */
+.foot {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: var(--s7) var(--s6);
+  border-top: 1px solid var(--ink);
+  box-shadow: inset 0 1px 0 var(--hair);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--s5);
+  align-items: center;
+  font-size: 14px;
+  color: var(--ink-soft);
+}
+.foot .colophon-mark {
+  font-family: var(--serif-display);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--ink);
+}
+.foot .colophon-mark .accent { color: var(--accent); }
+.foot .set-in {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mute);
+  text-align: right;
+}
+
+/* =============================================================================
+   Responsive — collapse to one column under ~860px
+   ============================================================================= */
+@media (max-width: 1100px) {
+  .shell { grid-template-columns: 232px 1fr; }
+  .toc { display: none; }
+  .cats { grid-template-columns: 1fr 1fr; }
+  .cat:nth-child(3n) { border-right: 1px solid var(--hair); }
+  .cat:nth-child(2n) { border-right: 0; }
+  .hero { grid-template-columns: 1.3fr 1fr; }
+}
+
+@media (max-width: 860px) {
+  body { font-size: 16px; }
+  .shell { grid-template-columns: 1fr; }
+  .sidebar { display: none; }
+  .main { padding: var(--s6) var(--s5); max-width: 100%; }
+  .hero { grid-template-columns: 1fr; }
+  .hero .copy { border-right: 0; border-bottom: 1px solid var(--hair); padding: var(--s7) var(--s5); }
+  .specimen { padding: var(--s6) var(--s5); }
+  .cats { grid-template-columns: 1fr; }
+  .cat { border-right: 0; }
+  .cat:nth-child(3n), .cat:nth-child(2n) { border-right: 0; }
+  .metrics { grid-template-columns: 1fr 1fr; }
+  .metrics .m:nth-child(2n) { border-right: 0; }
+  .bar-inner { grid-template-columns: 1fr auto; }
+  .search { display: none; }
+  .pager { grid-template-columns: 1fr; }
+  .foot { grid-template-columns: 1fr; }
+  .foot .set-in { text-align: left; }
+}
+
+@media (max-width: 560px) {
+  .bar nav a { padding: var(--s3) var(--s4); }
+  .hero h1 { font-size: clamp(36px, 11vw, 56px); }
+  .specimen .glyph { font-size: 88px; }
+  .content > p:first-of-type::first-letter { font-size: 3.6em; }
+}

--- a/examples/letterpress/templates/404.html
+++ b/examples/letterpress/templates/404.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <span class="kicker">Error · Out of register</span>
+    <h1><span class="accent">404</span> — this leaf was never set.</h1>
+    <p class="deck">The page you asked for is not in this edition. Return to the <a href="{{ base_url }}/docs/">documentation</a> or the <a href="{{ base_url }}/">title page</a> and try another impression.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/" class="primary">Title page</a>
+      <a href="{{ base_url }}/docs/">Browse the docs</a>
+    </div>
+  </div>
+  <div class="specimen">
+    <div class="plate">
+      <div class="glyph">?</div>
+      <div class="scale">Missing sort</div>
+      <div class="meta">No matching forme</div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/letterpress/templates/_sidebar.html
+++ b/examples/letterpress/templates/_sidebar.html
@@ -1,0 +1,28 @@
+<aside class="sidebar">
+  <h4>Start the press</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+    <li><a href="{{ base_url }}/docs/your-first-page/">Your first page</a></li>
+    <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+  </ul>
+
+  <h4>Composition</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a></li>
+    <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+    <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+  </ul>
+
+  <h4>Guides</h4>
+  <ul>
+    <li><a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a></li>
+    <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+    <li><a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a></li>
+  </ul>
+
+  <h4>Reference</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/cli/">CLI reference</a></li>
+    <li><a href="{{ base_url }}/docs/template-filters/">Template filters</a></li>
+  </ul>
+</aside>

--- a/examples/letterpress/templates/footer.html
+++ b/examples/letterpress/templates/footer.html
@@ -1,0 +1,6 @@
+<footer class="foot">
+  <div class="colophon-mark">{{ site.title }} <span class="accent">·</span> {{ site.description }}</div>
+  <div class="set-in">Set in Spectral · Impressed by Hwaro · © {{ current_year }}</div>
+</footer>
+</body>
+</html>

--- a/examples/letterpress/templates/header.html
+++ b/examples/letterpress/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,700;0,800;1,300;1,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="mark"></span>{{ site.title }}</a>
+    <div class="search">
+      <input type="text" placeholder="Search the type case…" />
+      <span class="kbd">/</span>
+    </div>
+    <nav>
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/guides/">Guides</a>
+      <a href="{{ base_url }}/about/">Colophon</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">Source</a>
+    </nav>
+  </div>
+</header>

--- a/examples/letterpress/templates/home.html
+++ b/examples/letterpress/templates/home.html
@@ -1,0 +1,69 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <span class="kicker">Documentation · Set by hand</span>
+    <h1>Docs worth <span class="accent">pressing</span> into <em>paper</em>.</h1>
+    <p class="deck">Letterpress is a documentation theme built like a well-set book: a serif display face inked into warm cotton stock, oxblood accents, debossed hairlines, and a true drop-cap on every page. Quiet, deliberate, and made to be read slowly.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/installation/" class="primary">Begin printing</a>
+      <a href="{{ base_url }}/docs/">Browse the docs</a>
+      <a class="kbd">brew install hahwul/hwaro/hwaro</a>
+    </div>
+  </div>
+  <div class="specimen">
+    <div class="plate">
+      <div class="glyph">Aa</div>
+      <div class="scale">Spectral · Source Serif 4</div>
+      <div class="meta">Specimen No. 01 · 17 / 30 pt</div>
+    </div>
+  </div>
+</section>
+
+<section class="cats">
+  <a href="{{ base_url }}/docs/installation/" class="cat">
+    <div class="icon accent">I</div>
+    <h3>Installation</h3>
+    <p>Three commands and the press is running. Then a few pages on how strict you want your composition to be.</p>
+    <span class="read">Read the entry</span>
+  </a>
+  <a href="{{ base_url }}/docs/sections-and-pages/" class="cat">
+    <div class="icon">II</div>
+    <h3>Sections &amp; pages</h3>
+    <p>How content is set into formes, how sections behave, and why <code>_index.md</code> carries more weight than it looks.</p>
+    <span class="read">Read the entry</span>
+  </a>
+  <a href="{{ base_url }}/docs/templates/" class="cat">
+    <div class="icon">III</div>
+    <h3>Templates</h3>
+    <p>Crinja templates, where to keep them, and the small set of globals you are allowed to count on.</p>
+    <span class="read">Read the entry</span>
+  </a>
+  <a href="{{ base_url }}/guides/build-pipeline/" class="cat">
+    <div class="icon">IV</div>
+    <h3>The build pipeline</h3>
+    <p>What happens between <code>hwaro build</code> and <code>public/</code>, set out in seven readable phases.</p>
+    <span class="read">Read the entry</span>
+  </a>
+  <a href="{{ base_url }}/guides/i18n/" class="cat">
+    <div class="icon">V</div>
+    <h3>Internationalization</h3>
+    <p>Multilingual editions without the foot guns. One default locale, one rule for fallbacks, no surprises.</p>
+    <span class="read">Read the entry</span>
+  </a>
+  <a href="{{ base_url }}/guides/deploying/" class="cat">
+    <div class="icon ink">VI</div>
+    <h3>Deploying</h3>
+    <p>Cookbook entries for GitHub Pages, Cloudflare Pages, and a Bash script for the rest of the run.</p>
+    <span class="read">Read the entry</span>
+  </a>
+</section>
+
+<section class="metrics">
+  <div class="m"><div class="v accent">v0.14</div><div class="k">Current edition</div></div>
+  <div class="m"><div class="v">3</div><div class="k">Type families</div></div>
+  <div class="m"><div class="v">12</div><div class="k">Pages set</div></div>
+  <div class="m"><div class="v">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/letterpress/templates/page.html
+++ b/examples/letterpress/templates/page.html
@@ -1,0 +1,52 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb">
+      <span class="accent">¶</span>
+      {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a> /{% endif %}
+      <span>{{ page.title }}</span>
+    </div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+
+    <div class="content">{{ content | safe }}</div>
+
+    <div class="fleuron" aria-hidden="true">
+      <svg width="30" height="16" viewBox="0 0 30 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 1 C 9 1, 5 5, 1 8 C 5 11, 9 15, 15 15 C 21 15, 25 11, 29 8 C 25 5, 21 1, 15 1 Z" stroke="currentColor" stroke-width="1.2" fill="none"/>
+        <circle cx="15" cy="8" r="2" fill="currentColor"/>
+      </svg>
+    </div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b">
+        <div class="k">← Previous leaf</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">Next leaf →</div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+  </main>
+  <aside class="toc">
+    <h5>On this page</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/letterpress/templates/section.html
+++ b/examples/letterpress/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">¶</span> / <span>{{ section.title }}</span></div>
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+
+    <div class="cats" style="margin-top:24px;border-top:1px solid var(--ink);">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 4 == 1 %}accent{% elif loop.index % 4 == 0 %}ink{% endif %}">{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read the entry</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5>{{ section.pages | length }} entries</h5>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/letterpress/templates/taxonomy.html
+++ b/examples/letterpress/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">¶</span> / <span>{{ taxonomy_name }}</span></div>
+    <h1>All {{ taxonomy_name }}</h1>
+    <div class="content">
+      <ul>
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term }}</a> · {{ term.pages | length }} entries</li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/letterpress/templates/taxonomy_term.html
+++ b/examples/letterpress/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">¶</span> / <a href="{{ base_url }}/tags/">tags</a> / <span>{{ taxonomy_term }}</span></div>
+    <h1>{{ taxonomy_term }}</h1>
+    <div class="cats" style="margin-top:24px;border-top:1px solid var(--ink);">
+    {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 4 == 1 %}accent{% elif loop.index % 4 == 0 %}ink{% endif %}">{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read the entry</span>
+      </a>
+    {% endfor %}
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/newsprint/AGENTS.md
+++ b/examples/newsprint/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md - AI Agent Instructions for the Newsprint theme (Hwaro broadsheet documentation site)
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->
+
+- **Theme:** Newsprint — a broadsheet newspaper documentation theme (a daily technical gazette). Keep the editorial voice: datelines, kickers, decks, pull-quotes.
+- **No color washes / fades, ever.** Avoid that CSS technique entirely; the word for it must not appear in any file. Use solid fills, borders, box-shadow, and outlines only.
+- **No emojis.** Geometric Unicode glyphs (squares, section marks) are fine.
+- **Palette lives in CSS variables** in `static/css/style.css`: newsprint off-white (`--paper`), black ink (`--ink`), single spot red (`--spot`). Do not introduce new accent colors.
+- **Type system:** Playfair Display (nameplate/display), PT Serif (body), Oswald (kickers/labels), JetBrains Mono (code). Loaded in `templates/header.html`.
+- **Signature components:** the masthead/nameplate, the front-page (home.html), article pages, and the classifieds-style sidebar (`_sidebar.html`). Restyle freely but keep the Crinja variable patterns intact.

--- a/examples/newsprint/archetypes/default.md
+++ b/examples/newsprint/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/newsprint/config.toml
+++ b/examples/newsprint/config.toml
@@ -1,0 +1,197 @@
+title = "Newsprint"
+description = "A broadsheet newspaper documentation theme: a daily technical gazette set in ink and hairline rules."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/newsprint/content/about.md
+++ b/examples/newsprint/content/about.md
@@ -1,0 +1,33 @@
++++
+title = "About the Press"
+description = "The editorial line behind Newsprint, the choices set in type, and where to file your corrections."
+date = "2026-04-01"
++++
+
+Newsprint dresses technical documentation in the clothes of a broadsheet daily. It borrows the broadsheet's instincts: a commanding nameplate, ruled columns, small-caps subheads, and pull-quotes that carry the weight of an editorial. The aim is not nostalgia. It is legibility. A newspaper has spent two centuries learning how to make dense text scannable, and a documentation site has exactly the same problem to solve.
+
+## The editorial line
+
+- Black ink on newsprint off-white, with a single spot red reserved for the nameplate and the cues that matter.
+- Hairline rules everywhere, set with intention. A rule is a sentence the reader does not have to read.
+- Three type families, each with a job: a display serif for the masthead, a body serif for the prose, and a condensed sans for kickers and labels.
+- Solid fills and box-shadows only. No faded color washes, no frosted glass, no animation that runs on scroll.
+
+> A newspaper has spent two centuries learning how to make dense text scannable. Documentation has exactly the same problem to solve.
+
+## What this is not
+
+This is not a marketing template. There is no carousel, no testimonial wall, no hero video. Every component on the front page earns its column inches by pointing the reader at something they came to read.
+
+## Set in type
+
+| Element | Typeface | Role |
+| --- | --- | --- |
+| Nameplate | Playfair Display 900 | The masthead title |
+| Body | PT Serif | Article prose and decks |
+| Kickers & labels | Oswald | Datelines, subheads, cues |
+| Listings | JetBrains Mono | Code and configuration |
+
+## License of record
+
+MIT. Set it, print it, fork it. Corrections and improvements are welcome at the repository.

--- a/examples/newsprint/content/docs/_index.md
+++ b/examples/newsprint/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "The Documentation Desk"
+description = "The reference section of record: installation, configuration, templates, and the daily workflow, filed for easy retrieval."
+sort_by = "weight"
++++

--- a/examples/newsprint/content/docs/cli.md
+++ b/examples/newsprint/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "Every command, every flag, and the one or two you reach for in the daily print run."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name>` | Scaffold a new site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/newsprint/content/docs/configuration.md
+++ b/examples/newsprint/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "Every dial in config.toml, what it does, and the smallest sensible default to set it to."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/newsprint/content/docs/installation.md
+++ b/examples/newsprint/content/docs/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
+description = "Three commands to a working press. Homebrew, Docker, or source — then your first edition is on the stand."
+weight = 1
+date = "2026-05-01"
++++
+
+Newsprint runs on the Hwaro static site generator. You can install it from Homebrew, run it under Docker, or build it from source. Pick whichever gets you to a running press fastest.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve --open
+```
+
+The dev server opens `http://localhost:3000` in your browser. Any edit to `content/`, `templates/`, or `static/` reloads in under 50ms, so the page on screen is always the latest edition.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.0 or newer
+```
+
+If you see anything older, your package manager has cached an old version. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Move on to **Your first page**, where you will set a single piece of content, give it a template, and watch the press render it.

--- a/examples/newsprint/content/docs/sections-and-pages.md
+++ b/examples/newsprint/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "How content is filed, how sections behave, and why _index.md earns more than its keep."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/newsprint/content/docs/taxonomies.md
+++ b/examples/newsprint/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Tags, categories, and the occasional custom subject index. How to declare them and how to set them in templates."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/newsprint/content/docs/template-filters.md
+++ b/examples/newsprint/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A reference of the most useful template filters, with examples set ready for you to paste."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/newsprint/content/docs/templates.md
+++ b/examples/newsprint/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Crinja-flavored templates, where to file them, and the small set of globals you may count on."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/newsprint/content/docs/your-first-page.md
+++ b/examples/newsprint/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "A short walkthrough that ends with a set page, a clean proof, and the satisfaction of a green build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/newsprint/content/guides/_index.md
+++ b/examples/newsprint/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "The Guides Desk"
+description = "Longer dispatches: cookbook recipes for the build pipeline, multilingual editions, and getting your gazette into print on a CDN."
+sort_by = "weight"
++++

--- a/examples/newsprint/content/guides/build-pipeline.md
+++ b/examples/newsprint/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "What happens between hwaro build and public/, reported in seven readable phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/newsprint/content/guides/deploying.md
+++ b/examples/newsprint/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Dispatches for GitHub Pages, Cloudflare Pages, and a plain Bash script for the rest of the newsroom."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/newsprint/content/guides/i18n.md
+++ b/examples/newsprint/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/newsprint/content/index.md
+++ b/examples/newsprint/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Newsprint"
+description = "A broadsheet newspaper documentation theme: a daily technical gazette set in ink and hairline rules."
+template = "home"
++++

--- a/examples/newsprint/static/css/style.css
+++ b/examples/newsprint/static/css/style.css
@@ -1,0 +1,981 @@
+/* =============================================================================
+   NEWSPRINT — a broadsheet documentation theme for Hwaro
+   A daily technical gazette: nameplate, ruled columns, ink on newsprint.
+   Hand-authored. Hairline rules and ledger-like restraint. Solid fills only.
+   ========================================================================== */
+
+/* ----------------------------------------------------------------------------
+   1. DESIGN TOKENS
+   ------------------------------------------------------------------------- */
+:root {
+  /* Palette — newsprint off-white, black ink, single spot red */
+  --paper:        #f4f1e9;
+  --paper-deep:   #ece8dc;
+  --paper-card:   #faf8f2;
+  --ink:          #16140f;
+  --ink-soft:     #3a352c;
+  --ink-faint:    #6b6457;
+  --spot:         #b0261c;
+  --spot-deep:    #8c1d15;
+  --rule:         #16140f;
+  --rule-warm:    #b8b0a0;
+  --rule-hair:    #d6cfbf;
+
+  /* Type */
+  --display: "Playfair Display", Georgia, "Times New Roman", serif;
+  --body:    "PT Serif", Georgia, "Times New Roman", serif;
+  --label:   "Oswald", "Arial Narrow", system-ui, sans-serif;
+  --mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Spacing scale */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+
+  --shell-max: 1180px;
+  --measure: 68ch;
+}
+
+/* ----------------------------------------------------------------------------
+   2. RESET & BASE
+   ------------------------------------------------------------------------- */
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background-color: var(--paper);
+  color: var(--ink);
+  font-family: var(--body);
+  font-size: 18px;
+  line-height: 1.62;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--ink); text-decoration: none; }
+
+img { max-width: 100%; height: auto; }
+
+::selection { background: var(--spot); color: var(--paper); }
+
+:focus-visible { outline: 2px solid var(--spot); outline-offset: 2px; }
+
+/* ----------------------------------------------------------------------------
+   3. MASTHEAD / NAMEPLATE  (signature component A)
+   ------------------------------------------------------------------------- */
+.masthead {
+  background: var(--paper);
+  padding: var(--sp-5) var(--sp-5) 0;
+}
+
+.masthead-rule {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  height: 0;
+  border-top: 3px solid var(--ink);
+  position: relative;
+}
+.masthead-rule::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0;
+  top: 3px;
+  border-top: 1px solid var(--ink);
+}
+.masthead-rule--top { margin-bottom: var(--sp-4); }
+.masthead-rule--bottom { margin-top: var(--sp-4); }
+
+.masthead-inner {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: var(--sp-4);
+}
+
+.dateline {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.dateline--right { text-align: right; }
+.dateline-kicker { font-weight: 600; color: var(--ink); letter-spacing: 0.1em; }
+.dateline-meta {
+  font-weight: 400;
+  font-style: italic;
+  font-family: var(--body);
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 13px;
+}
+
+.nameplate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  line-height: 0.92;
+}
+.nameplate-pre {
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 19px;
+  color: var(--ink-soft);
+  margin-bottom: 2px;
+  letter-spacing: 0.02em;
+}
+.nameplate-title {
+  font-family: var(--display);
+  font-weight: 900;
+  font-size: clamp(38px, 7vw, 84px);
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.nameplate:hover .nameplate-title { color: var(--spot); }
+
+.gazette-nav {
+  max-width: var(--shell-max);
+  margin: var(--sp-4) auto 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: var(--sp-3);
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  font-size: 13px;
+  font-weight: 500;
+  padding-bottom: var(--sp-4);
+}
+.gazette-nav a {
+  color: var(--ink);
+  padding: 2px 0;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.12s ease, color 0.12s ease;
+}
+.gazette-nav a:hover, .gazette-nav a:focus-visible { border-bottom-color: var(--spot); color: var(--spot); }
+.gazette-nav .nav-dot { color: var(--rule-warm); }
+.gazette-nav .nav-cta { color: var(--spot); }
+.gazette-nav .nav-cta:hover { border-bottom-color: var(--spot); }
+
+/* ----------------------------------------------------------------------------
+   4. FRONT PAGE  (signature component B)
+   ------------------------------------------------------------------------- */
+.frontpage {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: var(--sp-7) var(--sp-5) var(--sp-8);
+}
+
+.frontpage-rule {
+  height: 0;
+  border-top: 1px solid var(--ink);
+  margin: var(--sp-6) 0;
+}
+.frontpage-rule--double {
+  border-top: 3px solid var(--ink);
+  position: relative;
+}
+.frontpage-rule--double::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 3px;
+  border-top: 1px solid var(--ink);
+}
+
+/* Lead article */
+.lead { text-align: center; max-width: 880px; margin: 0 auto; }
+.lead-kicker {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--sp-3);
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--spot);
+  margin-bottom: var(--sp-4);
+}
+.lead-kicker-tag {
+  color: var(--ink-soft);
+  font-weight: 400;
+  border-left: 1px solid var(--rule-warm);
+  padding-left: var(--sp-3);
+}
+.lead-headline {
+  font-family: var(--display);
+  font-weight: 900;
+  font-size: clamp(34px, 6vw, 62px);
+  line-height: 1.04;
+  letter-spacing: -0.012em;
+  margin: 0 0 var(--sp-4);
+}
+.standfirst {
+  font-family: var(--body);
+  font-style: italic;
+  font-size: clamp(18px, 2.4vw, 22px);
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 64ch;
+  margin: 0 auto var(--sp-5);
+}
+.byline-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: var(--sp-3);
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+.byline { font-weight: 600; color: var(--ink); }
+.byline-dot { color: var(--rule-warm); }
+.byline-loc { font-weight: 400; }
+.byline-link {
+  color: var(--spot);
+  font-weight: 600;
+  border-bottom: 1px solid transparent;
+}
+.byline-link:hover { border-bottom-color: var(--spot); }
+
+/* Three-column intro with column rules + drop cap */
+.columns {
+  column-count: 3;
+  column-gap: var(--sp-6);
+  column-rule: 1px solid var(--rule-hair);
+  font-size: 17px;
+  line-height: 1.66;
+  text-align: justify;
+  hyphens: auto;
+}
+.columns p { margin: 0 0 var(--sp-4); }
+.columns p:first-child { margin-top: 0; }
+.dropcap::first-letter {
+  font-family: var(--display);
+  font-weight: 900;
+  float: left;
+  font-size: 4.6em;
+  line-height: 0.78;
+  padding: 6px 10px 0 0;
+  color: var(--spot);
+}
+.columns code {
+  font-family: var(--mono);
+  font-size: 0.82em;
+  background: var(--paper-deep);
+  padding: 1px 5px;
+  border: 1px solid var(--rule-hair);
+}
+
+/* Boxed INDEX */
+.index-box {
+  border: 2px solid var(--ink);
+  padding: var(--sp-5) var(--sp-6) var(--sp-6);
+  background: var(--paper-card);
+}
+.index-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-5);
+}
+.index-head h2 {
+  font-family: var(--display);
+  font-weight: 800;
+  font-size: clamp(24px, 4vw, 34px);
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.index-head-mark { color: var(--spot); font-size: 14px; }
+.index-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+}
+.index-entry {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: var(--sp-3);
+  padding: var(--sp-4) var(--sp-4);
+  border-top: 1px solid var(--rule-hair);
+  transition: background 0.12s ease;
+}
+.index-entry:nth-child(odd) { border-right: 1px solid var(--rule-hair); }
+.index-grid > .index-entry:nth-child(1),
+.index-grid > .index-entry:nth-child(2) { border-top: none; }
+.index-entry:hover { background: var(--paper-deep); }
+.index-num {
+  font-family: var(--label);
+  font-weight: 700;
+  font-size: 20px;
+  color: var(--spot);
+  font-feature-settings: "tnum";
+}
+.index-body { display: flex; flex-direction: column; gap: 3px; }
+.index-body strong {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 19px;
+}
+.index-entry:hover .index-body strong { color: var(--spot); }
+.index-body span { font-size: 14px; line-height: 1.4; color: var(--ink-soft); }
+.index-body code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  background: var(--paper-deep);
+  padding: 0 3px;
+  border: 1px solid var(--rule-hair);
+}
+.index-page {
+  font-family: var(--label);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--ink-faint);
+  border: 1px solid var(--rule-warm);
+  padding: 1px 6px;
+}
+
+/* Ledger of figures */
+.ledger {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+.ledger-cell {
+  text-align: center;
+  padding: var(--sp-5) var(--sp-3);
+  border-right: 1px solid var(--rule-hair);
+}
+.ledger-cell:last-child { border-right: none; }
+.ledger-figure {
+  display: block;
+  font-family: var(--display);
+  font-weight: 900;
+  font-size: clamp(28px, 5vw, 44px);
+  line-height: 1;
+  color: var(--ink);
+}
+.ledger-cell:nth-child(1) .ledger-figure,
+.ledger-cell:nth-child(4) .ledger-figure { color: var(--spot); }
+.ledger-unit { font-size: 0.5em; font-family: var(--label); font-weight: 500; color: var(--ink-faint); }
+.ledger-caption {
+  display: block;
+  margin-top: var(--sp-2);
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+
+/* ----------------------------------------------------------------------------
+   5. ARTICLE SHELL + SIDEBAR + TOC
+   ------------------------------------------------------------------------- */
+.shell {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: var(--sp-6) var(--sp-5) var(--sp-8);
+  display: grid;
+  grid-template-columns: 232px minmax(0, 1fr) 200px;
+  gap: var(--sp-6);
+  align-items: start;
+}
+
+/* Classifieds / Index sidebar  (signature component D) */
+.classifieds {
+  position: sticky;
+  top: var(--sp-4);
+  border: 1px solid var(--ink);
+  background: var(--paper-card);
+  padding: 0 0 var(--sp-2);
+}
+.classifieds-masthead {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-3);
+  background: var(--ink);
+  color: var(--paper);
+  padding: var(--sp-2) var(--sp-3);
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 13px;
+  font-weight: 600;
+}
+.classifieds-mark { color: var(--spot); font-size: 10px; }
+.classifieds-group { padding: var(--sp-3) var(--sp-4) 0; }
+.classifieds-head {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--spot);
+  margin: 0 0 var(--sp-2);
+  padding-bottom: var(--sp-1);
+  border-bottom: 1px solid var(--rule-hair);
+}
+.classifieds-list { list-style: none; margin: 0 0 var(--sp-3); padding: 0; }
+.classifieds-list li { border-bottom: 1px dotted var(--rule-warm); }
+.classifieds-list li:last-child { border-bottom: none; }
+.classifieds-list a {
+  display: block;
+  padding: 6px 2px;
+  font-family: var(--body);
+  font-size: 15px;
+  color: var(--ink-soft);
+  transition: color 0.1s ease, padding-left 0.1s ease;
+}
+.classifieds-list a:hover, .classifieds-list a:focus-visible {
+  color: var(--spot);
+  padding-left: 6px;
+}
+.classifieds-notice {
+  margin: var(--sp-3) var(--sp-4) 0;
+  padding: var(--sp-3);
+  border: 1px solid var(--rule-warm);
+  background: var(--paper-deep);
+}
+.classifieds-notice-label {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--spot);
+}
+.classifieds-notice p { margin: 4px 0 0; font-size: 13px; font-style: italic; color: var(--ink-soft); line-height: 1.4; }
+
+/* TOC column */
+.toc {
+  position: sticky;
+  top: var(--sp-4);
+  font-size: 14px;
+}
+.toc-head, .toc h5 {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 var(--sp-3);
+  padding-bottom: var(--sp-2);
+  border-bottom: 2px solid var(--ink);
+}
+.toc ul { list-style: none; margin: 0; padding: 0; }
+.toc li { margin: 0; }
+.toc a {
+  display: block;
+  padding: 5px 0 5px var(--sp-3);
+  color: var(--ink-faint);
+  border-left: 1px solid var(--rule-hair);
+  line-height: 1.35;
+  transition: color 0.1s ease, border-color 0.1s ease;
+}
+.toc a:hover, .toc a:focus-visible { color: var(--spot); border-left-color: var(--spot); }
+.toc ul ul a { padding-left: var(--sp-5); font-size: 13px; }
+
+/* ----------------------------------------------------------------------------
+   6. ARTICLE  (signature component C)
+   ------------------------------------------------------------------------- */
+.article { min-width: 0; }
+
+.breadcrumb {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-bottom: var(--sp-4);
+}
+.breadcrumb a { color: var(--ink-soft); }
+.breadcrumb a:hover { color: var(--spot); }
+.breadcrumb-sep { color: var(--rule-warm); margin: 0 6px; }
+.breadcrumb-current { color: var(--ink); font-weight: 500; }
+
+.article-head { margin-bottom: var(--sp-4); }
+.article-kicker {
+  display: inline-block;
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--spot);
+  margin-bottom: var(--sp-3);
+}
+.article-title {
+  font-family: var(--display);
+  font-weight: 800;
+  font-size: clamp(32px, 5vw, 50px);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--sp-3);
+}
+.article-deck {
+  font-family: var(--body);
+  font-style: italic;
+  font-size: clamp(18px, 2.2vw, 21px);
+  line-height: 1.5;
+  color: var(--ink-soft);
+  margin: 0 0 var(--sp-4);
+  max-width: var(--measure);
+}
+.article-byline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp-3);
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+.article-byline .byline { color: var(--ink); }
+.article-byline .byline-date { font-weight: 400; }
+
+.article-rule {
+  height: 0;
+  border-top: 3px solid var(--ink);
+  position: relative;
+  margin-bottom: var(--sp-5);
+}
+.article-rule::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 3px;
+  border-top: 1px solid var(--ink);
+}
+
+/* ----------------------------------------------------------------------------
+   7. CONTENT — style EVERYTHING inside .content
+   ------------------------------------------------------------------------- */
+.content {
+  max-width: var(--measure);
+  font-size: 18px;
+  line-height: 1.68;
+}
+.content > *:first-child { margin-top: 0; }
+
+.content p { margin: 0 0 var(--sp-4); }
+
+.content h1, .content h2, .content h3, .content h4 {
+  font-family: var(--display);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  scroll-margin-top: var(--sp-5);
+}
+.content h2 {
+  font-weight: 800;
+  font-size: 28px;
+  margin: var(--sp-7) 0 var(--sp-3);
+  padding-top: var(--sp-4);
+  border-top: 1px solid var(--rule-hair);
+}
+.content h3 {
+  /* small-caps subhead */
+  font-family: var(--label);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 17px;
+  color: var(--ink);
+  margin: var(--sp-6) 0 var(--sp-3);
+}
+.content h3::before {
+  content: "\00A7";
+  color: var(--spot);
+  margin-right: 8px;
+  font-family: var(--display);
+}
+.content h4 {
+  font-weight: 700;
+  font-size: 20px;
+  margin: var(--sp-5) 0 var(--sp-2);
+}
+
+.content a {
+  color: var(--spot);
+  border-bottom: 1px solid var(--rule-warm);
+  transition: border-color 0.1s ease, background 0.1s ease;
+}
+.content a:hover, .content a:focus-visible {
+  border-bottom-color: var(--spot);
+  background: rgba(176, 38, 28, 0.06);
+}
+
+/* Lists */
+.content ul, .content ol { margin: 0 0 var(--sp-4); padding-left: var(--sp-5); }
+.content li { margin: 0 0 var(--sp-2); padding-left: var(--sp-1); }
+.content ul li::marker { color: var(--spot); content: "\25AA  "; }
+.content ol { list-style: none; counter-reset: news; padding-left: 0; }
+.content ol > li {
+  counter-increment: news;
+  position: relative;
+  padding-left: var(--sp-6);
+}
+.content ol > li::before {
+  content: counter(news);
+  position: absolute;
+  left: 0; top: 0.15em;
+  font-family: var(--label);
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--paper);
+  background: var(--ink);
+  width: 22px; height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Inline code */
+.content code {
+  font-family: var(--mono);
+  font-size: 0.84em;
+  background: var(--paper-card);
+  color: var(--spot-deep);
+  padding: 1px 5px;
+  border: 1px solid var(--rule-hair);
+}
+
+/* Code blocks */
+.content pre {
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.6;
+  background: var(--ink);
+  color: var(--paper);
+  padding: var(--sp-5) var(--sp-5);
+  margin: 0 0 var(--sp-5);
+  overflow-x: auto;
+  border: 1px solid var(--ink);
+  border-left: 4px solid var(--spot);
+  position: relative;
+}
+.content pre::before {
+  content: "LISTING";
+  position: absolute;
+  top: 0; right: 0;
+  font-family: var(--label);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--ink);
+  background: var(--paper-deep);
+  padding: 2px 8px;
+  border-left: 1px solid var(--ink-faint);
+  border-bottom: 1px solid var(--ink-faint);
+}
+.content pre code {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* Blockquote — pull-quote */
+.content blockquote {
+  margin: var(--sp-6) 0;
+  padding: var(--sp-4) 0 var(--sp-4) var(--sp-6);
+  border: none;
+  border-top: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+  position: relative;
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(20px, 3vw, 26px);
+  line-height: 1.34;
+  color: var(--ink);
+}
+.content blockquote::before {
+  content: "\201C";
+  position: absolute;
+  left: -6px; top: 2px;
+  font-family: var(--display);
+  font-size: 56px;
+  line-height: 1;
+  color: var(--spot);
+}
+.content blockquote p { margin: 0; }
+.content blockquote p + p { margin-top: var(--sp-3); }
+
+/* Tables — ruled ledger */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 var(--sp-5);
+  font-size: 16px;
+  border-top: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+}
+.content thead th {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--ink);
+  color: var(--ink);
+}
+.content tbody td {
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--rule-hair);
+  vertical-align: top;
+}
+.content tbody tr:last-child td { border-bottom: none; }
+.content tbody tr:hover td { background: var(--paper-deep); }
+.content table code { background: var(--paper-deep); }
+
+/* Horizontal rule */
+.content hr {
+  border: none;
+  height: 0;
+  border-top: 1px solid var(--ink);
+  margin: var(--sp-6) auto;
+  width: 60%;
+  position: relative;
+  text-align: center;
+}
+.content hr::after {
+  content: "\25AA \25AA \25AA";
+  position: absolute;
+  left: 50%; top: -11px;
+  transform: translateX(-50%);
+  background: var(--paper);
+  padding: 0 var(--sp-3);
+  color: var(--spot);
+  font-size: 9px;
+  letter-spacing: 0.3em;
+}
+
+.content img { border: 1px solid var(--ink); }
+.content strong { font-weight: 700; }
+.content em { font-style: italic; }
+
+/* ----------------------------------------------------------------------------
+   8. PAGER
+   ------------------------------------------------------------------------- */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-4);
+  margin-top: var(--sp-7);
+  padding-top: var(--sp-5);
+  border-top: 1px solid var(--ink);
+}
+.pager-spacer { display: block; }
+.pager-link {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: var(--sp-4);
+  border: 1px solid var(--ink);
+  background: var(--paper-card);
+  transition: background 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
+}
+.pager-next { text-align: right; }
+.pager-link:hover {
+  background: var(--paper-deep);
+  box-shadow: 4px 4px 0 var(--ink);
+  transform: translate(-1px, -1px);
+}
+.pager-dir {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 11px;
+  color: var(--spot);
+  font-weight: 600;
+}
+.pager-title {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--ink);
+}
+
+/* ----------------------------------------------------------------------------
+   9. SECTION LISTING / TERM LISTING
+   ------------------------------------------------------------------------- */
+.section-list { list-style: none; margin: 0; padding: 0; }
+.section-item { border-bottom: 1px solid var(--rule-hair); }
+.section-item:first-child { border-top: 1px solid var(--ink); }
+.section-item:last-child { border-bottom: 1px solid var(--ink); }
+.section-link {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-2);
+  transition: background 0.12s ease, padding-left 0.12s ease;
+}
+.section-link:hover { background: var(--paper-deep); padding-left: var(--sp-4); }
+.section-num {
+  font-family: var(--display);
+  font-weight: 900;
+  font-size: 30px;
+  line-height: 1;
+  color: var(--spot);
+  font-feature-settings: "tnum";
+  min-width: 42px;
+}
+.section-text { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.section-headline {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1.15;
+  color: var(--ink);
+}
+.section-link:hover .section-headline { color: var(--spot); }
+.section-summary { font-size: 15px; color: var(--ink-soft); line-height: 1.45; }
+.section-cue {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+.section-link:hover .section-cue { color: var(--spot); }
+
+.term-list { list-style: none; padding: 0; }
+.term-list li {
+  padding: var(--sp-2) 0;
+  border-bottom: 1px solid var(--rule-hair);
+}
+.term-list a { font-family: var(--display); font-weight: 700; font-size: 19px; color: var(--ink); }
+.term-list a:hover { color: var(--spot); }
+.term-count {
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-left: var(--sp-3);
+}
+
+/* ----------------------------------------------------------------------------
+   10. COLOPHON / FOOTER
+   ------------------------------------------------------------------------- */
+.colophon { margin-top: var(--sp-7); }
+.colophon-rule {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  border-top: 3px solid var(--ink);
+  position: relative;
+}
+.colophon-rule::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 3px;
+  border-top: 1px solid var(--ink);
+}
+.colophon-inner {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: var(--sp-6) var(--sp-5) var(--sp-8);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--sp-6);
+}
+.colophon-block { border-left: 1px solid var(--rule-hair); padding-left: var(--sp-4); }
+.colophon-block:first-child { border-left: none; padding-left: 0; }
+.colophon-label {
+  display: block;
+  font-family: var(--label);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--spot);
+  margin-bottom: var(--sp-2);
+}
+.colophon-block strong { font-family: var(--display); font-weight: 800; font-size: 20px; }
+.colophon-block p { margin: var(--sp-1) 0 0; font-size: 14px; color: var(--ink-soft); line-height: 1.45; }
+
+/* ----------------------------------------------------------------------------
+   11. NOT FOUND
+   ------------------------------------------------------------------------- */
+.notfound { padding: var(--sp-7) 0; }
+
+/* ----------------------------------------------------------------------------
+   12. RESPONSIVE
+   ------------------------------------------------------------------------- */
+@media (max-width: 1040px) {
+  .shell { grid-template-columns: 210px minmax(0, 1fr); }
+  .toc { display: none; }
+}
+
+@media (max-width: 860px) {
+  body { font-size: 17px; }
+  .masthead { padding: var(--sp-4) var(--sp-4) 0; }
+  .masthead-inner { grid-template-columns: 1fr; gap: var(--sp-2); }
+  .dateline { display: none; }
+  .nameplate-title { white-space: normal; }
+  .gazette-nav { gap: var(--sp-2); font-size: 12px; }
+
+  .frontpage { padding: var(--sp-6) var(--sp-4) var(--sp-7); }
+  .columns { column-count: 1; column-rule: none; text-align: left; hyphens: none; }
+  .index-grid { grid-template-columns: 1fr; }
+  .index-entry:nth-child(odd) { border-right: none; }
+  .index-grid > .index-entry:nth-child(2) { border-top: 1px solid var(--rule-hair); }
+  .ledger { grid-template-columns: repeat(2, 1fr); }
+  .ledger-cell:nth-child(2) { border-right: none; }
+  .ledger-cell:nth-child(1), .ledger-cell:nth-child(2) { border-bottom: 1px solid var(--rule-hair); }
+
+  .shell {
+    grid-template-columns: 1fr;
+    padding: var(--sp-5) var(--sp-4) var(--sp-7);
+    gap: var(--sp-5);
+  }
+  .classifieds { position: static; }
+  .content, .article-deck { max-width: none; }
+
+  .pager { grid-template-columns: 1fr; }
+  .pager-next { text-align: left; }
+
+  .colophon-inner { grid-template-columns: 1fr; gap: var(--sp-4); }
+  .colophon-block { border-left: none; padding-left: 0; }
+}
+
+@media (max-width: 480px) {
+  .lead-kicker { flex-direction: column; gap: var(--sp-1); }
+  .lead-kicker-tag { border-left: none; padding-left: 0; }
+  .ledger { grid-template-columns: 1fr; }
+  .ledger-cell { border-right: none; border-bottom: 1px solid var(--rule-hair); }
+  .ledger-cell:last-child { border-bottom: none; }
+}

--- a/examples/newsprint/templates/404.html
+++ b/examples/newsprint/templates/404.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<main class="frontpage" role="main">
+  <article class="lead notfound">
+    <div class="lead-kicker">
+      <span>Stop Press</span>
+      <span class="lead-kicker-tag">Error 404</span>
+    </div>
+    <h1 class="lead-headline">This Page Has Gone to Press Elsewhere</h1>
+    <p class="standfirst">The article you requested does not appear in this edition. It may have been moved, retitled, or never set in type. Consult the index below to find your way back into circulation.</p>
+    <div class="byline-row">
+      <a class="byline-link" href="{{ base_url }}/docs/">Read the documentation &rarr;</a>
+      <span class="byline-dot">&middot;</span>
+      <a class="byline-link" href="{{ base_url }}/">Return to the front page &rarr;</a>
+    </div>
+  </article>
+</main>
+
+{% include "footer.html" %}

--- a/examples/newsprint/templates/_sidebar.html
+++ b/examples/newsprint/templates/_sidebar.html
@@ -1,0 +1,47 @@
+<aside class="classifieds" aria-label="Section index">
+  <div class="classifieds-masthead">
+    <span class="classifieds-mark">&#9632;</span>
+    <span class="classifieds-title">The Index</span>
+    <span class="classifieds-mark">&#9632;</span>
+  </div>
+
+  <section class="classifieds-group">
+    <h4 class="classifieds-head">Getting Started</h4>
+    <ul class="classifieds-list">
+      <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+      <li><a href="{{ base_url }}/docs/your-first-page/">Your First Page</a></li>
+      <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+    </ul>
+  </section>
+
+  <section class="classifieds-group">
+    <h4 class="classifieds-head">Concepts</h4>
+    <ul class="classifieds-list">
+      <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; Pages</a></li>
+      <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+      <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+    </ul>
+  </section>
+
+  <section class="classifieds-group">
+    <h4 class="classifieds-head">Guides</h4>
+    <ul class="classifieds-list">
+      <li><a href="{{ base_url }}/guides/build-pipeline/">The Build Pipeline</a></li>
+      <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+      <li><a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a></li>
+    </ul>
+  </section>
+
+  <section class="classifieds-group">
+    <h4 class="classifieds-head">Reference</h4>
+    <ul class="classifieds-list">
+      <li><a href="{{ base_url }}/docs/cli/">CLI Reference</a></li>
+      <li><a href="{{ base_url }}/docs/template-filters/">Template Filters</a></li>
+    </ul>
+  </section>
+
+  <div class="classifieds-notice">
+    <span class="classifieds-notice-label">Wanted</span>
+    <p>Improvements, corrections, and pull requests. Apply at the repository.</p>
+  </div>
+</aside>

--- a/examples/newsprint/templates/footer.html
+++ b/examples/newsprint/templates/footer.html
@@ -1,0 +1,20 @@
+<footer class="colophon">
+  <div class="colophon-rule"></div>
+  <div class="colophon-inner">
+    <div class="colophon-block">
+      <span class="colophon-label">Masthead</span>
+      <strong>{{ site.title }}</strong>
+      <p>{{ site.description }}</p>
+    </div>
+    <div class="colophon-block">
+      <span class="colophon-label">Composition</span>
+      <p>Set in Playfair Display &amp; PT Serif. Type founded for the Hwaro static press.</p>
+    </div>
+    <div class="colophon-block">
+      <span class="colophon-label">Notice</span>
+      <p>&copy; {{ current_year }} &middot; All rights reserved &middot; Printed on recycled pixels.</p>
+    </div>
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/newsprint/templates/header.html
+++ b/examples/newsprint/templates/header.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,800;0,900;1,400;1,700&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&family=Oswald:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="masthead" role="banner">
+  <div class="masthead-rule masthead-rule--top"></div>
+  <div class="masthead-inner">
+    <div class="dateline dateline--left">
+      <span class="dateline-kicker">Established MMXXVI</span>
+      <span class="dateline-meta">Printed for the Crystal Press</span>
+    </div>
+    <a class="nameplate" href="{{ base_url }}/">
+      <span class="nameplate-pre">The Daily</span>
+      <span class="nameplate-title">{{ site.title }}</span>
+    </a>
+    <div class="dateline dateline--right">
+      <span class="dateline-kicker">Vol. I &middot; No. 1</span>
+      <span class="dateline-meta">{{ current_year }} Edition</span>
+    </div>
+  </div>
+  <div class="masthead-rule masthead-rule--bottom"></div>
+  <nav class="gazette-nav" aria-label="Primary">
+    <a href="{{ base_url }}/docs/">Documentation</a>
+    <span class="nav-dot">&middot;</span>
+    <a href="{{ base_url }}/guides/">Guides</a>
+    <span class="nav-dot">&middot;</span>
+    <a href="{{ base_url }}/about/">About the Press</a>
+    <span class="nav-dot">&middot;</span>
+    <a href="https://github.com/hahwul/hwaro" class="nav-cta">Source &amp; Repository</a>
+  </nav>
+</header>

--- a/examples/newsprint/templates/home.html
+++ b/examples/newsprint/templates/home.html
@@ -1,0 +1,112 @@
+{% include "header.html" %}
+
+<main class="frontpage" role="main">
+
+  <article class="lead">
+    <div class="lead-kicker">
+      <span>Special Documentation Edition</span>
+      <span class="lead-kicker-tag">Filed under: Static Sites</span>
+    </div>
+    <h1 class="lead-headline">A Newspaper for Your Documentation, Set in Ink &amp; Hairlines</h1>
+    <p class="standfirst">Newsprint dresses technical writing in the clothes of a broadsheet daily: a thundering nameplate, ruled columns, small-caps subheads, and pull-quotes with the authority of an editorial. Built on the Hwaro static site generator, it renders in milliseconds and reads like the morning paper.</p>
+    <div class="byline-row">
+      <span class="byline">By the Editorial Desk</span>
+      <span class="byline-dot">&middot;</span>
+      <span class="byline-loc">The Crystal Press</span>
+      <span class="byline-dot">&middot;</span>
+      <a class="byline-link" href="{{ base_url }}/docs/installation/">Begin reading &rarr;</a>
+    </div>
+  </article>
+
+  <div class="frontpage-rule"></div>
+
+  <section class="columns" aria-label="Front page introduction">
+    <p class="dropcap">Documentation deserves better than another flat dashboard. Newsprint treats every page as a printed article &mdash; with a dateline, a deck, ruled columns, and the visible grid of a composing room. Nothing here is decorative for its own sake; the rules and the rhythm exist to make long-form technical prose easy to scan and a pleasure to read.</p>
+    <p>The theme ships as a complete documentation site. There are eight reference articles, three longer guides, and an about page, all written in plain Markdown and rendered by Hwaro's Crinja templates. You write the words; the press handles the layout, the type, and the typesetting.</p>
+    <p>Everything is editable. The palette lives in CSS variables, the nameplate is a single template, and the front page you are reading now is one file. Fork it, change the title in <code>config.toml</code>, and you have your own daily gazette. No build step beyond <code>hwaro build</code>, no runtime, no JavaScript framework demanding tribute.</p>
+  </section>
+
+  <div class="frontpage-rule frontpage-rule--double"></div>
+
+  <section class="index-box" aria-label="Index of sections">
+    <header class="index-head">
+      <span class="index-head-mark">&#9632;</span>
+      <h2>Inside This Edition</h2>
+      <span class="index-head-mark">&#9632;</span>
+    </header>
+    <div class="index-grid">
+      <a href="{{ base_url }}/docs/installation/" class="index-entry">
+        <span class="index-num">01</span>
+        <span class="index-body">
+          <strong>Installation</strong>
+          <span>Three commands to a working press. Homebrew, Docker, or source.</span>
+        </span>
+        <span class="index-page">A1</span>
+      </a>
+      <a href="{{ base_url }}/docs/sections-and-pages/" class="index-entry">
+        <span class="index-num">02</span>
+        <span class="index-body">
+          <strong>Sections &amp; Pages</strong>
+          <span>How content is filed and why <code>_index.md</code> earns its keep.</span>
+        </span>
+        <span class="index-page">A4</span>
+      </a>
+      <a href="{{ base_url }}/docs/templates/" class="index-entry">
+        <span class="index-num">03</span>
+        <span class="index-body">
+          <strong>Templates</strong>
+          <span>Crinja layouts and the globals you may count on.</span>
+        </span>
+        <span class="index-page">A6</span>
+      </a>
+      <a href="{{ base_url }}/docs/configuration/" class="index-entry">
+        <span class="index-num">04</span>
+        <span class="index-body">
+          <strong>Configuration</strong>
+          <span>Every dial in <code>config.toml</code> and its sanest default.</span>
+        </span>
+        <span class="index-page">A7</span>
+      </a>
+      <a href="{{ base_url }}/guides/build-pipeline/" class="index-entry">
+        <span class="index-num">05</span>
+        <span class="index-body">
+          <strong>The Build Pipeline</strong>
+          <span>From <code>build</code> to <code>public/</code> in seven readable phases.</span>
+        </span>
+        <span class="index-page">B1</span>
+      </a>
+      <a href="{{ base_url }}/guides/deploying/" class="index-entry">
+        <span class="index-num">06</span>
+        <span class="index-body">
+          <strong>Deploying</strong>
+          <span>Dispatches for Pages, Cloudflare, and plain rsync.</span>
+        </span>
+        <span class="index-page">B3</span>
+      </a>
+    </div>
+  </section>
+
+  <div class="frontpage-rule"></div>
+
+  <section class="ledger" aria-label="Edition particulars">
+    <div class="ledger-cell">
+      <span class="ledger-figure">v0.14</span>
+      <span class="ledger-caption">Current Edition</span>
+    </div>
+    <div class="ledger-cell">
+      <span class="ledger-figure">12</span>
+      <span class="ledger-caption">Articles in Print</span>
+    </div>
+    <div class="ledger-cell">
+      <span class="ledger-figure">&lt;50<span class="ledger-unit">ms</span></span>
+      <span class="ledger-caption">Press Run, Per Page</span>
+    </div>
+    <div class="ledger-cell">
+      <span class="ledger-figure">MIT</span>
+      <span class="ledger-caption">License of Record</span>
+    </div>
+  </section>
+
+</main>
+
+{% include "footer.html" %}

--- a/examples/newsprint/templates/page.html
+++ b/examples/newsprint/templates/page.html
@@ -1,0 +1,58 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="article" role="main">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="{{ base_url }}/">Front Page</a>
+      <span class="breadcrumb-sep">/</span>
+      {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a><span class="breadcrumb-sep">/</span>{% endif %}
+      <span class="breadcrumb-current">{{ page.title }}</span>
+    </nav>
+
+    <header class="article-head">
+      {% if page.section %}<span class="article-kicker">{{ page.section }} desk</span>{% endif %}
+      <h1 class="article-title">{{ page.title }}</h1>
+      {% if page.description %}<p class="article-deck">{{ page.description }}</p>{% endif %}
+      <div class="article-byline">
+        <span class="byline">By the Documentation Desk</span>
+        <span class="byline-dot">&middot;</span>
+        {% if page.date %}<span class="byline-date">Filed {{ page.date }}</span>{% else %}<span class="byline-date">Latest Edition</span>{% endif %}
+      </div>
+    </header>
+
+    <div class="article-rule"></div>
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <nav class="pager" aria-label="Article navigation">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="pager-link pager-prev">
+        <span class="pager-dir">&larr; Previous Dispatch</span>
+        <span class="pager-title">{{ page.lower.title }}</span>
+      </a>
+      {% else %}<div class="pager-spacer"></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="pager-link pager-next">
+        <span class="pager-dir">Next Dispatch &rarr;</span>
+        <span class="pager-title">{{ page.higher.title }}</span>
+      </a>
+      {% endif %}
+    </nav>
+    {% endif %}
+  </main>
+
+  <aside class="toc" aria-label="On this page">
+    <h5 class="toc-head">In This Column</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top of article</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/newsprint/templates/section.html
+++ b/examples/newsprint/templates/section.html
@@ -1,0 +1,49 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="article" role="main">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="{{ base_url }}/">Front Page</a>
+      <span class="breadcrumb-sep">/</span>
+      <span class="breadcrumb-current">{{ section.title }}</span>
+    </nav>
+
+    <header class="article-head section-head">
+      <span class="article-kicker">Section Front</span>
+      <h1 class="article-title">{{ section.title }}</h1>
+      {% if section.description %}<p class="article-deck">{{ section.description }}</p>{% endif %}
+      <div class="article-byline">
+        <span class="byline">{{ section.pages | length }} articles on file</span>
+        <span class="byline-dot">&middot;</span>
+        <span class="byline-date">The Crystal Press</span>
+      </div>
+    </header>
+
+    <div class="article-rule"></div>
+
+    <ol class="section-list">
+      {% for post in section.pages %}
+      <li class="section-item">
+        <a href="{{ base_url }}{{ post.url }}" class="section-link">
+          <span class="section-num">{{ loop.index }}</span>
+          <span class="section-text">
+            <strong class="section-headline">{{ post.title }}</strong>
+            {% if post.description %}<span class="section-summary">{{ post.description }}</span>{% endif %}
+          </span>
+          <span class="section-cue">Read &rarr;</span>
+        </a>
+      </li>
+      {% endfor %}
+    </ol>
+  </main>
+
+  <aside class="toc" aria-label="Section particulars">
+    <h5 class="toc-head">On File</h5>
+    <ul>
+      <li><a href="#">{{ section.pages | length }} articles</a></li>
+    </ul>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/newsprint/templates/taxonomy.html
+++ b/examples/newsprint/templates/taxonomy.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="article" role="main">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="{{ base_url }}/">Front Page</a>
+      <span class="breadcrumb-sep">/</span>
+      <span class="breadcrumb-current">{{ taxonomy_name }}</span>
+    </nav>
+
+    <header class="article-head">
+      <span class="article-kicker">The Subject Index</span>
+      <h1 class="article-title">All {{ taxonomy_name }}</h1>
+    </header>
+
+    <div class="article-rule"></div>
+
+    <div class="content">
+      <ul class="term-list">
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term }}</a> <span class="term-count">{{ term.pages | length }} articles</span></li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  <aside class="toc" aria-label=""></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/newsprint/templates/taxonomy_term.html
+++ b/examples/newsprint/templates/taxonomy_term.html
@@ -1,0 +1,39 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="article" role="main">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="{{ base_url }}/">Front Page</a>
+      <span class="breadcrumb-sep">/</span>
+      <a href="{{ base_url }}/tags/">tags</a>
+      <span class="breadcrumb-sep">/</span>
+      <span class="breadcrumb-current">{{ taxonomy_term }}</span>
+    </nav>
+
+    <header class="article-head">
+      <span class="article-kicker">Filed Under</span>
+      <h1 class="article-title">{{ taxonomy_term }}</h1>
+    </header>
+
+    <div class="article-rule"></div>
+
+    <ol class="section-list">
+    {% for post in taxonomy_pages %}
+      <li class="section-item">
+        <a href="{{ base_url }}{{ post.url }}" class="section-link">
+          <span class="section-num">{{ loop.index }}</span>
+          <span class="section-text">
+            <strong class="section-headline">{{ post.title }}</strong>
+            {% if post.description %}<span class="section-summary">{{ post.description }}</span>{% endif %}
+          </span>
+          <span class="section-cue">Read &rarr;</span>
+        </a>
+      </li>
+    {% endfor %}
+    </ol>
+  </main>
+  <aside class="toc" aria-label=""></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/orrery/AGENTS.md
+++ b/examples/orrery/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - Orrery, a brass astronomical-instrument documentation theme for Hwaro
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/orrery/archetypes/default.md
+++ b/examples/orrery/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/orrery/config.toml
+++ b/examples/orrery/config.toml
@@ -1,0 +1,197 @@
+title = "Orrery"
+description = "A dark, brass astronomical-instrument documentation theme — docs charted like an antique star atlas."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/orrery/content/about.md
+++ b/examples/orrery/content/about.md
@@ -1,0 +1,30 @@
++++
+title = "About"
+description = "The thinking behind Orrery — the palette, the type, and the antique-instrument metaphor that holds it together."
+date = "2026-04-01"
++++
+
+Orrery takes its visual cues from the brass orrery and the engraved star atlas: instruments built to make something vast feel measurable. It is a dark, scholarly theme for documentation that wants to read like a precision instrument rather than a landing page.
+
+## The choices we have made
+
+- A single solid accent — antique brass at `#c2a14d` — used for rings, rules, and roundels. No blends, no glows.
+- Orbital motifs drawn as plain 1px circle strokes, with small solid planet dots placed on each ring.
+- A graticule of faint star-grey hairlines behind the hero, painted with solid lines and solid dots.
+- Coordinate kickers set in small-caps mono, so every section reads like a catalogue entry.
+
+## The type system
+
+- **Cormorant Garamond** for display — high-contrast, engraved, at home on a star chart.
+- **Spectral** for body copy — a serif that stays legible at length on a dark field.
+- **IBM Plex Mono** for coordinates, labels, and code, set in small-caps where it can be.
+
+All three are served from Google Fonts and committed deliberately, not chosen by accident.
+
+## What this is not
+
+This is not a marketing theme. There is no carousel, no testimonial wall, and no animation that fires on scroll. The orrery turns only in the imagination.
+
+## License
+
+MIT. Use it, fork it, chart your own constellations, and send improvements.

--- a/examples/orrery/content/docs/_index.md
+++ b/examples/orrery/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The core almanac — installation, the content tree, templates, and the daily workflow of charting a Hwaro site."
+sort_by = "weight"
++++

--- a/examples/orrery/content/docs/cli.md
+++ b/examples/orrery/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "The ephemeris of commands — every flag, and the one or two you actually reach for each day."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name>` | Scaffold a new site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/orrery/content/docs/configuration.md
+++ b/examples/orrery/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "The instrument's dials — every setting in config.toml, what it tunes, and the smallest sensible default."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/orrery/content/docs/installation.md
+++ b/examples/orrery/content/docs/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
+description = "First light — three commands and the dev server is on the sky. Then it is only a question of how strict you set the config."
+weight = 1
+date = "2026-05-01"
++++
+
+Orrery runs on the Hwaro static site generator. You can install it from Homebrew, run it under Docker, or build it from source.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve --open
+```
+
+The dev server will open `http://localhost:3000` in your browser. Any edit to `content/`, `templates/`, or `static/` reloads in under 50ms.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.0 or newer
+```
+
+If you see anything older, your package manager has cached an old version. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Move on to **Your first page**, where you will write a single piece of content, give it a template, and watch it render.

--- a/examples/orrery/content/docs/sections-and-pages.md
+++ b/examples/orrery/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "How content is charted into a tree, how sections behave, and why _index.md quietly does more than it lets on."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/orrery/content/docs/taxonomies.md
+++ b/examples/orrery/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Constellations — tags, categories, and custom groupings. How to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/orrery/content/docs/template-filters.md
+++ b/examples/orrery/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A working reference of the most useful template filters, with examples you can lift straight off the page."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/orrery/content/docs/templates.md
+++ b/examples/orrery/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "The lens — Crinja templates, where they live, and the small set of globals you are allowed to count on."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/orrery/content/docs/your-first-page.md
+++ b/examples/orrery/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "A short walkthrough that ends with one rendered page and the quiet satisfaction of a clean build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/orrery/content/guides/_index.md
+++ b/examples/orrery/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "Field guides — longer observations for common situations and the occasional edge of the chart."
+sort_by = "weight"
++++

--- a/examples/orrery/content/guides/build-pipeline.md
+++ b/examples/orrery/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "The movement of the works — what turns between hwaro build and public/, traced through seven legible phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/orrery/content/guides/deploying.md
+++ b/examples/orrery/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Transit — recipes for GitHub Pages, Cloudflare Pages, and a plain Bash script for the rest of the sky."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/orrery/content/guides/i18n.md
+++ b/examples/orrery/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Parallax — multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/orrery/content/index.md
+++ b/examples/orrery/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Orrery"
+description = "A dark, brass astronomical-instrument documentation theme — docs charted like an antique star atlas."
+template = "home"
++++

--- a/examples/orrery/static/css/style.css
+++ b/examples/orrery/static/css/style.css
@@ -1,0 +1,908 @@
+/* =============================================================================
+   ORRERY — a brass astronomical-instrument documentation theme.
+   Concept: the docs as a clockwork orrery / antique star atlas.
+   Solid colors only — flat fills, borders and box-shadow. Rings & stars are
+   solid strokes (border-radius circles) and planets are solid dots.
+   ============================================================================= */
+
+:root {
+  /* Palette — deep night navy on near-black, antique brass, parchment ink */
+  --void:    #080c14;   /* near-black backdrop */
+  --night:   #0e1626;   /* deep night navy panels */
+  --night-2: #121d31;   /* raised navy */
+  --night-3: #0b1220;   /* recessed navy */
+  --brass:   #c2a14d;   /* antique brass accent — SOLID */
+  --brass-d: #5f5026;   /* dimmed brass for hairlines */
+  --brass-dim: #6f5d2f; /* deep brass */
+  --parch:   #e8e2d2;   /* parchment off-white text */
+  --parch-2: #c4bda9;   /* muted parchment */
+  --parch-3: #8b8674;   /* faint parchment / captions */
+  --grat:    #26334a;   /* star-grey graticule lines */
+  --grat-2:  #1a2336;   /* fainter graticule */
+  --star:    #5a6b86;   /* dim star dot */
+  --rose:    #b8554a;   /* mars-red used very sparingly */
+
+  --rule: var(--brass-d);
+  --code-bg: #0a1120;
+
+  --serif: "Spectral", Georgia, serif;
+  --display: "Cormorant Garamond", "Spectral", Georgia, serif;
+  --mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  --maxw: 1320px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--void);
+  color: var(--parch);
+  font-family: var(--serif);
+  font-size: 16.5px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: inherit; text-decoration: none; }
+
+::selection { background: var(--brass); color: var(--void); }
+
+/* =============================================================================
+   Top bar / masthead
+   ============================================================================= */
+.bar {
+  border-bottom: 1px solid var(--rule);
+  background: var(--night-3);
+  position: sticky; top: 0; z-index: 40;
+}
+.bar-inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: stretch;
+  max-width: var(--maxw);
+  margin: 0 auto;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 26px;
+  border-right: 1px solid var(--rule);
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 25px;
+  letter-spacing: 0.01em;
+  color: var(--parch);
+}
+/* Brand mark: a tiny solid orrery — concentric brass rings + planet dot */
+.brand .mark {
+  position: relative;
+  width: 30px; height: 30px;
+  border: 1px solid var(--brass);
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.brand .mark::after {
+  content: "";
+  position: absolute;
+  left: 50%; top: 50%;
+  width: 16px; height: 16px;
+  margin: -8px 0 0 -8px;
+  border: 1px solid var(--brass);
+  border-radius: 50%;
+}
+.brand .mark::before {
+  content: "";
+  position: absolute;
+  left: 50%; top: -2px;
+  width: 4px; height: 4px;
+  margin-left: -2px;
+  background: var(--brass);
+  border-radius: 50%;
+}
+
+.search {
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  border-right: 1px solid var(--rule);
+}
+.search input {
+  border: 0; background: transparent;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--parch-2);
+  padding: 14px 0;
+  width: 100%;
+  outline: none;
+  letter-spacing: 0.02em;
+}
+.search input::placeholder { color: var(--parch-3); }
+.search .kbd {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  padding: 3px 8px;
+  border: 1px solid var(--brass-d);
+  color: var(--brass);
+  letter-spacing: 0.08em;
+}
+
+.bar nav { display: flex; align-items: stretch; }
+.bar nav a {
+  padding: 16px 22px;
+  display: flex; align-items: center;
+  border-left: 1px solid var(--rule);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--parch-2);
+  transition: color 140ms ease, background 140ms ease;
+}
+.bar nav a:hover { background: var(--night-2); color: var(--brass); }
+.bar nav a:focus-visible { outline: 1px solid var(--brass); outline-offset: -1px; }
+.bar nav a.cta { color: var(--brass); }
+.bar nav a.cta:hover { background: var(--brass); color: var(--void); }
+
+/* =============================================================================
+   Layout shell
+   ============================================================================= */
+.shell {
+  display: grid;
+  grid-template-columns: 290px 1fr 250px;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  min-height: calc(100vh - 60px);
+}
+
+.sidebar {
+  border-right: 1px solid var(--rule);
+  padding: 40px 26px;
+  position: sticky; top: 60px;
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+  background: var(--night-3);
+}
+
+.sidebar h4 {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--parch-3);
+  margin: 30px 0 12px;
+  position: relative;
+  padding-left: 22px;
+  display: flex;
+  align-items: center;
+}
+/* roundel before each sidebar group — a solid brass ring with a dot */
+.sidebar h4::before {
+  content: "";
+  position: absolute; left: 0; top: 50%;
+  width: 12px; height: 12px;
+  margin-top: -6px;
+  border: 1px solid var(--brass);
+  border-radius: 50%;
+}
+.sidebar h4::after {
+  content: "";
+  position: absolute; left: 4px; top: 50%;
+  width: 4px; height: 4px;
+  margin-top: -2px;
+  background: var(--brass);
+  border-radius: 50%;
+}
+.sidebar h4:first-child { margin-top: 0; }
+
+.sidebar ul { list-style: none; padding: 0; margin: 0; }
+.sidebar li { font-size: 15px; }
+.sidebar a {
+  display: block;
+  padding: 7px 14px 7px 22px;
+  border-left: 1px solid transparent;
+  color: var(--parch-2);
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.sidebar a:hover { color: var(--parch); border-left-color: var(--brass-dim); }
+.sidebar a.active {
+  border-left-color: var(--brass);
+  color: var(--brass);
+  background: var(--night-2);
+}
+
+.main { padding: 60px 68px; min-width: 0; }
+.main-inner { max-width: 760px; }
+
+/* TOC rail */
+.toc {
+  border-left: 1px solid var(--rule);
+  padding: 60px 24px;
+  position: sticky; top: 60px;
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+  font-size: 13.5px;
+}
+.toc h5 {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--parch-3);
+  margin: 0 0 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--grat);
+}
+.toc ul { list-style: none; padding: 0; margin: 0; }
+.toc li { padding: 5px 0; }
+.toc a { color: var(--parch-3); transition: color 120ms ease; }
+.toc a:hover { color: var(--brass); }
+.toc ul ul { padding-left: 14px; border-left: 1px solid var(--grat); margin: 4px 0 4px 2px; }
+
+/* =============================================================================
+   Article header
+   ============================================================================= */
+.crumb {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--parch-3);
+  margin-bottom: 22px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.crumb .accent { color: var(--brass); }
+.crumb a:hover { color: var(--brass); }
+
+/* the "coordinate" kicker above headings */
+.coord {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--brass);
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.coord::before {
+  content: "";
+  width: 28px; height: 1px;
+  background: var(--brass);
+}
+
+.main h1 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(44px, 6vw, 66px);
+  line-height: 1.02;
+  letter-spacing: -0.01em;
+  margin: 0 0 18px;
+  color: var(--parch);
+}
+.main .deck {
+  font-size: 21px;
+  color: var(--parch-2);
+  margin: 0 0 14px;
+  max-width: 60ch;
+  line-height: 1.55;
+  font-weight: 300;
+  font-style: italic;
+  font-family: var(--display);
+}
+
+/* hairline brass rule with a central star node */
+.starrule {
+  border: 0;
+  height: 1px;
+  background: var(--brass);
+  margin: 40px 0;
+  position: relative;
+  overflow: visible;
+  opacity: 0.6;
+}
+.starrule::after {
+  content: "\2726";
+  position: absolute;
+  left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--brass);
+  background: var(--void);
+  padding: 0 14px;
+  font-size: 13px;
+  opacity: 1;
+}
+
+/* =============================================================================
+   .content prose
+   ============================================================================= */
+.content { font-size: 16.5px; }
+
+.content h2 {
+  font-family: var(--display);
+  font-size: 33px;
+  font-weight: 600;
+  margin: 52px 0 16px;
+  letter-spacing: 0;
+  color: var(--parch);
+  padding-top: 16px;
+  border-top: 1px solid var(--grat);
+  position: relative;
+}
+/* small brass roundel marking each section heading */
+.content h2::before {
+  content: "";
+  position: absolute;
+  left: 0; top: -7px;
+  width: 13px; height: 13px;
+  border: 1px solid var(--brass);
+  border-radius: 50%;
+  background: var(--void);
+}
+.content h2::after {
+  content: "";
+  position: absolute;
+  left: 4px; top: -3px;
+  width: 5px; height: 5px;
+  background: var(--brass);
+  border-radius: 50%;
+}
+.content h3 {
+  font-family: var(--display);
+  font-size: 25px;
+  font-weight: 600;
+  margin: 36px 0 12px;
+  color: var(--parch);
+}
+.content h4 {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--brass);
+  margin: 30px 0 10px;
+}
+.content p { margin: 0 0 18px; max-width: 70ch; color: var(--parch); }
+.content strong { color: var(--parch); font-weight: 600; }
+.content em { color: var(--parch-2); }
+
+.content a {
+  color: var(--brass);
+  border-bottom: 1px solid var(--brass-dim);
+  transition: border-color 120ms ease, color 120ms ease;
+}
+.content a:hover { border-bottom-color: var(--brass); color: var(--parch); }
+
+.content code {
+  font-family: var(--mono);
+  background: var(--code-bg);
+  border: 1px solid var(--grat);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  color: var(--brass);
+}
+.content pre {
+  background: var(--code-bg);
+  border: 1px solid var(--brass-d);
+  padding: 22px 24px;
+  overflow-x: auto;
+  font-size: 13.5px;
+  line-height: 1.6;
+  font-family: var(--mono);
+  margin: 26px 0;
+  position: relative;
+  border-radius: 4px;
+}
+.content pre code { background: none; border: 0; padding: 0; color: var(--parch); font-size: inherit; }
+/* coordinate tick label on code blocks */
+.content pre::before {
+  content: "\2726";
+  position: absolute; top: 10px; right: 14px;
+  font-size: 11px; color: var(--brass-dim);
+}
+
+.content blockquote {
+  border-left: 2px solid var(--brass);
+  background: var(--night-3);
+  padding: 16px 24px;
+  margin: 26px 0;
+  font-style: italic;
+  font-family: var(--display);
+  font-size: 20px;
+  color: var(--parch-2);
+}
+.content blockquote p:last-child { margin-bottom: 0; }
+
+.content ul, .content ol { padding-left: 26px; margin: 0 0 18px; }
+.content li { margin-bottom: 8px; }
+.content ul li::marker { color: var(--brass); }
+.content ol li::marker { color: var(--brass); font-family: var(--mono); font-size: 0.9em; }
+
+.content hr {
+  border: 0;
+  height: 1px;
+  background: var(--brass);
+  opacity: 0.6;
+  margin: 40px 0;
+  position: relative;
+}
+.content hr::after {
+  content: "\2726";
+  position: absolute; left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--brass);
+  background: var(--void);
+  padding: 0 14px;
+  font-size: 12px;
+}
+
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 26px 0;
+  font-size: 14.5px;
+}
+.content th {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--brass);
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--brass-d);
+  background: var(--night-3);
+}
+.content td {
+  padding: 11px 16px;
+  border-bottom: 1px solid var(--grat);
+  color: var(--parch-2);
+  vertical-align: top;
+}
+.content tr:hover td { background: var(--night-3); }
+.content td code { white-space: nowrap; }
+
+.content img { max-width: 100%; height: auto; border: 1px solid var(--grat); border-radius: 4px; }
+
+/* =============================================================================
+   Pager
+   ============================================================================= */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+  margin-top: 60px;
+  padding-top: 40px;
+  border-top: 1px solid var(--brass-d);
+}
+.pager .b {
+  border: 1px solid var(--grat);
+  padding: 20px 24px;
+  background: var(--night-3);
+  border-radius: 4px;
+  transition: border-color 140ms ease, background 140ms ease;
+}
+.pager .b:hover { border-color: var(--brass); background: var(--night-2); }
+.pager .b .k {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--brass);
+}
+.pager .b .t {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 22px;
+  margin-top: 6px;
+  color: var(--parch);
+}
+.pager .next { text-align: right; }
+
+/* =============================================================================
+   HERO — the orrery centerpiece (concentric solid brass rings + planet dots)
+   ============================================================================= */
+.hero {
+  display: grid;
+  grid-template-columns: 1.25fr 0.9fr;
+  border-bottom: 1px solid var(--rule);
+  max-width: var(--maxw);
+  margin: 0 auto;
+  background: var(--night-3);
+  position: relative;
+  overflow: hidden;
+}
+.hero > * { position: relative; z-index: 1; }
+
+.hero .copy {
+  padding: 72px 56px;
+  border-right: 1px solid var(--rule);
+}
+.hero .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--brass);
+  margin-bottom: 22px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.hero .eyebrow::before {
+  content: "";
+  width: 9px; height: 9px;
+  border: 1px solid var(--brass);
+  border-radius: 50%;
+}
+.hero h1 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(48px, 6.5vw, 88px);
+  line-height: 0.98;
+  letter-spacing: -0.01em;
+  margin: 0 0 26px;
+  color: var(--parch);
+}
+.hero h1 .brass { color: var(--brass); font-style: italic; }
+.hero .deck {
+  font-size: 21px;
+  color: var(--parch-2);
+  max-width: 50ch;
+  margin: 0 0 34px;
+  line-height: 1.6;
+  font-family: var(--serif);
+  font-weight: 300;
+}
+.hero .cta-row { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
+.hero .cta-row a {
+  border: 1px solid var(--brass-d);
+  padding: 14px 24px;
+  font-family: var(--mono);
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--parch);
+  border-radius: 3px;
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+}
+.hero .cta-row a:hover { border-color: var(--brass); color: var(--brass); }
+.hero .cta-row a:focus-visible { outline: 1px solid var(--brass); outline-offset: 2px; }
+.hero .cta-row a.primary { background: var(--brass); color: var(--void); border-color: var(--brass); }
+.hero .cta-row a.primary:hover { background: transparent; color: var(--brass); }
+.hero .cta-row a.kbd {
+  background: var(--code-bg);
+  color: var(--brass);
+  text-transform: none;
+  letter-spacing: 0.04em;
+}
+
+/* The orrery diagram: concentric rings drawn as solid border circles,
+   each carrying a planet dot on its orbit. A star-field of solid dots is
+   painted behind it with layered solid box-shadows. */
+.orrery {
+  display: grid;
+  place-items: center;
+  padding: 40px;
+  min-height: 360px;
+  position: relative;
+}
+/* star field: a single 1px dot replicated as many solid box-shadows */
+.orrery .starfield {
+  position: absolute;
+  top: 24px; left: 24px;
+  width: 1px; height: 1px;
+  border-radius: 50%;
+  background: var(--star);
+  box-shadow:
+    18px 30px 0 0 var(--star), 64px 12px 0 0 var(--grat),
+    120px 48px 0 0 var(--star), 190px 22px 0 0 var(--grat),
+    240px 70px 0 0 var(--star), 300px 36px 0 0 var(--grat),
+    40px 96px 0 0 var(--grat), 150px 110px 0 0 var(--star),
+    280px 130px 0 0 var(--grat), 90px 160px 0 0 var(--star),
+    210px 180px 0 0 var(--grat), 320px 200px 0 0 var(--star),
+    24px 230px 0 0 var(--grat), 130px 250px 0 0 var(--star),
+    250px 270px 0 0 var(--grat), 60px 300px 0 0 var(--star),
+    180px 320px 0 0 var(--grat), 300px 310px 0 0 var(--star);
+}
+.orrery-fig {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  display: grid;
+  place-items: center;
+}
+.orrery-fig .ring {
+  position: absolute;
+  left: 50%; top: 50%;
+  border: 1px solid var(--brass-dim);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+.orrery-fig .ring.r1 { width: 70px; height: 70px; }
+.orrery-fig .ring.r2 { width: 140px; height: 140px; }
+.orrery-fig .ring.r3 { width: 220px; height: 220px; }
+.orrery-fig .ring.r4 { width: 310px; height: 310px; border-color: var(--brass-d); }
+.orrery-fig .ring.dashed { border-style: dashed; }
+
+/* the sun: solid brass disc at the center */
+.orrery-fig .sun {
+  position: absolute;
+  width: 26px; height: 26px;
+  background: var(--brass);
+  border-radius: 50%;
+  box-shadow: 0 0 0 6px var(--night-2);
+}
+
+/* planets: solid dots positioned on the rings */
+.orrery-fig .planet {
+  position: absolute;
+  left: 50%; top: 50%;
+  border-radius: 50%;
+  background: var(--parch);
+}
+.orrery-fig .p1 { width: 7px; height: 7px; margin: -3.5px 0 0 -3.5px; transform: translate(35px, 0); background: var(--rose); }
+.orrery-fig .p2 { width: 9px; height: 9px; margin: -4.5px 0 0 -4.5px; transform: translate(-48px, 48px); background: var(--parch); }
+.orrery-fig .p3 { width: 11px; height: 11px; margin: -5.5px 0 0 -5.5px; transform: translate(96px, -55px); background: var(--brass); }
+.orrery-fig .p4 { width: 8px; height: 8px; margin: -4px 0 0 -4px; transform: translate(-120px, -78px); background: var(--star); }
+
+/* coordinate label floating on the diagram */
+.orrery-fig .coord-tag {
+  position: absolute;
+  bottom: 4px; right: 4px;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.1em;
+  color: var(--brass);
+  border: 1px solid var(--brass-d);
+  padding: 3px 7px;
+  background: var(--night-3);
+}
+
+/* =============================================================================
+   Category cards (home + section listings)
+   ============================================================================= */
+.cats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  max-width: var(--maxw);
+  margin: 0 auto;
+  border-bottom: 1px solid var(--rule);
+}
+.cat {
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 38px 34px;
+  background: var(--night-3);
+  transition: background 140ms ease;
+  position: relative;
+}
+.cats .cat:nth-child(3n) { border-right: 0; }
+.cat:hover { background: var(--night-2); }
+.cat:hover .read { color: var(--brass); border-bottom-color: var(--brass); }
+
+/* section emblem: miniature concentric rings with a planet dot */
+.cat .emblem {
+  position: relative;
+  width: 44px; height: 44px;
+  margin-bottom: 22px;
+  border: 1px solid var(--brass);
+  border-radius: 50%;
+}
+.cat .emblem::after {
+  content: "";
+  position: absolute;
+  left: 50%; top: 50%;
+  width: 22px; height: 22px;
+  margin: -11px 0 0 -11px;
+  border: 1px solid var(--brass-d);
+  border-radius: 50%;
+}
+.cat .emblem .dot {
+  position: absolute;
+  left: 50%; top: -3px;
+  width: 6px; height: 6px;
+  margin-left: -3px;
+  background: var(--brass);
+  border-radius: 50%;
+}
+.cat .emblem .idx {
+  position: absolute;
+  left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--brass);
+}
+
+.cat .kicker {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--parch-3);
+  margin-bottom: 8px;
+}
+.cat h3 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 27px;
+  margin: 0 0 10px;
+  letter-spacing: 0;
+  color: var(--parch);
+}
+.cat p { color: var(--parch-2); font-size: 15px; line-height: 1.6; margin: 0 0 16px; }
+.cat .read {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--parch-2);
+  border-bottom: 1px solid var(--brass-dim);
+  padding-bottom: 2px;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+/* =============================================================================
+   Ephemeris strip (home metrics)
+   ============================================================================= */
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--rule);
+  max-width: var(--maxw);
+  margin: 0 auto;
+  background: var(--night);
+}
+.metrics .m { padding: 28px 30px; border-right: 1px solid var(--rule); }
+.metrics .m:last-child { border-right: 0; }
+.metrics .v {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 38px;
+  letter-spacing: 0;
+  color: var(--brass);
+  line-height: 1;
+}
+.metrics .v span { color: var(--parch-3); font-size: 18px; }
+.metrics .k {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--parch-3);
+  margin-top: 10px;
+}
+
+/* =============================================================================
+   Section / listing intro
+   ============================================================================= */
+.section-head {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 56px 68px 36px;
+  border-bottom: 1px solid var(--rule);
+}
+.section-head h1 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(44px, 6vw, 64px);
+  margin: 8px 0 14px;
+  color: var(--parch);
+}
+.section-head .deck {
+  font-size: 20px;
+  color: var(--parch-2);
+  max-width: 62ch;
+  font-family: var(--display);
+  font-style: italic;
+  font-weight: 300;
+}
+.section-head .count {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--parch-3);
+  margin-top: 18px;
+}
+
+/* =============================================================================
+   Footer
+   ============================================================================= */
+.foot {
+  padding: 40px 30px;
+  border-top: 1px solid var(--rule);
+  max-width: var(--maxw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 26px;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  color: var(--parch-3);
+}
+.foot strong { font-family: var(--display); font-size: 17px; color: var(--brass); font-weight: 600; letter-spacing: 0; }
+.foot .node { color: var(--brass); }
+.foot a:hover { color: var(--brass); }
+
+/* =============================================================================
+   404
+   ============================================================================= */
+.lost {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  border-bottom: 1px solid var(--rule);
+  min-height: 60vh;
+  background: var(--night-3);
+}
+.lost .copy { padding: 80px 56px; border-right: 1px solid var(--rule); align-self: center; }
+.lost h1 {
+  font-family: var(--display);
+  font-size: clamp(48px, 7vw, 92px);
+  font-weight: 600;
+  margin: 0 0 20px;
+  color: var(--parch);
+}
+.lost h1 .brass { color: var(--brass); font-style: italic; }
+.lost .deck { font-size: 20px; color: var(--parch-2); font-family: var(--serif); }
+.lost .deck a { color: var(--brass); border-bottom: 1px solid var(--brass-dim); }
+.lost .deck a:hover { border-bottom-color: var(--brass); }
+
+/* =============================================================================
+   Responsive — collapse to one column under ~860px
+   ============================================================================= */
+@media (max-width: 1180px) {
+  .shell { grid-template-columns: 250px 1fr; }
+  .toc { display: none; }
+  .cats { grid-template-columns: 1fr 1fr; }
+  .cats .cat:nth-child(3n) { border-right: 1px solid var(--rule); }
+  .cats .cat:nth-child(2n) { border-right: 0; }
+}
+
+@media (max-width: 860px) {
+  .bar-inner { grid-template-columns: 1fr; }
+  .brand { border-right: 0; border-bottom: 1px solid var(--rule); }
+  .search { display: none; }
+  .bar nav { overflow-x: auto; }
+  .bar nav a:first-child { border-left: 0; }
+
+  .shell { grid-template-columns: 1fr; }
+  .sidebar { display: none; }
+  .main { padding: 40px 26px; }
+
+  .hero { grid-template-columns: 1fr; }
+  .hero .copy { border-right: 0; border-bottom: 1px solid var(--rule); padding: 48px 30px; }
+  .orrery { min-height: 300px; }
+
+  .cats { grid-template-columns: 1fr; }
+  .cats .cat,
+  .cats .cat:nth-child(3n),
+  .cats .cat:nth-child(2n) { border-right: 0; }
+
+  .metrics { grid-template-columns: 1fr 1fr; }
+  .metrics .m:nth-child(2n) { border-right: 0; }
+
+  .section-head { padding: 40px 26px 28px; }
+
+  .lost { grid-template-columns: 1fr; }
+  .lost .copy { border-right: 0; border-bottom: 1px solid var(--rule); padding: 48px 30px; }
+
+  .pager { grid-template-columns: 1fr; }
+  .pager .next { text-align: left; }
+
+  .foot { grid-template-columns: 1fr; gap: 12px; }
+}

--- a/examples/orrery/templates/404.html
+++ b/examples/orrery/templates/404.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<section class="lost">
+  <div class="copy">
+    <div class="coord">No fix · Off the chart</div>
+    <h1><span class="brass">404</span> — beyond<br>the catalogue.</h1>
+    <p class="deck">This coordinate returns no object. Re-orient to the <a href="{{ base_url }}/docs/">documentation</a> or steer back to the <a href="{{ base_url }}/">observatory</a>.</p>
+  </div>
+  <div class="orrery">
+    <span class="starfield" aria-hidden="true"></span>
+    <div class="orrery-fig" role="img" aria-label="An empty orrery with orbital rings and no charted body.">
+      <span class="ring r1 dashed"></span>
+      <span class="ring r2"></span>
+      <span class="ring r3 dashed"></span>
+      <span class="ring r4"></span>
+      <span class="sun"></span>
+      <span class="planet p3"></span>
+      <span class="coord-tag">No object found</span>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/orrery/templates/_sidebar.html
+++ b/examples/orrery/templates/_sidebar.html
@@ -1,0 +1,28 @@
+<aside class="sidebar">
+  <h4>First Light</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+    <li><a href="{{ base_url }}/docs/your-first-page/">Your first page</a></li>
+    <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+  </ul>
+
+  <h4>Charting Content</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a></li>
+    <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+    <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+  </ul>
+
+  <h4>Field Guides</h4>
+  <ul>
+    <li><a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a></li>
+    <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+    <li><a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a></li>
+  </ul>
+
+  <h4>Ephemeris</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/cli/">CLI reference</a></li>
+    <li><a href="{{ base_url }}/docs/template-filters/">Template filters</a></li>
+  </ul>
+</aside>

--- a/examples/orrery/templates/footer.html
+++ b/examples/orrery/templates/footer.html
@@ -1,0 +1,7 @@
+<footer class="foot">
+  <div><strong>{{ site.title }}</strong></div>
+  <div>{{ site.description }}</div>
+  <div>© {{ current_year }} <span class="node">✦</span> Set in Cormorant Garamond &amp; Spectral</div>
+</footer>
+</body>
+</html>

--- a/examples/orrery/templates/header.html
+++ b/examples/orrery/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Spectral:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="mark"></span>{{ site.title }}</a>
+    <div class="search">
+      <input type="text" placeholder="Search the atlas…" aria-label="Search documentation" />
+      <span class="kbd">⌘ K</span>
+    </div>
+    <nav>
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/guides/">Guides</a>
+      <a href="{{ base_url }}/about/">About</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/examples/orrery/templates/home.html
+++ b/examples/orrery/templates/home.html
@@ -1,0 +1,83 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <div class="eyebrow">Atlas Edition · Hwaro Static Generator</div>
+    <h1>Documentation set like a <span class="brass">star chart</span>.</h1>
+    <p class="deck">Orrery is a dark, scholarly documentation theme modelled on the antique astronomical instrument: concentric brass orbits, parchment type, and coordinate labels drawn in small-caps. Built for projects that want their docs to read like an instrument, not a brochure.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/installation/" class="primary">Begin observation</a>
+      <a href="{{ base_url }}/docs/">Browse the index</a>
+      <a class="kbd">$ brew install hahwul/hwaro/hwaro</a>
+    </div>
+  </div>
+  <div class="orrery">
+    <span class="starfield" aria-hidden="true"></span>
+    <div class="orrery-fig" role="img" aria-label="A brass orrery diagram of concentric orbital rings around a central sun.">
+      <span class="ring r1"></span>
+      <span class="ring r2 dashed"></span>
+      <span class="ring r3"></span>
+      <span class="ring r4"></span>
+      <span class="sun"></span>
+      <span class="planet p1"></span>
+      <span class="planet p2"></span>
+      <span class="planet p3"></span>
+      <span class="planet p4"></span>
+      <span class="coord-tag">R.A. 14h 06m · DEC +12°</span>
+    </div>
+  </div>
+</section>
+
+<section class="cats">
+  <a href="{{ base_url }}/docs/installation/" class="cat">
+    <div class="emblem"><span class="dot"></span><span class="idx">I</span></div>
+    <div class="kicker">Mag. 01 · First Light</div>
+    <h3>Installation</h3>
+    <p>Three commands and the dev server lights up. Then it is only a question of how strict you set the configuration.</p>
+    <span class="read">Observe →</span>
+  </a>
+  <a href="{{ base_url }}/docs/sections-and-pages/" class="cat">
+    <div class="emblem"><span class="dot"></span><span class="idx">II</span></div>
+    <div class="kicker">Mag. 02 · The Tree</div>
+    <h3>Sections &amp; pages</h3>
+    <p>How content is charted, how sections behave, and why <code>_index.md</code> quietly does more than it lets on.</p>
+    <span class="read">Observe →</span>
+  </a>
+  <a href="{{ base_url }}/docs/templates/" class="cat">
+    <div class="emblem"><span class="dot"></span><span class="idx">III</span></div>
+    <div class="kicker">Mag. 03 · The Lens</div>
+    <h3>Templates</h3>
+    <p>Crinja templates, where they live, and the small set of globals you are allowed to count on.</p>
+    <span class="read">Observe →</span>
+  </a>
+  <a href="{{ base_url }}/guides/build-pipeline/" class="cat">
+    <div class="emblem"><span class="dot"></span><span class="idx">IV</span></div>
+    <div class="kicker">Mag. 04 · The Movement</div>
+    <h3>Build pipeline</h3>
+    <p>What turns between <code>hwaro build</code> and <code>public/</code>, traced through seven legible phases.</p>
+    <span class="read">Observe →</span>
+  </a>
+  <a href="{{ base_url }}/guides/i18n/" class="cat">
+    <div class="emblem"><span class="dot"></span><span class="idx">V</span></div>
+    <div class="kicker">Mag. 05 · Parallax</div>
+    <h3>Internationalization</h3>
+    <p>Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises.</p>
+    <span class="read">Observe →</span>
+  </a>
+  <a href="{{ base_url }}/guides/deploying/" class="cat">
+    <div class="emblem"><span class="dot"></span><span class="idx">VI</span></div>
+    <div class="kicker">Mag. 06 · Transit</div>
+    <h3>Deploying</h3>
+    <p>Recipes for GitHub Pages, Cloudflare Pages, and a plain Bash script for the rest of the sky.</p>
+    <span class="read">Observe →</span>
+  </a>
+</section>
+
+<section class="metrics">
+  <div class="m"><div class="v">v0.14</div><div class="k">Current epoch</div></div>
+  <div class="m"><div class="v">11<span> pp</span></div><div class="k">Charted pages</div></div>
+  <div class="m"><div class="v">&lt;50<span> ms</span></div><div class="k">Live reload</div></div>
+  <div class="m"><div class="v">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/orrery/templates/page.html
+++ b/examples/orrery/templates/page.html
@@ -1,0 +1,50 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+   <div class="main-inner">
+    <div class="crumb">
+      <span class="accent">✦</span>
+      <a href="{{ base_url }}/">Atlas</a>
+      {% if page.section %}/ <a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a>{% endif %}
+      / <span>{{ page.title }}</span>
+    </div>
+    <div class="coord">R.A. 14h 06m · DEC +12°</div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+    <hr class="starrule">
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b">
+        <div class="k">← Inferior orbit</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">Superior orbit →</div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+   </div>
+  </main>
+  <aside class="toc">
+    <h5>Coordinates</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top of page</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/orrery/templates/section.html
+++ b/examples/orrery/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="section-head">
+  <div class="coord">Catalogue · {{ section.title }}</div>
+  <h1>{{ section.title }}</h1>
+  {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+  <div class="count">{{ section.pages | length }} entries charted</div>
+</div>
+
+<section class="cats">
+  {% for post in section.pages %}
+  <a href="{{ base_url }}{{ post.url }}" class="cat">
+    <div class="emblem"><span class="dot"></span><span class="idx">{{ loop.index }}</span></div>
+    <div class="kicker">Mag. {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+    <h3>{{ post.title }}</h3>
+    {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+    <span class="read">Observe →</span>
+  </a>
+  {% endfor %}
+</section>
+
+{% include "footer.html" %}

--- a/examples/orrery/templates/taxonomy.html
+++ b/examples/orrery/templates/taxonomy.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<div class="section-head">
+  <div class="coord">Constellations · {{ taxonomy_name }}</div>
+  <h1>All {{ taxonomy_name }}</h1>
+  <div class="count">{{ taxonomy_terms | length }} terms catalogued</div>
+</div>
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+   <div class="main-inner">
+    <div class="content">
+      <ul>
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term }}</a> — {{ term.pages | length }} entries</li>
+      {% endfor %}
+      </ul>
+    </div>
+   </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/orrery/templates/taxonomy_term.html
+++ b/examples/orrery/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+
+<div class="section-head">
+  <div class="coord">Constellation · {{ taxonomy_term }}</div>
+  <h1>{{ taxonomy_term }}</h1>
+  <div class="count">{{ taxonomy_pages | length }} entries under this term</div>
+</div>
+
+<section class="cats">
+  {% for post in taxonomy_pages %}
+  <a href="{{ base_url }}{{ post.url }}" class="cat">
+    <div class="emblem"><span class="dot"></span><span class="idx">{{ loop.index }}</span></div>
+    <div class="kicker">Mag. {% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+    <h3>{{ post.title }}</h3>
+    {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+    <span class="read">Observe →</span>
+  </a>
+  {% endfor %}
+</section>
+
+{% include "footer.html" %}

--- a/examples/quadrille/AGENTS.md
+++ b/examples/quadrille/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for the Quadrille Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/quadrille/archetypes/default.md
+++ b/examples/quadrille/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/quadrille/config.toml
+++ b/examples/quadrille/config.toml
@@ -1,0 +1,197 @@
+title = "Quadrille"
+description = "An engineer's graph-paper notebook documentation theme — precise notes ruled to the grid."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/quadrille/content/about.md
+++ b/examples/quadrille/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "About"
+description = "Why Quadrille looks like graph paper, the design rules behind it, and where to send corrections."
+date = "2026-04-01"
++++
+
+Quadrille is a documentation theme drawn on an engineer's graph paper. It takes its look from the cheap, dependable quadrille notebook every lab and machine shop keeps on the bench: a faint cyan grid, ink in graphite, the occasional correction in red pencil. Documentation, we think, reads more honestly when the ruling is visible and everything lands on the line.
+
+## The drawing conventions
+
+- A real graph-paper background — a minor grid every 24 px and a major line every fifth square — drawn with tiled solid-color SVG ruling, with no soft fades anywhere.
+- Headings carry monospace plate numbers, the way a figure in a manual is labelled before it is described.
+- Callouts are framed as figures, with L-shaped corner ticks and a measured caption.
+- A margin rail carries the revision mark and dimension ticks, so each sheet reads like a page torn from a notebook.
+
+## What this is not
+
+This is not a marketing theme. There is no carousel, no testimonial wall, and no animation that fires on scroll. The grid does the decorating. Your words do the rest.
+
+## Built on Hwaro
+
+Quadrille is a theme for [Hwaro](https://github.com/hahwul/hwaro), a fast static site generator written in Crystal. Scaffold a docs site with `hwaro init my-docs --scaffold docs`, preview it with `hwaro serve`, and ship it with `hwaro build`.
+
+## License
+
+MIT. Use it, fork it, rule your own lines, and send corrections.

--- a/examples/quadrille/content/docs/_index.md
+++ b/examples/quadrille/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The core reference, ruled sheet by sheet — installation, configuration, and the daily Hwaro workflow."
+sort_by = "weight"
++++

--- a/examples/quadrille/content/docs/cli.md
+++ b/examples/quadrille/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "Every command, every flag, and the two you actually reach for every working day."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose. A handful of commands cover the whole notebook workflow.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name> --scaffold docs` | Scaffold a new docs site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build the site to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000` starts on port 4000. `hwaro build --minify --skip-image-processing` is the fastest production build, and `hwaro build --base-url "https://example.com"` rules the URLs for the host you are shipping to.

--- a/examples/quadrille/content/docs/configuration.md
+++ b/examples/quadrille/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "Every setting in config.toml, what it does, and the smallest sensible default to start from."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews — the documentation equivalent of drawing past the margin.

--- a/examples/quadrille/content/docs/installation.md
+++ b/examples/quadrille/content/docs/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
+description = "Tap, install, scaffold — three commands to a ruled page, then settings to taste."
+weight = 1
+date = "2026-05-01"
++++
+
+Quadrille is a theme for the Hwaro static site generator. Install Hwaro from Homebrew, scaffold a docs site, and you are looking at your own graph paper in under a minute.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve
+```
+
+The dev server opens `http://localhost:3000`. Any edit to `content/`, `templates/`, or `static/` reloads almost instantly, so you can write with the page open beside you.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.0 or newer
+```
+
+If you see something older, your package manager has cached a previous release. Run `brew upgrade hwaro` and check again.
+
+## Where to next
+
+Move on to **Your first page**, where you write one sheet of content, give it a template, and watch it render on the grid.

--- a/examples/quadrille/content/docs/sections-and-pages.md
+++ b/examples/quadrille/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "How content is filed, how sections behave, and why _index.md is doing more than it looks."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/quadrille/content/docs/taxonomies.md
+++ b/examples/quadrille/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Tags, categories, and the occasional custom index — how to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/quadrille/content/docs/template-filters.md
+++ b/examples/quadrille/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A bench reference of the most useful template filters, with examples you can paste straight in."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/quadrille/content/docs/templates.md
+++ b/examples/quadrille/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Crinja templates, where they live, and the short set of globals you can count on every build."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/quadrille/content/docs/your-first-page.md
+++ b/examples/quadrille/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "A short walkthrough that ends with one rendered sheet and the quiet satisfaction of a green build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is one sheet: a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already on the bench.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/quadrille/content/guides/_index.md
+++ b/examples/quadrille/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "Longer field notes for real situations — the build pipeline traced phase by phase, plus i18n and deployment."
+sort_by = "weight"
++++

--- a/examples/quadrille/content/guides/build-pipeline.md
+++ b/examples/quadrille/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "What happens between hwaro build and public/, traced in seven readable phases like a diagram."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/quadrille/content/guides/deploying.md
+++ b/examples/quadrille/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying"
+description = "Field notes for GitHub Pages, Cloudflare Pages, and a plain Bash script for everyone else."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/quadrille/content/guides/i18n.md
+++ b/examples/quadrille/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/quadrille/content/index.md
+++ b/examples/quadrille/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Quadrille"
+description = "An engineer's graph-paper notebook documentation theme — precise notes ruled to the grid."
+template = "home"
++++

--- a/examples/quadrille/static/css/style.css
+++ b/examples/quadrille/static/css/style.css
@@ -1,0 +1,722 @@
+/* =============================================================================
+   QUADRILLE — an engineer's graph-paper notebook documentation theme
+   Precise notes on quadrille paper. Minor + major grid, figure callouts,
+   plate-numbered headings, a margin rail of revision/dimension marks.
+   Grid is drawn with a tiled solid-color SVG. No soft fades anywhere.
+   ============================================================================= */
+
+/* ---------------------------------------------------------------- Tokens -- */
+:root {
+  /* Paper + grid */
+  --paper:        #fcfcfa;
+  --paper-2:      #f6f7f3;
+  --grid-minor:   #d7e6ef;
+  --grid-major:   #b9d2e0;
+
+  /* Ink */
+  --ink:          #1f2933;
+  --ink-soft:     #46535f;
+  --ink-faint:    #7a8893;
+
+  /* Accents */
+  --blue:         #2459b0;
+  --blue-deep:    #1b427f;
+  --blue-wash:    #e9f0fa;
+  --red:          #cc3b2e;
+  --red-wash:     #fbeae8;
+
+  /* Lines */
+  --rule:         #c9d6de;
+  --rule-strong:  #1f2933;
+
+  /* Type */
+  --sans: 'IBM Plex Sans', 'Inter', system-ui, -apple-system, sans-serif;
+  --mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Rhythm — everything aligns to a 24px module (the paper square) */
+  --u:   24px;
+  --u2:  48px;
+  --maxw: 1240px;
+  --radius: 2px;
+}
+
+/* --------------------------------------------------------------- Reset --- */
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--ink);
+  background-color: var(--paper);
+
+  /* THE GRAPH PAPER — two tiled inline solid-color SVGs.
+     Minor 24px grid + major 120px grid. Solid 1px lines only. */
+  background-image:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cpath d='M120 0H0V120' fill='none' stroke='%23b9d2e0' stroke-width='1'/%3E%3C/svg%3E"),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath d='M24 0H0V24' fill='none' stroke='%23d7e6ef' stroke-width='1'/%3E%3C/svg%3E");
+  background-size: 120px 120px, 24px 24px;
+  background-position: 0 0, 0 0;
+}
+
+img { max-width: 100%; height: auto; }
+
+a { color: var(--blue); text-decoration: none; }
+a:hover { color: var(--blue-deep); }
+
+::selection { background: var(--blue); color: var(--paper); }
+
+/* --------------------------------------------------------- Top bar ------- */
+.bar {
+  position: sticky; top: 0; z-index: 50;
+  background: var(--paper);
+  border-bottom: 2px solid var(--rule-strong);
+}
+.bar-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 var(--u);
+  height: 64px;
+  display: flex; align-items: center; gap: var(--u);
+}
+.brand {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.brand:hover { color: var(--ink); }
+/* the brand mark: a tiny quadrille square with a registration cross */
+.brand .mark {
+  width: 22px; height: 22px;
+  border: 2px solid var(--blue);
+  position: relative;
+  flex: none;
+}
+.brand .mark::before,
+.brand .mark::after {
+  content: ""; position: absolute; background: var(--red);
+}
+.brand .mark::before { left: 50%; top: 2px; bottom: 2px; width: 2px; transform: translateX(-50%); }
+.brand .mark::after  { top: 50%; left: 2px; right: 2px; height: 2px; transform: translateY(-50%); }
+
+.search {
+  margin-left: auto;
+  display: flex; align-items: center; gap: 8px;
+  border: 1.5px solid var(--rule);
+  background: var(--paper);
+  padding: 6px 10px;
+  min-width: 220px;
+}
+.search input {
+  border: 0; background: transparent; outline: none;
+  font-family: var(--mono); font-size: 13px; color: var(--ink);
+  width: 100%;
+}
+.search input::placeholder { color: var(--ink-faint); }
+.kbd {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--ink-soft);
+  border: 1.5px solid var(--rule);
+  padding: 2px 6px;
+  white-space: nowrap;
+  background: var(--paper-2);
+}
+.bar nav { display: flex; align-items: center; gap: 4px; }
+.bar nav a {
+  font-family: var(--mono); font-size: 13px;
+  color: var(--ink-soft);
+  padding: 8px 12px;
+  border: 1.5px solid transparent;
+}
+.bar nav a:hover { color: var(--ink); border-color: var(--rule); }
+.bar nav a.cta {
+  color: var(--paper); background: var(--blue);
+  border-color: var(--blue);
+}
+.bar nav a.cta:hover { background: var(--blue-deep); border-color: var(--blue-deep); color: var(--paper); }
+
+/* --------------------------------------------------------- Hero ---------- */
+.hero {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: var(--u2) var(--u);
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: var(--u2);
+  align-items: center;
+}
+.hero .copy h1 {
+  font-size: clamp(34px, 5vw, 56px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 var(--u);
+  font-weight: 600;
+}
+.hero .copy h1 .red  { color: var(--red); }
+.hero .copy h1 .blue { color: var(--blue); }
+.deck {
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  margin: 0 0 var(--u2);
+}
+.cta-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+.cta-row a {
+  font-family: var(--mono);
+  font-size: 14px;
+  padding: 11px 18px;
+  border: 2px solid var(--ink);
+  color: var(--ink);
+}
+.cta-row a:hover { background: var(--ink); color: var(--paper); }
+.cta-row a.primary {
+  background: var(--blue); border-color: var(--blue); color: var(--paper);
+}
+.cta-row a.primary:hover { background: var(--blue-deep); border-color: var(--blue-deep); }
+.cta-row a.kbd {
+  border-color: var(--rule); color: var(--ink-soft); background: var(--paper-2);
+}
+.cta-row a.kbd:hover { background: var(--paper-2); color: var(--ink-soft); }
+
+/* Hero plate — a framed quadrille specimen with measurement ticks */
+.plate {
+  position: relative;
+  background: var(--paper);
+  border: 2px solid var(--ink);
+  aspect-ratio: 1 / 1;
+  background-image:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath d='M24 0H0V24' fill='none' stroke='%23cfe1ec' stroke-width='1'/%3E%3C/svg%3E");
+  background-size: 24px 24px;
+  background-position: 0 0;
+  padding: var(--u);
+  display: flex; flex-direction: column; justify-content: space-between;
+}
+.plate .pl-tag {
+  font-family: var(--mono); font-size: 12px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--blue);
+}
+.plate .pl-fig {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: clamp(28px, 4vw, 44px);
+  color: var(--ink);
+  line-height: 1;
+}
+.plate .pl-sub {
+  font-family: var(--mono); font-size: 12px; color: var(--ink-soft);
+  margin-top: 6px;
+}
+.plate .pl-meta {
+  font-family: var(--mono); font-size: 11px; color: var(--ink-faint);
+  display: flex; justify-content: space-between;
+  border-top: 1.5px solid var(--rule);
+  padding-top: 8px;
+}
+/* corner ticks on the plate */
+.plate::before, .plate::after {
+  content: ""; position: absolute; width: 14px; height: 14px;
+  border: 2px solid var(--red);
+}
+.plate::before { top: -2px; left: -2px; border-right: 0; border-bottom: 0; }
+.plate::after  { bottom: -2px; right: -2px; border-left: 0; border-top: 0; }
+
+/* --------------------------------------------------- Category cards ------ */
+.cats {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: var(--u) var(--u) var(--u2);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.cats .cat {
+  position: relative;
+  display: flex; flex-direction: column;
+  padding: var(--u);
+  background: var(--paper);
+  border: 1.5px solid var(--rule);
+  margin: -0.75px;
+  color: var(--ink);
+  min-height: 180px;
+  transition: border-color .12s ease, background .12s ease;
+}
+.cats .cat:hover {
+  border-color: var(--ink);
+  background: var(--paper-2);
+  z-index: 2;
+}
+.cat .icon {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 13px;
+  width: 34px; height: 34px;
+  display: flex; align-items: center; justify-content: center;
+  border: 2px solid var(--ink);
+  margin-bottom: 14px;
+}
+.cat .icon.red   { color: var(--red);  border-color: var(--red);  }
+.cat .icon.blue  { color: var(--blue); border-color: var(--blue); }
+.cat .icon.ink   { color: var(--ink);  border-color: var(--ink);  }
+.cat .icon.green { color: var(--blue-deep); border-color: var(--blue-deep); }
+.cat h3 {
+  margin: 0 0 8px;
+  font-size: 18px; font-weight: 600; letter-spacing: -0.01em;
+}
+.cat p {
+  margin: 0 0 16px;
+  font-size: 14px; line-height: 1.55; color: var(--ink-soft);
+}
+.cat code {
+  font-family: var(--mono); font-size: 0.85em;
+  background: var(--blue-wash); color: var(--blue-deep);
+  padding: 1px 5px; border: 1px solid #cfe0f4;
+}
+.cat .read {
+  margin-top: auto;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--blue);
+  letter-spacing: 0.02em;
+}
+.cat:hover .read { color: var(--blue-deep); }
+
+/* ------------------------------------------------------- Spec strip ------ */
+.metrics {
+  max-width: var(--maxw);
+  margin: 0 auto var(--u2);
+  padding: 0 var(--u);
+  display: grid; grid-template-columns: repeat(4, 1fr);
+}
+.metrics .m {
+  border-top: 2px solid var(--ink);
+  border-right: 1.5px solid var(--rule);
+  padding: var(--u) 0 var(--u) 14px;
+}
+.metrics .m:last-child { border-right: 0; }
+.metrics .v {
+  font-family: var(--mono); font-weight: 600;
+  font-size: 30px; line-height: 1; color: var(--ink);
+}
+.metrics .v.red  { color: var(--red); }
+.metrics .v.blue { color: var(--blue); }
+.metrics .v.ink  { color: var(--ink); }
+.metrics .k {
+  margin-top: 8px;
+  font-family: var(--mono); font-size: 11px;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--ink-faint);
+}
+
+/* ====================================================== DOC LAYOUT ======= */
+.shell {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: var(--u) var(--u) var(--u2);
+  display: grid;
+  grid-template-columns: 230px minmax(0, 1fr) 200px;
+  gap: var(--u2);
+  align-items: start;
+}
+
+/* ----- Sidebar (left) ----------------------------------------------------- */
+.sidebar {
+  position: sticky; top: 88px;
+  font-size: 14px;
+  border-left: 2px solid var(--ink);
+  padding-left: var(--u);
+}
+.sidebar h4 {
+  margin: var(--u) 0 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  display: flex; align-items: center; gap: 8px;
+}
+.sidebar h4:first-child { margin-top: 0; }
+.sidebar h4::before {
+  content: ""; width: 10px; height: 10px; flex: none;
+  border: 2px solid var(--ink-faint);
+}
+.sidebar h4.red::before   { background: var(--red);  border-color: var(--red);  }
+.sidebar h4.blue::before  { background: var(--blue); border-color: var(--blue); }
+.sidebar h4.yellow::before{ background: var(--paper); border-color: var(--ink); }
+.sidebar h4.green::before { background: var(--ink); border-color: var(--ink); }
+.sidebar ul { list-style: none; margin: 0; padding: 0; }
+.sidebar li { margin: 0; }
+.sidebar li a {
+  display: block;
+  padding: 5px 10px;
+  color: var(--ink-soft);
+  border-left: 2px solid transparent;
+  margin-left: -2px;
+}
+.sidebar li a:hover {
+  color: var(--blue);
+  border-left-color: var(--blue);
+  background: var(--paper-2);
+}
+
+/* ----- Main column -------------------------------------------------------- */
+.main { min-width: 0; }
+
+.crumb {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-bottom: 14px;
+  letter-spacing: 0.01em;
+}
+.crumb a { color: var(--ink-soft); }
+.crumb a:hover { color: var(--blue); }
+.crumb .accent { color: var(--red); }
+.crumb span:last-child { color: var(--ink); }
+
+.main > h1 {
+  font-size: clamp(30px, 4vw, 42px);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0 0 12px;
+  font-weight: 600;
+}
+.main > .deck {
+  font-size: 17px;
+  margin: 0 0 var(--u);
+  padding-bottom: var(--u);
+  border-bottom: 2px solid var(--ink);
+  max-width: none;
+}
+
+/* ============================================ .content — STYLE EVERYTHING = */
+.content { font-size: 16px; color: var(--ink); counter-reset: plate; }
+.content > *:first-child { margin-top: 0; }
+
+/* Plate-numbered headings — mono counter prefix */
+.content h2, .content h3, .content h4 {
+  position: relative;
+  letter-spacing: -0.01em;
+  scroll-margin-top: 88px;
+}
+.content h2 {
+  counter-increment: plate;
+  font-size: 26px;
+  margin: var(--u2) 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1.5px solid var(--rule);
+  font-weight: 600;
+}
+.content h2::before {
+  content: "§" counter(plate, decimal-leading-zero);
+  display: block;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--blue);
+  letter-spacing: 0.08em;
+  margin-bottom: 2px;
+}
+.content h3 {
+  font-size: 20px;
+  margin: var(--u2) 0 10px;
+  font-weight: 600;
+}
+.content h3::before {
+  content: "—";
+  font-family: var(--mono);
+  color: var(--red);
+  margin-right: 8px;
+}
+.content h4 {
+  font-size: 16px;
+  margin: var(--u) 0 8px;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-soft);
+  font-weight: 600;
+}
+
+.content p { margin: 0 0 var(--u); }
+.content a { border-bottom: 1.5px solid currentColor; }
+.content a:hover { background: var(--blue-wash); }
+
+.content strong { font-weight: 600; color: var(--ink); }
+.content em { font-style: italic; }
+
+/* Lists with mono tick markers */
+.content ul, .content ol { margin: 0 0 var(--u); padding-left: 0; }
+.content ul { list-style: none; }
+.content ul li {
+  position: relative;
+  padding-left: 26px;
+  margin-bottom: 8px;
+}
+.content ul li::before {
+  content: "+";
+  position: absolute; left: 6px; top: 0;
+  font-family: var(--mono); font-weight: 600;
+  color: var(--blue);
+}
+.content ol {
+  list-style: none;
+  counter-reset: ol;
+}
+.content ol li {
+  position: relative;
+  padding-left: 34px;
+  margin-bottom: 8px;
+  counter-increment: ol;
+}
+.content ol li::before {
+  content: counter(ol, decimal-leading-zero);
+  position: absolute; left: 0; top: 0;
+  font-family: var(--mono); font-size: 12px; font-weight: 600;
+  color: var(--red);
+  border: 1.5px solid var(--red);
+  padding: 0 4px;
+  line-height: 1.5;
+}
+.content li > ul, .content li > ol { margin-top: 8px; margin-bottom: 0; }
+
+/* Inline code */
+.content code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  background: var(--paper-2);
+  color: var(--blue-deep);
+  border: 1px solid var(--rule);
+  padding: 1px 5px;
+  border-radius: var(--radius);
+}
+
+/* Code blocks — a taped-in printout on the grid */
+.content pre {
+  font-family: var(--mono);
+  font-size: 13.5px;
+  line-height: 1.7;
+  background: #f4f6f8;
+  color: var(--ink);
+  border: 1.5px solid var(--ink);
+  border-left: 3px solid var(--blue);
+  padding: var(--u);
+  margin: 0 0 var(--u);
+  overflow-x: auto;
+  position: relative;
+}
+.content pre code {
+  background: none; border: 0; padding: 0; color: inherit; font-size: inherit;
+}
+
+/* SIGNATURE: figure callout — blockquote styled as FIG. plate with ticks */
+.content blockquote {
+  position: relative;
+  margin: var(--u2) 0;
+  padding: var(--u) var(--u) 14px;
+  background: var(--paper);
+  border: 1.5px solid var(--blue);
+  color: var(--ink-soft);
+  font-size: 15px;
+}
+.content blockquote::before {
+  content: "FIG.";
+  position: absolute; top: -10px; left: 16px;
+  font-family: var(--mono); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--blue);
+  background: var(--paper);
+  padding: 0 8px;
+}
+/* L-shaped corner tick on the figure callout */
+.content blockquote::after {
+  content: "";
+  position: absolute; right: -1px; bottom: -1px;
+  width: 16px; height: 16px;
+  border-right: 3px solid var(--red);
+  border-bottom: 3px solid var(--red);
+}
+.content blockquote p:last-child { margin-bottom: 0; }
+.content blockquote p { margin-bottom: 10px; }
+
+/* Tables — engineering datasheet */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 var(--u);
+  font-size: 14px;
+}
+.content thead th {
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--paper);
+  background: var(--ink);
+  padding: 8px 12px;
+  border: 1px solid var(--ink);
+}
+.content tbody td {
+  padding: 8px 12px;
+  border: 1px solid var(--rule);
+  vertical-align: top;
+}
+.content tbody tr:nth-child(even) td { background: var(--paper-2); }
+.content tbody tr:hover td { background: var(--blue-wash); }
+
+/* Horizontal rule — a measured dimension line */
+.content hr {
+  border: 0;
+  height: 0;
+  border-top: 2px solid var(--ink);
+  margin: var(--u2) 0;
+  position: relative;
+}
+.content hr::after {
+  content: "·";
+  position: absolute; left: 50%; top: -14px; transform: translateX(-50%);
+  font-family: var(--mono); color: var(--red); font-size: 22px;
+  background: var(--paper); padding: 0 10px;
+}
+
+/* ----- TOC (right rail) — the MARGIN RAIL with revision/dimension marks --- */
+.toc {
+  position: sticky; top: 88px;
+  font-size: 13px;
+  padding-left: var(--u);
+  border-left: 2px solid var(--ink);
+}
+.toc h5 {
+  margin: 0 0 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-soft);
+}
+.toc ul { list-style: none; margin: 0; padding: 0; }
+.toc li { margin: 0; }
+.toc a {
+  display: block;
+  padding: 4px 0 4px 16px;
+  color: var(--ink-faint);
+  position: relative;
+  line-height: 1.4;
+}
+/* dimension tick on each TOC entry */
+.toc a::before {
+  content: "";
+  position: absolute; left: 0; top: 13px;
+  width: 8px; height: 1.5px; background: var(--rule);
+}
+.toc a:hover { color: var(--blue); }
+.toc a:hover::before { background: var(--blue); width: 12px; }
+.toc ul ul a { padding-left: 28px; }
+.toc ul ul a::before { left: 14px; width: 6px; }
+
+/* the margin metadata block under the rail */
+.rail-meta {
+  margin-top: var(--u);
+  padding-top: 12px;
+  border-top: 1.5px solid var(--rule);
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  line-height: 1.8;
+}
+.rail-meta .row { display: flex; justify-content: space-between; gap: 8px; }
+.rail-meta .row span:last-child { color: var(--ink-soft); }
+.rail-meta .rev {
+  display: inline-block;
+  margin-top: 8px;
+  color: var(--red);
+  border: 1.5px solid var(--red);
+  padding: 1px 6px;
+}
+
+/* ----- Pager -------------------------------------------------------------- */
+.pager {
+  display: grid; grid-template-columns: 1fr 1fr; gap: var(--u);
+  margin-top: var(--u2);
+  padding-top: var(--u);
+  border-top: 2px solid var(--ink);
+}
+.pager .b {
+  border: 1.5px solid var(--rule);
+  padding: 14px var(--u);
+  color: var(--ink);
+  transition: border-color .12s ease, background .12s ease;
+}
+.pager .b:hover { border-color: var(--ink); background: var(--paper-2); }
+.pager .b.next { text-align: right; }
+.pager .k {
+  font-family: var(--mono); font-size: 11px;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--blue);
+  margin-bottom: 4px;
+}
+.pager .t { font-weight: 600; font-size: 15px; }
+
+/* ----- Footer ------------------------------------------------------------- */
+.foot {
+  border-top: 2px solid var(--rule-strong);
+  background: var(--paper);
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: var(--u);
+  display: flex; flex-wrap: wrap; gap: 8px; justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+.foot strong { color: var(--ink); font-weight: 600; }
+
+/* =============================================================== Responsive */
+@media (max-width: 1080px) {
+  .shell { grid-template-columns: 200px minmax(0, 1fr); }
+  .toc { display: none; }
+}
+
+@media (max-width: 860px) {
+  .bar-inner { gap: 12px; }
+  .search { display: none; }
+  .bar nav a:not(.cta) { display: none; }
+
+  .hero {
+    grid-template-columns: 1fr;
+    gap: var(--u);
+    padding: var(--u2) var(--u) var(--u);
+  }
+  .hero .plate { max-width: 360px; }
+
+  .cats { grid-template-columns: 1fr; }
+  .cats .cat { margin: -0.75px 0; }
+  .metrics { grid-template-columns: 1fr 1fr; }
+  .metrics .m:nth-child(2) { border-right: 0; }
+
+  .shell {
+    grid-template-columns: 1fr;
+    gap: var(--u);
+  }
+  .sidebar {
+    position: static;
+    border-left: 0;
+    border-top: 2px solid var(--ink);
+    padding-left: 0; padding-top: var(--u);
+  }
+  .pager { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 520px) {
+  .metrics { grid-template-columns: 1fr; }
+  .metrics .m { border-right: 0; }
+  .cta-row a { flex: 1 1 auto; text-align: center; }
+}

--- a/examples/quadrille/templates/404.html
+++ b/examples/quadrille/templates/404.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <h1><span class="red">404</span> — this sheet is blank.</h1>
+    <p class="deck">The page you requested is not filed in this notebook. Try the <a href="{{ base_url }}/docs/" style="color:var(--blue);border-bottom:1.5px solid var(--blue);">documentation</a> or return to the <a href="{{ base_url }}/" style="color:var(--blue);border-bottom:1.5px solid var(--blue);">cover sheet</a>.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/" class="primary">Back to docs →</a>
+      <a href="{{ base_url }}/">Cover sheet</a>
+    </div>
+  </div>
+  <div class="plate">
+    <div>
+      <div class="pl-tag">Plate — Missing</div>
+      <div class="pl-fig">FIG. ——</div>
+      <div class="pl-sub">no entry on file</div>
+    </div>
+    <div class="pl-meta">
+      <span>STATUS 404</span>
+      <span>SHEET 0/0</span>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/quadrille/templates/_sidebar.html
+++ b/examples/quadrille/templates/_sidebar.html
@@ -1,0 +1,28 @@
+<aside class="sidebar">
+  <h4 class="red">Start Here</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+    <li><a href="{{ base_url }}/docs/your-first-page/">Your first page</a></li>
+    <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+  </ul>
+
+  <h4 class="blue">Concepts</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a></li>
+    <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+    <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+  </ul>
+
+  <h4 class="yellow">Guides</h4>
+  <ul>
+    <li><a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a></li>
+    <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+    <li><a href="{{ base_url }}/guides/deploying/">Deploying</a></li>
+  </ul>
+
+  <h4 class="green">Reference</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/cli/">CLI reference</a></li>
+    <li><a href="{{ base_url }}/docs/template-filters/">Template filters</a></li>
+  </ul>
+</aside>

--- a/examples/quadrille/templates/footer.html
+++ b/examples/quadrille/templates/footer.html
@@ -1,0 +1,6 @@
+<footer class="foot">
+  <div><strong>{{ site.title }}</strong> · {{ site.description }}</div>
+  <div>© {{ current_year }} · Rev. C · Ruled to 24 px · Set in IBM Plex</div>
+</footer>
+</body>
+</html>

--- a/examples/quadrille/templates/header.html
+++ b/examples/quadrille/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="mark"></span>{{ site.title }}</a>
+    <div class="search">
+      <input type="text" placeholder="Search the notebook…" />
+      <span class="kbd">/</span>
+    </div>
+    <nav>
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/guides/">Guides</a>
+      <a href="{{ base_url }}/about/">About</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/examples/quadrille/templates/home.html
+++ b/examples/quadrille/templates/home.html
@@ -1,0 +1,72 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <h1>Documentation, ruled to the <span class="blue">millimetre</span> and marked in <span class="red">red pencil</span>.</h1>
+    <p class="deck">Quadrille is a documentation theme drawn on engineer's graph paper. Plate-numbered headings, figure callouts with corner ticks, and a margin rail of revision marks — every element snaps to the grid, the way a careful notebook should.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/installation/" class="primary">Open the notebook →</a>
+      <a href="{{ base_url }}/docs/">Browse docs</a>
+      <a class="kbd">$ hwaro serve</a>
+    </div>
+  </div>
+  <div class="plate">
+    <div>
+      <div class="pl-tag">Plate I — Specimen</div>
+      <div class="pl-fig">FIG. 01</div>
+      <div class="pl-sub">quadrille · 24 px pitch</div>
+    </div>
+    <div class="pl-meta">
+      <span>SCALE 1:1</span>
+      <span>SHEET 1/1</span>
+    </div>
+  </div>
+</section>
+
+<section class="cats">
+  <a href="{{ base_url }}/docs/installation/" class="cat">
+    <div class="icon red">01</div>
+    <h3>Installation</h3>
+    <p>Tap, install, scaffold. Three commands and a dev server later you are looking at your own ruled page.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/sections-and-pages/" class="cat">
+    <div class="icon blue">02</div>
+    <h3>Sections &amp; pages</h3>
+    <p>How content is filed, why <code>_index.md</code> turns a folder into a section, and how slugs are derived.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/templates/" class="cat">
+    <div class="icon ink">03</div>
+    <h3>Templates</h3>
+    <p>Crinja templates, where they live, and the short list of globals you can rely on every single build.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/build-pipeline/" class="cat">
+    <div class="icon green">04</div>
+    <h3>Build pipeline</h3>
+    <p>What happens between <code>hwaro build</code> and <code>public/</code>, traced phase by phase like a diagram.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/i18n/" class="cat">
+    <div class="icon red">05</div>
+    <h3>Internationalization</h3>
+    <p>Multilingual sites with one default locale and one fallback rule. No surprises, no foot guns.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/deploying/" class="cat">
+    <div class="icon blue">06</div>
+    <h3>Deploying</h3>
+    <p>Field notes for GitHub Pages, Cloudflare Pages, and a plain rsync script for everyone else.</p>
+    <span class="read">Read →</span>
+  </a>
+</section>
+
+<section class="metrics">
+  <div class="m"><div class="v red">0.14</div><div class="k">Hwaro tested on</div></div>
+  <div class="m"><div class="v">24<span style="color:var(--ink-faint);font-size:16px;"> px</span></div><div class="k">Grid pitch</div></div>
+  <div class="m"><div class="v blue">12</div><div class="k">Sheets / pages</div></div>
+  <div class="m"><div class="v ink">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/quadrille/templates/page.html
+++ b/examples/quadrille/templates/page.html
@@ -1,0 +1,51 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb">
+      <span class="accent">+</span> /
+      {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a> /{% endif %}
+      <span>{{ page.title }}</span>
+    </div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b">
+        <div class="k">← Previous sheet</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">Next sheet →</div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+  </main>
+  <aside class="toc">
+    <h5>On this sheet</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top of sheet</a></li>
+      </ul>
+    {% endif %}
+    <div class="rail-meta">
+      <div class="row"><span>SHEET</span><span>{{ page.title }}</span></div>
+      {% if page.section %}<div class="row"><span>FILE</span><span>{{ page.section }}</span></div>{% endif %}
+      <div class="row"><span>SCALE</span><span>1:1</span></div>
+      <span class="rev">REV. C</span>
+    </div>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/quadrille/templates/section.html
+++ b/examples/quadrille/templates/section.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">+</span> / <span>{{ section.title }}</span></div>
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+
+    <div class="cats">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 4 == 1 %}red{% elif loop.index % 4 == 2 %}blue{% elif loop.index % 4 == 3 %}ink{% else %}green{% endif %}">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5>{{ section.pages | length }} sheets</h5>
+    <div class="rail-meta">
+      <div class="row"><span>FILE</span><span>{{ section.title }}</span></div>
+      <div class="row"><span>SHEETS</span><span>{{ section.pages | length }}</span></div>
+      <span class="rev">REV. C</span>
+    </div>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/quadrille/templates/taxonomy.html
+++ b/examples/quadrille/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">+</span> / <span>{{ taxonomy_name }}</span></div>
+    <h1>All {{ taxonomy_name }}</h1>
+    <div class="content">
+      <ul>
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term }}</a> · {{ term.pages | length }} sheets</li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/quadrille/templates/taxonomy_term.html
+++ b/examples/quadrille/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">+</span> / <a href="{{ base_url }}/tags/">tags</a> / <span>{{ taxonomy_term }}</span></div>
+    <h1>#{{ taxonomy_term }}</h1>
+    <div class="cats">
+    {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 4 == 1 %}red{% elif loop.index % 4 == 2 %}blue{% elif loop.index % 4 == 3 %}ink{% else %}green{% endif %}">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read →</span>
+      </a>
+    {% endfor %}
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/risograph/AGENTS.md
+++ b/examples/risograph/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md - AI Agent Instructions for the Risograph theme (Hwaro Site)
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+- **Risograph aesthetic.** The two-ink riso look comes from SOLID flat spot inks plus an OFFSET solid-color shadow (`text-shadow`/`box-shadow` in the second ink). Use only solid fills, borders, and box-shadows — never any blended color transition, and never fake halftone with radial fills.
+- **Two spot inks only:** fluorescent pink `#ff5277` and riso blue `#355cff`, on warm paper `#f3efe2`, with near-black ink `#191919` for body text. Use the CSS variables in `static/css/style.css`.
+- **No emojis.** Geometric Unicode and inline SVG are fine.
+- **Use `{{ base_url }}`** for every internal link.

--- a/examples/risograph/archetypes/default.md
+++ b/examples/risograph/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/risograph/config.toml
+++ b/examples/risograph/config.toml
@@ -1,0 +1,197 @@
+title = "Risograph"
+description = "A two-ink risograph-print documentation theme — flat spot inks, knockout type, and a deliberate off-register shadow."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/risograph/content/about.md
+++ b/examples/risograph/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "About"
+description = "Why Risograph looks like a two-ink zine, the choices behind it, and where to send fixes."
+date = "2026-04-01"
++++
+
+Risograph is a documentation theme that pretends your docs came off a Riso duplicator. A Riso lays down one flat spot ink per drum, and the sheet feeds through twice — once for pink, once for blue. The drums never line up perfectly, so every print has a faint off-register shadow. That accident is the whole aesthetic here, used on purpose.
+
+## The choices we have made
+
+- Two spot inks only: fluorescent pink (`#ff5277`) and riso blue (`#355cff`), printed on warm uncoated paper.
+- The mis-registration is real CSS, not decoration: headings and panels carry a solid second-ink shadow offset by a few pixels.
+- Flat color blocks with knockout (paper-colored) type. No gloss, no soft shadows, no blended fills.
+- Printer's furniture is part of the page: crop marks in the corners, a registration target up top, a colophon in the footer.
+
+## How the overprint works
+
+There are no halftone dots and no blurred shadows anywhere in the stylesheet. The riso look comes entirely from two tricks: a solid `text-shadow` in the opposite ink for type, and a solid `box-shadow` offset for panels. Move the offset and the whole print shifts register — exactly like a real two-pass run.
+
+## What this is not
+
+This is not a marketing theme. There is no carousel, no testimonial wall, and nothing that animates as you scroll. It is built to make long technical documents pleasant to read and easy to skim.
+
+## License
+
+MIT. Print it, fork it, send a better registration.

--- a/examples/risograph/content/docs/_index.md
+++ b/examples/risograph/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The core plates: install, write, configure, and run the daily build."
+sort_by = "weight"
++++

--- a/examples/risograph/content/docs/cli.md
+++ b/examples/risograph/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "Every command, every flag, and the one or two you actually need every day."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name> --scaffold docs` | Scaffold a new docs site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro build --base-url "https://example.com"` | Build with a production host. |
+| `hwaro build --minify` | Minify the output. |
+| `hwaro build --drafts` | Include draft content. |
+
+## A note on flags
+
+`hwaro serve -p 8080` starts the dev server on port 8080 instead of the default 3000. `hwaro build --minify --base-url "https://example.com"` is the canonical production run — set the host at build time so local previews stay on `localhost`.

--- a/examples/risograph/content/docs/configuration.md
+++ b/examples/risograph/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "Every setting in config.toml, what it does, and the smallest sensible default."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/risograph/content/docs/installation.md
+++ b/examples/risograph/content/docs/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
+description = "Two commands to a running docs site — install Hwaro, scaffold the docs, and start the press."
+weight = 1
+date = "2026-05-01"
++++
+
+Risograph runs on the Hwaro static site generator. You can install it from Homebrew, run it under Docker, or build it from source.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve
+```
+
+The dev server runs at `http://localhost:3000`. Any edit to `content/`, `templates/`, or `static/` reloads in well under a second.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.2 or newer
+```
+
+If you see anything older, your package manager has cached an old version. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Move on to **Your first page**, where you will write a single piece of content, give it a template, and watch it render.

--- a/examples/risograph/content/docs/sections-and-pages.md
+++ b/examples/risograph/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "How content is organized, how sections behave, and why _index.md is doing more than it looks."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/risograph/content/docs/taxonomies.md
+++ b/examples/risograph/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Tags, categories, and the occasional custom one. How to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/risograph/content/docs/template-filters.md
+++ b/examples/risograph/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "A reference of the most useful template filters, with examples you can paste."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/risograph/content/docs/templates.md
+++ b/examples/risograph/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "Jinja-flavored templates, where to put them, and the small set of globals you can count on."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/risograph/content/docs/your-first-page.md
+++ b/examples/risograph/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "A small walkthrough that ends with a rendered page and the satisfaction of a green build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it. For a production run, set the host with `hwaro build --base-url "https://example.com"`.

--- a/examples/risograph/content/guides/_index.md
+++ b/examples/risograph/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "Longer recipes for the build, multilingual runs, and shipping the finished sheet to a host."
+sort_by = "weight"
++++

--- a/examples/risograph/content/guides/build-pipeline.md
+++ b/examples/risograph/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "What happens between hwaro build and public/, in seven readable phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/risograph/content/guides/deploying.md
+++ b/examples/risograph/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "Cookbook entries for GitHub Pages, Cloudflare Pages, and a Bash script for the rest of you."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/risograph/content/guides/i18n.md
+++ b/examples/risograph/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Multilingual sites without the foot guns. One default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/risograph/content/index.md
+++ b/examples/risograph/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Risograph"
+description = "A two-ink risograph-print documentation theme — flat spot inks, knockout type, and a deliberate off-register shadow."
+template = "home"
++++

--- a/examples/risograph/static/css/style.css
+++ b/examples/risograph/static/css/style.css
@@ -1,0 +1,667 @@
+/* =============================================================================
+   RISOGRAPH — a two-ink riso-print zine documentation theme
+   Concept: docs run off a Riso duplicator with two spot inks.
+   The look comes from SOLID flat spot inks + an OFFSET solid-color shadow
+   (mis-registration). Absolutely no blended fills, no halftone dots.
+   ============================================================================= */
+
+:root {
+  /* paper stock */
+  --paper:      #f3efe2;   /* warm uncoated paper */
+  --paper-2:    #ece6d6;   /* second sheet / panel tint */
+  --ink:        #191919;   /* near-black key ink */
+
+  /* the TWO spot inks */
+  --pink:       #ff5277;   /* fluorescent pink */
+  --pink-deep:  #e83b62;
+  --blue:       #355cff;   /* riso blue */
+  --blue-deep:  #2546d6;
+
+  /* derived ink tints for body text */
+  --ink-soft:   #3a3733;
+  --mute:       #75706a;
+  --hair:       #cfc8b6;
+  --code-bg:    #ece6d6;
+
+  /* registration */
+  --off:        4px;       /* mis-registration offset */
+  --rule:       3px;       /* press rule weight */
+
+  --max:        1320px;
+}
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: inherit; text-decoration: none; }
+
+::selection { background: var(--pink); color: var(--paper); }
+
+/* =============================================================================
+   PAGE FRAME — registration crosshairs + corner crop marks
+   ============================================================================= */
+.page-frame { position: fixed; inset: 0; pointer-events: none; z-index: 5; }
+
+/* corner crop ticks */
+.crop { position: fixed; width: 26px; height: 26px; z-index: 6; pointer-events: none; }
+.crop::before, .crop::after { content: ""; position: absolute; background: var(--ink); }
+.crop::before { width: 26px; height: var(--rule); }
+.crop::after  { width: var(--rule); height: 26px; }
+.crop.tl { top: 14px; left: 14px; }
+.crop.tl::before { top: 0; left: 0; } .crop.tl::after { top: 0; left: 0; }
+.crop.tr { top: 14px; right: 14px; }
+.crop.tr::before { top: 0; right: 0; } .crop.tr::after { top: 0; right: 0; }
+.crop.bl { bottom: 14px; left: 14px; }
+.crop.bl::before { bottom: 0; left: 0; } .crop.bl::after { bottom: 0; left: 0; }
+.crop.br { bottom: 14px; right: 14px; }
+.crop.br::before { bottom: 0; right: 0; } .crop.br::after { bottom: 0; right: 0; }
+
+/* registration crosshair target (top-right of viewport) */
+.reg-target {
+  position: fixed; top: 64px; right: 22px; z-index: 6;
+  width: 30px; height: 30px; pointer-events: none;
+}
+
+/* =============================================================================
+   TOP BAR
+   ============================================================================= */
+.bar {
+  border-bottom: var(--rule) solid var(--ink);
+  background: var(--paper);
+  position: sticky; top: 0; z-index: 30;
+}
+.bar-inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: stretch;
+}
+
+.brand {
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 26px;
+  border-right: var(--rule) solid var(--ink);
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: 19px;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+}
+/* two-ink overprint mark: pink square with offset blue square */
+.brand .mark {
+  position: relative; width: 22px; height: 22px;
+  background: var(--pink);
+  box-shadow: var(--off) var(--off) 0 var(--blue);
+}
+.brand:hover .mark { box-shadow: calc(var(--off) * -1) var(--off) 0 var(--blue); }
+
+.search {
+  display: flex; align-items: center;
+  padding: 0 24px;
+  border-right: var(--rule) solid var(--ink);
+}
+.search input {
+  border: 0; background: transparent;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px; color: var(--ink);
+  padding: 14px 0; width: 100%; outline: none;
+}
+.search input::placeholder { color: var(--mute); }
+.search .kbd {
+  font-family: "JetBrains Mono", monospace; font-size: 11px;
+  padding: 3px 8px; border: 2px solid var(--ink); color: var(--ink);
+  white-space: nowrap;
+}
+
+.bar nav { display: flex; }
+.bar nav a {
+  display: flex; align-items: center;
+  padding: 16px 22px;
+  border-right: var(--rule) solid var(--ink);
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 13px; font-weight: 600;
+  letter-spacing: 0.02em; text-transform: uppercase;
+}
+.bar nav a:last-child { border-right: 0; }
+.bar nav a:hover { background: var(--ink); color: var(--paper); }
+.bar nav a.cta {
+  background: var(--blue); color: var(--paper);
+}
+.bar nav a.cta:hover { background: var(--pink); color: var(--paper); }
+
+/* =============================================================================
+   SHELL LAYOUT
+   ============================================================================= */
+.shell {
+  display: grid;
+  grid-template-columns: 290px minmax(0, 1fr) 248px;
+  min-height: calc(100vh - 60px);
+  max-width: var(--max);
+  margin: 0 auto;
+  border-left: var(--rule) solid var(--ink);
+  border-right: var(--rule) solid var(--ink);
+}
+
+/* =============================================================================
+   SIDEBAR
+   ============================================================================= */
+.sidebar {
+  border-right: var(--rule) solid var(--ink);
+  padding: 34px 26px;
+  position: sticky; top: 60px;
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+  background: var(--paper);
+}
+.sidebar h4 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  margin: 26px 0 12px;
+  display: inline-block;
+  padding: 4px 10px;
+  color: var(--paper);
+}
+.sidebar h4:first-child { margin-top: 0; }
+/* knockout-text chips with offset overprint shadow */
+.sidebar h4.pink { background: var(--pink); box-shadow: var(--off) var(--off) 0 var(--blue); }
+.sidebar h4.blue { background: var(--blue); box-shadow: var(--off) var(--off) 0 var(--pink); }
+.sidebar h4.ink  { background: var(--ink);  box-shadow: var(--off) var(--off) 0 var(--pink); }
+.sidebar h4.outline {
+  background: transparent; color: var(--ink);
+  border: 2px solid var(--ink); box-shadow: var(--off) var(--off) 0 var(--blue);
+}
+
+.sidebar ul { list-style: none; padding: 0; margin: 0 0 4px; }
+.sidebar li { font-size: 14.5px; }
+.sidebar a {
+  display: block;
+  padding: 7px 12px 7px 14px;
+  border-left: 3px solid transparent;
+  color: var(--ink-soft);
+  font-weight: 500;
+}
+.sidebar a:hover { background: var(--paper-2); border-left-color: var(--pink); color: var(--ink); }
+.sidebar a.active {
+  border-left-color: var(--pink); color: var(--ink);
+  font-weight: 700; background: var(--paper-2);
+}
+
+/* =============================================================================
+   MAIN COLUMN
+   ============================================================================= */
+.main { padding: 58px 64px; min-width: 0; }
+
+.toc {
+  border-left: var(--rule) solid var(--ink);
+  padding: 58px 22px;
+  position: sticky; top: 60px;
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+  font-size: 13px;
+  background: var(--paper);
+}
+.toc h5 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 10px; letter-spacing: 0.26em;
+  text-transform: uppercase;
+  margin: 0 0 14px;
+  display: inline-block;
+  padding: 4px 9px;
+  background: var(--ink); color: var(--paper);
+  box-shadow: 3px 3px 0 var(--pink);
+}
+.toc ul { list-style: none; padding: 0; margin: 0; }
+.toc li { padding: 0; }
+.toc a {
+  display: block; padding: 5px 0 5px 12px;
+  border-left: 2px solid var(--hair);
+  color: var(--ink-soft);
+}
+.toc a:hover { color: var(--blue); border-left-color: var(--blue); }
+
+/* =============================================================================
+   ARTICLE HEAD
+   ============================================================================= */
+.crumb {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px; color: var(--mute);
+  margin-bottom: 16px;
+  display: flex; gap: 7px; flex-wrap: wrap; align-items: center;
+}
+.crumb .accent { color: var(--pink); font-weight: 700; }
+.crumb a { color: var(--blue); }
+.crumb a:hover { border-bottom: 2px solid var(--blue); }
+
+.main h1 {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: clamp(38px, 5vw, 58px);
+  line-height: 1.0;
+  letter-spacing: -0.035em;
+  margin: 0 0 20px;
+  text-transform: uppercase;
+  color: var(--ink);
+  /* mis-registration: blue ghost offset under the key ink */
+  text-shadow: var(--off) var(--off) 0 var(--blue);
+}
+.main .deck {
+  font-size: 20px; color: var(--ink-soft);
+  margin: 0 0 38px; max-width: 60ch; line-height: 1.5;
+  border-left: var(--rule) solid var(--pink);
+  padding-left: 18px;
+}
+
+/* =============================================================================
+   .content — markdown body
+   ============================================================================= */
+.content { font-size: 16px; }
+
+.content h2 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 30px; font-weight: 700;
+  margin: 52px 0 16px;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  color: var(--pink);
+  text-shadow: 3px 3px 0 var(--ink);
+}
+.content h3 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 21px; font-weight: 700;
+  margin: 36px 0 12px;
+  letter-spacing: -0.01em;
+  color: var(--blue);
+}
+.content h4 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 16px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.04em;
+  margin: 28px 0 10px;
+}
+.content p { margin: 0 0 18px; max-width: 72ch; }
+.content strong { font-weight: 700; color: var(--ink); }
+.content em { font-style: italic; }
+
+.content a {
+  color: var(--blue);
+  border-bottom: 2px solid var(--blue);
+  font-weight: 600;
+  transition: background 100ms ease, color 100ms ease;
+}
+.content a:hover { background: var(--blue); color: var(--paper); border-bottom-color: var(--blue); }
+
+.content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--code-bg);
+  border: 1.5px solid var(--hair);
+  padding: 1px 6px;
+  font-size: 0.9em;
+  color: var(--pink-deep);
+}
+.content pre {
+  background: var(--ink);
+  color: var(--paper);
+  border: var(--rule) solid var(--ink);
+  box-shadow: var(--off) var(--off) 0 var(--pink);
+  padding: 22px 24px;
+  overflow-x: auto;
+  font-size: 13.5px;
+  font-family: "JetBrains Mono", monospace;
+  margin: 26px 0 32px;
+  position: relative;
+}
+.content pre code {
+  background: transparent; border: 0; padding: 0;
+  color: inherit; font-size: inherit;
+}
+.content pre::before {
+  content: "RISO · KEY";
+  position: absolute; top: 8px; right: 14px;
+  font-size: 9px; letter-spacing: 0.22em;
+  color: var(--pink);
+}
+
+.content blockquote {
+  border: var(--rule) solid var(--ink);
+  background: var(--paper-2);
+  box-shadow: var(--off) var(--off) 0 var(--blue);
+  padding: 18px 22px;
+  margin: 28px 0 34px;
+  font-size: 16px;
+  position: relative;
+}
+.content blockquote::before {
+  content: "❝";
+  font-family: "Space Grotesk", sans-serif;
+  position: absolute; top: -14px; left: 16px;
+  background: var(--pink); color: var(--paper);
+  width: 26px; height: 26px; line-height: 26px; text-align: center;
+  font-size: 16px;
+}
+.content blockquote p { margin: 0; }
+.content blockquote p + p { margin-top: 12px; }
+
+.content ul, .content ol { padding-left: 0; margin: 0 0 18px; list-style: none; }
+.content ul li, .content ol li { position: relative; padding-left: 28px; margin-bottom: 8px; max-width: 70ch; }
+.content ul li::before {
+  content: ""; position: absolute; left: 4px; top: 9px;
+  width: 9px; height: 9px; background: var(--pink);
+  box-shadow: 3px 0 0 var(--blue);
+}
+.content ol { counter-reset: ri; }
+.content ol li { counter-increment: ri; }
+.content ol li::before {
+  content: counter(ri);
+  position: absolute; left: 0; top: 2px;
+  width: 20px; height: 20px; line-height: 20px; text-align: center;
+  background: var(--blue); color: var(--paper);
+  font-family: "Space Grotesk", sans-serif; font-weight: 700; font-size: 11px;
+}
+
+.content hr {
+  border: 0; height: var(--rule); background: var(--ink);
+  margin: 40px 0; box-shadow: 0 6px 0 var(--pink);
+}
+
+/* tables — two-ink ledger */
+.content table {
+  width: 100%; border-collapse: collapse;
+  margin: 26px 0 34px;
+  border: var(--rule) solid var(--ink);
+  font-size: 14.5px;
+}
+.content thead th {
+  background: var(--pink); color: var(--paper);
+  font-family: "Space Grotesk", sans-serif; font-weight: 700;
+  text-align: left; text-transform: uppercase;
+  letter-spacing: 0.04em; font-size: 12px;
+  padding: 11px 16px;
+  border-right: 2px solid var(--ink);
+}
+.content thead th:last-child { border-right: 0; }
+.content tbody td {
+  padding: 11px 16px;
+  border-top: 2px solid var(--ink);
+  border-right: 2px solid var(--hair);
+  vertical-align: top;
+}
+.content tbody td:last-child { border-right: 0; }
+.content tbody tr:nth-child(even) { background: var(--paper-2); }
+
+.content img { max-width: 100%; height: auto; border: var(--rule) solid var(--ink); box-shadow: var(--off) var(--off) 0 var(--blue); }
+
+/* =============================================================================
+   PAGER
+   ============================================================================= */
+.pager {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 18px;
+  margin-top: 60px;
+}
+.pager .b {
+  border: var(--rule) solid var(--ink);
+  background: var(--paper);
+  padding: 18px 22px;
+  box-shadow: var(--off) var(--off) 0 var(--blue);
+  transition: box-shadow 100ms ease, transform 100ms ease;
+}
+.pager .b:hover { box-shadow: var(--off) var(--off) 0 var(--pink); transform: translate(-2px, -2px); }
+.pager .b .k {
+  font-family: "JetBrains Mono", monospace; font-size: 11px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--pink-deep);
+}
+.pager .b .t {
+  font-family: "Space Grotesk", sans-serif; font-weight: 700;
+  font-size: 18px; margin-top: 4px;
+}
+.pager .next { text-align: right; }
+
+/* =============================================================================
+   HOME — HERO
+   ============================================================================= */
+.hero {
+  display: grid;
+  grid-template-columns: 1.45fr 1fr;
+  border-bottom: var(--rule) solid var(--ink);
+  max-width: var(--max); margin: 0 auto;
+  border-left: var(--rule) solid var(--ink);
+  border-right: var(--rule) solid var(--ink);
+}
+.hero .copy { padding: 70px 58px; border-right: var(--rule) solid var(--ink); }
+.hero h1 {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: clamp(44px, 6vw, 88px);
+  line-height: 0.94;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  margin: 0 0 26px;
+  text-shadow: 5px 5px 0 var(--blue);
+}
+.hero h1 .pink { color: var(--pink); text-shadow: 5px 5px 0 var(--ink); }
+.hero h1 .blue { color: var(--blue); text-shadow: 5px 5px 0 var(--pink); }
+.hero .deck { font-size: 20px; color: var(--ink-soft); max-width: 52ch; margin: 0 0 32px; line-height: 1.5; }
+.hero .cta-row { display: flex; flex-wrap: wrap; gap: 0; }
+.hero .cta-row a {
+  border: var(--rule) solid var(--ink);
+  padding: 15px 24px;
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700; font-size: 14px;
+  letter-spacing: 0.03em; text-transform: uppercase;
+}
+.hero .cta-row a + a { border-left: 0; }
+.hero .cta-row a.primary { background: var(--pink); color: var(--paper); }
+.hero .cta-row a.primary:hover { background: var(--blue); }
+.hero .cta-row a.ghost:hover { background: var(--ink); color: var(--paper); }
+.hero .cta-row a.kbd { font-family: "JetBrains Mono", monospace; background: var(--paper-2); text-transform: none; letter-spacing: 0; }
+
+/* ink-swatch panel */
+.swatches {
+  position: relative;
+  padding: 40px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 18px;
+  background: var(--paper-2);
+}
+.swatch {
+  border: var(--rule) solid var(--ink);
+  position: relative;
+  display: flex; align-items: flex-end;
+  padding: 12px;
+  min-height: 92px;
+}
+.swatch .tag {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px; letter-spacing: 0.12em;
+  background: var(--paper); color: var(--ink);
+  border: 2px solid var(--ink);
+  padding: 2px 6px;
+}
+.swatch.pink { background: var(--pink); box-shadow: var(--off) var(--off) 0 var(--blue); }
+.swatch.blue { background: var(--blue); box-shadow: var(--off) var(--off) 0 var(--pink); }
+.swatch.ink  { background: var(--ink); box-shadow: var(--off) var(--off) 0 var(--pink); }
+.swatch.ink .tag, .swatch.blue .tag { color: var(--ink); }
+.swatch.paper { background: var(--paper); }
+.swatch.span2 { grid-column: span 2; }
+.swatch.overprint {
+  background: var(--pink);
+  box-shadow: inset 0 0 0 0 transparent, var(--off) var(--off) 0 var(--blue);
+}
+
+/* =============================================================================
+   HOME — CATEGORY GRID
+   ============================================================================= */
+.cats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  max-width: var(--max); margin: 0 auto;
+  border-left: var(--rule) solid var(--ink);
+  border-right: var(--rule) solid var(--ink);
+}
+.cat {
+  border-right: var(--rule) solid var(--ink);
+  border-bottom: var(--rule) solid var(--ink);
+  padding: 38px 34px;
+  background: var(--paper);
+  transition: background 120ms ease;
+}
+.cat:nth-child(3n) { border-right: 0; }
+.cat:hover { background: var(--paper-2); }
+.cat .icon {
+  width: 40px; height: 40px; margin-bottom: 20px;
+  border: var(--rule) solid var(--ink);
+  display: grid; place-items: center;
+  font-family: "Space Grotesk", sans-serif; font-weight: 700; font-size: 18px;
+}
+.cat .icon.pink { background: var(--pink); color: var(--paper); box-shadow: 3px 3px 0 var(--blue); }
+.cat .icon.blue { background: var(--blue); color: var(--paper); box-shadow: 3px 3px 0 var(--pink); }
+.cat .icon.ink  { background: var(--ink); color: var(--paper); box-shadow: 3px 3px 0 var(--pink); }
+.cat .icon.paper { background: var(--paper); color: var(--ink); box-shadow: 3px 3px 0 var(--blue); }
+.cat h3 {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700; font-size: 22px;
+  margin: 0 0 10px; letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+.cat p { color: var(--ink-soft); font-size: 14.5px; line-height: 1.55; margin: 0 0 16px; }
+.cat p code { font-family: "JetBrains Mono", monospace; background: var(--code-bg); padding: 1px 5px; font-size: 0.88em; border: 1px solid var(--hair); }
+.cat .read {
+  font-family: "JetBrains Mono", monospace; font-size: 12px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--ink); border-bottom: 3px solid var(--pink); padding-bottom: 2px;
+}
+.cat:hover .read { border-bottom-color: var(--blue); }
+
+/* =============================================================================
+   HOME — RUN SHEET (metrics)
+   ============================================================================= */
+.runsheet {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  max-width: var(--max); margin: 0 auto;
+  border-left: var(--rule) solid var(--ink);
+  border-right: var(--rule) solid var(--ink);
+  border-bottom: var(--rule) solid var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+}
+.runsheet .m { padding: 26px 30px; border-right: 2px solid #3a3a3a; }
+.runsheet .m:last-child { border-right: 0; }
+.runsheet .v {
+  font-family: "Space Grotesk", sans-serif; font-weight: 700;
+  font-size: 34px; letter-spacing: -0.03em;
+}
+.runsheet .v.pink { color: var(--pink); }
+.runsheet .v.blue { color: #94a9ff; }
+.runsheet .v .unit { color: #8c8c8c; font-size: 18px; }
+.runsheet .k {
+  font-family: "JetBrains Mono", monospace; font-size: 11px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: #b6b1a4; margin-top: 6px;
+}
+
+/* =============================================================================
+   FOOTER — colophon
+   ============================================================================= */
+.foot {
+  max-width: var(--max); margin: 0 auto;
+  border-top: var(--rule) solid var(--ink);
+  border-left: var(--rule) solid var(--ink);
+  border-right: var(--rule) solid var(--ink);
+  padding: 0;
+  background: var(--paper);
+}
+.foot-grid {
+  display: grid; grid-template-columns: 1fr auto;
+  gap: 24px; align-items: flex-start;
+  padding: 34px 30px;
+}
+.foot strong { font-family: "Space Grotesk", sans-serif; text-transform: uppercase; letter-spacing: -0.01em; }
+.foot .col-title {
+  font-family: "Space Grotesk", sans-serif; font-weight: 700;
+  font-size: 18px; text-transform: uppercase;
+  text-shadow: 3px 3px 0 var(--pink);
+  margin-bottom: 6px;
+}
+.foot .tagline { font-size: 14px; color: var(--ink-soft); max-width: 50ch; }
+/* colophon: 2-color riso paper-stock note */
+.colophon {
+  border-top: var(--rule) solid var(--ink);
+  background: var(--paper-2);
+  padding: 18px 30px;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 14px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px; letter-spacing: 0.04em; color: var(--ink-soft);
+}
+.colophon .ink-dot { display: inline-flex; align-items: center; gap: 7px; }
+.colophon .dot { width: 13px; height: 13px; border: 2px solid var(--ink); display: inline-block; }
+.colophon .dot.pink { background: var(--pink); }
+.colophon .dot.blue { background: var(--blue); }
+.colophon .sep { color: var(--hair); }
+
+/* =============================================================================
+   RESPONSIVE
+   ============================================================================= */
+@media (max-width: 1180px) {
+  .shell { grid-template-columns: 260px minmax(0, 1fr); }
+  .toc { display: none; }
+}
+@media (max-width: 980px) {
+  .hero { grid-template-columns: 1fr; }
+  .hero .copy { border-right: 0; border-bottom: var(--rule) solid var(--ink); padding: 48px 34px; }
+  .cats { grid-template-columns: 1fr 1fr; }
+  .cat:nth-child(3n) { border-right: var(--rule) solid var(--ink); }
+  .cat:nth-child(2n) { border-right: 0; }
+  .runsheet { grid-template-columns: 1fr 1fr; }
+  .runsheet .m:nth-child(2n) { border-right: 0; }
+  .runsheet .m:nth-child(-n+2) { border-bottom: 2px solid #3a3a3a; }
+}
+@media (max-width: 860px) {
+  body { font-size: 15.5px; }
+  .reg-target, .crop { display: none; }
+  .shell {
+    grid-template-columns: 1fr;
+    border-left: 0; border-right: 0;
+  }
+  .sidebar {
+    display: block; position: static; height: auto;
+    border-right: 0; border-bottom: var(--rule) solid var(--ink);
+  }
+  .main { padding: 38px 24px; }
+  .main h1 { text-shadow: 3px 3px 0 var(--blue); }
+  .hero { border-left: 0; border-right: 0; }
+  .hero .copy { padding: 40px 24px; }
+  .hero h1 { text-shadow: 3px 3px 0 var(--blue); }
+  .swatches { grid-template-columns: 1fr 1fr; padding: 28px; }
+  .cats { grid-template-columns: 1fr; border-left: 0; border-right: 0; }
+  .cat { border-right: 0 !important; }
+  .runsheet { grid-template-columns: 1fr 1fr; border-left: 0; border-right: 0; }
+  .foot { border-left: 0; border-right: 0; }
+  .foot-grid { grid-template-columns: 1fr; }
+  .bar-inner { grid-template-columns: 1fr; }
+  .brand, .search { border-right: 0; border-bottom: var(--rule) solid var(--ink); }
+  .bar nav { flex-wrap: wrap; }
+  .bar nav a { flex: 1 1 auto; justify-content: center; border-bottom: 2px solid var(--ink); }
+  .pager { grid-template-columns: 1fr; }
+  .pager .next { text-align: left; }
+}
+@media (max-width: 480px) {
+  .swatches { grid-template-columns: 1fr; }
+  .runsheet { grid-template-columns: 1fr; }
+  .runsheet .m { border-right: 0; border-bottom: 2px solid #3a3a3a; }
+}

--- a/examples/risograph/templates/404.html
+++ b/examples/risograph/templates/404.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <h1><span class="pink">404</span> — off the press.</h1>
+    <p class="deck">This page never made it onto the plate. Try the <a href="{{ base_url }}/docs/" style="color:var(--blue);border-bottom:2px solid var(--blue);font-weight:600;">documentation</a> or head back to the <a href="{{ base_url }}/" style="color:var(--blue);border-bottom:2px solid var(--blue);font-weight:600;">front page</a>.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/" class="primary">← Back to front →</a>
+      <a href="{{ base_url }}/docs/" class="ghost">Open the docs</a>
+    </div>
+  </div>
+  <div class="swatches">
+    <div class="swatch pink"><span class="tag">MISFEED</span></div>
+    <div class="swatch ink"><span class="tag">NO PLATE</span></div>
+    <div class="swatch blue span2"><span class="tag">PAGE NOT FOUND</span></div>
+    <div class="swatch overprint"><span class="tag">404</span></div>
+    <div class="swatch paper"><span class="tag">BLANK</span></div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/risograph/templates/_sidebar.html
+++ b/examples/risograph/templates/_sidebar.html
@@ -1,0 +1,28 @@
+<aside class="sidebar">
+  <h4 class="pink">Start Here</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/installation/">Installation</a></li>
+    <li><a href="{{ base_url }}/docs/your-first-page/">Your first page</a></li>
+    <li><a href="{{ base_url }}/docs/configuration/">Configuration</a></li>
+  </ul>
+
+  <h4 class="blue">Concepts</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a></li>
+    <li><a href="{{ base_url }}/docs/templates/">Templates</a></li>
+    <li><a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a></li>
+  </ul>
+
+  <h4 class="ink">Guides</h4>
+  <ul>
+    <li><a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a></li>
+    <li><a href="{{ base_url }}/guides/i18n/">Internationalization</a></li>
+    <li><a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a></li>
+  </ul>
+
+  <h4 class="outline">Reference</h4>
+  <ul>
+    <li><a href="{{ base_url }}/docs/cli/">CLI reference</a></li>
+    <li><a href="{{ base_url }}/docs/template-filters/">Template filters</a></li>
+  </ul>
+</aside>

--- a/examples/risograph/templates/footer.html
+++ b/examples/risograph/templates/footer.html
@@ -1,0 +1,24 @@
+<footer class="foot">
+  <div class="foot-grid">
+    <div>
+      <div class="col-title">{{ site.title }}</div>
+      <div class="tagline">{{ site.description }}</div>
+    </div>
+    <div class="tagline" style="text-align:right;">
+      Built with <strong>Hwaro</strong><br>
+      MIT licensed · © {{ current_year }}
+    </div>
+  </div>
+  <div class="colophon">
+    <span>COLOPHON</span>
+    <span class="sep">/</span>
+    <span class="ink-dot"><span class="dot pink"></span> Fluorescent Pink</span>
+    <span class="ink-dot"><span class="dot blue"></span> Riso Blue</span>
+    <span class="sep">/</span>
+    <span>2-color riso on warm uncoated stock</span>
+    <span class="sep">/</span>
+    <span>Set in Space Grotesk &amp; Inter · Edition v1.4</span>
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/risograph/templates/header.html
+++ b/examples/risograph/templates/header.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<!-- printer's crop marks + registration target -->
+<span class="crop tl"></span>
+<span class="crop tr"></span>
+<span class="crop bl"></span>
+<span class="crop br"></span>
+<svg class="reg-target" viewBox="0 0 30 30" aria-hidden="true" focusable="false">
+  <circle cx="15" cy="15" r="11" fill="none" stroke="#ff5277" stroke-width="2"/>
+  <circle cx="15" cy="15" r="6"  fill="none" stroke="#355cff" stroke-width="2"/>
+  <line x1="15" y1="0" x2="15" y2="30" stroke="#191919" stroke-width="1.5"/>
+  <line x1="0" y1="15" x2="30" y2="15" stroke="#191919" stroke-width="1.5"/>
+</svg>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand"><span class="mark"></span>{{ site.title }}</a>
+    <div class="search">
+      <input type="text" placeholder="Search the run…" aria-label="Search documentation" />
+      <span class="kbd">⌘ K</span>
+    </div>
+    <nav>
+      <a href="{{ base_url }}/docs/">Docs</a>
+      <a href="{{ base_url }}/guides/">Guides</a>
+      <a href="{{ base_url }}/about/">About</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/examples/risograph/templates/home.html
+++ b/examples/risograph/templates/home.html
@@ -1,0 +1,68 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <h1>Docs run off a <span class="pink">two-ink</span> <span class="blue">duplicator</span>.</h1>
+    <p class="deck">Risograph is a documentation theme that prints like a zine — two bold spot inks, knockout type, and a deliberate off-register shadow on every heading. Flat color, visible rules, and not a single drop of gloss.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/installation/" class="primary">Start the run →</a>
+      <a href="{{ base_url }}/docs/" class="ghost">Browse docs</a>
+      <a class="kbd">$ hwaro serve</a>
+    </div>
+  </div>
+  <div class="swatches">
+    <div class="swatch pink"><span class="tag">PINK · 032</span></div>
+    <div class="swatch blue"><span class="tag">BLUE · 072</span></div>
+    <div class="swatch ink span2"><span class="tag">KEY · 100K</span></div>
+    <div class="swatch paper"><span class="tag">PAPER · UNCOATED</span></div>
+    <div class="swatch overprint"><span class="tag">OVERPRINT · +4PX</span></div>
+  </div>
+</section>
+
+<section class="cats">
+  <a href="{{ base_url }}/docs/installation/" class="cat">
+    <div class="icon pink">1</div>
+    <h3>Installation</h3>
+    <p>One <code>brew install</code> and a scaffold command put a running docs site on your desk in under a minute.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/sections-and-pages/" class="cat">
+    <div class="icon blue">2</div>
+    <h3>Sections &amp; pages</h3>
+    <p>How content is laid out, how sections list their pages, and why <code>_index.md</code> earns its keep.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/docs/templates/" class="cat">
+    <div class="icon ink">3</div>
+    <h3>Templates</h3>
+    <p>Crinja templates, where they live, and the small set of globals you are allowed to count on.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/build-pipeline/" class="cat">
+    <div class="icon paper">4</div>
+    <h3>Build pipeline</h3>
+    <p>What happens between <code>hwaro build</code> and <code>public/</code>, broken into seven readable plates.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/i18n/" class="cat">
+    <div class="icon pink">5</div>
+    <h3>Internationalization</h3>
+    <p>Multilingual docs without the foot guns. One default locale, one rule for fallbacks, no surprises.</p>
+    <span class="read">Read →</span>
+  </a>
+  <a href="{{ base_url }}/guides/deploying/" class="cat">
+    <div class="icon blue">6</div>
+    <h3>Deploying</h3>
+    <p>Recipes for GitHub Pages, Cloudflare Pages, and a plain <code>rsync</code> for everyone else.</p>
+    <span class="read">Read →</span>
+  </a>
+</section>
+
+<section class="runsheet">
+  <div class="m"><div class="v pink">v1.4</div><div class="k">Current edition</div></div>
+  <div class="m"><div class="v">2<span class="unit"> inks</span></div><div class="k">Pink + Blue</div></div>
+  <div class="m"><div class="v blue">112</div><div class="k">Documented pages</div></div>
+  <div class="m"><div class="v">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/risograph/templates/page.html
+++ b/examples/risograph/templates/page.html
@@ -1,0 +1,45 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb">
+      <span class="accent">~</span> /
+      {% if page.section %}<a href="{{ base_url }}/{{ page.section }}/">{{ page.section }}</a> /{% endif %}
+      <span>{{ page.title }}</span>
+    </div>
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b">
+        <div class="k">← Previous</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">Next →</div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+  </main>
+  <aside class="toc">
+    <h5>On this page</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/risograph/templates/section.html
+++ b/examples/risograph/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">~</span> / <span>{{ section.title }}</span></div>
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+
+    <div class="cats" style="margin-top:24px;border-top:3px solid var(--ink);">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 4 == 1 %}pink{% elif loop.index % 4 == 2 %}blue{% elif loop.index % 4 == 3 %}ink{% else %}paper{% endif %}">{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5>{{ section.pages | length }} entries</h5>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/risograph/templates/taxonomy.html
+++ b/examples/risograph/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">~</span> / <span>{{ taxonomy_name }}</span></div>
+    <h1>All {{ taxonomy_name }}</h1>
+    <div class="content">
+      <ul>
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}">{{ term }}</a> · {{ term.pages | length }} entries</li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/risograph/templates/taxonomy_term.html
+++ b/examples/risograph/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <div class="crumb"><span class="accent">~</span> / <a href="{{ base_url }}/tags/">tags</a> / <span>{{ taxonomy_term }}</span></div>
+    <h1>#{{ taxonomy_term }}</h1>
+    <div class="cats" style="margin-top:24px;border-top:3px solid var(--ink);">
+    {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="cat">
+        <div class="icon {% if loop.index % 4 == 1 %}pink{% elif loop.index % 4 == 2 %}blue{% elif loop.index % 4 == 3 %}ink{% else %}paper{% endif %}">{{ loop.index }}</div>
+        <h3>{{ post.title }}</h3>
+        {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        <span class="read">Read →</span>
+      </a>
+    {% endfor %}
+    </div>
+  </main>
+  <aside class="toc"></aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/transit/AGENTS.md
+++ b/examples/transit/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - Transit (subway/metro wayfinding docs theme) for Hwaro
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/transit/archetypes/default.md
+++ b/examples/transit/archetypes/default.md
@@ -1,0 +1,9 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = ""
+tags = {{ tags }}
++++
+
+# {{ title }}

--- a/examples/transit/config.toml
+++ b/examples/transit/config.toml
@@ -1,0 +1,197 @@
+title = "Transit"
+description = "A dark, subway-map documentation theme. Navigate the docs like a transit network at night — every section is a line, every page a station."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github-dark"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/transit/content/about.md
+++ b/examples/transit/content/about.md
@@ -1,0 +1,28 @@
++++
+title = "About"
+description = "About Transit, the design thinking behind it, and where the lines lead."
+date = "2026-04-01"
++++
+
+Transit is a documentation theme that borrows its language from the metro map. Sections are *lines*, pages are *stations*, and the sidebar is a route diagram you can follow with your finger. The whole thing runs in the dark, the way a transit map glows on a platform wall at night.
+
+## The choices we have made
+
+- A deep platform charcoal on near-black, so the route colors carry the contrast.
+- Four solid signage colors — red, blue, green, amber — one assigned to each line. Flat fills only, never blended.
+- Roundels: solid circles with a single letter, the way real networks badge their lines.
+- A signage grotesk set in caps for wayfinding labels, paired with a small mono for codes and commands.
+
+## How to read it
+
+- The **sidebar** is a route diagram. Each station is a dot; the page you are on is a filled roundel; section headers are double-ring interchange nodes.
+- **Breadcrumbs** are a route path: Home, then the line, then your station, joined by line bullets.
+- The **homepage** is a network map — several lines connecting the major destinations, with a legend underneath.
+
+## What this is not
+
+This is not a marketing theme. There is no carousel, no testimonial wall, and nothing that animates as you scroll. Just a clear map and a dark platform.
+
+## License
+
+MIT. Use it. Fork it. Extend the line.

--- a/examples/transit/content/docs/_index.md
+++ b/examples/transit/content/docs/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Documentation"
+description = "The main line. Board at Installation and ride straight through to Template Filters — every core station, in order, no transfers required."
+sort_by = "weight"
++++

--- a/examples/transit/content/docs/cli.md
+++ b/examples/transit/content/docs/cli.md
@@ -1,0 +1,29 @@
++++
+title = "CLI reference"
+description = "The driver's cab. Every command, every flag, and the one or two you actually reach for every day."
+weight = 7
+date = "2026-05-07"
++++
+
+The `hwaro` CLI is small on purpose.
+
+## Daily commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro init <name>` | Scaffold a new site. |
+| `hwaro serve` | Local dev server with hot reload. |
+| `hwaro build` | Build to `public/`. |
+| `hwaro new <path>` | Create a content file with frontmatter. |
+
+## Occasional commands
+
+| Command | Description |
+| --- | --- |
+| `hwaro doctor --fix` | Audit and patch the config. |
+| `hwaro tool check-links` | Look for broken internal links. |
+| `hwaro tool platform github-pages` | Generate a CI config. |
+
+## A note on flags
+
+`hwaro serve -p 4000 --open` will start on port 4000 and open the browser. `hwaro build --minify --skip-image-processing` is the fastest production build.

--- a/examples/transit/content/docs/configuration.md
+++ b/examples/transit/content/docs/configuration.md
@@ -1,0 +1,39 @@
++++
+title = "Configuration"
+description = "The control room. Every setting in config.toml, what it does, and the smallest sensible default."
+weight = 3
+date = "2026-05-03"
++++
+
+`config.toml` lives at the root of your site. It is the only configuration file you need.
+
+## Minimum viable config
+
+```toml
+title = "My Docs"
+description = "Docs for the my-docs project."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+```
+
+That is sufficient. Hwaro will fill in the rest with sensible defaults and warn you about anything ambiguous.
+
+## Common additions
+
+```toml
+[highlight]
+enabled = true
+theme = "github"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+```
+
+## A note on base_url
+
+Leave it as `http://localhost:3000` in your repository. Your CI workflow should override it at build time with `--base-url`. Hardcoding the production URL leads to broken local previews and broken self-respect.

--- a/examples/transit/content/docs/installation.md
+++ b/examples/transit/content/docs/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
+description = "First stop on the line. Three commands and you are standing on the platform with a running site."
+weight = 1
+date = "2026-05-01"
++++
+
+Transit runs on the Hwaro static site generator. You can install it from Homebrew or build it from source. This page is the first station on the Documentation line — board here.
+
+## Quickstart
+
+```sh
+brew install hahwul/hwaro/hwaro
+hwaro init my-docs --scaffold docs
+cd my-docs && hwaro serve --open
+```
+
+The dev server will open `http://localhost:3000` in your browser. Any edit to `content/`, `templates/`, or `static/` reloads almost instantly — like a train arriving on time.
+
+## Verifying the install
+
+```sh
+hwaro --version
+# => 0.14.0 or newer
+```
+
+If you see anything older, your package manager has cached an old version. Run `brew upgrade hwaro` and try again.
+
+## Where to next
+
+Ride one stop to **Your first page**, where you will write a single piece of content, give it a template, and watch it render.

--- a/examples/transit/content/docs/sections-and-pages.md
+++ b/examples/transit/content/docs/sections-and-pages.md
@@ -1,0 +1,40 @@
++++
+title = "Sections & pages"
+description = "Lines and stations. How content is organized, how sections behave, and why _index.md is doing more than it looks."
+weight = 4
+date = "2026-05-04"
++++
+
+A *section* is a directory under `content/` that contains an `_index.md`. The `_index.md` is the listing page for that section.
+
+## Anatomy
+
+```
+content/
+├── _index.md          # the home section (optional)
+├── about.md           # a single page
+└── docs/
+    ├── _index.md      # the docs section's listing page
+    ├── installation.md
+    └── configuration.md
+```
+
+A page inside `content/docs/` is automatically a member of the `docs` section. You will see `page.section == "docs"` inside templates.
+
+## Sort options
+
+In a section's `_index.md`, you can set:
+
+```toml
+sort_by = "date"      # or "weight" or "title"
+reverse = true
+paginate = 20
+```
+
+If you choose `weight`, lower numbers come first.
+
+## Transparent sections
+
+A section with `transparent = true` in its `_index.md` exposes its pages to its parent. This is useful when you want a deep tree but a flat listing.
+
+> Use transparency sparingly. It is the kind of feature that, when overused, makes a content tree harder to reason about.

--- a/examples/transit/content/docs/taxonomies.md
+++ b/examples/transit/content/docs/taxonomies.md
@@ -1,0 +1,38 @@
++++
+title = "Taxonomies"
+description = "Interchange stations. Tags, categories, and custom groupings — how to declare them and how to template them."
+weight = 6
+date = "2026-05-06"
++++
+
+A taxonomy is a way of grouping pages by a shared field. `tags` is the most common one, but you can declare any.
+
+## Declaring
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "authors"
+```
+
+## Using
+
+In a page's frontmatter:
+
+```toml
+tags = ["onboarding", "guide"]
+authors = ["A. Editor"]
+```
+
+Hwaro will generate `/tags/` and `/tags/onboarding/` URLs automatically. Your `taxonomy.html` template renders the list of terms. Your `taxonomy_term.html` template renders one term's pages.
+
+## A small idiom
+
+If you only care about the first tag in a list, this is the canonical shortcut:
+
+```jinja
+{% if page.tags %}<span class="tag">{{ page.tags | first }}</span>{% endif %}
+```

--- a/examples/transit/content/docs/template-filters.md
+++ b/examples/transit/content/docs/template-filters.md
@@ -1,0 +1,33 @@
++++
+title = "Template filters"
+description = "End of the line. A reference of the most useful template filters, with examples you can paste straight in."
+weight = 8
+date = "2026-05-08"
++++
+
+Filters are applied with the pipe operator: `{{ thing | filter }}`.
+
+## Most-used
+
+| Filter | Example |
+| --- | --- |
+| `date(format)` | `{{ page.date \| date(format="%B %d, %Y") }}` |
+| `slugify` | `{{ "Hello world" \| slugify }}` |
+| `upper` | `{{ title \| upper }}` |
+| `lower` | `{{ title \| lower }}` |
+| `replace(from, to)` | `{{ title \| replace(from=" ", to="-") }}` |
+| `default(value)` | `{{ desc \| default(value="No description") }}` |
+| `truncate_words(n)` | `{{ summary \| truncate_words(n=30) }}` |
+
+## For collections
+
+| Filter | Example |
+| --- | --- |
+| `sort_by(attribute)` | `{{ pages \| sort_by(attribute="date") }}` |
+| `reverse` | `{{ pages \| reverse }}` |
+| `group_by(attribute)` | `{{ pages \| group_by(attribute="section") }}` |
+| `first` / `last` | `{{ items \| first }}` |
+| `length` | `{{ items \| length }}` |
+| `slice(start, end)` | `{{ items \| slice(end=5) }}` |
+
+> Filters compose. You can write `{{ pages \| sort_by(attribute="date") \| reverse \| slice(end=5) }}` and it does what it looks like it does.

--- a/examples/transit/content/docs/templates.md
+++ b/examples/transit/content/docs/templates.md
@@ -1,0 +1,43 @@
++++
+title = "Templates"
+description = "The signage system. Jinja-flavored templates, where to put them, and the small set of globals you can count on."
+weight = 5
+date = "2026-05-05"
++++
+
+Templates live in `templates/`. They use Crinja, a Crystal port of Jinja2, so most things look familiar.
+
+## The required templates
+
+- `page.html` — the default for any single page.
+- `section.html` — the listing page for a section.
+- `taxonomy.html` and `taxonomy_term.html` — for `/tags/` and `/tags/foo/`.
+- `404.html` — the not-found page.
+
+Anything beyond that is optional. You can include partials with `{% include %}` and use `{% extends %}` for inheritance.
+
+## Globals
+
+| Variable | What it is |
+| --- | --- |
+| `site` | The whole site, with `pages`, `sections`, `taxonomies`. |
+| `page` | The current page. |
+| `section` | The current section, on listing pages. |
+| `base_url` | Always available. Always prepended to links. |
+| `current_year` | An integer. Useful in the footer. |
+
+## A worked example
+
+```jinja
+{% include "header.html" %}
+
+<article>
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<time>{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+  <div class="content">{{ content | safe }}</div>
+</article>
+
+{% include "footer.html" %}
+```
+
+Rendered content is `{{ content | safe }}`, not `{{ page.content }}`. Common pitfall.

--- a/examples/transit/content/docs/your-first-page.md
+++ b/examples/transit/content/docs/your-first-page.md
@@ -1,0 +1,37 @@
++++
+title = "Your first page"
+description = "Second stop. A short walkthrough that ends at a rendered page and the green light of a clean build."
+weight = 2
+date = "2026-05-02"
++++
+
+Every page is a markdown file with TOML frontmatter at the top. Open `content/index.md` and you will see one already.
+
+## Anatomy of a page
+
+```toml
++++
+title = "Welcome"
+date = "2026-05-01"
+description = "A short summary."
+tags = ["intro"]
++++
+
+This is the body. Write whatever you like. Markdown.
+```
+
+The block between `+++` delimiters is parsed as TOML and exposed to your templates as `page.title`, `page.date`, and so on. Everything below is markdown.
+
+## A note on file naming
+
+- `_index.md` makes a directory into a *section* — a thing with a listing page.
+- Anything else becomes an individual page under that section.
+- Slug derives from the filename unless you set `slug` explicitly in frontmatter.
+
+## Building
+
+```sh
+hwaro build
+```
+
+The result appears in `public/`. The default output is unminified so you can read it. Pass `--minify` once you trust it.

--- a/examples/transit/content/guides/_index.md
+++ b/examples/transit/content/guides/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Guides"
+description = "The branch line. Longer routes for specific destinations — the build pipeline, multilingual sites, and getting your site onto a CDN."
+sort_by = "weight"
++++

--- a/examples/transit/content/guides/build-pipeline.md
+++ b/examples/transit/content/guides/build-pipeline.md
@@ -1,0 +1,38 @@
++++
+title = "The build pipeline"
+description = "The depot. What happens between hwaro build and public/, traced through seven readable phases."
+weight = 1
+date = "2026-05-09"
++++
+
+The build pipeline runs in seven phases, in order. Each phase reads the output of the previous one.
+
+## Phase 1 — Discover
+
+Walk the `content/` tree. Identify sections by `_index.md`. Identify pages by anything else with a markdown extension. Build a single in-memory tree.
+
+## Phase 2 — Parse
+
+Parse the TOML frontmatter for every page. Validate against the known fields. Stop on unknown required fields. Warn on unknown optional ones.
+
+## Phase 3 — Render markdown
+
+Run each page's body through the markdown processor. Apply syntax highlighting if enabled.
+
+## Phase 4 — Build site graph
+
+Assemble the `site.pages`, `site.sections`, and `site.taxonomies` collections. Compute pagination groups.
+
+## Phase 5 — Render templates
+
+For every page, pick the right template and render it. This is the only phase that requires the templates directory.
+
+## Phase 6 — Static assets
+
+Copy `static/` verbatim into `public/`. Process images if `--skip-image-processing` is not set.
+
+## Phase 7 — Sitemap, feeds, search
+
+Generate `sitemap.xml`, RSS/Atom feeds, search indexes, and any other endpoint described by config.
+
+> If you understand the seven phases, you understand the entire pipeline. Everything else is convenience.

--- a/examples/transit/content/guides/deploying.md
+++ b/examples/transit/content/guides/deploying.md
@@ -1,0 +1,34 @@
++++
+title = "Deploying to a CDN"
+description = "The terminus. Cookbook entries for GitHub Pages, Cloudflare Pages, and a Bash script for everyone else."
+weight = 3
+date = "2026-05-11"
++++
+
+A built Hwaro site is just static files. Any host that can serve them will do.
+
+## GitHub Pages
+
+```yaml
+- name: Build
+  run: hwaro build --minify --base-url "${{ env.PAGES_URL }}"
+- name: Upload
+  uses: actions/upload-pages-artifact@v3
+  with:
+    path: public
+- name: Deploy
+  uses: actions/deploy-pages@v4
+```
+
+## Cloudflare Pages
+
+In the Pages project settings, set the build command to `hwaro build --minify` and the output directory to `public`. Set `BASE_URL` as an environment variable and pass `--base-url $BASE_URL`.
+
+## A small Bash script
+
+```sh
+hwaro build --minify --base-url https://example.com
+rsync -a --delete public/ user@host:/var/www/example/
+```
+
+There is no special deployment mode. There is no required runtime. The output of `hwaro build` is exactly what gets served.

--- a/examples/transit/content/guides/i18n.md
+++ b/examples/transit/content/guides/i18n.md
@@ -1,0 +1,32 @@
++++
+title = "Internationalization"
+description = "Parallel lines. Multilingual sites without the foot guns — one default locale, one rule for fallbacks, no surprises."
+weight = 2
+date = "2026-05-10"
++++
+
+Hwaro supports content in multiple languages. The model is intentionally small.
+
+## One default locale
+
+You declare a `default_language` in `config.toml`. All pages without an explicit language fall back to it.
+
+```toml
+default_language = "en"
+languages = ["en", "ko", "ja"]
+```
+
+## One rule for fallbacks
+
+If a page exists in one language but not another, the missing one is *not* synthesized. It simply does not appear in that language's section. This avoids the worst class of i18n bugs: rendering an English page inside a Korean section because the Korean translation was missing.
+
+## File naming
+
+```
+content/
+├── about.md           # default language
+├── about.ko.md        # Korean version
+└── about.ja.md        # Japanese version
+```
+
+That is the whole convention.

--- a/examples/transit/content/index.md
+++ b/examples/transit/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Transit"
+description = "A dark, subway-map documentation theme. Navigate the docs like a transit network at night — every section is a line, every page a station."
+template = "home"
++++

--- a/examples/transit/static/css/style.css
+++ b/examples/transit/static/css/style.css
@@ -1,0 +1,770 @@
+/* ==========================================================================
+   TRANSIT — a subway / metro wayfinding documentation theme (dark)
+   Concept: navigating docs like a transit network at night.
+   Solid signage colors only. Flat fills, borders, box-shadow.
+   ========================================================================== */
+
+:root {
+  /* Platform surfaces */
+  --void:        #0e0f12;   /* near-black, the tunnel */
+  --platform:    #15171c;   /* deep platform charcoal */
+  --platform-2:  #1b1e25;   /* raised panel */
+  --platform-3:  #21252e;   /* hover panel */
+  --rail:        #2c313c;   /* hairlines / inactive rail */
+  --rail-soft:   #383f4c;
+
+  /* Signage type */
+  --sign:        #f2f3f5;   /* off-white signage */
+  --sign-mute:   #aab0bd;
+  --sign-dim:    #6f7787;
+
+  /* Route colors (solid signage) */
+  --red:    #e2483d;
+  --blue:   #2f7fe0;
+  --green:  #2faa5a;
+  --amber:  #e7a52b;
+
+  /* Roundel ink (text drawn on the solid roundel) */
+  --on-red:   #ffffff;
+  --on-blue:  #ffffff;
+  --on-green: #06210f;
+  --on-amber: #1c1402;
+
+  --code-bg: #0a0b0e;
+
+  --r-sm: 6px;
+  --r-md: 10px;
+  --gap: 24px;
+
+  --shadow: 0 2px 0 0 rgba(0,0,0,0.5), 0 14px 34px -18px rgba(0,0,0,0.9);
+  --sans: "Barlow", system-ui, -apple-system, sans-serif;
+  --cond: "Barlow Condensed", "Barlow", system-ui, sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--void);
+  color: var(--sign);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.68;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: inherit; text-decoration: none; }
+
+::selection { background: var(--blue); color: #fff; }
+
+/* ===== Wayfinding primitives ===================================== */
+.tag-code {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--sign-dim);
+}
+
+/* Roundel = solid circle with a centered letter/number */
+.roundel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  font-family: var(--cond);
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  color: #fff;
+  background: var(--rail-soft);
+}
+.r-red   { background: var(--red);   color: var(--on-red); }
+.r-blue  { background: var(--blue);  color: var(--on-blue); }
+.r-green { background: var(--green); color: var(--on-green); }
+.r-amber { background: var(--amber); color: var(--on-amber); }
+
+/* Small solid line bullet */
+.line-bullet {
+  display: inline-block;
+  width: 11px; height: 11px;
+  border-radius: 50%;
+  margin-right: 8px;
+  vertical-align: -1px;
+  background: var(--rail-soft);
+}
+.l-red   { background: var(--red); }
+.l-blue  { background: var(--blue); }
+.l-green { background: var(--green); }
+.l-amber { background: var(--amber); }
+
+/* ===== Top bar ================================================== */
+.bar {
+  position: sticky; top: 0; z-index: 40;
+  background: var(--platform);
+  border-bottom: 1px solid var(--rail);
+}
+.bar-inner {
+  max-width: 1320px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 18px;
+  padding: 12px 24px;
+}
+.brand { display: flex; align-items: center; gap: 12px; }
+.brand-roundel { width: 36px; height: 36px; font-size: 20px; background: var(--red); color: var(--on-red); }
+.brand-name {
+  font-family: var(--cond);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.brand-sub {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: var(--sign-dim);
+  text-transform: uppercase;
+  border-left: 1px solid var(--rail);
+  padding-left: 12px;
+}
+.search {
+  display: flex; align-items: center; gap: 10px;
+  max-width: 420px; width: 100%;
+  margin: 0 auto;
+  background: var(--void);
+  border: 1px solid var(--rail);
+  border-radius: 999px;
+  padding: 8px 14px;
+}
+.search:focus-within { border-color: var(--blue); }
+.search-ico { color: var(--sign-dim); font-size: 12px; }
+.search input {
+  flex: 1; background: none; border: none; outline: none;
+  color: var(--sign); font-family: var(--sans); font-size: 14px;
+}
+.search input::placeholder { color: var(--sign-dim); }
+.kbd {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--sign-mute);
+  border: 1px solid var(--rail);
+  border-radius: 5px;
+  padding: 2px 7px;
+}
+.bar nav { display: flex; align-items: center; gap: 6px; }
+.bar nav a {
+  display: inline-flex; align-items: center;
+  font-family: var(--cond);
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--sign-mute);
+  padding: 7px 12px;
+  border-radius: var(--r-sm);
+}
+.bar nav a:hover { color: var(--sign); background: var(--platform-2); }
+.bar nav a.cta {
+  color: var(--void);
+  background: var(--sign);
+}
+.bar nav a.cta:hover { background: #fff; }
+
+/* ===== Layout shell ============================================= */
+.shell {
+  max-width: 1320px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 286px minmax(0, 1fr) 220px;
+  gap: 40px;
+  padding: 36px 24px 80px;
+  align-items: start;
+}
+.main { min-width: 0; }
+
+/* ===== SIGNATURE 1: Sidebar as a transit line =================== */
+.sidebar { position: sticky; top: 92px; align-self: start; }
+.sidebar-head {
+  display: flex; flex-direction: column; gap: 2px;
+  padding-bottom: 14px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--rail);
+}
+.sidebar-sub { font-size: 13px; color: var(--sign-dim); }
+
+.line {
+  --route: var(--rail-soft);
+  position: relative;
+  padding-left: 26px;
+  margin-bottom: 8px;
+}
+.line-blue  { --route: var(--blue); }
+.line-green { --route: var(--green); }
+.line-amber { --route: var(--amber); }
+
+/* the solid vertical route rail */
+.line::before {
+  content: "";
+  position: absolute;
+  left: 9px; top: 14px; bottom: 14px;
+  width: 4px;
+  border-radius: 4px;
+  background: var(--route);
+}
+
+.interchange { position: relative; display: flex; align-items: center; padding: 6px 0; }
+.line-name {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--cond);
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--sign);
+}
+.line-name .roundel { width: 26px; height: 26px; font-size: 14px; }
+.line-name:hover { color: var(--sign); }
+.line-name:hover .roundel { outline: 2px solid var(--route); outline-offset: 2px; }
+.line-name-static { cursor: default; }
+
+.stations { list-style: none; margin: 0 0 4px; padding: 0; }
+.stations li { position: relative; }
+.stations li a {
+  display: block;
+  padding: 7px 10px 7px 4px;
+  font-size: 14.5px;
+  color: var(--sign-mute);
+  border-radius: var(--r-sm);
+  transition: color .12s, background .12s;
+}
+.stations li a:hover { color: var(--sign); background: var(--platform-2); }
+
+/* station dots / interchange nodes sit on the rail */
+.node {
+  position: absolute;
+  left: -22px; top: 50%;
+  transform: translateY(-50%);
+  width: 11px; height: 11px;
+  border-radius: 50%;
+  background: var(--platform);
+  border: 3px solid var(--route);
+  z-index: 1;
+}
+.interchange .node-interchange {
+  left: -21px;
+  width: 15px; height: 15px;
+  background: var(--void);
+  border: 4px solid var(--route);
+  box-shadow: 0 0 0 3px var(--platform);
+}
+
+/* active page = filled roundel station */
+.stations li.is-here a {
+  color: var(--sign);
+  background: var(--platform-3);
+  font-weight: 600;
+}
+.stations li.is-here .node {
+  background: var(--route);
+  border-color: var(--route);
+  width: 15px; height: 15px;
+  left: -24px;
+  box-shadow: 0 0 0 3px var(--platform), 0 0 12px var(--route);
+}
+
+/* terminus stop tick */
+.stations li.terminus .node { border-radius: 3px; }
+
+.legend {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--rail);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.legend-row { display: flex; align-items: center; gap: 9px; font-size: 12.5px; color: var(--sign-mute); }
+.node-mini {
+  width: 11px; height: 11px; border-radius: 50%;
+  background: var(--platform); border: 3px solid var(--rail-soft);
+}
+.node-mini.node-interchange { width: 13px; height: 13px; border-width: 4px; border-color: var(--sign-mute); }
+.node-mini.node-here { background: var(--blue); border-color: var(--blue); }
+
+/* ===== Route breadcrumbs (A -> B -> C) ========================= */
+.route {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  font-family: var(--cond);
+  font-size: 14px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 22px;
+}
+.route a { color: var(--sign-mute); display: inline-flex; align-items: center; }
+.route a:hover { color: var(--sign); }
+.route-arrow { color: var(--sign-dim); font-family: var(--sans); }
+.route-now { color: var(--sign); display: inline-flex; align-items: center; font-weight: 700; }
+
+/* ===== SIGNATURE 2: Station name plates ======================== */
+.plate {
+  --pl: var(--blue);
+  display: flex; align-items: center; gap: 18px;
+  background: var(--platform);
+  border: 1px solid var(--rail);
+  border-left: 6px solid var(--pl);
+  border-radius: var(--r-md);
+  padding: 20px 24px;
+  box-shadow: var(--shadow);
+}
+.plate-blue  { --pl: var(--blue); }
+.plate-green { --pl: var(--green); }
+.plate-amber { --pl: var(--amber); }
+.plate .roundel { width: 52px; height: 52px; font-size: 26px; }
+.plate-body { display: flex; flex-direction: column; gap: 4px; }
+.plate-kicker {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--sign-dim);
+}
+.plate h1 {
+  margin: 0;
+  font-family: var(--cond);
+  font-weight: 700;
+  font-size: clamp(30px, 4.4vw, 44px);
+  line-height: 1.02;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
+.deck {
+  color: var(--sign-mute);
+  font-size: 18px;
+  line-height: 1.6;
+  margin: 18px 0 28px;
+  max-width: 64ch;
+}
+
+/* ===== Pager =================================================== */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 48px;
+  padding-top: 28px;
+  border-top: 1px solid var(--rail);
+}
+.pager .b {
+  background: var(--platform);
+  border: 1px solid var(--rail);
+  border-radius: var(--r-md);
+  padding: 16px 18px;
+  transition: border-color .14s, background .14s, transform .14s;
+}
+.pager .b:hover { border-color: var(--blue); background: var(--platform-2); transform: translateY(-2px); }
+.pager .b.next { text-align: right; }
+.pager .k {
+  font-family: var(--mono);
+  font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--sign-dim);
+  margin-bottom: 6px;
+}
+.pager .t { font-family: var(--cond); font-weight: 600; font-size: 19px; text-transform: uppercase; letter-spacing: 0.03em; }
+
+/* ===== Section station list ==================================== */
+.station-list {
+  margin-top: 28px;
+  border: 1px solid var(--rail);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  background: var(--platform);
+}
+.station-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 44px 30px 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--rail);
+  transition: background .14s;
+}
+.station-card:last-child { border-bottom: none; }
+.station-card:hover { background: var(--platform-2); }
+.station-num {
+  font-family: var(--mono);
+  font-size: 13px; font-weight: 700;
+  color: var(--sign-dim);
+}
+.station-rail { position: relative; height: 100%; }
+.station-rail::before {
+  content: ""; position: absolute; left: 13px; top: -18px; bottom: -18px; width: 4px;
+  background: var(--blue);
+}
+.station-card.is-origin .station-rail::before { top: 50%; }
+.station-card.is-terminus .station-rail::before { bottom: 50%; }
+.station-rail .node {
+  position: absolute; left: 8px; top: 50%; transform: translateY(-50%);
+  width: 13px; height: 13px; background: var(--platform); border: 3px solid var(--blue);
+}
+.station-card:hover .station-rail .node { background: var(--blue); box-shadow: 0 0 10px var(--blue); }
+.station-text h3 {
+  margin: 0 0 3px;
+  font-family: var(--cond);
+  font-weight: 600; font-size: 21px;
+  text-transform: uppercase; letter-spacing: 0.03em;
+}
+.station-text p { margin: 0; color: var(--sign-mute); font-size: 14.5px; line-height: 1.5; }
+.station-go { font-size: 20px; color: var(--sign-dim); transition: transform .14s, color .14s; }
+.station-card:hover .station-go { color: var(--sign); transform: translateX(4px); }
+
+/* ===== Right TOC platform ====================================== */
+.toc { position: sticky; top: 92px; align-self: start; font-size: 14px; }
+.toc h5 {
+  margin: 0 0 12px;
+  font-family: var(--cond);
+  font-weight: 600; font-size: 14px; letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--sign-mute);
+  display: flex; align-items: center; gap: 8px;
+}
+.toc ul { list-style: none; margin: 0; padding: 0; border-left: 2px solid var(--rail); }
+.toc li a {
+  display: block; padding: 5px 0 5px 14px; margin-left: -2px;
+  color: var(--sign-dim); border-left: 2px solid transparent;
+  font-size: 13.5px;
+}
+.toc li a:hover { color: var(--sign); border-left-color: var(--blue); }
+.term-index { list-style: none; margin: 0; padding: 0; }
+.term-index li {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 16px; border: 1px solid var(--rail); border-radius: var(--r-sm);
+  margin-bottom: 8px; background: var(--platform);
+}
+.term-index li a { display: flex; align-items: center; font-family: var(--cond); font-size: 18px; text-transform: uppercase; }
+.term-index li:hover { border-color: var(--green); }
+
+/* ===== HOMEPAGE: hero ========================================== */
+.hero {
+  max-width: 1320px; margin: 0 auto;
+  display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 56px;
+  padding: 72px 24px 48px; align-items: center;
+}
+.hero-tag { display: inline-block; margin-bottom: 18px; }
+.hero h1 {
+  margin: 0;
+  font-family: var(--cond);
+  font-weight: 700;
+  font-size: clamp(40px, 6vw, 68px);
+  line-height: 0.98;
+  letter-spacing: 0.005em;
+  text-transform: uppercase;
+}
+.hl-blue  { color: var(--blue); }
+.hl-amber { color: var(--amber); }
+.hl-red   { color: var(--red); }
+.hero .deck { margin-top: 22px; font-size: 19px; }
+.cta-row { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; margin-top: 30px; }
+.primary {
+  font-family: var(--cond);
+  font-weight: 700; font-size: 17px; letter-spacing: 0.06em; text-transform: uppercase;
+  background: var(--blue); color: #fff;
+  padding: 13px 22px; border-radius: var(--r-sm);
+  transition: transform .14s, background .14s;
+}
+.primary:hover { transform: translateY(-2px); background: #3a8df0; }
+.ghost {
+  font-family: var(--cond);
+  font-weight: 600; font-size: 17px; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--sign); border: 1px solid var(--rail-soft);
+  padding: 12px 20px; border-radius: var(--r-sm);
+}
+.ghost:hover { border-color: var(--sign); background: var(--platform-2); }
+.mono-cta {
+  font-family: var(--mono); font-size: 13px;
+  color: var(--sign-mute); background: var(--code-bg);
+  border: 1px solid var(--rail); padding: 11px 16px;
+}
+
+/* ===== SIGNATURE 3: Homepage network map ======================= */
+.map {
+  background: var(--platform);
+  border: 1px solid var(--rail);
+  border-radius: var(--r-md);
+  padding: 22px 24px;
+  box-shadow: var(--shadow);
+}
+.map-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-bottom: 16px; margin-bottom: 18px;
+  border-bottom: 1px solid var(--rail);
+  font-size: 13px; color: var(--sign-dim);
+}
+.map-lines { display: flex; flex-direction: column; gap: 20px; }
+.map-line {
+  --route: var(--rail-soft);
+  position: relative;
+  display: flex; align-items: center; gap: 0;
+  padding-left: 2px;
+  min-height: 36px;
+}
+.ml-blue  { --route: var(--blue); }
+.ml-green { --route: var(--green); }
+.ml-amber { --route: var(--amber); }
+.ml-red   { --route: var(--red); }
+.map-line .roundel { width: 30px; height: 30px; font-size: 16px; z-index: 2; }
+.ml-rail {
+  height: 5px; flex: 1; max-width: 50px;
+  background: var(--route);
+}
+.ml-dashed { background: none; border-top: 5px dashed var(--route); height: 0; align-self: center; }
+.ml-stop {
+  width: 14px; height: 14px; border-radius: 50%; flex: 0 0 auto;
+  background: var(--platform); border: 4px solid var(--route);
+  margin: 0 18px 0 -2px;
+  position: relative;
+}
+.ml-stop::before {
+  content: ""; position: absolute; left: -22px; top: 50%; transform: translateY(-50%);
+  width: 18px; height: 5px; background: var(--route);
+}
+.ml-end { background: var(--route); }
+.ml-label {
+  margin-left: 8px;
+  font-family: var(--cond); font-weight: 600; font-size: 16px;
+  text-transform: uppercase; letter-spacing: 0.05em; color: var(--sign);
+  white-space: nowrap;
+}
+
+/* legend bar under hero */
+.legend-bar {
+  max-width: 1320px; margin: 0 auto;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 16px;
+  padding: 18px 24px;
+  border-top: 1px solid var(--rail);
+  border-bottom: 1px solid var(--rail);
+}
+.legend-chip {
+  display: inline-flex; align-items: center;
+  font-family: var(--cond); font-weight: 600; font-size: 15px;
+  text-transform: uppercase; letter-spacing: 0.05em; color: var(--sign-mute);
+}
+
+/* ===== Destinations grid ======================================= */
+.destinations { max-width: 1320px; margin: 0 auto; padding: 56px 24px 8px; }
+.section-title { margin: 0 0 22px; }
+.dest-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.dest {
+  --route: var(--blue);
+  display: flex; flex-direction: column; align-items: flex-start; gap: 10px;
+  background: var(--platform);
+  border: 1px solid var(--rail);
+  border-top: 4px solid var(--route);
+  border-radius: var(--r-md);
+  padding: 22px;
+  transition: transform .15s, border-color .15s, background .15s;
+}
+.dest-blue  { --route: var(--blue); }
+.dest-green { --route: var(--green); }
+.dest-amber { --route: var(--amber); }
+.dest:hover { transform: translateY(-4px); background: var(--platform-2); }
+.dest .roundel { width: 30px; height: 30px; font-size: 15px; }
+.dest h3 {
+  margin: 0;
+  font-family: var(--cond); font-weight: 700; font-size: 23px;
+  text-transform: uppercase; letter-spacing: 0.03em;
+}
+.dest p { margin: 0; color: var(--sign-mute); font-size: 14.5px; flex: 1; }
+.dest code { font-family: var(--mono); font-size: 12.5px; background: var(--code-bg); padding: 1px 6px; border-radius: 4px; color: var(--amber); }
+.dest-go {
+  font-family: var(--cond); font-weight: 700; font-size: 15px;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--route);
+}
+
+/* ===== Metrics ================================================= */
+.metrics {
+  max-width: 1320px; margin: 48px auto 0;
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+  padding: 0 24px;
+}
+.metrics .m {
+  background: var(--platform);
+  border: 1px solid var(--rail);
+  border-radius: var(--r-md);
+  padding: 26px 24px;
+  margin: 0 4px;
+}
+.metrics .v {
+  font-family: var(--cond); font-weight: 700; font-size: 40px; line-height: 1;
+  letter-spacing: 0.01em;
+}
+.c-red { color: var(--red); } .c-blue { color: var(--blue); }
+.c-green { color: var(--green); } .c-amber { color: var(--amber); }
+.metrics .k { margin-top: 8px; font-size: 13px; color: var(--sign-dim); text-transform: uppercase; letter-spacing: 0.08em; }
+
+.inline-link { border-bottom: 2px solid; padding-bottom: 1px; }
+.l-blue-link { color: var(--blue); border-color: var(--blue); }
+.l-amber-link { color: var(--amber); border-color: var(--amber); }
+.hero-404 .map-lines { gap: 26px; }
+
+/* ===== .content prose ========================================== */
+.content { font-size: 16px; line-height: 1.75; color: #dfe2e8; }
+.content > *:first-child { margin-top: 0; }
+.content h2 {
+  margin: 44px 0 14px;
+  padding-top: 18px;
+  border-top: 1px solid var(--rail);
+  font-family: var(--cond);
+  font-weight: 700; font-size: 27px; letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--sign);
+}
+.content h2::before {
+  content: ""; display: inline-block;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--blue); margin-right: 12px; vertical-align: 1px;
+}
+.content h3 {
+  margin: 30px 0 10px;
+  font-family: var(--cond); font-weight: 600; font-size: 21px;
+  text-transform: uppercase; letter-spacing: 0.03em; color: var(--sign);
+}
+.content h4 { margin: 24px 0 8px; font-family: var(--cond); font-weight: 600; font-size: 17px; text-transform: uppercase; letter-spacing: 0.05em; }
+.content p { margin: 0 0 18px; }
+.content a {
+  color: var(--blue);
+  border-bottom: 1px solid var(--rail-soft);
+  transition: border-color .12s;
+}
+.content a:hover { border-bottom-color: var(--blue); }
+.content strong { color: var(--sign); font-weight: 700; }
+.content ul, .content ol { margin: 0 0 18px; padding-left: 24px; }
+.content li { margin: 6px 0; }
+.content ul li::marker { color: var(--blue); }
+.content ol li::marker { color: var(--blue); font-family: var(--mono); font-weight: 700; }
+
+.content code {
+  font-family: var(--mono);
+  font-size: 13.5px;
+  background: var(--code-bg);
+  color: var(--amber);
+  padding: 2px 7px;
+  border-radius: 5px;
+  border: 1px solid var(--rail);
+}
+.content pre {
+  background: var(--code-bg);
+  border: 1px solid var(--rail);
+  border-left: 4px solid var(--blue);
+  border-radius: var(--r-md);
+  padding: 18px 20px;
+  overflow-x: auto;
+  margin: 0 0 22px;
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+.content pre code { background: none; border: none; padding: 0; color: #e6e8ee; font-size: 13.5px; }
+
+.content blockquote {
+  margin: 0 0 22px;
+  padding: 14px 20px;
+  background: var(--platform);
+  border: 1px solid var(--rail);
+  border-left: 4px solid var(--amber);
+  border-radius: var(--r-sm);
+  color: var(--sign-mute);
+}
+.content blockquote p:last-child { margin-bottom: 0; }
+
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 24px;
+  font-size: 14.5px;
+  border: 1px solid var(--rail);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.content th {
+  text-align: left;
+  background: var(--platform-2);
+  font-family: var(--cond); font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.05em; font-size: 13px;
+  color: var(--sign);
+  padding: 12px 16px;
+  border-bottom: 2px solid var(--blue);
+}
+.content td { padding: 11px 16px; border-bottom: 1px solid var(--rail); color: var(--sign-mute); }
+.content tr:last-child td { border-bottom: none; }
+.content tbody tr:hover td { background: var(--platform); color: #dfe2e8; }
+.content td code, .content th code { font-size: 12.5px; }
+
+.content hr { border: none; border-top: 1px solid var(--rail); margin: 32px 0; }
+.content img { max-width: 100%; border-radius: var(--r-md); border: 1px solid var(--rail); }
+
+/* ===== Footer ================================================== */
+.foot {
+  max-width: 1320px; margin: 64px auto 0;
+  padding: 0 24px 56px;
+}
+.foot-line { display: flex; gap: 0; height: 6px; border-radius: 6px; overflow: hidden; margin-bottom: 28px; }
+.foot-line .line-bullet { width: 25%; height: 6px; border-radius: 0; margin: 0; }
+.foot-grid { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 20px; }
+.foot-brand { display: flex; align-items: center; gap: 14px; }
+.foot-brand strong { font-family: var(--cond); font-size: 20px; letter-spacing: 0.06em; text-transform: uppercase; }
+.foot-brand p { margin: 2px 0 0; color: var(--sign-dim); font-size: 13.5px; max-width: 52ch; }
+.foot-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; font-size: 13px; color: var(--sign-dim); }
+
+/* ===== Responsive ============================================== */
+@media (max-width: 1080px) {
+  .shell { grid-template-columns: 250px minmax(0, 1fr); }
+  .toc { display: none; }
+  .hero { grid-template-columns: 1fr; gap: 36px; }
+  .dest-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 860px) {
+  body { font-size: 15px; }
+  .bar-inner { grid-template-columns: auto auto; gap: 10px; }
+  .search { display: none; }
+  .brand-sub { display: none; }
+  .bar nav { justify-self: end; }
+  .bar nav a:not(.cta) { padding: 6px 8px; font-size: 14px; }
+
+  /* one column: the route rail relayouts into a panel */
+  .shell { grid-template-columns: 1fr; gap: 28px; padding-top: 24px; }
+  .sidebar {
+    position: static;
+    border: 1px solid var(--rail);
+    border-radius: var(--r-md);
+    background: var(--platform);
+    padding: 18px 18px 6px;
+  }
+  .line { padding-left: 24px; }
+
+  .dest-grid { grid-template-columns: 1fr; }
+  .metrics { grid-template-columns: repeat(2, 1fr); }
+  .metrics .m { margin: 0; }
+  .pager { grid-template-columns: 1fr; }
+  .station-card { grid-template-columns: 30px 24px 1fr auto; gap: 10px; padding: 16px; }
+  .station-num { display: none; }
+  .ml-label { font-size: 14px; }
+  .foot-grid { flex-direction: column; align-items: flex-start; }
+  .foot-meta { align-items: flex-start; }
+}
+
+@media (max-width: 520px) {
+  .map-line .ml-stop:nth-of-type(n+3) { display: none; }
+  .plate { gap: 14px; padding: 16px; }
+  .plate .roundel { width: 42px; height: 42px; font-size: 22px; }
+  .metrics { grid-template-columns: 1fr; }
+}

--- a/examples/transit/templates/404.html
+++ b/examples/transit/templates/404.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<section class="hero hero-404">
+  <div class="copy">
+    <span class="tag-code hero-tag">SERVICE NOTICE</span>
+    <h1><span class="hl-red">404</span> — this station is closed.</h1>
+    <p class="deck">The platform you requested is not on the current map. Take the <a href="{{ base_url }}/docs/" class="inline-link l-blue-link">Documentation line</a> or return to the <a href="{{ base_url }}/" class="inline-link l-amber-link">network map</a>.</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/" class="primary">Back to the map →</a>
+      <a href="{{ base_url }}/docs/" class="ghost">Open Documentation</a>
+    </div>
+  </div>
+  <div class="map" aria-hidden="true">
+    <div class="map-head"><span class="tag-code">OUT OF SERVICE</span><span>no route found</span></div>
+    <div class="map-lines">
+      <div class="map-line ml-red">
+        <span class="roundel r-red">×</span>
+        <span class="ml-rail ml-dashed"></span>
+        <span class="ml-stop ml-end"></span>
+        <span class="ml-label">Closed</span>
+      </div>
+      <div class="map-line ml-blue">
+        <span class="roundel r-blue">1</span>
+        <span class="ml-rail"></span>
+        <span class="ml-stop"></span><span class="ml-stop"></span>
+        <span class="ml-stop ml-end"></span>
+        <span class="ml-label">Documentation</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/transit/templates/_sidebar.html
+++ b/examples/transit/templates/_sidebar.html
@@ -1,0 +1,100 @@
+<aside class="sidebar">
+  <div class="sidebar-head">
+    <span class="tag-code">ROUTE MAP</span>
+    <span class="sidebar-sub">All lines &amp; stations</span>
+  </div>
+
+  {# ===== Line 1 — Documentation (blue) ===== #}
+  <nav class="line line-blue">
+    <div class="interchange">
+      <span class="node node-interchange"></span>
+      <a href="{{ base_url }}/docs/" class="line-name">
+        <span class="roundel r-blue">1</span>
+        <span>Documentation</span>
+      </a>
+    </div>
+    <ul class="stations">
+      <li class="{% if page.url == '/docs/installation/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/docs/installation/">Installation</a>
+      </li>
+      <li class="{% if page.url == '/docs/your-first-page/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/docs/your-first-page/">Your first page</a>
+      </li>
+      <li class="{% if page.url == '/docs/configuration/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/docs/configuration/">Configuration</a>
+      </li>
+      <li class="{% if page.url == '/docs/sections-and-pages/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/docs/sections-and-pages/">Sections &amp; pages</a>
+      </li>
+      <li class="{% if page.url == '/docs/templates/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/docs/templates/">Templates</a>
+      </li>
+      <li class="{% if page.url == '/docs/taxonomies/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/docs/taxonomies/">Taxonomies</a>
+      </li>
+      <li class="{% if page.url == '/docs/cli/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/docs/cli/">CLI reference</a>
+      </li>
+      <li class="{% if page.url == '/docs/template-filters/' %}is-here{% endif %} terminus">
+        <span class="node"></span>
+        <a href="{{ base_url }}/docs/template-filters/">Template filters</a>
+      </li>
+    </ul>
+  </nav>
+
+  {# ===== Line 2 — Guides (green) ===== #}
+  <nav class="line line-green">
+    <div class="interchange">
+      <span class="node node-interchange"></span>
+      <a href="{{ base_url }}/guides/" class="line-name">
+        <span class="roundel r-green">2</span>
+        <span>Guides</span>
+      </a>
+    </div>
+    <ul class="stations">
+      <li class="{% if page.url == '/guides/build-pipeline/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/guides/build-pipeline/">The build pipeline</a>
+      </li>
+      <li class="{% if page.url == '/guides/i18n/' %}is-here{% endif %}">
+        <span class="node"></span>
+        <a href="{{ base_url }}/guides/i18n/">Internationalization</a>
+      </li>
+      <li class="{% if page.url == '/guides/deploying/' %}is-here{% endif %} terminus">
+        <span class="node"></span>
+        <a href="{{ base_url }}/guides/deploying/">Deploying to a CDN</a>
+      </li>
+    </ul>
+  </nav>
+
+  {# ===== Line 3 — About (amber) ===== #}
+  <nav class="line line-amber">
+    <div class="interchange">
+      <span class="node node-interchange"></span>
+      <span class="line-name line-name-static">
+        <span class="roundel r-amber">3</span>
+        <span>Information</span>
+      </span>
+    </div>
+    <ul class="stations">
+      <li class="{% if page.url == '/about/' %}is-here{% endif %} terminus">
+        <span class="node"></span>
+        <a href="{{ base_url }}/about/">About this network</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="legend">
+    <span class="tag-code">LEGEND</span>
+    <span class="legend-row"><span class="node-mini node-interchange"></span> Interchange (section)</span>
+    <span class="legend-row"><span class="node-mini"></span> Station (page)</span>
+    <span class="legend-row"><span class="node-mini node-here"></span> You are here</span>
+  </div>
+</aside>

--- a/examples/transit/templates/footer.html
+++ b/examples/transit/templates/footer.html
@@ -1,0 +1,23 @@
+<footer class="foot">
+  <div class="foot-line" aria-hidden="true">
+    <span class="line-bullet l-red"></span>
+    <span class="line-bullet l-blue"></span>
+    <span class="line-bullet l-green"></span>
+    <span class="line-bullet l-amber"></span>
+  </div>
+  <div class="foot-grid">
+    <div class="foot-brand">
+      <span class="roundel brand-roundel">T</span>
+      <div>
+        <strong>{{ site.title }}</strong>
+        <p>{{ site.description }}</p>
+      </div>
+    </div>
+    <div class="foot-meta">
+      <span class="tag-code">END OF LINE</span>
+      <span>© {{ current_year }} · v1.0 · Set in Barlow</span>
+    </div>
+  </div>
+</footer>
+</body>
+</html>

--- a/examples/transit/templates/header.html
+++ b/examples/transit/templates/header.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) }}">
+  <title>{{ page.title }} · {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=Barlow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="bar">
+  <div class="bar-inner">
+    <a href="{{ base_url }}/" class="brand">
+      <span class="roundel brand-roundel">T</span>
+      <span class="brand-name">{{ site.title }}</span>
+      <span class="brand-sub">Network</span>
+    </a>
+    <div class="search">
+      <span class="search-ico" aria-hidden="true">○</span>
+      <input type="text" placeholder="Find a station…" aria-label="Search" />
+      <span class="kbd">⌘K</span>
+    </div>
+    <nav>
+      <a href="{{ base_url }}/docs/"><span class="line-bullet l-blue"></span>Docs</a>
+      <a href="{{ base_url }}/guides/"><span class="line-bullet l-green"></span>Guides</a>
+      <a href="{{ base_url }}/about/"><span class="line-bullet l-amber"></span>About</a>
+      <a href="https://github.com/hahwul/hwaro" class="cta">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/examples/transit/templates/home.html
+++ b/examples/transit/templates/home.html
@@ -1,0 +1,106 @@
+{% include "header.html" %}
+
+<section class="hero">
+  <div class="copy">
+    <span class="tag-code hero-tag">NETWORK MAP · LIVE</span>
+    <h1>Read the docs like a <span class="hl-blue">transit map</span> at <span class="hl-amber">night</span>.</h1>
+    <p class="deck">{{ site.description }}</p>
+    <div class="cta-row">
+      <a href="{{ base_url }}/docs/installation/" class="primary">Board at Installation →</a>
+      <a href="{{ base_url }}/docs/" class="ghost">Open the map</a>
+      <a class="kbd mono-cta">$ brew install hahwul/hwaro/hwaro</a>
+    </div>
+  </div>
+
+  <div class="map" aria-hidden="true">
+    <div class="map-head"><span class="tag-code">NETWORK</span><span>3 lines · 12 stations</span></div>
+    <div class="map-lines">
+      <div class="map-line ml-blue">
+        <span class="roundel r-blue">1</span>
+        <span class="ml-rail"></span>
+        <span class="ml-stop"></span><span class="ml-stop"></span><span class="ml-stop"></span>
+        <span class="ml-stop ml-end"></span>
+        <span class="ml-label">Documentation</span>
+      </div>
+      <div class="map-line ml-green">
+        <span class="roundel r-green">2</span>
+        <span class="ml-rail"></span>
+        <span class="ml-stop"></span><span class="ml-stop"></span>
+        <span class="ml-stop ml-end"></span>
+        <span class="ml-label">Guides</span>
+      </div>
+      <div class="map-line ml-amber">
+        <span class="roundel r-amber">3</span>
+        <span class="ml-rail"></span>
+        <span class="ml-stop ml-end"></span>
+        <span class="ml-label">Information</span>
+      </div>
+      <div class="map-line ml-red">
+        <span class="roundel r-red">R</span>
+        <span class="ml-rail"></span>
+        <span class="ml-stop"></span><span class="ml-stop"></span>
+        <span class="ml-stop ml-end"></span>
+        <span class="ml-label">Reference</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="legend-bar">
+  <span class="tag-code">LINES IN SERVICE</span>
+  <span class="legend-chip"><span class="line-bullet l-blue"></span>1 · Documentation</span>
+  <span class="legend-chip"><span class="line-bullet l-green"></span>2 · Guides</span>
+  <span class="legend-chip"><span class="line-bullet l-amber"></span>3 · Information</span>
+  <span class="legend-chip"><span class="line-bullet l-red"></span>R · Reference</span>
+</section>
+
+<section class="destinations">
+  <h2 class="section-title"><span class="tag-code">MAJOR DESTINATIONS</span></h2>
+  <div class="dest-grid">
+    <a href="{{ base_url }}/docs/installation/" class="dest dest-blue">
+      <span class="roundel r-blue">1</span>
+      <h3>Installation</h3>
+      <p>First stop on the line. Two commands and you are on the platform with a running site.</p>
+      <span class="dest-go">Arrive →</span>
+    </a>
+    <a href="{{ base_url }}/docs/sections-and-pages/" class="dest dest-blue">
+      <span class="roundel r-blue">1</span>
+      <h3>Sections &amp; pages</h3>
+      <p>Lines and stations: how content is organized, and why <code>_index.md</code> does more than it looks.</p>
+      <span class="dest-go">Arrive →</span>
+    </a>
+    <a href="{{ base_url }}/docs/templates/" class="dest dest-blue">
+      <span class="roundel r-blue">1</span>
+      <h3>Templates</h3>
+      <p>The signage system. Crinja templates, where to put them, and the globals you can count on.</p>
+      <span class="dest-go">Arrive →</span>
+    </a>
+    <a href="{{ base_url }}/guides/build-pipeline/" class="dest dest-green">
+      <span class="roundel r-green">2</span>
+      <h3>Build pipeline</h3>
+      <p>The depot. What happens between <code>build</code> and <code>public/</code>, traced in seven phases.</p>
+      <span class="dest-go">Arrive →</span>
+    </a>
+    <a href="{{ base_url }}/guides/i18n/" class="dest dest-green">
+      <span class="roundel r-green">2</span>
+      <h3>Internationalization</h3>
+      <p>Parallel lines. Multilingual sites without the foot guns — one locale, one fallback rule.</p>
+      <span class="dest-go">Arrive →</span>
+    </a>
+    <a href="{{ base_url }}/guides/deploying/" class="dest dest-amber">
+      <span class="roundel r-amber">3</span>
+      <h3>Deploying</h3>
+      <p>The terminus. Recipes for GitHub Pages, Cloudflare Pages, and a Bash script for everyone else.</p>
+      <span class="dest-go">Arrive →</span>
+    </a>
+  </div>
+</section>
+
+<section class="metrics">
+  <div class="m"><div class="v c-red">v1.0</div><div class="k">Current release</div></div>
+  <div class="m"><div class="v c-blue">12</div><div class="k">Stations documented</div></div>
+  <div class="m"><div class="v c-green">3</div><div class="k">Lines in service</div></div>
+  <div class="m"><div class="v c-amber">MIT</div><div class="k">License</div></div>
+</section>
+
+{% include "footer.html" %}

--- a/examples/transit/templates/page.html
+++ b/examples/transit/templates/page.html
@@ -1,0 +1,56 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <nav class="route" aria-label="Breadcrumb">
+      <a href="{{ base_url }}/"><span class="line-bullet l-red"></span>Home</a>
+      <span class="route-arrow">→</span>
+      {% if page.section %}
+        <a href="{{ base_url }}/{{ page.section }}/"><span class="line-bullet l-blue"></span>{{ page.section }}</a>
+        <span class="route-arrow">→</span>
+      {% endif %}
+      <span class="route-now"><span class="line-bullet l-amber"></span>{{ page.title }}</span>
+    </nav>
+
+    <header class="plate plate-blue">
+      <span class="roundel r-blue">{% if page.section %}{{ page.section | first | upper }}{% else %}T{% endif %}</span>
+      <div class="plate-body">
+        <span class="plate-kicker">{% if page.section %}{{ page.section | upper }} LINE · STATION{% else %}STATION{% endif %}</span>
+        <h1>{{ page.title }}</h1>
+      </div>
+    </header>
+    {% if page.description %}<p class="deck">{{ page.description }}</p>{% endif %}
+
+    <div class="content">{{ content | safe }}</div>
+
+    {% if page.lower or page.higher %}
+    <div class="pager">
+      {% if page.lower %}
+      <a href="{{ base_url }}{{ page.lower.url }}" class="b prev">
+        <div class="k"><span class="route-arrow">←</span> Previous station</div>
+        <div class="t">{{ page.lower.title }}</div>
+      </a>
+      {% else %}<div></div>{% endif %}
+      {% if page.higher %}
+      <a href="{{ base_url }}{{ page.higher.url }}" class="b next">
+        <div class="k">Next station <span class="route-arrow">→</span></div>
+        <div class="t">{{ page.higher.title }}</div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+  </main>
+  <aside class="toc">
+    <h5><span class="tag-code">PLATFORM</span> On this page</h5>
+    {% if page.toc %}
+      {{ page.toc | safe }}
+    {% else %}
+      <ul>
+        <li><a href="#">Top of platform</a></li>
+      </ul>
+    {% endif %}
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/transit/templates/section.html
+++ b/examples/transit/templates/section.html
@@ -1,0 +1,55 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <nav class="route" aria-label="Breadcrumb">
+      <a href="{{ base_url }}/"><span class="line-bullet l-red"></span>Home</a>
+      <span class="route-arrow">→</span>
+      <span class="route-now"><span class="line-bullet l-blue"></span>{{ section.title }}</span>
+    </nav>
+
+    {% if section.title == "Guides" %}
+    <header class="plate plate-green">
+      <span class="roundel r-green">2</span>
+      <div class="plate-body">
+        <span class="plate-kicker">LINE 2 · {{ section.pages | length }} STATIONS</span>
+        <h1>{{ section.title }}</h1>
+      </div>
+    </header>
+    {% else %}
+    <header class="plate plate-blue">
+      <span class="roundel r-blue">1</span>
+      <div class="plate-body">
+        <span class="plate-kicker">LINE 1 · {{ section.pages | length }} STATIONS</span>
+        <h1>{{ section.title }}</h1>
+      </div>
+    </header>
+    {% endif %}
+    {% if section.description %}<p class="deck">{{ section.description }}</p>{% endif %}
+
+    <div class="station-list">
+      {% for post in section.pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="station-card{% if loop.first %} is-origin{% endif %}{% if loop.last %} is-terminus{% endif %}">
+        <span class="station-num">{{ loop.index }}</span>
+        <div class="station-rail" aria-hidden="true"><span class="node"></span></div>
+        <div class="station-text">
+          <h3>{{ post.title }}</h3>
+          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        </div>
+        <span class="station-go">→</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5><span class="tag-code">LINE</span> {{ section.pages | length }} stations</h5>
+    <ul>
+      {% for post in section.pages %}
+      <li><a href="{{ base_url }}{{ post.url }}">{{ loop.index }}. {{ post.title }}</a></li>
+      {% endfor %}
+    </ul>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/transit/templates/taxonomy.html
+++ b/examples/transit/templates/taxonomy.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <nav class="route" aria-label="Breadcrumb">
+      <a href="{{ base_url }}/"><span class="line-bullet l-red"></span>Home</a>
+      <span class="route-arrow">→</span>
+      <span class="route-now"><span class="line-bullet l-green"></span>{{ taxonomy_name }}</span>
+    </nav>
+
+    <header class="plate plate-green">
+      <span class="roundel r-green">#</span>
+      <div class="plate-body">
+        <span class="plate-kicker">INTERCHANGE INDEX</span>
+        <h1>All {{ taxonomy_name }}</h1>
+      </div>
+    </header>
+
+    <div class="content">
+      <ul class="term-index">
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ base_url }}{{ term.url }}"><span class="line-bullet l-green"></span>{{ term }}</a> <span class="tag-code">{{ term.pages | length }}</span></li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  <aside class="toc">
+    <h5><span class="tag-code">INDEX</span> Interchanges</h5>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/examples/transit/templates/taxonomy_term.html
+++ b/examples/transit/templates/taxonomy_term.html
@@ -1,0 +1,41 @@
+{% include "header.html" %}
+
+<div class="shell">
+  {% include "_sidebar.html" %}
+  <main class="main">
+    <nav class="route" aria-label="Breadcrumb">
+      <a href="{{ base_url }}/"><span class="line-bullet l-red"></span>Home</a>
+      <span class="route-arrow">→</span>
+      <a href="{{ base_url }}/tags/"><span class="line-bullet l-green"></span>tags</a>
+      <span class="route-arrow">→</span>
+      <span class="route-now"><span class="line-bullet l-amber"></span>{{ taxonomy_term }}</span>
+    </nav>
+
+    <header class="plate plate-green">
+      <span class="roundel r-green">#</span>
+      <div class="plate-body">
+        <span class="plate-kicker">INTERCHANGE</span>
+        <h1>#{{ taxonomy_term }}</h1>
+      </div>
+    </header>
+
+    <div class="station-list">
+    {% for post in taxonomy_pages %}
+      <a href="{{ base_url }}{{ post.url }}" class="station-card{% if loop.first %} is-origin{% endif %}{% if loop.last %} is-terminus{% endif %}">
+        <span class="station-num">{{ loop.index }}</span>
+        <div class="station-rail" aria-hidden="true"><span class="node"></span></div>
+        <div class="station-text">
+          <h3>{{ post.title }}</h3>
+          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+        </div>
+        <span class="station-go">→</span>
+      </a>
+    {% endfor %}
+    </div>
+  </main>
+  <aside class="toc">
+    <h5><span class="tag-code">CONNECTS</span> Stations</h5>
+  </aside>
+</div>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -9230,5 +9230,65 @@
     "blog",
     "editorial",
     "retro"
+  ],
+  "letterpress": [
+    "light",
+    "docs",
+    "editorial",
+    "letterpress"
+  ],
+  "newsprint": [
+    "light",
+    "docs",
+    "editorial",
+    "newspaper"
+  ],
+  "card-catalog": [
+    "light",
+    "docs",
+    "library",
+    "retro"
+  ],
+  "quadrille": [
+    "light",
+    "docs",
+    "technical",
+    "engineering"
+  ],
+  "transit": [
+    "dark",
+    "docs",
+    "wayfinding",
+    "navigation"
+  ],
+  "datasheet": [
+    "dark",
+    "docs",
+    "api",
+    "technical"
+  ],
+  "deco": [
+    "dark",
+    "docs",
+    "editorial",
+    "artdeco"
+  ],
+  "risograph": [
+    "light",
+    "docs",
+    "print",
+    "editorial"
+  ],
+  "constructivist": [
+    "light",
+    "docs",
+    "editorial",
+    "bold"
+  ],
+  "orrery": [
+    "dark",
+    "docs",
+    "scientific",
+    "editorial"
   ]
 }


### PR DESCRIPTION
## Summary

Ten new production-quality documentation themes for `examples/`, each with a committed, instantly-recognizable art direction. The brief was bold, original design at production quality — **no gradients, no emojis** (solid fills, borders, box-shadow, and inline SVG only).

| Theme | Mode | Concept |
|-------|------|---------|
| `letterpress` | light | Classic letterpress impression — pressed/inked headings, true drop caps, fleuron rules, colophon footer |
| `newsprint` | light | Broadsheet gazette — nameplate masthead, 3-column front page with drop cap, pull-quotes, classifieds sidebar |
| `card-catalog` | light | Library card catalog — manila cards, Dewey call numbers, punched holes, rubber-stamp labels, drawer-label sidebar |
| `quadrille` | light | Engineer's graph-paper notebook — real quadrille grid, `FIG.` callouts with corner ticks, plate-number headings |
| `transit` | dark | Subway wayfinding — sidebar rendered as a transit line (station dots, interchange nodes), station-plate headers, network-map home |
| `datasheet` | dark | Semiconductor datasheet — IC pinout diagram, ABSOLUTE-MAX/electrical-characteristics tables, numbered sections, revision footer |
| `deco` | dark | 1920s Art Deco — stepped skyscraper emblem, solid-brass sunburst, symmetric ziggurat frames, lozenge rules |
| `risograph` | light | Two-ink riso print — misregistration offset shadows, crop/registration marks, knockout two-ink panels, ink-swatch colophon |
| `constructivist` | light | Soviet agitprop — diagonal red band, giant ghosted numerals, angled tabs; reading column kept upright |
| `orrery` | dark | Astronomical orrery — concentric brass rings with planet dots, star-chart field, coordinate kickers |

## Each theme

- Builds cleanly with `hwaro build` (15 pages each), full content depth (8 docs + 3 guides + about), all rewritten in-voice
- 580–981 lines of hand-authored CSS with a real font pairing, committed palette, and 2–3 signature components
- Responsive (single column under ~860px), styled `.content` (code, tables, blockquotes, headings, lists), real hover/focus states
- Registered in `tags.json`

## Verification

- `hwaro build --base-url …` → **Build complete!** for all 10 (10/10)
- `scripts/lint-examples.sh` → **Lint passed** (no placeholder content, no pictographic emoji)
- `grep -rin "gradient"` → **0 occurrences** across all 10
- No emoji (only allowed typographic/geometric glyphs below U+27C0)
- No `axiom-grid`/Bauhaus residue from the scaffold
- All 20 home/doc pages screenshot-reviewed for production quality

Build output (`public/`) is gitignored and not included.