### PR TITLE
Add 5 modern liquid-glass blog examples

### DIFF
--- a/examples/halcyon-pane/AGENTS.md
+++ b/examples/halcyon-pane/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/halcyon-pane/config.toml
+++ b/examples/halcyon-pane/config.toml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Halcyon Pane"
+description = "A calm, sage-toned journal on unhurried technology, attention, and building tools that respect a person's focus."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.6
+
+[robots]
+enabled = true
+filename = "robots.txt"
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"
+full_content = true
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/examples/halcyon-pane/content/about.md
+++ b/examples/halcyon-pane/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Halcyon Pane"
+description = "Why calm technology is worth writing about."
+template = "page"
++++
+
+For a long time I measured good software by how much it could do. More features, more notifications, more ways to pull me back in. Then I spent a year actually paying attention to how those tools made me feel, and the answer was mostly: frayed.
+
+Calm technology is an old idea — Mark Weiser and John Seely Brown were writing about it in the nineties — but it has never been more relevant. The premise is simple: technology should inform without overwhelming, and sit in the background until it's genuinely needed.
+
+Halcyon Pane is where I think through what that means in practice. How to design a notification that respects a person. When the right number of features is fewer. Why the best interface is sometimes the one you forget is there. I don't always get it right, but I'd rather aim at calm than at engagement.

--- a/examples/halcyon-pane/content/index.md
+++ b/examples/halcyon-pane/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "Notes on calm technology and unhurried work"
+description = "A sage-toned journal about attention, focus, and tools that don't shout."
+template = "index"
++++
+
+Halcyon Pane is about the kind of technology that gets out of your way. Software that doesn't buzz for attention every few minutes, interfaces that trust you to find your own pace, tools designed for the long, quiet stretch of real work. We have enough things demanding our focus. This is a journal for the ones that protect it.

--- a/examples/halcyon-pane/content/posts/_index.md
+++ b/examples/halcyon-pane/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Writing"
+description = "Essays on calm technology and attention, newest first."
+template = "section"
+sort_by = "date"
++++
+
+Everything published on Halcyon Pane.

--- a/examples/halcyon-pane/content/posts/fewer-features.md
+++ b/examples/halcyon-pane/content/posts/fewer-features.md
@@ -1,0 +1,23 @@
++++
+title = "The Right Number of Features Is Fewer"
+description = "Every feature you add is a tax on every feature that came before. Calm tools say no for a living."
+date = "2026-04-18"
+template = "page"
+tags = ["product", "calm-tech", "design"]
++++
+
+Feature lists grow in one direction. Something gets added every release; almost nothing gets removed. Each addition feels small and reasonable in isolation. The accumulated weight is what eventually makes a tool feel exhausting to open.
+
+A new feature isn't free even if nobody uses it. It's another item in the menu, another setting in the panel, another concept the new user has to file away before they can do the one thing they came to do. You pay for it in clarity, forever.
+
+{% alert(type="note") %}Before adding a feature, try to name the feature it replaces. If you can't remove anything, you're not designing — you're accumulating. The discipline is in the subtraction.{% end %}
+
+## Calm tools are defined by their no
+
+The software that feels calm is almost always the software that said no a hundred times. No to the integration that three people requested. No to the dashboard nobody needs. No to the clever thing that would have been fun to build and miserable to maintain.
+
+Saying no is harder than saying yes, because yes makes someone happy today and no makes a vague future user happy in a way you'll never see. But that future user is real, and they will open a tool that does one thing clearly instead of forty things vaguely.
+
+## Protect the core path
+
+For any tool, there's a path that ninety percent of people are there to walk. Every feature you add either clears that path or clutters it. The calm move is to keep optimizing the path and resist decorating the edges. Less to learn, less to maintain, less to get in the way of the work.

--- a/examples/halcyon-pane/content/posts/interfaces-that-disappear.md
+++ b/examples/halcyon-pane/content/posts/interfaces-that-disappear.md
@@ -1,0 +1,23 @@
++++
+title = "The Best Interface Disappears"
+description = "An interface you stop noticing is doing its job. Visibility is not the same as quality."
+date = "2026-03-21"
+template = "page"
+tags = ["design", "calm-tech", "attention"]
++++
+
+There's a temptation, when you've worked hard on an interface, to make sure people see it. The animations, the custom controls, the personality in every corner. It's natural to want the craft to be noticed.
+
+But the highest compliment a tool can earn is being forgotten. The light switch you never think about. The pen that just writes. When an interface disappears, all that's left is the person and the thing they came to do — which is the entire point.
+
+## Friction is information
+
+When you *do* notice an interface, it's usually because something went wrong. A control didn't behave the way you expected. A label was ambiguous. A step you didn't anticipate appeared. Noticing is friction, and friction is the tool intruding on the work.
+
+So treat every "huh?" moment as a bug, even when nothing crashed. The goal isn't a memorable interface. It's an invisible one — present when summoned, gone when not.
+
+> A great tool feels less like a destination and more like a window. You don't admire the glass; you look through it.
+
+## Quiet is a feature
+
+This runs against a lot of industry instinct, where visibility is engagement and engagement is the metric. But the tools people keep for years are rarely the loudest. They're the ones that earned trust by staying out of the way — by being there at the exact moment of need and silent the rest of the time. That quiet is not the absence of design. It's the hardest kind to pull off.

--- a/examples/halcyon-pane/content/posts/the-notification-tax.md
+++ b/examples/halcyon-pane/content/posts/the-notification-tax.md
@@ -1,0 +1,23 @@
++++
+title = "The Notification Tax"
+description = "Every notification is a small withdrawal from a person's attention. Most apps spend like the account is infinite."
+date = "2026-05-25"
+template = "page"
+tags = ["attention", "calm-tech", "design"]
++++
+
+Every notification you send costs the recipient something. Not just the seconds it takes to glance at it — the far larger cost of breaking concentration and clawing it back. Researchers have put the recovery time at well over twenty minutes for deep work. You interrupt someone for two seconds; you've spent twenty of their minutes.
+
+Most software treats attention like a free resource. It isn't. It's the scarcest thing your users have, and you're taxing it every time the badge lights up.
+
+## Ask: would I send this in person?
+
+A useful filter before shipping any notification: imagine walking into the person's office, tapping them on the shoulder, and saying it out loud. "Someone you follow posted a photo." "You haven't opened the app in three days." Said aloud, most notifications are obviously rude. The screen just makes the rudeness easy to ignore.
+
+The ones that survive the test tend to be the ones the user actually asked for: the thing is ready, the message is from a real person, the deadline is now.
+
+## Batch, delay, and default to silence
+
+Calm technology doesn't mean no notifications. It means deliberate ones. Batch the non-urgent into a single daily digest. Delay anything that isn't time-sensitive to a moment the user chose. And make silence the default — let people opt *into* interruption rather than spending their first ten minutes opting out.
+
+The product won't feel less alive. It'll feel respectful, which is rarer and worth more.

--- a/examples/halcyon-pane/templates/404.html
+++ b/examples/halcyon-pane/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="notfound glass">
+  <p class="notfound-code">404</p>
+  <h1 class="notfound-title">Nothing to see here</h1>
+  <p class="notfound-text">This page is quiet because it doesn't exist. Take a breath, then head back to somewhere that does.</p>
+  <a class="button" href="{{ base_url }}/">Back home</a>
+</section>
+{% endblock content %}

--- a/examples/halcyon-pane/templates/base.html
+++ b/examples/halcyon-pane/templates/base.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Outfit:wght@500;600;700&display=swap" rel="stylesheet">
+
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --bg: #e7efe9;
+      --ink: #1d2a26;
+      --muted: #5d716b;
+      --accent: #2f7d6e;
+      --accent-deep: #1f5a4f;
+      --line: rgba(29, 42, 38, 0.10);
+
+      --glass-bg: rgba(255, 255, 255, 0.5);
+      --glass-border: rgba(255, 255, 255, 0.7);
+      --glass-shadow: 0 16px 44px rgba(31, 70, 60, 0.13);
+      --glass-spec: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+
+      --radius: 26px;
+      --radius-sm: 16px;
+      --font-body: 'Inter', system-ui, sans-serif;
+      --font-head: 'Outfit', system-ui, sans-serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0; font-family: var(--font-body); color: var(--ink);
+      background: var(--bg); line-height: 1.7; min-height: 100vh;
+      -webkit-font-smoothing: antialiased; position: relative; overflow-x: hidden;
+    }
+
+    /* Calm color fields beneath the glass — solid fills, no gradients */
+    .field { position: fixed; z-index: 0; border-radius: 50%; filter: blur(100px); pointer-events: none; }
+    .field-a { width: 470px; height: 470px; background: #b9dcc6; opacity: 0.7; top: -130px; left: -90px; }
+    .field-b { width: 520px; height: 520px; background: #aed8d0; opacity: 0.6; bottom: -170px; right: -120px; }
+    .field-c { width: 350px; height: 350px; background: #dde6bc; opacity: 0.55; top: 42%; left: 16%; }
+
+    .glass {
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(20px) saturate(160%); -webkit-backdrop-filter: blur(20px) saturate(160%);
+      border-radius: var(--radius);
+    }
+
+    .wrap { max-width: 900px; margin: 0 auto; padding: 0 1.4rem; position: relative; z-index: 1; }
+
+    /* Header */
+    .site-header {
+      position: sticky; top: 1rem; z-index: 50;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.85rem 1.5rem; margin: 1rem 0 2.5rem;
+    }
+    .site-logo { font-family: var(--font-head); font-weight: 700; font-size: 1.18rem; letter-spacing: -0.01em; color: var(--ink); text-decoration: none; }
+    .site-logo .dot { color: var(--accent); }
+    .site-nav { display: flex; gap: 0.3rem; }
+    .site-nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; font-weight: 500; padding: 0.4rem 0.85rem; border-radius: 999px; transition: color 0.2s, background 0.2s; }
+    .site-nav a:hover { color: var(--accent-deep); background: rgba(47, 125, 110, 0.1); }
+
+    .site-main { min-height: 60vh; padding-bottom: 1rem; }
+
+    /* Hero */
+    .hero { padding: 3.2rem 2.6rem; margin-bottom: 2.6rem; }
+    .hero-eyebrow { font-family: var(--font-head); text-transform: uppercase; letter-spacing: 0.22em; font-size: 0.72rem; color: var(--accent); margin: 0 0 0.9rem; font-weight: 600; }
+    .hero-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2.2rem, 6vw, 3.4rem); line-height: 1.08; letter-spacing: -0.02em; margin: 0 0 1rem; font-weight: 700; }
+    .hero-lede { font-size: 1.13rem; color: var(--muted); max-width: 54ch; }
+    .hero-lede p:first-child { margin-top: 0; }
+    .hero-actions { display: flex; gap: 0.7rem; margin-top: 1.9rem; flex-wrap: wrap; }
+
+    .button {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+      font-family: var(--font-head); font-weight: 600; font-size: 0.9rem;
+      padding: 0.72rem 1.5rem; border-radius: 999px; text-decoration: none;
+      background: var(--accent); color: #f1f8f4; border: 1px solid transparent;
+      transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+      box-shadow: 0 8px 22px rgba(47, 125, 110, 0.24);
+    }
+    .button:hover { transform: translateY(-2px); background: var(--accent-deep); box-shadow: 0 12px 28px rgba(47, 125, 110, 0.3); }
+    .button-ghost { background: rgba(255,255,255,0.5); color: var(--ink); border-color: var(--glass-border); box-shadow: none; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
+    .button-ghost:hover { background: rgba(255,255,255,0.82); color: var(--accent-deep); box-shadow: none; }
+
+    /* Feed — airy grid with a featured first card */
+    .post-feed { margin-bottom: 3rem; }
+    .feed-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1.5rem; }
+    .feed-title { font-family: var(--font-head); font-size: 1.45rem; margin: 0; letter-spacing: -0.01em; }
+    .feed-all { color: var(--accent); text-decoration: none; font-weight: 600; font-size: 0.88rem; }
+    .feed-all:hover { color: var(--accent-deep); }
+
+    .post-list { list-style: none; margin: 0; padding: 0; display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.2rem; }
+    .post-list .post-card:first-child { grid-column: 1 / -1; }
+    .post-card { transition: transform 0.25s, box-shadow 0.25s; }
+    .post-card:hover { transform: translateY(-4px); box-shadow: 0 24px 54px rgba(31, 70, 60, 0.2), var(--glass-spec); }
+    .post-card-link { display: block; padding: 1.7rem 1.9rem; text-decoration: none; color: inherit; height: 100%; }
+    .post-card-date { font-size: 0.76rem; color: var(--muted); font-weight: 500; letter-spacing: 0.05em; text-transform: uppercase; }
+    .post-card-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: 1.32rem; line-height: 1.2; letter-spacing: -0.01em; margin: 0.55rem 0 0.5rem; }
+    .post-list .post-card:first-child .post-card-title { font-size: 1.7rem; }
+    .post-card-desc { color: var(--muted); margin: 0 0 0.9rem; font-size: 0.99rem; }
+    .read-more { font-family: var(--font-head); font-weight: 600; font-size: 0.86rem; color: var(--accent); }
+
+    /* Tags */
+    .tag-row { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 0.9rem 0 0; }
+    .tag { font-size: 0.74rem; font-weight: 600; letter-spacing: 0.02em; padding: 0.27rem 0.72rem; border-radius: 999px; text-decoration: none; background: rgba(47, 125, 110, 0.1); color: var(--accent-deep); border: 1px solid rgba(47, 125, 110, 0.18); }
+    a.tag:hover { background: rgba(47, 125, 110, 0.18); }
+
+    /* Single post */
+    .post { max-width: 700px; margin: 0 auto; }
+    .post-header { padding: 2.6rem 2.4rem 2rem; margin-bottom: 2.2rem; }
+    .post-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2rem, 5vw, 2.7rem); line-height: 1.1; letter-spacing: -0.02em; margin: 0 0 0.9rem; }
+    .post-meta { color: var(--muted); font-size: 0.88rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+    .meta-sep { opacity: 0.5; }
+    .post-content { font-size: 1.06rem; }
+
+    .section-head { margin: 1rem 0 2rem; }
+    .section-eyebrow { font-family: var(--font-head); text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.72rem; color: var(--accent); font-weight: 600; margin: 0 0 0.5rem; }
+    .section-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2rem, 5vw, 2.8rem); letter-spacing: -0.02em; margin: 0 0 0.5rem; }
+    .section-desc { color: var(--muted); font-size: 1.07rem; margin: 0; }
+    .section-intro { margin-bottom: 2rem; }
+
+    /* Post navigation */
+    .post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 2.5rem; padding: 1.3rem 1.6rem; }
+    .post-nav-link { display: flex; flex-direction: column; gap: 0.25rem; text-decoration: none; color: var(--ink); max-width: 46%; }
+    .post-nav-link.next { text-align: right; margin-left: auto; }
+    .post-nav-label { font-size: 0.76rem; color: var(--accent); font-weight: 600; }
+    .post-nav-title { font-family: var(--font-head); font-weight: 600; font-size: 0.98rem; }
+    .post-nav-link:hover .post-nav-title { color: var(--accent-deep); }
+
+    /* Terms */
+    .term-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 0.8rem; }
+    .term-item { padding: 0; }
+    .term-item a { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.7rem 1.2rem; text-decoration: none; color: var(--ink); font-family: var(--font-head); font-weight: 600; }
+    .term-item:hover a { color: var(--accent-deep); }
+    .term-count { background: rgba(47, 125, 110, 0.12); color: var(--accent-deep); border-radius: 999px; padding: 0.05rem 0.55rem; font-size: 0.76rem; }
+
+    /* Taxonomy auto-generated lists */
+    .tax-body .taxonomy-terms, .tax-body .taxonomy-pages { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 0.8rem; }
+    .tax-body li { margin: 0; }
+    .tax-body li a {
+      display: block; padding: 1rem 1.3rem; text-decoration: none; color: var(--ink);
+      font-family: var(--font-head); font-weight: 600;
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(16px) saturate(150%); -webkit-backdrop-filter: blur(16px) saturate(150%);
+      border-radius: var(--radius-sm); transition: transform 0.2s, color 0.2s;
+    }
+    .tax-body li a:hover { transform: translateY(-3px); color: var(--accent-deep); }
+
+    /* Pagination */
+    .pagination { display: flex; align-items: center; justify-content: center; gap: 1rem; margin: 2.5rem 0 1rem; }
+    .page-link { text-decoration: none; color: var(--accent); font-weight: 600; font-family: var(--font-head); padding: 0.5rem 1rem; border-radius: 999px; }
+    .page-link:hover { background: rgba(47, 125, 110, 0.1); }
+    .page-link.disabled { color: var(--muted); opacity: 0.45; }
+    .page-current { font-family: var(--font-head); color: var(--muted); font-size: 0.9rem; }
+
+    /* Callout */
+    .callout { display: flex; gap: 0.9rem; align-items: flex-start; padding: 1.1rem 1.3rem; border-radius: var(--radius-sm); margin: 1.6rem 0; background: rgba(47, 125, 110, 0.07); border: 1px solid rgba(47, 125, 110, 0.18); }
+    .callout-label { font-family: var(--font-head); font-size: 0.68rem; font-weight: 700; letter-spacing: 0.08em; color: #f1f8f4; background: var(--accent); padding: 0.18rem 0.55rem; border-radius: 6px; flex-shrink: 0; margin-top: 0.2rem; }
+    .callout-body { color: var(--ink); }
+    .callout-body p { margin: 0; }
+    .callout-warning { background: rgba(180, 120, 40, 0.1); border-color: rgba(180, 120, 40, 0.28); }
+    .callout-warning .callout-label { background: #b07c2a; }
+
+    /* 404 */
+    .notfound { text-align: center; padding: 4rem 2rem; }
+    .notfound-code { font-family: var(--font-head); font-size: 5rem; font-weight: 700; color: var(--accent); margin: 0; letter-spacing: -0.04em; }
+    .notfound-title { font-family: var(--font-head); font-size: 1.6rem; margin: 0.5rem 0 1rem; }
+    .notfound-text { color: var(--muted); max-width: 40ch; margin: 0 auto 1.8rem; }
+
+    /* Footer */
+    .site-footer { text-align: center; padding: 1.8rem; margin: 3rem 0 2rem; color: var(--muted); font-size: 0.9rem; }
+    .site-footer a { color: var(--accent); text-decoration: none; }
+    .site-footer a:hover { color: var(--accent-deep); }
+
+    /* Content typography */
+    .post-content h2, .post-content h3, .post-content h4 { font-family: var(--font-head); letter-spacing: -0.01em; line-height: 1.25; margin: 2rem 0 0.8rem; }
+    .post-content h2 { font-size: 1.5rem; }
+    .post-content h3 { font-size: 1.24rem; }
+    .post-content p { margin: 1.1rem 0; }
+    .post-content a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; }
+    .post-content a:hover { color: var(--accent-deep); }
+    .post-content ul, .post-content ol { padding-left: 1.3rem; }
+    .post-content li { margin: 0.4rem 0; }
+    .post-content img { max-width: 100%; height: auto; border-radius: var(--radius-sm); }
+    .post-content blockquote { margin: 1.6rem 0; padding: 0.6rem 1.3rem; border-left: 3px solid var(--accent); background: rgba(47, 125, 110, 0.05); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; color: var(--ink); font-style: italic; }
+    .post-content code { font-family: ui-monospace, Menlo, monospace; font-size: 0.88em; background: rgba(29, 42, 38, 0.07); padding: 0.15rem 0.4rem; border-radius: 6px; }
+    .post-content pre { background: #16211d; color: #e7efe9; padding: 1.3rem 1.5rem; border-radius: var(--radius-sm); overflow-x: auto; font-size: 0.9rem; }
+    .post-content pre code { background: none; padding: 0; color: inherit; }
+    .post-content hr { border: 0; height: 1px; background: var(--line); margin: 2.5rem 0; }
+    .post-content table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.95rem; }
+    .post-content th, .post-content td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid var(--line); }
+    .post-content th { font-family: var(--font-head); }
+
+    @media (max-width: 680px) {
+      .site-header { flex-direction: column; gap: 0.7rem; padding: 1rem; top: 0.5rem; }
+      .hero { padding: 2.3rem 1.6rem; }
+      .hero-title { font-size: 1.85rem; }
+      .post-list { grid-template-columns: 1fr; }
+      .post-list .post-card:first-child .post-card-title { font-size: 1.4rem; }
+      .post-header { padding: 1.9rem 1.6rem 1.5rem; }
+      .post-nav { flex-direction: column; }
+      .post-nav-link, .post-nav-link.next { max-width: 100%; text-align: left; margin-left: 0; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="field field-a"></div>
+  <div class="field field-b"></div>
+  <div class="field field-c"></div>
+
+  <div class="wrap">
+    <header class="site-header glass">
+      <a href="{{ base_url }}/" class="site-logo">halcyon<span class="dot">.</span>pane</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Blog</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="site-footer">
+      <p>Halcyon Pane &mdash; built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+    </footer>
+  </div>
+
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/halcyon-pane/templates/index.html
+++ b/examples/halcyon-pane/templates/index.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero glass">
+  <p class="hero-eyebrow">{{ site.title }}</p>
+  <h1 class="hero-title">{{ page.title | default(value=site.title) }}</h1>
+  <div class="hero-lede">
+    {{ content | safe }}
+  </div>
+  <div class="hero-actions">
+    <a class="button" href="#writing">Latest posts</a>
+    <a class="button button-ghost" href="{{ base_url }}/about/">About</a>
+  </div>
+</section>
+
+{% set posts = site.pages | selectattr("date") | sort(attribute="date", reverse=true) %}
+{% if posts %}
+<section class="post-feed" id="writing">
+  <div class="feed-head">
+    <h2 class="feed-title">Latest writing</h2>
+    <a class="feed-all" href="{{ base_url }}/posts/">All posts &rarr;</a>
+  </div>
+  <ul class="post-list">
+    {% for post in posts %}
+    {% if loop.index0 < 6 %}
+    <li class="post-card glass">
+      <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+        <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+        <h3 class="post-card-title">{{ post.title }}</h3>
+        {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+        {% if post.tags %}
+        <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+        {% endif %}
+        <span class="read-more">Read more &rarr;</span>
+      </a>
+    </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+{% endblock content %}

--- a/examples/halcyon-pane/templates/page.html
+++ b/examples/halcyon-pane/templates/page.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="post">
+  {% if page.title is present %}
+  <header class="post-header glass">
+    <h1 class="post-title">{{ page.title }}</h1>
+    <div class="post-meta">
+      {% if page.date is present %}<time datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+      {% if page.reading_time is present %}<span class="meta-sep">/</span><span>{{ page.reading_time }} min read</span>{% endif %}
+    </div>
+    {% if page.tags %}
+    <div class="tag-row">
+      {% for tag in page.tags %}<a class="tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>{% endfor %}
+    </div>
+    {% endif %}
+  </header>
+  {% endif %}
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+  {% if page.lower or page.higher %}
+  <nav class="post-nav glass">
+    {% if page.higher %}
+    <a class="post-nav-link prev" href="{{ base_url }}{{ page.higher.url }}">
+      <span class="post-nav-label">&larr; Previous</span>
+      <span class="post-nav-title">{{ page.higher.title }}</span>
+    </a>
+    {% else %}<span></span>{% endif %}
+    {% if page.lower %}
+    <a class="post-nav-link next" href="{{ base_url }}{{ page.lower.url }}">
+      <span class="post-nav-label">Next &rarr;</span>
+      <span class="post-nav-title">{{ page.lower.title }}</span>
+    </a>
+    {% endif %}
+  </nav>
+  {% endif %}
+</article>
+{% endblock content %}

--- a/examples/halcyon-pane/templates/section.html
+++ b/examples/halcyon-pane/templates/section.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <h1 class="section-title">{{ page.title | default(value=page.section | capitalize) }}</h1>
+  {% if page.description %}<p class="section-desc">{{ page.description }}</p>{% endif %}
+</header>
+{% if content %}<div class="post-content section-intro">{{ content | safe }}</div>{% endif %}
+{% if section.pages %}
+<ul class="post-list">
+  {% for post in section.pages %}
+  <li class="post-card glass">
+    <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+      {% if post.date %}
+      <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+      {% endif %}
+      <h2 class="post-card-title">{{ post.title | default(value=post.slug) }}</h2>
+      {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+      {% if post.tags %}
+      <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+      {% endif %}
+      <span class="read-more">Read more &rarr;</span>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if pagination is present and pagination.total_pages > 1 %}
+<nav class="pagination">
+  {% if pagination.prev is present %}<a class="page-link" href="{{ base_url }}{{ pagination.prev }}">&larr; Newer</a>{% else %}<span class="page-link disabled">&larr; Newer</span>{% endif %}
+  <span class="page-current">{{ pagination.current_page }} / {{ pagination.total_pages }}</span>
+  {% if pagination.next is present %}<a class="page-link" href="{{ base_url }}{{ pagination.next }}">Older &rarr;</a>{% else %}<span class="page-link disabled">Older &rarr;</span>{% endif %}
+</nav>
+{% endif %}
+{% endblock content %}

--- a/examples/halcyon-pane/templates/shortcodes/alert.html
+++ b/examples/halcyon-pane/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<aside class="callout callout-{{ type | default(value='note') }}">
+  <span class="callout-label">{{ type | default(value="note") | upper }}</span>
+  <div class="callout-body">{{ body }}</div>
+</aside>

--- a/examples/halcyon-pane/templates/taxonomy.html
+++ b/examples/halcyon-pane/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Index</p>
+  <h1 class="section-title">{{ page.title | default(value="Tags") | e }}</h1>
+  <p class="section-desc">Every topic written about so far.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/halcyon-pane/templates/taxonomy_term.html
+++ b/examples/halcyon-pane/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Tagged</p>
+  <h1 class="section-title">{{ page.title | default(value="Tag") | e }}</h1>
+  <p class="section-desc">Posts filed under this topic.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/lilac-frost/AGENTS.md
+++ b/examples/lilac-frost/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lilac-frost/config.toml
+++ b/examples/lilac-frost/config.toml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Lilac Frost"
+description = "A soft, pastel-toned journal about creative play, side projects, and the quiet joy of making things that don't have to matter."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.6
+
+[robots]
+enabled = true
+filename = "robots.txt"
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"
+full_content = true
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/examples/lilac-frost/content/about.md
+++ b/examples/lilac-frost/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Lilac Frost"
+description = "A soft spot for projects that don't have to matter."
+template = "page"
++++
+
+I have a folder called `experiments` with forty-one subfolders in it. Most are dead ends. A few became things I'm proud of. Exactly none of them started with a roadmap.
+
+Lilac Frost grew out of that folder. It's a journal about creative play — the kind of making that doesn't need to justify itself with a launch, a metric, or a market. I think we've over-optimized our hobbies into side hustles, and lost something in the trade: the permission to build a useless thing just because the idea wouldn't leave us alone.
+
+So this is a quiet argument for the useless project. For finishing things at a small scale. For treating constraints as a playground instead of a prison. Pull up a chair. Bring something half-built.

--- a/examples/lilac-frost/content/index.md
+++ b/examples/lilac-frost/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "A journal about making things for the joy of it"
+description = "Soft notes on creative play, side projects, and finishing what you start."
+template = "index"
++++
+
+Lilac Frost is a notebook about the things we make when nobody's paying us to. The weekend experiment, the tool only you will ever use, the project with no business plan and no point except that it was fun to build. Somewhere along the way, making got serious. This is a small attempt to make it playful again.

--- a/examples/lilac-frost/content/posts/_index.md
+++ b/examples/lilac-frost/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Writing"
+description = "Notes on creative play and finishing, newest first."
+template = "section"
+sort_by = "date"
++++
+
+Everything published on Lilac Frost.

--- a/examples/lilac-frost/content/posts/constraints-are-a-gift.md
+++ b/examples/lilac-frost/content/posts/constraints-are-a-gift.md
@@ -1,0 +1,21 @@
++++
+title = "Constraints Are a Gift"
+description = "A blank canvas is paralyzing. A small box is freeing. The best creative fuel is a good limitation."
+date = "2026-03-17"
+template = "page"
+tags = ["creativity", "play", "process"]
++++
+
+Hand someone unlimited time, budget, and scope, and watch them freeze. Total freedom is the enemy of starting — when anything is possible, nothing is obvious. The blank canvas isn't an invitation; it's an interrogation.
+
+Now hand the same person a tight constraint: build it in a weekend, in one file, using only three colors. Suddenly the ideas pour out. The box, paradoxically, sets you free.
+
+## Limits make decisions for you
+
+Most of the agony in a creative project is decision fatigue — a thousand tiny open questions, each one a place to stall. A good constraint closes most of those questions before you start. If the rule is "no JavaScript," you don't agonize over which framework. If the palette is fixed, you don't dither over color. The constraint decides, and you get to make things instead of choices.
+
+## Pick the constraint on purpose
+
+The trick is to choose your limitation deliberately rather than waiting for one to be imposed. Game jams do this with a theme and a deadline. Poets do it with a form. You can do it with anything: one afternoon, one tool, one tiny goal.
+
+The constraint doesn't have to be clever. It just has to be firm. A firm, slightly arbitrary rule is the best creative fuel there is — it turns the terrifying open field into a small, playful room where the only thing left to do is build.

--- a/examples/lilac-frost/content/posts/finishing-is-a-skill.md
+++ b/examples/lilac-frost/content/posts/finishing-is-a-skill.md
@@ -1,0 +1,25 @@
++++
+title = "Finishing Is a Skill"
+description = "Starting is easy and cheap. Finishing is a separate, learnable craft — and most unfinished projects die in the same place."
+date = "2026-04-12"
+template = "page"
+tags = ["side-projects", "process", "play"]
++++
+
+Everybody can start. The folder of abandoned projects is the universal artifact of anyone who makes things. Starting is the cheap part — it's all possibility and no compromise.
+
+Finishing is a different skill entirely, and the good news is that it's learnable.
+
+## Projects die at eighty percent
+
+There's a graveyard at the eighty-percent mark. The exciting problems are solved, the proof of concept works, and all that's left is the unglamorous twenty percent: the edge cases, the empty states, the polish, the actual shipping. This part is boring, and boredom is what kills more projects than difficulty ever does.
+
+Knowing the eighty-percent wall is coming is half the battle. When the excitement fades and the project feels suddenly tedious, that's not a sign it's a bad idea. It's a sign you've reached the part where finishing happens.
+
+{% alert(type="note") %}Define "done" before you start, and make it embarrassingly small. Not "a photo app" but "uploads one photo and shows it." You can always extend a finished thing. You can't extend a thing that never shipped.{% end %}
+
+## Shrink the finish line
+
+The reliable trick is to move the finish line closer until you can actually cross it. Cut scope ruthlessly. The grand version can be version two. Version one just has to *exist* — small, complete, and out of the unfinished folder.
+
+A finished tiny thing teaches you more than an abandoned ambitious thing, every single time. Finish small, finish often, and the skill compounds.

--- a/examples/lilac-frost/content/posts/useless-side-project.md
+++ b/examples/lilac-frost/content/posts/useless-side-project.md
@@ -1,0 +1,23 @@
++++
+title = "In Defense of the Useless Side Project"
+description = "Not every project needs an audience, a launch, or a reason. Some exist purely because the idea was fun."
+date = "2026-05-19"
+template = "page"
+tags = ["side-projects", "creativity", "play"]
++++
+
+Somewhere in the last decade, the side project got a job. It became the "portfolio piece," the "indie launch," the thing you build to escape your other job. Every weekend experiment now arrives with a pitch deck attached.
+
+I want to make a case for the other kind — the genuinely useless project. The one with no audience, no monetization, no point beyond the fact that you wanted to see if you could.
+
+## Useless is where the learning hides
+
+When a project has to succeed, you make safe choices. You reach for the framework you already know, the pattern that's proven, the path of least risk. When a project is allowed to be pointless, you take the weird turn. You try the technique you've never used because the stakes are zero. That's where the actual learning happens — in the experiments nobody's grading.
+
+> The project that taught me the most was a clock that displays the time as a color. Nobody needs it. I think about what I learned building it constantly.
+
+## Permission is the scarce resource
+
+The hard part isn't time or skill. It's permission — the internal voice asking what the *point* is. Giving yourself leave to build something that doesn't matter is a small act of rebellion against a culture that wants every hour to be productive.
+
+So build the useless thing. The generative art piece, the absurd browser extension, the tiny game only your friends will play. Joy is a sufficient reason. It always was; we just forgot.

--- a/examples/lilac-frost/templates/404.html
+++ b/examples/lilac-frost/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="notfound glass">
+  <p class="notfound-code">404</p>
+  <h1 class="notfound-title">This one got away</h1>
+  <p class="notfound-text">The page you wanted isn't here — maybe it was a half-built idea that never shipped. Let's head somewhere finished.</p>
+  <a class="button" href="{{ base_url }}/">Back home</a>
+</section>
+{% endblock content %}

--- a/examples/lilac-frost/templates/base.html
+++ b/examples/lilac-frost/templates/base.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Plus+Jakarta+Sans:wght@500;600;700&display=swap" rel="stylesheet">
+
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --bg: #ece9f6;
+      --ink: #251f37;
+      --muted: #6a6386;
+      --accent: #7c5cff;
+      --accent-deep: #5a35d6;
+      --line: rgba(37, 31, 55, 0.10);
+
+      --glass-bg: rgba(255, 255, 255, 0.52);
+      --glass-border: rgba(255, 255, 255, 0.72);
+      --glass-shadow: 0 16px 44px rgba(74, 52, 140, 0.15);
+      --glass-spec: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+
+      --radius: 24px;
+      --radius-sm: 15px;
+      --font-body: 'Inter', system-ui, sans-serif;
+      --font-head: 'Plus Jakarta Sans', system-ui, sans-serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0; font-family: var(--font-body); color: var(--ink);
+      background: var(--bg); line-height: 1.68; min-height: 100vh;
+      -webkit-font-smoothing: antialiased; position: relative; overflow-x: hidden;
+    }
+
+    /* Pastel color fields beneath the glass — solid fills, no gradients */
+    .field { position: fixed; z-index: 0; border-radius: 50%; filter: blur(95px); pointer-events: none; }
+    .field-a { width: 460px; height: 460px; background: #d3c6f6; opacity: 0.7; top: -120px; left: -90px; }
+    .field-b { width: 520px; height: 520px; background: #f4cdee; opacity: 0.6; bottom: -160px; right: -120px; }
+    .field-c { width: 350px; height: 350px; background: #c7d0f8; opacity: 0.6; top: 40%; right: 16%; }
+
+    .glass {
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(20px) saturate(165%); -webkit-backdrop-filter: blur(20px) saturate(165%);
+      border-radius: var(--radius);
+    }
+
+    .wrap { max-width: 880px; margin: 0 auto; padding: 0 1.4rem; position: relative; z-index: 1; }
+
+    /* Header */
+    .site-header {
+      position: sticky; top: 1rem; z-index: 50;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.85rem 1.5rem; margin: 1rem 0 2.5rem;
+    }
+    .site-logo { font-family: var(--font-head); font-weight: 700; font-size: 1.16rem; letter-spacing: -0.02em; color: var(--ink); text-decoration: none; }
+    .site-logo .dot { color: var(--accent); }
+    .site-nav { display: flex; gap: 0.3rem; }
+    .site-nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; font-weight: 500; padding: 0.4rem 0.85rem; border-radius: 999px; transition: color 0.2s, background 0.2s; }
+    .site-nav a:hover { color: var(--accent-deep); background: rgba(124, 92, 255, 0.1); }
+
+    .site-main { min-height: 60vh; padding-bottom: 1rem; }
+
+    /* Hero */
+    .hero { padding: 3.2rem 2.6rem; margin-bottom: 2.6rem; }
+    .hero-eyebrow { font-family: var(--font-head); text-transform: uppercase; letter-spacing: 0.22em; font-size: 0.72rem; color: var(--accent); margin: 0 0 0.9rem; font-weight: 700; }
+    .hero-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2.2rem, 6vw, 3.4rem); line-height: 1.07; letter-spacing: -0.03em; margin: 0 0 1rem; font-weight: 700; }
+    .hero-lede { font-size: 1.12rem; color: var(--muted); max-width: 54ch; }
+    .hero-lede p:first-child { margin-top: 0; }
+    .hero-actions { display: flex; gap: 0.7rem; margin-top: 1.9rem; flex-wrap: wrap; }
+
+    .button {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+      font-family: var(--font-head); font-weight: 600; font-size: 0.9rem;
+      padding: 0.72rem 1.5rem; border-radius: 999px; text-decoration: none;
+      background: var(--accent); color: #fff; border: 1px solid transparent;
+      transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+      box-shadow: 0 8px 24px rgba(124, 92, 255, 0.32);
+    }
+    .button:hover { transform: translateY(-2px); background: var(--accent-deep); box-shadow: 0 12px 30px rgba(124, 92, 255, 0.4); }
+    .button-ghost { background: rgba(255,255,255,0.52); color: var(--ink); border-color: var(--glass-border); box-shadow: none; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
+    .button-ghost:hover { background: rgba(255,255,255,0.84); color: var(--accent-deep); box-shadow: none; }
+
+    /* Feed — soft pastel grid */
+    .post-feed { margin-bottom: 3rem; }
+    .feed-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1.5rem; }
+    .feed-title { font-family: var(--font-head); font-size: 1.45rem; margin: 0; letter-spacing: -0.02em; }
+    .feed-all { color: var(--accent); text-decoration: none; font-weight: 600; font-size: 0.88rem; }
+    .feed-all:hover { color: var(--accent-deep); }
+
+    .post-list { list-style: none; margin: 0; padding: 0; display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.1rem; }
+    .post-card { transition: transform 0.25s, box-shadow 0.25s; }
+    .post-card:hover { transform: translateY(-4px) scale(1.01); box-shadow: 0 24px 54px rgba(74, 52, 140, 0.22), var(--glass-spec); }
+    .post-card-link { display: block; padding: 1.7rem 1.8rem; text-decoration: none; color: inherit; height: 100%; }
+    .post-card-date { font-size: 0.76rem; color: var(--muted); font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; }
+    .post-card-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: 1.3rem; line-height: 1.2; letter-spacing: -0.02em; margin: 0.55rem 0 0.5rem; }
+    .post-card-desc { color: var(--muted); margin: 0 0 0.9rem; font-size: 0.98rem; }
+    .read-more { font-family: var(--font-head); font-weight: 600; font-size: 0.86rem; color: var(--accent); }
+
+    /* Tags */
+    .tag-row { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 0.9rem 0 0; }
+    .tag { font-size: 0.73rem; font-weight: 600; letter-spacing: 0.02em; padding: 0.27rem 0.72rem; border-radius: 999px; text-decoration: none; background: rgba(124, 92, 255, 0.1); color: var(--accent-deep); border: 1px solid rgba(124, 92, 255, 0.18); }
+    a.tag:hover { background: rgba(124, 92, 255, 0.18); }
+
+    /* Single post */
+    .post { max-width: 700px; margin: 0 auto; }
+    .post-header { padding: 2.6rem 2.4rem 2rem; margin-bottom: 2.2rem; }
+    .post-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2rem, 5vw, 2.7rem); line-height: 1.1; letter-spacing: -0.03em; margin: 0 0 0.9rem; }
+    .post-meta { color: var(--muted); font-size: 0.88rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+    .meta-sep { opacity: 0.5; }
+    .post-content { font-size: 1.06rem; }
+
+    .section-head { margin: 1rem 0 2rem; }
+    .section-eyebrow { font-family: var(--font-head); text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.72rem; color: var(--accent); font-weight: 700; margin: 0 0 0.5rem; }
+    .section-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2rem, 5vw, 2.8rem); letter-spacing: -0.03em; margin: 0 0 0.5rem; }
+    .section-desc { color: var(--muted); font-size: 1.07rem; margin: 0; }
+    .section-intro { margin-bottom: 2rem; }
+
+    /* Post navigation */
+    .post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 2.5rem; padding: 1.3rem 1.6rem; }
+    .post-nav-link { display: flex; flex-direction: column; gap: 0.25rem; text-decoration: none; color: var(--ink); max-width: 46%; }
+    .post-nav-link.next { text-align: right; margin-left: auto; }
+    .post-nav-label { font-size: 0.76rem; color: var(--accent); font-weight: 600; }
+    .post-nav-title { font-family: var(--font-head); font-weight: 600; font-size: 0.98rem; }
+    .post-nav-link:hover .post-nav-title { color: var(--accent-deep); }
+
+    /* Terms */
+    .term-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 0.8rem; }
+    .term-item { padding: 0; }
+    .term-item a { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.7rem 1.2rem; text-decoration: none; color: var(--ink); font-family: var(--font-head); font-weight: 600; }
+    .term-item:hover a { color: var(--accent-deep); }
+    .term-count { background: rgba(124, 92, 255, 0.12); color: var(--accent-deep); border-radius: 999px; padding: 0.05rem 0.55rem; font-size: 0.76rem; }
+
+    /* Taxonomy auto-generated lists */
+    .tax-body .taxonomy-terms, .tax-body .taxonomy-pages { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 0.8rem; }
+    .tax-body li { margin: 0; }
+    .tax-body li a {
+      display: block; padding: 1rem 1.3rem; text-decoration: none; color: var(--ink);
+      font-family: var(--font-head); font-weight: 600;
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(16px) saturate(150%); -webkit-backdrop-filter: blur(16px) saturate(150%);
+      border-radius: var(--radius-sm); transition: transform 0.2s, color 0.2s;
+    }
+    .tax-body li a:hover { transform: translateY(-3px); color: var(--accent-deep); }
+
+    /* Pagination */
+    .pagination { display: flex; align-items: center; justify-content: center; gap: 1rem; margin: 2.5rem 0 1rem; }
+    .page-link { text-decoration: none; color: var(--accent); font-weight: 600; font-family: var(--font-head); padding: 0.5rem 1rem; border-radius: 999px; }
+    .page-link:hover { background: rgba(124, 92, 255, 0.1); }
+    .page-link.disabled { color: var(--muted); opacity: 0.45; }
+    .page-current { font-family: var(--font-head); color: var(--muted); font-size: 0.9rem; }
+
+    /* Callout */
+    .callout { display: flex; gap: 0.9rem; align-items: flex-start; padding: 1.1rem 1.3rem; border-radius: var(--radius-sm); margin: 1.6rem 0; background: rgba(124, 92, 255, 0.07); border: 1px solid rgba(124, 92, 255, 0.18); }
+    .callout-label { font-family: var(--font-head); font-size: 0.68rem; font-weight: 700; letter-spacing: 0.08em; color: #fff; background: var(--accent); padding: 0.18rem 0.55rem; border-radius: 6px; flex-shrink: 0; margin-top: 0.2rem; }
+    .callout-body { color: var(--ink); }
+    .callout-body p { margin: 0; }
+    .callout-warning { background: rgba(214, 110, 60, 0.09); border-color: rgba(214, 110, 60, 0.26); }
+    .callout-warning .callout-label { background: #d66e3c; }
+
+    /* 404 */
+    .notfound { text-align: center; padding: 4rem 2rem; }
+    .notfound-code { font-family: var(--font-head); font-size: 5rem; font-weight: 700; color: var(--accent); margin: 0; letter-spacing: -0.04em; }
+    .notfound-title { font-family: var(--font-head); font-size: 1.6rem; margin: 0.5rem 0 1rem; }
+    .notfound-text { color: var(--muted); max-width: 40ch; margin: 0 auto 1.8rem; }
+
+    /* Footer */
+    .site-footer { text-align: center; padding: 1.8rem; margin: 3rem 0 2rem; color: var(--muted); font-size: 0.9rem; }
+    .site-footer a { color: var(--accent); text-decoration: none; }
+    .site-footer a:hover { color: var(--accent-deep); }
+
+    /* Content typography */
+    .post-content h2, .post-content h3, .post-content h4 { font-family: var(--font-head); letter-spacing: -0.02em; line-height: 1.25; margin: 2rem 0 0.8rem; }
+    .post-content h2 { font-size: 1.5rem; }
+    .post-content h3 { font-size: 1.24rem; }
+    .post-content p { margin: 1.1rem 0; }
+    .post-content a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; }
+    .post-content a:hover { color: var(--accent-deep); }
+    .post-content ul, .post-content ol { padding-left: 1.3rem; }
+    .post-content li { margin: 0.4rem 0; }
+    .post-content img { max-width: 100%; height: auto; border-radius: var(--radius-sm); }
+    .post-content blockquote { margin: 1.6rem 0; padding: 0.6rem 1.3rem; border-left: 3px solid var(--accent); background: rgba(124, 92, 255, 0.05); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; color: var(--ink); font-style: italic; }
+    .post-content code { font-family: ui-monospace, Menlo, monospace; font-size: 0.88em; background: rgba(37, 31, 55, 0.07); padding: 0.15rem 0.4rem; border-radius: 6px; }
+    .post-content pre { background: #1d1830; color: #ece9f6; padding: 1.3rem 1.5rem; border-radius: var(--radius-sm); overflow-x: auto; font-size: 0.9rem; }
+    .post-content pre code { background: none; padding: 0; color: inherit; }
+    .post-content hr { border: 0; height: 1px; background: var(--line); margin: 2.5rem 0; }
+    .post-content table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.95rem; }
+    .post-content th, .post-content td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid var(--line); }
+    .post-content th { font-family: var(--font-head); }
+
+    @media (max-width: 680px) {
+      .site-header { flex-direction: column; gap: 0.7rem; padding: 1rem; top: 0.5rem; }
+      .hero { padding: 2.3rem 1.6rem; }
+      .hero-title { font-size: 1.85rem; }
+      .post-list { grid-template-columns: 1fr; }
+      .post-header { padding: 1.9rem 1.6rem 1.5rem; }
+      .post-nav { flex-direction: column; }
+      .post-nav-link, .post-nav-link.next { max-width: 100%; text-align: left; margin-left: 0; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="field field-a"></div>
+  <div class="field field-b"></div>
+  <div class="field field-c"></div>
+
+  <div class="wrap">
+    <header class="site-header glass">
+      <a href="{{ base_url }}/" class="site-logo">lilac<span class="dot">.</span>frost</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Blog</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="site-footer">
+      <p>Lilac Frost &mdash; built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+    </footer>
+  </div>
+
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/lilac-frost/templates/index.html
+++ b/examples/lilac-frost/templates/index.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero glass">
+  <p class="hero-eyebrow">{{ site.title }}</p>
+  <h1 class="hero-title">{{ page.title | default(value=site.title) }}</h1>
+  <div class="hero-lede">
+    {{ content | safe }}
+  </div>
+  <div class="hero-actions">
+    <a class="button" href="#writing">Latest posts</a>
+    <a class="button button-ghost" href="{{ base_url }}/about/">About</a>
+  </div>
+</section>
+
+{% set posts = site.pages | selectattr("date") | sort(attribute="date", reverse=true) %}
+{% if posts %}
+<section class="post-feed" id="writing">
+  <div class="feed-head">
+    <h2 class="feed-title">Latest writing</h2>
+    <a class="feed-all" href="{{ base_url }}/posts/">All posts &rarr;</a>
+  </div>
+  <ul class="post-list">
+    {% for post in posts %}
+    {% if loop.index0 < 6 %}
+    <li class="post-card glass">
+      <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+        <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+        <h3 class="post-card-title">{{ post.title }}</h3>
+        {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+        {% if post.tags %}
+        <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+        {% endif %}
+        <span class="read-more">Read more &rarr;</span>
+      </a>
+    </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+{% endblock content %}

--- a/examples/lilac-frost/templates/page.html
+++ b/examples/lilac-frost/templates/page.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="post">
+  {% if page.title is present %}
+  <header class="post-header glass">
+    <h1 class="post-title">{{ page.title }}</h1>
+    <div class="post-meta">
+      {% if page.date is present %}<time datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+      {% if page.reading_time is present %}<span class="meta-sep">/</span><span>{{ page.reading_time }} min read</span>{% endif %}
+    </div>
+    {% if page.tags %}
+    <div class="tag-row">
+      {% for tag in page.tags %}<a class="tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>{% endfor %}
+    </div>
+    {% endif %}
+  </header>
+  {% endif %}
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+  {% if page.lower or page.higher %}
+  <nav class="post-nav glass">
+    {% if page.higher %}
+    <a class="post-nav-link prev" href="{{ base_url }}{{ page.higher.url }}">
+      <span class="post-nav-label">&larr; Previous</span>
+      <span class="post-nav-title">{{ page.higher.title }}</span>
+    </a>
+    {% else %}<span></span>{% endif %}
+    {% if page.lower %}
+    <a class="post-nav-link next" href="{{ base_url }}{{ page.lower.url }}">
+      <span class="post-nav-label">Next &rarr;</span>
+      <span class="post-nav-title">{{ page.lower.title }}</span>
+    </a>
+    {% endif %}
+  </nav>
+  {% endif %}
+</article>
+{% endblock content %}

--- a/examples/lilac-frost/templates/section.html
+++ b/examples/lilac-frost/templates/section.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <h1 class="section-title">{{ page.title | default(value=page.section | capitalize) }}</h1>
+  {% if page.description %}<p class="section-desc">{{ page.description }}</p>{% endif %}
+</header>
+{% if content %}<div class="post-content section-intro">{{ content | safe }}</div>{% endif %}
+{% if section.pages %}
+<ul class="post-list">
+  {% for post in section.pages %}
+  <li class="post-card glass">
+    <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+      {% if post.date %}
+      <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+      {% endif %}
+      <h2 class="post-card-title">{{ post.title | default(value=post.slug) }}</h2>
+      {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+      {% if post.tags %}
+      <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+      {% endif %}
+      <span class="read-more">Read more &rarr;</span>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if pagination is present and pagination.total_pages > 1 %}
+<nav class="pagination">
+  {% if pagination.prev is present %}<a class="page-link" href="{{ base_url }}{{ pagination.prev }}">&larr; Newer</a>{% else %}<span class="page-link disabled">&larr; Newer</span>{% endif %}
+  <span class="page-current">{{ pagination.current_page }} / {{ pagination.total_pages }}</span>
+  {% if pagination.next is present %}<a class="page-link" href="{{ base_url }}{{ pagination.next }}">Older &rarr;</a>{% else %}<span class="page-link disabled">Older &rarr;</span>{% endif %}
+</nav>
+{% endif %}
+{% endblock content %}

--- a/examples/lilac-frost/templates/shortcodes/alert.html
+++ b/examples/lilac-frost/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<aside class="callout callout-{{ type | default(value='note') }}">
+  <span class="callout-label">{{ type | default(value="note") | upper }}</span>
+  <div class="callout-body">{{ body }}</div>
+</aside>

--- a/examples/lilac-frost/templates/taxonomy.html
+++ b/examples/lilac-frost/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Index</p>
+  <h1 class="section-title">{{ page.title | default(value="Tags") | e }}</h1>
+  <p class="section-desc">Every topic written about so far.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/lilac-frost/templates/taxonomy_term.html
+++ b/examples/lilac-frost/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Tagged</p>
+  <h1 class="section-title">{{ page.title | default(value="Tag") | e }}</h1>
+  <p class="section-desc">Posts filed under this topic.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/prism-drift/AGENTS.md
+++ b/examples/prism-drift/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/prism-drift/config.toml
+++ b/examples/prism-drift/config.toml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Prism Drift"
+description = "A bright, frosted-glass blog about design systems, light, and the craft of clear interfaces."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.6
+
+[robots]
+enabled = true
+filename = "robots.txt"
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"
+full_content = true
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/examples/prism-drift/content/about.md
+++ b/examples/prism-drift/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Prism Drift"
+description = "Why this blog exists and what you'll find here."
+template = "page"
++++
+
+Prism Drift started as a folder of half-finished CSS experiments and a stubborn belief that most interfaces try too hard.
+
+I write here about the small decisions that decide whether a screen feels calm or cluttered — type scales, the physics of translucency, how one accent color can carry an entire layout if you trust it. The pieces are short on purpose. A good idea usually fits in a few hundred words; everything past that is throat-clearing.
+
+If you build things people look at all day, you're in the right place. Pour something, scroll slowly, disagree with me by email.

--- a/examples/prism-drift/content/index.md
+++ b/examples/prism-drift/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "Notes on light, type, and clear interfaces"
+description = "A frosted-glass blog about design systems and the craft of clarity."
+template = "index"
++++
+
+Prism Drift is a small journal about the parts of interface design that don't shout: the weight of a single accent, the way a frosted surface borrows color from what sits behind it, the discipline of leaving things out.

--- a/examples/prism-drift/content/posts/_index.md
+++ b/examples/prism-drift/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Writing"
+description = "Field notes on interface craft, one idea at a time."
+template = "section"
+sort_by = "date"
++++
+
+Everything published on Prism Drift, newest first.

--- a/examples/prism-drift/content/posts/designing-with-light.md
+++ b/examples/prism-drift/content/posts/designing-with-light.md
@@ -1,0 +1,27 @@
++++
+title = "Designing With Light, Not Color"
+description = "Translucent surfaces don't need a palette. They borrow one from whatever sits behind them."
+date = "2026-05-18"
+template = "page"
+tags = ["design", "glass", "color"]
++++
+
+The fastest way to make an interface feel heavy is to fill every panel with a flat, opaque color. The screen turns into a stack of cards competing for attention, each one insisting on its own background.
+
+Frosted glass solves this almost by accident. A translucent panel doesn't carry a color of its own — it samples the color underneath it and blurs it into something soft. Move the panel, and its tint changes. The design stays alive instead of locking into a fixed swatch.
+
+## Let the background do the work
+
+The trick is to give the glass something worth blurring. A single flat backdrop produces flat glass. Place two or three large, soft fields of color behind the layout — well out of focus — and every translucent surface picks up a faint, shifting wash.
+
+> A glass panel over a white wall is just a gray box. A glass panel over color is jewelry.
+
+You don't need motion or gradients for this. Solid color blocks, heavily blurred, sitting far behind the content layer, are enough. The blur is doing the gradient's job without any of the banding.
+
+## Keep the tint honest
+
+The temptation is to crank the saturation until the glass glows. Resist it. The effect reads as *real* only when the tint stays subtle — somewhere between five and fifteen percent. Past that, it stops looking like glass and starts looking like a colored filter.
+
+{% alert(type="note") %}A quick test: screenshot your glass panel, then desaturate it. If it still reads as a clean, layered surface, your structure is doing the work. If it collapses into mud, you were leaning on color to hide weak hierarchy.{% end %}
+
+Light is a better material than color because it's responsive. Build with it, and the interface feels like it belongs to the screen rather than painted on top of it.

--- a/examples/prism-drift/content/posts/glass-without-gimmick.md
+++ b/examples/prism-drift/content/posts/glass-without-gimmick.md
@@ -1,0 +1,25 @@
++++
+title = "Glass Without the Gimmick"
+description = "Glassmorphism earned its bad reputation honestly. Here's how to use it without joining the pile."
+date = "2026-03-30"
+template = "page"
+tags = ["glass", "design", "css"]
++++
+
+Glassmorphism went from fresh to cliché in about eighteen months. Every dashboard sprouted blurry panels; every landing page floated cards over a stock photo. The technique wasn't the problem. The overuse was.
+
+Used sparingly, a frosted surface still does something no flat panel can: it suggests depth honestly. You can tell what's in front and what's behind. That's genuinely useful for navigation that stays fixed while content scrolls underneath.
+
+## Three rules that keep it tasteful
+
+**One, blur with intent.** A sticky header and maybe the content cards. Not every element. When everything is glass, the layering cue disappears and you're left with a foggy mess.
+
+**Two, give the edge a highlight.** Real glass catches light along its top edge. A one-pixel inset highlight — brighter than the panel, no gradient required — is the difference between "frosted glass" and "semi-transparent div."
+
+**Three, mind the contrast.** Text on glass can drift below readable contrast the moment the background shifts. Keep the panel opaque enough that body text never has to fight the wallpaper.
+
+## When to skip it entirely
+
+If the content is dense — long articles, data tables, forms — drop the glass. Translucency is a garnish for chrome and navigation, not a treatment for the things people actually read. The reading surface should be calm and solid.
+
+Glass works when it's the exception. The moment it becomes the default, it stops signaling depth and starts signaling that you reached for the same effect as everyone else.

--- a/examples/prism-drift/content/posts/single-accent.md
+++ b/examples/prism-drift/content/posts/single-accent.md
@@ -1,0 +1,23 @@
++++
+title = "The Quiet Power of a Single Accent"
+description = "One accent color, used with discipline, will out-design a six-color palette every time."
+date = "2026-04-27"
+template = "page"
+tags = ["design", "color", "systems"]
++++
+
+Most palettes are too big. A designer picks a primary, a secondary, a tertiary, two accents, a warning, a success — and then spends the rest of the project deciding which of seven blues a button should be.
+
+Try the opposite. Pick one accent. Give yourself a neutral ink for text, a soft canvas for background, and exactly one color that means *something is interactive or important here*. That's the whole system.
+
+## Constraint creates meaning
+
+When only one color pops, that color becomes a signal. The eye learns it in seconds: this is where I click, this is what matters. With six accents, nothing is a signal because everything is.
+
+Links, primary buttons, active states, focus rings, the little dot in a logo — all the same hue. Repetition turns a color into a brand without a single brand guideline.
+
+## Earn your second color slowly
+
+You'll eventually want a second color, usually for warnings or errors. Add it only when the interface genuinely needs to say *stop*. Even then, keep it muted. A warning amber at sixty percent saturation reads as serious. At full blast it reads as a toy.
+
+The restraint isn't minimalism for its own sake. It's that a small palette is easier to keep consistent, easier to theme, and far easier for someone else to extend without breaking the logic. One accent is a decision. Seven accents is a series of arguments you'll have with yourself forever.

--- a/examples/prism-drift/templates/404.html
+++ b/examples/prism-drift/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="notfound glass">
+  <p class="notfound-code">404</p>
+  <h1 class="notfound-title">This page drifted out of focus</h1>
+  <p class="notfound-text">The page you were looking for has moved or never existed. Let's get you back to clearer ground.</p>
+  <a class="button" href="{{ base_url }}/">Back home</a>
+</section>
+{% endblock content %}

--- a/examples/prism-drift/templates/base.html
+++ b/examples/prism-drift/templates/base.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --bg: #e8eaf3;
+      --ink: #181b2a;
+      --muted: #5b6079;
+      --accent: #4f46e5;
+      --accent-deep: #3730a3;
+      --line: rgba(24, 27, 42, 0.09);
+
+      --glass-bg: rgba(255, 255, 255, 0.55);
+      --glass-border: rgba(255, 255, 255, 0.72);
+      --glass-shadow: 0 14px 40px rgba(42, 46, 84, 0.14);
+      --glass-spec: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+
+      --radius: 22px;
+      --radius-sm: 14px;
+      --font-body: 'Inter', system-ui, sans-serif;
+      --font-head: 'Space Grotesk', system-ui, sans-serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      font-family: var(--font-body);
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.65;
+      min-height: 100vh;
+      -webkit-font-smoothing: antialiased;
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    /* Soft color fields that the glass refracts over — solid fills, no gradients */
+    .field { position: fixed; z-index: 0; border-radius: 50%; filter: blur(90px); opacity: 0.55; pointer-events: none; }
+    .field-a { width: 460px; height: 460px; background: #c4caff; top: -120px; left: -90px; }
+    .field-b { width: 520px; height: 520px; background: #ffd3e6; bottom: -160px; right: -120px; opacity: 0.5; }
+    .field-c { width: 360px; height: 360px; background: #c6f2e4; top: 38%; right: 18%; opacity: 0.4; }
+
+    .glass {
+      background: var(--glass-bg);
+      border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(20px) saturate(170%);
+      -webkit-backdrop-filter: blur(20px) saturate(170%);
+      border-radius: var(--radius);
+    }
+
+    .wrap { max-width: 880px; margin: 0 auto; padding: 0 1.4rem; position: relative; z-index: 1; }
+
+    /* Header */
+    .site-header {
+      position: sticky; top: 1rem; z-index: 50;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.85rem 1.4rem; margin: 1rem 0 2.5rem;
+    }
+    .site-logo {
+      font-family: var(--font-head); font-weight: 700; font-size: 1.15rem;
+      letter-spacing: -0.02em; color: var(--ink); text-decoration: none;
+    }
+    .site-logo .dot { color: var(--accent); }
+    .site-nav { display: flex; gap: 0.4rem; }
+    .site-nav a {
+      color: var(--muted); text-decoration: none; font-size: 0.92rem; font-weight: 500;
+      padding: 0.4rem 0.85rem; border-radius: 999px; transition: color 0.2s, background 0.2s;
+    }
+    .site-nav a:hover { color: var(--accent-deep); background: rgba(79, 70, 229, 0.1); }
+
+    .site-main { min-height: 60vh; padding-bottom: 1rem; }
+
+    /* Hero */
+    .hero { padding: 3rem 2.4rem; margin-bottom: 2.5rem; }
+    .hero-eyebrow { font-family: var(--font-head); text-transform: uppercase; letter-spacing: 0.22em; font-size: 0.72rem; color: var(--accent); margin: 0 0 0.9rem; font-weight: 600; }
+    .hero-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2.2rem, 6vw, 3.4rem); line-height: 1.04; letter-spacing: -0.03em; margin: 0 0 1rem; font-weight: 700; }
+    .hero-lede { font-size: 1.12rem; color: var(--muted); max-width: 52ch; }
+    .hero-lede p:first-child { margin-top: 0; }
+    .hero-actions { display: flex; gap: 0.7rem; margin-top: 1.8rem; flex-wrap: wrap; }
+
+    .button {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+      font-family: var(--font-head); font-weight: 600; font-size: 0.92rem;
+      padding: 0.7rem 1.4rem; border-radius: 999px; text-decoration: none;
+      background: var(--accent); color: #fff; border: 1px solid transparent;
+      transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+      box-shadow: 0 8px 20px rgba(79, 70, 229, 0.28);
+    }
+    .button:hover { transform: translateY(-2px); background: var(--accent-deep); box-shadow: 0 12px 26px rgba(79, 70, 229, 0.34); }
+    .button-ghost { background: rgba(255,255,255,0.5); color: var(--ink); border-color: var(--glass-border); box-shadow: none; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
+    .button-ghost:hover { background: rgba(255,255,255,0.8); color: var(--accent-deep); box-shadow: none; }
+
+    /* Feed */
+    .post-feed { margin-bottom: 3rem; }
+    .feed-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1.4rem; }
+    .feed-title { font-family: var(--font-head); font-size: 1.45rem; margin: 0; letter-spacing: -0.02em; }
+    .feed-all { color: var(--accent); text-decoration: none; font-weight: 600; font-size: 0.9rem; }
+    .feed-all:hover { color: var(--accent-deep); }
+
+    .post-list { list-style: none; margin: 0; padding: 0; display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.1rem; }
+    .post-card { transition: transform 0.25s, box-shadow 0.25s; }
+    .post-card:hover { transform: translateY(-4px); box-shadow: 0 22px 48px rgba(42, 46, 84, 0.2), var(--glass-spec); }
+    .post-card-link { display: block; padding: 1.6rem 1.7rem; text-decoration: none; color: inherit; height: 100%; }
+    .post-card-date { font-size: 0.78rem; color: var(--muted); font-weight: 500; letter-spacing: 0.04em; text-transform: uppercase; }
+    .post-card-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: 1.3rem; line-height: 1.2; letter-spacing: -0.02em; margin: 0.55rem 0 0.5rem; }
+    .post-card-desc { color: var(--muted); margin: 0 0 0.9rem; font-size: 0.98rem; }
+    .read-more { font-family: var(--font-head); font-weight: 600; font-size: 0.88rem; color: var(--accent); }
+
+    /* Tags */
+    .tag-row { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 0.9rem 0 0; }
+    .tag {
+      font-size: 0.74rem; font-weight: 600; letter-spacing: 0.03em;
+      padding: 0.28rem 0.7rem; border-radius: 999px; text-decoration: none;
+      background: rgba(79, 70, 229, 0.1); color: var(--accent-deep); border: 1px solid rgba(79, 70, 229, 0.16);
+    }
+    a.tag:hover { background: rgba(79, 70, 229, 0.18); }
+
+    /* Single post */
+    .post { max-width: 720px; margin: 0 auto; }
+    .post-header { padding: 2.4rem 2.2rem 1.8rem; margin-bottom: 2rem; }
+    .post-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(1.9rem, 5vw, 2.7rem); line-height: 1.08; letter-spacing: -0.03em; margin: 0 0 0.9rem; }
+    .post-meta { color: var(--muted); font-size: 0.9rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+    .meta-sep { opacity: 0.5; }
+    .post-content { font-size: 1.06rem; }
+
+    .section-head { margin: 1rem 0 2rem; }
+    .section-eyebrow { font-family: var(--font-head); text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.72rem; color: var(--accent); font-weight: 600; margin: 0 0 0.5rem; }
+    .section-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2rem, 5vw, 2.8rem); letter-spacing: -0.03em; margin: 0 0 0.5rem; }
+    .section-desc { color: var(--muted); font-size: 1.08rem; margin: 0; }
+    .section-intro { margin-bottom: 2rem; }
+
+    /* Post navigation */
+    .post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 2.5rem; padding: 1.3rem 1.6rem; }
+    .post-nav-link { display: flex; flex-direction: column; gap: 0.25rem; text-decoration: none; color: var(--ink); max-width: 46%; }
+    .post-nav-link.next { text-align: right; margin-left: auto; }
+    .post-nav-label { font-size: 0.78rem; color: var(--accent); font-weight: 600; }
+    .post-nav-title { font-family: var(--font-head); font-weight: 600; font-size: 0.98rem; }
+    .post-nav-link:hover .post-nav-title { color: var(--accent-deep); }
+
+    /* Terms */
+    .term-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 0.8rem; }
+    .term-item { padding: 0; }
+    .term-item a { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.7rem 1.2rem; text-decoration: none; color: var(--ink); font-family: var(--font-head); font-weight: 600; }
+    .term-item:hover a { color: var(--accent-deep); }
+    .term-count { background: rgba(79, 70, 229, 0.12); color: var(--accent-deep); border-radius: 999px; padding: 0.05rem 0.55rem; font-size: 0.78rem; }
+
+    /* Taxonomy auto-generated lists */
+    .tax-body .taxonomy-terms, .tax-body .taxonomy-pages { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 0.8rem; }
+    .tax-body li { margin: 0; }
+    .tax-body li a {
+      display: block; padding: 1rem 1.3rem; text-decoration: none; color: var(--ink);
+      font-family: var(--font-head); font-weight: 600;
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(16px) saturate(150%); -webkit-backdrop-filter: blur(16px) saturate(150%);
+      border-radius: var(--radius-sm); transition: transform 0.2s, color 0.2s;
+    }
+    .tax-body li a:hover { transform: translateY(-3px); color: var(--accent-deep); }
+
+    /* Pagination */
+    .pagination { display: flex; align-items: center; justify-content: center; gap: 1rem; margin: 2.5rem 0 1rem; }
+    .page-link { text-decoration: none; color: var(--accent); font-weight: 600; font-family: var(--font-head); padding: 0.5rem 1rem; border-radius: 999px; }
+    .page-link:hover { background: rgba(79, 70, 229, 0.1); }
+    .page-link.disabled { color: var(--muted); opacity: 0.45; }
+    .page-current { font-family: var(--font-head); color: var(--muted); font-size: 0.9rem; }
+
+    /* Callout */
+    .callout { display: flex; gap: 0.9rem; align-items: flex-start; padding: 1.1rem 1.3rem; border-radius: var(--radius-sm); margin: 1.6rem 0; background: rgba(79, 70, 229, 0.07); border: 1px solid rgba(79, 70, 229, 0.16); }
+    .callout-label { font-family: var(--font-head); font-size: 0.7rem; font-weight: 700; letter-spacing: 0.08em; color: #fff; background: var(--accent); padding: 0.18rem 0.55rem; border-radius: 6px; flex-shrink: 0; margin-top: 0.15rem; }
+    .callout-body { color: var(--ink); }
+    .callout-body p { margin: 0; }
+    .callout-warning { background: rgba(217, 119, 6, 0.08); border-color: rgba(217, 119, 6, 0.2); }
+    .callout-warning .callout-label { background: #d97706; }
+
+    /* 404 */
+    .notfound { text-align: center; padding: 4rem 2rem; }
+    .notfound-code { font-family: var(--font-head); font-size: 5rem; font-weight: 700; color: var(--accent); margin: 0; letter-spacing: -0.04em; }
+    .notfound-title { font-family: var(--font-head); font-size: 1.6rem; margin: 0.5rem 0 1rem; }
+    .notfound-text { color: var(--muted); max-width: 40ch; margin: 0 auto 1.8rem; }
+
+    /* Footer */
+    .site-footer { text-align: center; padding: 1.8rem; margin: 3rem 0 2rem; color: var(--muted); font-size: 0.9rem; }
+    .site-footer a { color: var(--accent); text-decoration: none; }
+    .site-footer a:hover { color: var(--accent-deep); }
+
+    /* Content typography */
+    .post-content h2, .post-content h3, .post-content h4 { font-family: var(--font-head); letter-spacing: -0.02em; line-height: 1.2; margin: 2rem 0 0.8rem; }
+    .post-content h2 { font-size: 1.55rem; }
+    .post-content h3 { font-size: 1.25rem; }
+    .post-content p { margin: 1.1rem 0; }
+    .post-content a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; }
+    .post-content a:hover { color: var(--accent-deep); }
+    .post-content ul, .post-content ol { padding-left: 1.3rem; }
+    .post-content li { margin: 0.4rem 0; }
+    .post-content img { max-width: 100%; height: auto; border-radius: var(--radius-sm); }
+    .post-content blockquote { margin: 1.6rem 0; padding: 0.6rem 1.3rem; border-left: 3px solid var(--accent); background: rgba(79, 70, 229, 0.05); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; color: var(--ink); font-style: italic; }
+    .post-content code { font-family: 'Space Grotesk', ui-monospace, monospace; font-size: 0.9em; background: rgba(24, 27, 42, 0.06); padding: 0.15rem 0.4rem; border-radius: 6px; }
+    .post-content pre { background: #14172a; color: #e6e8f5; padding: 1.3rem 1.5rem; border-radius: var(--radius-sm); overflow-x: auto; font-size: 0.9rem; }
+    .post-content pre code { background: none; padding: 0; color: inherit; }
+    .post-content hr { border: 0; height: 1px; background: var(--line); margin: 2.5rem 0; }
+    .post-content table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.95rem; }
+    .post-content th, .post-content td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid var(--line); }
+    .post-content th { font-family: var(--font-head); }
+
+    @media (max-width: 680px) {
+      .site-header { flex-direction: column; gap: 0.7rem; padding: 1rem; top: 0.5rem; }
+      .hero { padding: 2.2rem 1.5rem; }
+      .hero-title { font-size: 1.85rem; }
+      .post-list { grid-template-columns: 1fr; }
+      .post-header { padding: 1.8rem 1.5rem 1.4rem; }
+      .post-nav { flex-direction: column; }
+      .post-nav-link, .post-nav-link.next { max-width: 100%; text-align: left; margin-left: 0; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="field field-a"></div>
+  <div class="field field-b"></div>
+  <div class="field field-c"></div>
+
+  <div class="wrap">
+    <header class="site-header glass">
+      <a href="{{ base_url }}/" class="site-logo">prism<span class="dot">.</span>drift</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Blog</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="site-footer">
+      <p>Prism Drift &mdash; built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+    </footer>
+  </div>
+
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/prism-drift/templates/index.html
+++ b/examples/prism-drift/templates/index.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero glass">
+  <p class="hero-eyebrow">{{ site.title }}</p>
+  <h1 class="hero-title">{{ page.title | default(value=site.title) }}</h1>
+  <div class="hero-lede">
+    {{ content | safe }}
+  </div>
+  <div class="hero-actions">
+    <a class="button" href="#writing">Latest posts</a>
+    <a class="button button-ghost" href="{{ base_url }}/about/">About</a>
+  </div>
+</section>
+
+{% set posts = site.pages | selectattr("date") | sort(attribute="date", reverse=true) %}
+{% if posts %}
+<section class="post-feed" id="writing">
+  <div class="feed-head">
+    <h2 class="feed-title">Latest writing</h2>
+    <a class="feed-all" href="{{ base_url }}/posts/">All posts &rarr;</a>
+  </div>
+  <ul class="post-list">
+    {% for post in posts %}
+    {% if loop.index0 < 6 %}
+    <li class="post-card glass">
+      <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+        <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+        <h3 class="post-card-title">{{ post.title }}</h3>
+        {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+        {% if post.tags %}
+        <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+        {% endif %}
+        <span class="read-more">Read more &rarr;</span>
+      </a>
+    </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+{% endblock content %}

--- a/examples/prism-drift/templates/page.html
+++ b/examples/prism-drift/templates/page.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="post">
+  {% if page.title is present %}
+  <header class="post-header glass">
+    <h1 class="post-title">{{ page.title }}</h1>
+    <div class="post-meta">
+      {% if page.date is present %}<time datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+      {% if page.reading_time is present %}<span class="meta-sep">/</span><span>{{ page.reading_time }} min read</span>{% endif %}
+    </div>
+    {% if page.tags %}
+    <div class="tag-row">
+      {% for tag in page.tags %}<a class="tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>{% endfor %}
+    </div>
+    {% endif %}
+  </header>
+  {% endif %}
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+  {% if page.lower or page.higher %}
+  <nav class="post-nav glass">
+    {% if page.higher %}
+    <a class="post-nav-link prev" href="{{ base_url }}{{ page.higher.url }}">
+      <span class="post-nav-label">&larr; Previous</span>
+      <span class="post-nav-title">{{ page.higher.title }}</span>
+    </a>
+    {% else %}<span></span>{% endif %}
+    {% if page.lower %}
+    <a class="post-nav-link next" href="{{ base_url }}{{ page.lower.url }}">
+      <span class="post-nav-label">Next &rarr;</span>
+      <span class="post-nav-title">{{ page.lower.title }}</span>
+    </a>
+    {% endif %}
+  </nav>
+  {% endif %}
+</article>
+{% endblock content %}

--- a/examples/prism-drift/templates/section.html
+++ b/examples/prism-drift/templates/section.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <h1 class="section-title">{{ page.title | default(value=page.section | capitalize) }}</h1>
+  {% if page.description %}<p class="section-desc">{{ page.description }}</p>{% endif %}
+</header>
+{% if content %}<div class="post-content section-intro">{{ content | safe }}</div>{% endif %}
+{% if section.pages %}
+<ul class="post-list">
+  {% for post in section.pages %}
+  <li class="post-card glass">
+    <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+      {% if post.date %}
+      <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+      {% endif %}
+      <h2 class="post-card-title">{{ post.title | default(value=post.slug) }}</h2>
+      {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+      {% if post.tags %}
+      <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+      {% endif %}
+      <span class="read-more">Read more &rarr;</span>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if pagination is present and pagination.total_pages > 1 %}
+<nav class="pagination">
+  {% if pagination.prev is present %}<a class="page-link" href="{{ base_url }}{{ pagination.prev }}">&larr; Newer</a>{% else %}<span class="page-link disabled">&larr; Newer</span>{% endif %}
+  <span class="page-current">{{ pagination.current_page }} / {{ pagination.total_pages }}</span>
+  {% if pagination.next is present %}<a class="page-link" href="{{ base_url }}{{ pagination.next }}">Older &rarr;</a>{% else %}<span class="page-link disabled">Older &rarr;</span>{% endif %}
+</nav>
+{% endif %}
+{% endblock content %}

--- a/examples/prism-drift/templates/shortcodes/alert.html
+++ b/examples/prism-drift/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<aside class="callout callout-{{ type | default(value='note') }}">
+  <span class="callout-label">{{ type | default(value="note") | upper }}</span>
+  <div class="callout-body">{{ body }}</div>
+</aside>

--- a/examples/prism-drift/templates/taxonomy.html
+++ b/examples/prism-drift/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Index</p>
+  <h1 class="section-title">{{ page.title | default(value="Tags") | e }}</h1>
+  <p class="section-desc">Every topic written about so far.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/prism-drift/templates/taxonomy_term.html
+++ b/examples/prism-drift/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Tagged</p>
+  <h1 class="section-title">{{ page.title | default(value="Tag") | e }}</h1>
+  <p class="section-desc">Posts filed under this topic.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/umbra-glass/AGENTS.md
+++ b/examples/umbra-glass/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/umbra-glass/config.toml
+++ b/examples/umbra-glass/config.toml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Umbra Glass"
+description = "A dark-mode journal on low-light interface design, contrast, and building screens that are easy on the eyes after midnight."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.6
+
+[robots]
+enabled = true
+filename = "robots.txt"
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"
+full_content = true
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/examples/umbra-glass/content/about.md
+++ b/examples/umbra-glass/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Umbra Glass"
+description = "A field journal on designing for low light."
+template = "page"
++++
+
+I design software that people use when the rest of the house is asleep — dashboards for on-call engineers, reading apps, the kind of tools that live in dark rooms.
+
+Dark mode is treated like a coat of paint: invert the colors, ship it, move on. It deserves more than that. Contrast behaves differently in the dark. Pure white text glares. Saturated accents bloom. A shadow that grounded a card on a white page does nothing on black.
+
+Umbra Glass collects what I've learned building for those conditions. It's opinionated, occasionally wrong, and always written at an hour I should probably be asleep.

--- a/examples/umbra-glass/content/index.md
+++ b/examples/umbra-glass/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "Interfaces for the small hours"
+description = "A dark-mode journal on low-light design, contrast, and screens that are kind to tired eyes."
+template = "index"
++++
+
+Umbra Glass is written after dark, about designing for after dark. Most interface advice assumes a bright office and a fresh pair of eyes. This is the other shift — the dim room, the late hour, the screen that's the only light in the building.

--- a/examples/umbra-glass/content/posts/_index.md
+++ b/examples/umbra-glass/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Writing"
+description = "Notes on designing for low light, newest first."
+template = "section"
+sort_by = "date"
++++
+
+Everything published on Umbra Glass.

--- a/examples/umbra-glass/content/posts/contrast-is-a-budget.md
+++ b/examples/umbra-glass/content/posts/contrast-is-a-budget.md
@@ -1,0 +1,23 @@
++++
+title = "Contrast Is a Budget"
+description = "Maximum contrast everywhere is the same as no contrast at all. Spend it where it matters."
+date = "2026-04-15"
+template = "page"
+tags = ["contrast", "accessibility", "dark-mode"]
++++
+
+Pure white text on a pure black background scores beautifully on a contrast checker and feels terrible to read for more than a paragraph. The numbers say it's accessible; your eyes say it's a headache.
+
+Contrast is a budget, not a target. You have a finite amount of attention to direct, and if everything screams, nothing is heard.
+
+## Soften the body, sharpen the signal
+
+Body text doesn't need maximum contrast — it needs *comfortable* contrast. On a dark theme, that usually means an off-white around `#eef1f6` rather than `#ffffff`. The difference is small on paper and large after the tenth paragraph.
+
+Save your highest-contrast values for the things that should grab attention: the active link, the primary button, the one number that changed. When the body is calm, those moments actually land.
+
+{% alert(type="warning") %}Accessibility minimums are a floor, not a goal. Clearing 4.5:1 means text is *legible*; it says nothing about whether reading it for an hour is pleasant. Design for the hour, then check the floor.{% end %}
+
+## Test in the conditions of use
+
+A dark interface that looks balanced at full brightness in the afternoon can be blinding at 2 a.m. with the lights off — the exact situation it exists for. Turn your screen down, kill the room lights, and read your own product the way your users will. The contrast budget you set in daylight is almost always too high for the dark.

--- a/examples/umbra-glass/content/posts/designing-for-the-dark.md
+++ b/examples/umbra-glass/content/posts/designing-for-the-dark.md
@@ -1,0 +1,25 @@
++++
+title = "Dark Mode Is Not Inverted Light Mode"
+description = "Flipping a palette upside down produces a dark theme that fights the eye. Real dark design starts from black."
+date = "2026-05-22"
+template = "page"
+tags = ["dark-mode", "design", "contrast"]
++++
+
+The quickest way to ship a broken dark mode is to take your light theme and invert it. White becomes black, black becomes white, and every shadow, accent, and border comes along for the ride — now pointing the wrong way.
+
+It looks like dark mode. It feels wrong, and most people can't say why.
+
+## Light and dark aren't symmetric
+
+On a light page, you build hierarchy by *adding* darkness: darker text, darker borders, drop shadows that push elements down. In the dark, you can't add more dark — the background is already there. You build hierarchy by *adding light*: surfaces get lighter as they come forward, not darker.
+
+That single inversion of logic breaks every borrowed value. A shadow that grounded a card on white does nothing on near-black. You need an elevation system based on subtle lightening instead.
+
+> In light mode, closer means darker. In dark mode, closer means lighter. Everything else follows from that.
+
+## Start from the background, not the foreground
+
+Pick your darkest surface first — and don't make it pure black. Pure `#000` against bright content creates a halo effect called haloing or smearing on OLED panels, and it makes text edges shimmer. A very dark desaturated charcoal, somewhere around `#0d0f15`, is calmer and lets you layer lighter surfaces above it.
+
+From there, every panel is the background plus a few percent of white. Stack them and you get depth without a single shadow. The screen stops looking inverted and starts looking designed for the dark.

--- a/examples/umbra-glass/content/posts/the-glow-problem.md
+++ b/examples/umbra-glass/content/posts/the-glow-problem.md
@@ -1,0 +1,21 @@
++++
+title = "The Glow Problem"
+description = "Saturated accents bloom against a dark background. Here's how to keep them legible instead of radioactive."
+date = "2026-03-08"
+template = "page"
+tags = ["color", "dark-mode", "design"]
++++
+
+Take a vivid, saturated color that looks crisp on a white page and drop it onto near-black. It blooms. The edges smear, the color feels like it's vibrating, and small text set in it becomes genuinely hard to focus on.
+
+This is real optics, not a metaphor. High-saturation colors against dark backgrounds trigger an effect called chromatic aberration in the eye — the lens can't focus all wavelengths on the same plane, and the mismatch is worst at high saturation and high contrast.
+
+## Desaturate as you darken
+
+The fix is to pull saturation down as the background gets darker. The neon blue that pops on white should become a calmer, slightly muted teal or sky tone in the dark. It still reads as "the accent." It just stops glowing.
+
+A useful habit: pick the accent in light mode, then for dark mode keep the hue, drop the saturation by fifteen to twenty-five percent, and nudge the lightness up. The color stays recognizable while becoming readable.
+
+## Never set body text in the accent
+
+Whatever you do, don't set paragraphs of text in a saturated accent color on dark. Links are fine — they're short and you expect to focus on them. But a full sentence in glowing teal is a recipe for eye strain. Keep prose in your calm off-white, and let the accent appear in short, deliberate bursts. The glow is only a problem when it has to be read.

--- a/examples/umbra-glass/templates/404.html
+++ b/examples/umbra-glass/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="notfound glass">
+  <p class="notfound-code">404</p>
+  <h1 class="notfound-title">Lost in the dark</h1>
+  <p class="notfound-text">This page isn't here. It may have been archived, renamed, or never lit up at all.</p>
+  <a class="button" href="{{ base_url }}/">Back home</a>
+</section>
+{% endblock content %}

--- a/examples/umbra-glass/templates/base.html
+++ b/examples/umbra-glass/templates/base.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Sora:wght@500;600;700&display=swap" rel="stylesheet">
+
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --bg: #0d0f15;
+      --ink: #eef1f6;
+      --muted: #9aa3b2;
+      --accent: #4ecdc4;
+      --accent-deep: #86e6dd;
+      --line: rgba(255, 255, 255, 0.08);
+
+      --glass-bg: rgba(255, 255, 255, 0.045);
+      --glass-border: rgba(255, 255, 255, 0.10);
+      --glass-shadow: 0 18px 48px rgba(0, 0, 0, 0.55);
+      --glass-spec: inset 0 1px 0 rgba(255, 255, 255, 0.10);
+
+      --radius: 20px;
+      --radius-sm: 13px;
+      --font-body: 'Inter', system-ui, sans-serif;
+      --font-head: 'Sora', system-ui, sans-serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0; font-family: var(--font-body); color: var(--ink);
+      background: var(--bg); line-height: 1.7; min-height: 100vh;
+      -webkit-font-smoothing: antialiased; position: relative; overflow-x: hidden;
+    }
+
+    /* Soft glows behind the glass — solid fills, no gradients */
+    .field { position: fixed; z-index: 0; border-radius: 50%; filter: blur(110px); pointer-events: none; }
+    .field-a { width: 480px; height: 480px; background: #145e57; opacity: 0.55; top: -140px; left: -110px; }
+    .field-b { width: 540px; height: 540px; background: #1e2f63; opacity: 0.5; bottom: -180px; right: -130px; }
+    .field-c { width: 360px; height: 360px; background: #3a2a5e; opacity: 0.4; top: 42%; right: 24%; }
+
+    .glass {
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(22px) saturate(140%); -webkit-backdrop-filter: blur(22px) saturate(140%);
+      border-radius: var(--radius);
+    }
+
+    .wrap { max-width: 820px; margin: 0 auto; padding: 0 1.4rem; position: relative; z-index: 1; }
+
+    /* Header */
+    .site-header {
+      position: sticky; top: 1rem; z-index: 50;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.8rem 1.4rem; margin: 1rem 0 2.5rem;
+    }
+    .site-logo { font-family: var(--font-head); font-weight: 700; font-size: 1.12rem; letter-spacing: -0.01em; color: var(--ink); text-decoration: none; }
+    .site-logo .dot { color: var(--accent); }
+    .site-nav { display: flex; gap: 0.3rem; }
+    .site-nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; font-weight: 500; padding: 0.4rem 0.8rem; border-radius: 999px; transition: color 0.2s, background 0.2s; }
+    .site-nav a:hover { color: var(--accent-deep); background: rgba(78, 205, 196, 0.12); }
+
+    .site-main { min-height: 60vh; padding-bottom: 1rem; }
+
+    /* Hero */
+    .hero { padding: 3.2rem 2.4rem; margin-bottom: 2.6rem; }
+    .hero-eyebrow { font-family: var(--font-head); text-transform: uppercase; letter-spacing: 0.24em; font-size: 0.7rem; color: var(--accent); margin: 0 0 0.9rem; font-weight: 600; }
+    .hero-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2.1rem, 6vw, 3.3rem); line-height: 1.06; letter-spacing: -0.025em; margin: 0 0 1rem; font-weight: 700; }
+    .hero-lede { font-size: 1.1rem; color: var(--muted); max-width: 54ch; }
+    .hero-lede p:first-child { margin-top: 0; }
+    .hero-actions { display: flex; gap: 0.7rem; margin-top: 1.9rem; flex-wrap: wrap; }
+
+    .button {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+      font-family: var(--font-head); font-weight: 600; font-size: 0.9rem;
+      padding: 0.7rem 1.4rem; border-radius: 999px; text-decoration: none;
+      background: var(--accent); color: #06231f; border: 1px solid transparent;
+      transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+      box-shadow: 0 8px 24px rgba(78, 205, 196, 0.25);
+    }
+    .button:hover { transform: translateY(-2px); background: var(--accent-deep); box-shadow: 0 12px 30px rgba(78, 205, 196, 0.34); }
+    .button-ghost { background: rgba(255,255,255,0.05); color: var(--ink); border-color: var(--glass-border); box-shadow: none; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
+    .button-ghost:hover { background: rgba(255,255,255,0.1); color: var(--accent-deep); box-shadow: none; }
+
+    /* Feed — single editorial column */
+    .post-feed { margin-bottom: 3rem; }
+    .feed-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1.4rem; }
+    .feed-title { font-family: var(--font-head); font-size: 1.4rem; margin: 0; letter-spacing: -0.01em; }
+    .feed-all { color: var(--accent); text-decoration: none; font-weight: 600; font-size: 0.88rem; }
+    .feed-all:hover { color: var(--accent-deep); }
+
+    .post-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1rem; }
+    .post-card { transition: transform 0.25s, border-color 0.25s, box-shadow 0.25s; }
+    .post-card:hover { transform: translateY(-3px); border-color: rgba(78, 205, 196, 0.35); box-shadow: 0 24px 52px rgba(0,0,0,0.6), var(--glass-spec); }
+    .post-card-link { display: block; padding: 1.6rem 1.9rem; text-decoration: none; color: inherit; }
+    .post-card-date { font-size: 0.76rem; color: var(--muted); font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase; }
+    .post-card-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: 1.42rem; line-height: 1.18; letter-spacing: -0.015em; margin: 0.5rem 0 0.5rem; }
+    .post-card-desc { color: var(--muted); margin: 0 0 0.9rem; font-size: 1rem; }
+    .read-more { font-family: var(--font-head); font-weight: 600; font-size: 0.86rem; color: var(--accent); }
+
+    /* Tags */
+    .tag-row { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 0.9rem 0 0; }
+    .tag { font-size: 0.73rem; font-weight: 600; letter-spacing: 0.03em; padding: 0.26rem 0.7rem; border-radius: 999px; text-decoration: none; background: rgba(78, 205, 196, 0.12); color: var(--accent-deep); border: 1px solid rgba(78, 205, 196, 0.2); }
+    a.tag:hover { background: rgba(78, 205, 196, 0.2); }
+
+    /* Single post */
+    .post { max-width: 700px; margin: 0 auto; }
+    .post-header { padding: 2.4rem 2.2rem 1.8rem; margin-bottom: 2rem; }
+    .post-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(1.9rem, 5vw, 2.6rem); line-height: 1.1; letter-spacing: -0.025em; margin: 0 0 0.9rem; }
+    .post-meta { color: var(--muted); font-size: 0.88rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+    .meta-sep { opacity: 0.5; }
+    .post-content { font-size: 1.05rem; }
+
+    .section-head { margin: 1rem 0 2rem; }
+    .section-eyebrow { font-family: var(--font-head); text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.7rem; color: var(--accent); font-weight: 600; margin: 0 0 0.5rem; }
+    .section-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2rem, 5vw, 2.7rem); letter-spacing: -0.025em; margin: 0 0 0.5rem; }
+    .section-desc { color: var(--muted); font-size: 1.06rem; margin: 0; }
+    .section-intro { margin-bottom: 2rem; }
+
+    /* Post navigation */
+    .post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 2.5rem; padding: 1.3rem 1.6rem; }
+    .post-nav-link { display: flex; flex-direction: column; gap: 0.25rem; text-decoration: none; color: var(--ink); max-width: 46%; }
+    .post-nav-link.next { text-align: right; margin-left: auto; }
+    .post-nav-label { font-size: 0.76rem; color: var(--accent); font-weight: 600; }
+    .post-nav-title { font-family: var(--font-head); font-weight: 600; font-size: 0.96rem; }
+    .post-nav-link:hover .post-nav-title { color: var(--accent-deep); }
+
+    /* Terms */
+    .term-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 0.8rem; }
+    .term-item { padding: 0; }
+    .term-item a { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.7rem 1.2rem; text-decoration: none; color: var(--ink); font-family: var(--font-head); font-weight: 600; }
+    .term-item:hover a { color: var(--accent-deep); }
+    .term-count { background: rgba(78, 205, 196, 0.15); color: var(--accent-deep); border-radius: 999px; padding: 0.05rem 0.55rem; font-size: 0.76rem; }
+
+    /* Taxonomy auto-generated lists */
+    .tax-body .taxonomy-terms, .tax-body .taxonomy-pages { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 0.8rem; }
+    .tax-body li { margin: 0; }
+    .tax-body li a {
+      display: block; padding: 1rem 1.3rem; text-decoration: none; color: var(--ink);
+      font-family: var(--font-head); font-weight: 600;
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(16px) saturate(130%); -webkit-backdrop-filter: blur(16px) saturate(130%);
+      border-radius: var(--radius-sm); transition: transform 0.2s, color 0.2s, border-color 0.2s;
+    }
+    .tax-body li a:hover { transform: translateY(-3px); color: var(--accent-deep); border-color: rgba(78, 205, 196, 0.35); }
+
+    /* Pagination */
+    .pagination { display: flex; align-items: center; justify-content: center; gap: 1rem; margin: 2.5rem 0 1rem; }
+    .page-link { text-decoration: none; color: var(--accent); font-weight: 600; font-family: var(--font-head); padding: 0.5rem 1rem; border-radius: 999px; }
+    .page-link:hover { background: rgba(78, 205, 196, 0.12); }
+    .page-link.disabled { color: var(--muted); opacity: 0.45; }
+    .page-current { font-family: var(--font-head); color: var(--muted); font-size: 0.9rem; }
+
+    /* Callout */
+    .callout { display: flex; gap: 0.9rem; align-items: flex-start; padding: 1.1rem 1.3rem; border-radius: var(--radius-sm); margin: 1.6rem 0; background: rgba(78, 205, 196, 0.08); border: 1px solid rgba(78, 205, 196, 0.22); }
+    .callout-label { font-family: var(--font-head); font-size: 0.68rem; font-weight: 700; letter-spacing: 0.08em; color: #06231f; background: var(--accent); padding: 0.18rem 0.55rem; border-radius: 6px; flex-shrink: 0; margin-top: 0.15rem; }
+    .callout-body { color: var(--ink); }
+    .callout-body p { margin: 0; }
+    .callout-warning { background: rgba(244, 162, 97, 0.1); border-color: rgba(244, 162, 97, 0.3); }
+    .callout-warning .callout-label { background: #f4a261; color: #2a1500; }
+
+    /* 404 */
+    .notfound { text-align: center; padding: 4rem 2rem; }
+    .notfound-code { font-family: var(--font-head); font-size: 5rem; font-weight: 700; color: var(--accent); margin: 0; letter-spacing: -0.04em; }
+    .notfound-title { font-family: var(--font-head); font-size: 1.6rem; margin: 0.5rem 0 1rem; }
+    .notfound-text { color: var(--muted); max-width: 40ch; margin: 0 auto 1.8rem; }
+
+    /* Footer */
+    .site-footer { text-align: center; padding: 1.8rem; margin: 3rem 0 2rem; color: var(--muted); font-size: 0.88rem; }
+    .site-footer a { color: var(--accent); text-decoration: none; }
+    .site-footer a:hover { color: var(--accent-deep); }
+
+    /* Content typography */
+    .post-content h2, .post-content h3, .post-content h4 { font-family: var(--font-head); letter-spacing: -0.015em; line-height: 1.25; margin: 2rem 0 0.8rem; }
+    .post-content h2 { font-size: 1.5rem; }
+    .post-content h3 { font-size: 1.22rem; }
+    .post-content p { margin: 1.1rem 0; }
+    .post-content a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; }
+    .post-content a:hover { color: var(--accent-deep); }
+    .post-content ul, .post-content ol { padding-left: 1.3rem; }
+    .post-content li { margin: 0.4rem 0; }
+    .post-content img { max-width: 100%; height: auto; border-radius: var(--radius-sm); }
+    .post-content blockquote { margin: 1.6rem 0; padding: 0.6rem 1.3rem; border-left: 3px solid var(--accent); background: rgba(78, 205, 196, 0.06); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; color: var(--ink); font-style: italic; }
+    .post-content code { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 0.88em; background: rgba(255, 255, 255, 0.08); padding: 0.15rem 0.4rem; border-radius: 6px; color: var(--accent-deep); }
+    .post-content pre { background: #06080d; color: #d7dce6; padding: 1.3rem 1.5rem; border-radius: var(--radius-sm); overflow-x: auto; font-size: 0.9rem; border: 1px solid var(--line); }
+    .post-content pre code { background: none; padding: 0; color: inherit; }
+    .post-content hr { border: 0; height: 1px; background: var(--line); margin: 2.5rem 0; }
+    .post-content table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.95rem; }
+    .post-content th, .post-content td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid var(--line); }
+    .post-content th { font-family: var(--font-head); }
+
+    @media (max-width: 680px) {
+      .site-header { flex-direction: column; gap: 0.7rem; padding: 1rem; top: 0.5rem; }
+      .hero { padding: 2.2rem 1.5rem; }
+      .hero-title { font-size: 1.85rem; }
+      .post-header { padding: 1.8rem 1.5rem 1.4rem; }
+      .post-nav { flex-direction: column; }
+      .post-nav-link, .post-nav-link.next { max-width: 100%; text-align: left; margin-left: 0; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="field field-a"></div>
+  <div class="field field-b"></div>
+  <div class="field field-c"></div>
+
+  <div class="wrap">
+    <header class="site-header glass">
+      <a href="{{ base_url }}/" class="site-logo">umbra<span class="dot">/</span>glass</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Blog</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="site-footer">
+      <p>Umbra Glass &mdash; built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+    </footer>
+  </div>
+
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/umbra-glass/templates/index.html
+++ b/examples/umbra-glass/templates/index.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero glass">
+  <p class="hero-eyebrow">{{ site.title }}</p>
+  <h1 class="hero-title">{{ page.title | default(value=site.title) }}</h1>
+  <div class="hero-lede">
+    {{ content | safe }}
+  </div>
+  <div class="hero-actions">
+    <a class="button" href="#writing">Latest posts</a>
+    <a class="button button-ghost" href="{{ base_url }}/about/">About</a>
+  </div>
+</section>
+
+{% set posts = site.pages | selectattr("date") | sort(attribute="date", reverse=true) %}
+{% if posts %}
+<section class="post-feed" id="writing">
+  <div class="feed-head">
+    <h2 class="feed-title">Latest writing</h2>
+    <a class="feed-all" href="{{ base_url }}/posts/">All posts &rarr;</a>
+  </div>
+  <ul class="post-list">
+    {% for post in posts %}
+    {% if loop.index0 < 6 %}
+    <li class="post-card glass">
+      <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+        <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+        <h3 class="post-card-title">{{ post.title }}</h3>
+        {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+        {% if post.tags %}
+        <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+        {% endif %}
+        <span class="read-more">Read more &rarr;</span>
+      </a>
+    </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+{% endblock content %}

--- a/examples/umbra-glass/templates/page.html
+++ b/examples/umbra-glass/templates/page.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="post">
+  {% if page.title is present %}
+  <header class="post-header glass">
+    <h1 class="post-title">{{ page.title }}</h1>
+    <div class="post-meta">
+      {% if page.date is present %}<time datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+      {% if page.reading_time is present %}<span class="meta-sep">/</span><span>{{ page.reading_time }} min read</span>{% endif %}
+    </div>
+    {% if page.tags %}
+    <div class="tag-row">
+      {% for tag in page.tags %}<a class="tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>{% endfor %}
+    </div>
+    {% endif %}
+  </header>
+  {% endif %}
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+  {% if page.lower or page.higher %}
+  <nav class="post-nav glass">
+    {% if page.higher %}
+    <a class="post-nav-link prev" href="{{ base_url }}{{ page.higher.url }}">
+      <span class="post-nav-label">&larr; Previous</span>
+      <span class="post-nav-title">{{ page.higher.title }}</span>
+    </a>
+    {% else %}<span></span>{% endif %}
+    {% if page.lower %}
+    <a class="post-nav-link next" href="{{ base_url }}{{ page.lower.url }}">
+      <span class="post-nav-label">Next &rarr;</span>
+      <span class="post-nav-title">{{ page.lower.title }}</span>
+    </a>
+    {% endif %}
+  </nav>
+  {% endif %}
+</article>
+{% endblock content %}

--- a/examples/umbra-glass/templates/section.html
+++ b/examples/umbra-glass/templates/section.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <h1 class="section-title">{{ page.title | default(value=page.section | capitalize) }}</h1>
+  {% if page.description %}<p class="section-desc">{{ page.description }}</p>{% endif %}
+</header>
+{% if content %}<div class="post-content section-intro">{{ content | safe }}</div>{% endif %}
+{% if section.pages %}
+<ul class="post-list">
+  {% for post in section.pages %}
+  <li class="post-card glass">
+    <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+      {% if post.date %}
+      <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+      {% endif %}
+      <h2 class="post-card-title">{{ post.title | default(value=post.slug) }}</h2>
+      {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+      {% if post.tags %}
+      <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+      {% endif %}
+      <span class="read-more">Read more &rarr;</span>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if pagination is present and pagination.total_pages > 1 %}
+<nav class="pagination">
+  {% if pagination.prev is present %}<a class="page-link" href="{{ base_url }}{{ pagination.prev }}">&larr; Newer</a>{% else %}<span class="page-link disabled">&larr; Newer</span>{% endif %}
+  <span class="page-current">{{ pagination.current_page }} / {{ pagination.total_pages }}</span>
+  {% if pagination.next is present %}<a class="page-link" href="{{ base_url }}{{ pagination.next }}">Older &rarr;</a>{% else %}<span class="page-link disabled">Older &rarr;</span>{% endif %}
+</nav>
+{% endif %}
+{% endblock content %}

--- a/examples/umbra-glass/templates/shortcodes/alert.html
+++ b/examples/umbra-glass/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<aside class="callout callout-{{ type | default(value='note') }}">
+  <span class="callout-label">{{ type | default(value="note") | upper }}</span>
+  <div class="callout-body">{{ body }}</div>
+</aside>

--- a/examples/umbra-glass/templates/taxonomy.html
+++ b/examples/umbra-glass/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Index</p>
+  <h1 class="section-title">{{ page.title | default(value="Tags") | e }}</h1>
+  <p class="section-desc">Every topic written about so far.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/umbra-glass/templates/taxonomy_term.html
+++ b/examples/umbra-glass/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Tagged</p>
+  <h1 class="section-title">{{ page.title | default(value="Tag") | e }}</h1>
+  <p class="section-desc">Posts filed under this topic.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/vellum-glass/AGENTS.md
+++ b/examples/vellum-glass/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/vellum-glass/config.toml
+++ b/examples/vellum-glass/config.toml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Vellum Glass"
+description = "A warm, paper-toned journal on writing, editing, and the slow craft of getting words to sit still on the page."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.6
+
+[robots]
+enabled = true
+filename = "robots.txt"
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"
+full_content = true
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/examples/vellum-glass/content/about.md
+++ b/examples/vellum-glass/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Vellum Glass"
+description = "Notes from a working desk."
+template = "page"
++++
+
+I write for a living and edit other people's writing for the rest of it. After enough years of both, you start to notice the same handful of problems wearing different costumes.
+
+Vellum Glass is where I write those patterns down. Not rules, exactly — more like things I keep relearning. How to start when the page is blank. When to trust a long sentence and when to break it. Why the kindest thing you can do for a draft is leave it alone for a day.
+
+If you make things out of words, you'll recognize the struggles. I don't have a system to sell you. I just have a desk, a deadline, and the same blinking cursor as everyone else.

--- a/examples/vellum-glass/content/index.md
+++ b/examples/vellum-glass/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "On writing, editing, and the slow craft of words"
+description = "A paper-toned journal about getting sentences to sit still on the page."
+template = "index"
++++
+
+Vellum Glass is a journal about writing — not the romance of it, but the work. The cutting, the re-reading, the quiet satisfaction of a paragraph that finally holds its weight. These are notes from the desk, kept honest by the fact that I have to take my own advice.

--- a/examples/vellum-glass/content/posts/_index.md
+++ b/examples/vellum-glass/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "The Journal"
+description = "Notes on the craft of writing, newest first."
+template = "section"
+sort_by = "date"
++++
+
+Everything in the journal, most recent first.

--- a/examples/vellum-glass/content/posts/blank-page.md
+++ b/examples/vellum-glass/content/posts/blank-page.md
@@ -1,0 +1,23 @@
++++
+title = "The Tyranny of the Blank Page"
+description = "The blank page isn't asking for your best sentence. It's asking for any sentence. Start ugly."
+date = "2026-04-09"
+template = "page"
+tags = ["process", "craft"]
++++
+
+The blank page has a way of feeling like a judgment. You sit down with something to say, and the white expanse asks you to say it perfectly, immediately, in the first sentence. So you write nothing, because nothing is safer than something imperfect.
+
+The trick is to stop treating the first sentence as the front door. It's scaffolding. You'll tear it down later.
+
+## Write the bad version on purpose
+
+Give yourself permission to write the worst possible opening. Literally type "This is a post about X and here is the obvious thing about it." It's terrible, and that's the point — it gets words on the page, and words are easier to fix than emptiness.
+
+Almost always, your real opening is buried three paragraphs down, in the sentence where you finally stop explaining and start *saying*. You couldn't have found it without writing the three throwaway paragraphs first.
+
+{% alert(type="note") %}Keep a file of abandoned first sentences. When a page won't start, paste one in. It's a lie that you'll keep it — but the lie is enough to get moving, and movement is the whole game.{% end %}
+
+## Lower the stakes of the session
+
+A blank page feels heavy because you've decided this is *the writing*. Decide instead that it's just notes, just thinking-on-paper, just a draft nobody will ever see. The work that comes out of "this doesn't count" is, embarrassingly often, the work that counts.

--- a/examples/vellum-glass/content/posts/edit-sober.md
+++ b/examples/vellum-glass/content/posts/edit-sober.md
@@ -1,0 +1,25 @@
++++
+title = "Write Drunk, Edit Sober Is Bad Advice"
+description = "The famous line gets the spirit right and the mechanics wrong. Drafting and editing are different jobs, not different moods."
+date = "2026-05-20"
+template = "page"
+tags = ["editing", "craft", "process"]
++++
+
+The line gets quoted at every writing workshop: write drunk, edit sober. It's catchy, it's misattributed, and it has ruined more first drafts than writer's block ever did.
+
+The useful part is real. Drafting and editing *are* different jobs, and trying to do both at once is why so many people stall on the first paragraph. The harmful part is the framing — that drafting should be reckless and editing should be grim.
+
+## Drafting is not recklessness
+
+Good drafting isn't throwing words at the wall. It's writing forward without stopping to fix. You leave the typo, you leave the clumsy transition, you leave the sentence you know is wrong, and you keep moving. The discipline is in *not looking back*, not in lowering your standards.
+
+The moment you reach up to fix a word, you've switched jobs. Now you're editing a sentence inside a draft that doesn't exist yet, and the forward motion dies.
+
+## Editing is not punishment
+
+Editing sober shouldn't mean editing miserably. The sober part is just attention — reading what's actually on the page instead of what you meant. Most editing is addition by subtraction: the paragraph that says the same thing twice, the qualifier that weakens the claim, the throat-clearing first sentence that the second sentence makes unnecessary.
+
+> Cut the first sentence. Then read it again. You can usually cut the new first sentence too.
+
+Do the two jobs in separate sittings if you can. Draft today, edit tomorrow. The distance does what no amount of willpower can: it lets you read your own work like a stranger, which is the only way to fix it.

--- a/examples/vellum-glass/content/posts/short-sentence.md
+++ b/examples/vellum-glass/content/posts/short-sentence.md
@@ -1,0 +1,23 @@
++++
+title = "In Praise of the Short Sentence"
+description = "A long sentence can be beautiful. But the short one does the heavy lifting, and most writers don't trust it enough."
+date = "2026-03-14"
+template = "page"
+tags = ["prose", "craft", "editing"]
++++
+
+There's a romance to the long sentence — the kind that unspools across half a page, gathering clauses, accumulating qualifications, turning back on itself, building toward a release that finally arrives at a period you'd half forgotten was coming. Done well, it's gorgeous.
+
+Done by default, it's exhausting. And most of us write long by default, because the short sentence feels too plain to be good.
+
+## The short sentence is where meaning lands
+
+Read any writer you admire and watch what happens around their most important idea. The sentences get shorter. The clauses fall away. The point arrives in five words because five words is all it takes, and the brevity *is* the emphasis.
+
+A short sentence after a long one is a landing. The reader has been carried along, and then — stop. The full stop does work that no adjective can.
+
+## Vary, don't shorten everything
+
+This isn't a case for writing like a telegram. A page of nothing but short sentences reads like a ransom note. The point is rhythm: long sentences to carry, short ones to land. Build the wave, then let it break.
+
+When you edit, find your most important sentence in each section and ask whether it could be shorter. Usually it can. Usually it should be. The idea you most want the reader to keep is the one you should make easiest to carry out the door.

--- a/examples/vellum-glass/templates/404.html
+++ b/examples/vellum-glass/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="notfound glass">
+  <p class="notfound-code">404</p>
+  <h1 class="notfound-title">This page was never bound</h1>
+  <p class="notfound-text">The page you're after isn't in this volume. Perhaps it was cut in editing, or filed under another name.</p>
+  <a class="button" href="{{ base_url }}/">Back home</a>
+</section>
+{% endblock content %}

--- a/examples/vellum-glass/templates/base.html
+++ b/examples/vellum-glass/templates/base.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,500;0,600;0,700;1,500&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --bg: #f3ebdc;
+      --ink: #2c2118;
+      --muted: #8a7a64;
+      --accent: #bd5b35;
+      --accent-deep: #9a4527;
+      --line: rgba(44, 33, 24, 0.12);
+
+      --glass-bg: rgba(255, 251, 244, 0.55);
+      --glass-border: rgba(255, 255, 255, 0.65);
+      --glass-shadow: 0 16px 42px rgba(120, 86, 50, 0.16);
+      --glass-spec: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+
+      --radius: 18px;
+      --radius-sm: 12px;
+      --font-body: 'Inter', system-ui, sans-serif;
+      --font-head: 'Fraunces', Georgia, serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0; font-family: var(--font-body); color: var(--ink);
+      background: var(--bg); line-height: 1.7; min-height: 100vh;
+      -webkit-font-smoothing: antialiased; position: relative; overflow-x: hidden;
+    }
+
+    /* Warm color fields beneath the glass — solid fills, no gradients */
+    .field { position: fixed; z-index: 0; border-radius: 50%; filter: blur(95px); pointer-events: none; }
+    .field-a { width: 460px; height: 460px; background: #edc9a3; opacity: 0.65; top: -120px; left: -100px; }
+    .field-b { width: 520px; height: 520px; background: #e6b59a; opacity: 0.55; bottom: -160px; right: -120px; }
+    .field-c { width: 340px; height: 340px; background: #d7dfb8; opacity: 0.5; top: 40%; left: 18%; }
+
+    .glass {
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(20px) saturate(150%); -webkit-backdrop-filter: blur(20px) saturate(150%);
+      border-radius: var(--radius);
+    }
+
+    .wrap { max-width: 800px; margin: 0 auto; padding: 0 1.4rem; position: relative; z-index: 1; }
+
+    /* Header */
+    .site-header {
+      position: sticky; top: 1rem; z-index: 50;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.8rem 1.5rem; margin: 1rem 0 2.5rem;
+    }
+    .site-logo { font-family: var(--font-head); font-weight: 600; font-size: 1.3rem; letter-spacing: -0.01em; color: var(--ink); text-decoration: none; font-style: italic; }
+    .site-logo .dot { color: var(--accent); font-style: normal; }
+    .site-nav { display: flex; gap: 0.3rem; }
+    .site-nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; font-weight: 500; padding: 0.4rem 0.85rem; border-radius: 999px; transition: color 0.2s, background 0.2s; }
+    .site-nav a:hover { color: var(--accent-deep); background: rgba(189, 91, 53, 0.1); }
+
+    .site-main { min-height: 60vh; padding-bottom: 1rem; }
+
+    /* Hero */
+    .hero { padding: 3.2rem 2.6rem; margin-bottom: 2.8rem; }
+    .hero-eyebrow { font-family: var(--font-body); text-transform: uppercase; letter-spacing: 0.24em; font-size: 0.72rem; color: var(--accent); margin: 0 0 1rem; font-weight: 600; }
+    .hero-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2.3rem, 6vw, 3.6rem); line-height: 1.05; letter-spacing: -0.01em; margin: 0 0 1.1rem; font-weight: 600; }
+    .hero-lede { font-size: 1.15rem; color: var(--muted); max-width: 54ch; }
+    .hero-lede p:first-child { margin-top: 0; }
+    .hero-actions { display: flex; gap: 0.7rem; margin-top: 2rem; flex-wrap: wrap; }
+
+    .button {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+      font-family: var(--font-body); font-weight: 600; font-size: 0.9rem;
+      padding: 0.72rem 1.5rem; border-radius: 999px; text-decoration: none;
+      background: var(--accent); color: #fff7ef; border: 1px solid transparent;
+      transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+      box-shadow: 0 8px 22px rgba(189, 91, 53, 0.26);
+    }
+    .button:hover { transform: translateY(-2px); background: var(--accent-deep); box-shadow: 0 12px 28px rgba(189, 91, 53, 0.32); }
+    .button-ghost { background: rgba(255,251,244,0.55); color: var(--ink); border-color: var(--glass-border); box-shadow: none; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
+    .button-ghost:hover { background: rgba(255,251,244,0.85); color: var(--accent-deep); box-shadow: none; }
+
+    /* Feed — editorial numbered column */
+    .post-feed { margin-bottom: 3rem; }
+    .feed-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1.5rem; }
+    .feed-title { font-family: var(--font-head); font-size: 1.6rem; margin: 0; font-weight: 600; }
+    .feed-all { color: var(--accent); text-decoration: none; font-weight: 600; font-size: 0.88rem; }
+    .feed-all:hover { color: var(--accent-deep); }
+
+    .post-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1rem; counter-reset: post; }
+    .post-card { transition: transform 0.25s, box-shadow 0.25s; counter-increment: post; }
+    .post-card:hover { transform: translateY(-3px); box-shadow: 0 22px 50px rgba(120, 86, 50, 0.22), var(--glass-spec); }
+    .post-card-link { display: grid; grid-template-columns: auto 1fr; gap: 1.4rem; padding: 1.6rem 1.9rem; text-decoration: none; color: inherit; align-items: start; }
+    .post-card-link::before { content: counter(post, decimal-leading-zero); font-family: var(--font-head); font-size: 1.5rem; font-weight: 600; color: var(--accent); font-style: italic; line-height: 1; padding-top: 0.25rem; }
+    .post-card-date { font-size: 0.76rem; color: var(--muted); font-weight: 500; letter-spacing: 0.06em; text-transform: uppercase; }
+    .post-card-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: 1.5rem; line-height: 1.2; margin: 0.4rem 0 0.5rem; font-weight: 600; }
+    .post-card-desc { color: var(--muted); margin: 0 0 0.9rem; font-size: 1rem; }
+    .read-more { font-family: var(--font-body); font-weight: 600; font-size: 0.86rem; color: var(--accent); }
+
+    /* Tags */
+    .tag-row { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 0.9rem 0 0; }
+    .tag { font-size: 0.74rem; font-weight: 600; letter-spacing: 0.02em; padding: 0.26rem 0.7rem; border-radius: 999px; text-decoration: none; background: rgba(189, 91, 53, 0.1); color: var(--accent-deep); border: 1px solid rgba(189, 91, 53, 0.18); }
+    a.tag:hover { background: rgba(189, 91, 53, 0.18); }
+
+    /* Single post */
+    .post { max-width: 680px; margin: 0 auto; }
+    .post-header { padding: 2.6rem 2.4rem 2rem; margin-bottom: 2.2rem; }
+    .post-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2rem, 5vw, 2.9rem); line-height: 1.1; letter-spacing: -0.01em; margin: 0 0 0.9rem; font-weight: 600; }
+    .post-meta { color: var(--muted); font-size: 0.88rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+    .meta-sep { opacity: 0.5; }
+    .post-content { font-size: 1.08rem; }
+
+    .section-head { margin: 1rem 0 2rem; }
+    .section-eyebrow { font-family: var(--font-body); text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.72rem; color: var(--accent); font-weight: 600; margin: 0 0 0.5rem; }
+    .section-title { overflow-wrap: break-word; font-family: var(--font-head); font-size: clamp(2.1rem, 5vw, 2.9rem); margin: 0 0 0.5rem; font-weight: 600; }
+    .section-desc { color: var(--muted); font-size: 1.08rem; margin: 0; }
+    .section-intro { margin-bottom: 2rem; }
+
+    /* Post navigation */
+    .post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 2.5rem; padding: 1.3rem 1.6rem; }
+    .post-nav-link { display: flex; flex-direction: column; gap: 0.25rem; text-decoration: none; color: var(--ink); max-width: 46%; }
+    .post-nav-link.next { text-align: right; margin-left: auto; }
+    .post-nav-label { font-size: 0.76rem; color: var(--accent); font-weight: 600; }
+    .post-nav-title { font-family: var(--font-head); font-weight: 600; font-size: 1.02rem; }
+    .post-nav-link:hover .post-nav-title { color: var(--accent-deep); }
+
+    /* Terms */
+    .term-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 0.8rem; }
+    .term-item { padding: 0; }
+    .term-item a { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.7rem 1.2rem; text-decoration: none; color: var(--ink); font-family: var(--font-head); font-weight: 600; }
+    .term-item:hover a { color: var(--accent-deep); }
+    .term-count { background: rgba(189, 91, 53, 0.12); color: var(--accent-deep); border-radius: 999px; padding: 0.05rem 0.55rem; font-size: 0.76rem; font-family: var(--font-body); }
+
+    /* Taxonomy auto-generated lists */
+    .tax-body .taxonomy-terms, .tax-body .taxonomy-pages { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 0.8rem; }
+    .tax-body li { margin: 0; }
+    .tax-body li a {
+      display: block; padding: 1rem 1.3rem; text-decoration: none; color: var(--ink);
+      font-family: var(--font-head); font-weight: 600;
+      background: var(--glass-bg); border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow), var(--glass-spec);
+      backdrop-filter: blur(16px) saturate(140%); -webkit-backdrop-filter: blur(16px) saturate(140%);
+      border-radius: var(--radius-sm); transition: transform 0.2s, color 0.2s;
+    }
+    .tax-body li a:hover { transform: translateY(-3px); color: var(--accent-deep); }
+
+    /* Pagination */
+    .pagination { display: flex; align-items: center; justify-content: center; gap: 1rem; margin: 2.5rem 0 1rem; }
+    .page-link { text-decoration: none; color: var(--accent); font-weight: 600; font-family: var(--font-body); padding: 0.5rem 1rem; border-radius: 999px; }
+    .page-link:hover { background: rgba(189, 91, 53, 0.1); }
+    .page-link.disabled { color: var(--muted); opacity: 0.45; }
+    .page-current { font-family: var(--font-head); color: var(--muted); font-size: 0.95rem; }
+
+    /* Callout */
+    .callout { display: flex; gap: 0.9rem; align-items: flex-start; padding: 1.1rem 1.3rem; border-radius: var(--radius-sm); margin: 1.6rem 0; background: rgba(189, 91, 53, 0.07); border: 1px solid rgba(189, 91, 53, 0.18); }
+    .callout-label { font-family: var(--font-body); font-size: 0.68rem; font-weight: 700; letter-spacing: 0.08em; color: #fff7ef; background: var(--accent); padding: 0.18rem 0.55rem; border-radius: 6px; flex-shrink: 0; margin-top: 0.2rem; }
+    .callout-body { color: var(--ink); }
+    .callout-body p { margin: 0; }
+    .callout-warning { background: rgba(176, 124, 42, 0.1); border-color: rgba(176, 124, 42, 0.28); }
+    .callout-warning .callout-label { background: #b07c2a; }
+
+    /* 404 */
+    .notfound { text-align: center; padding: 4rem 2rem; }
+    .notfound-code { font-family: var(--font-head); font-size: 5rem; font-weight: 600; color: var(--accent); margin: 0; font-style: italic; }
+    .notfound-title { font-family: var(--font-head); font-size: 1.7rem; margin: 0.5rem 0 1rem; font-weight: 600; }
+    .notfound-text { color: var(--muted); max-width: 40ch; margin: 0 auto 1.8rem; }
+
+    /* Footer */
+    .site-footer { text-align: center; padding: 1.8rem; margin: 3rem 0 2rem; color: var(--muted); font-size: 0.9rem; }
+    .site-footer a { color: var(--accent); text-decoration: none; }
+    .site-footer a:hover { color: var(--accent-deep); }
+
+    /* Content typography */
+    .post-content h2, .post-content h3, .post-content h4 { font-family: var(--font-head); line-height: 1.25; margin: 2.1rem 0 0.8rem; font-weight: 600; }
+    .post-content h2 { font-size: 1.7rem; }
+    .post-content h3 { font-size: 1.32rem; }
+    .post-content p { margin: 1.15rem 0; }
+    .post-content a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; }
+    .post-content a:hover { color: var(--accent-deep); }
+    .post-content ul, .post-content ol { padding-left: 1.3rem; }
+    .post-content li { margin: 0.4rem 0; }
+    .post-content img { max-width: 100%; height: auto; border-radius: var(--radius-sm); }
+    .post-content blockquote { margin: 1.7rem 0; padding: 0.4rem 1.4rem; border-left: 3px solid var(--accent); background: rgba(189, 91, 53, 0.05); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; color: var(--ink); font-family: var(--font-head); font-style: italic; font-size: 1.2rem; }
+    .post-content code { font-family: ui-monospace, Menlo, monospace; font-size: 0.88em; background: rgba(44, 33, 24, 0.07); padding: 0.15rem 0.4rem; border-radius: 6px; }
+    .post-content pre { background: #2c2118; color: #f3ebdc; padding: 1.3rem 1.5rem; border-radius: var(--radius-sm); overflow-x: auto; font-size: 0.9rem; }
+    .post-content pre code { background: none; padding: 0; color: inherit; }
+    .post-content hr { border: 0; height: 1px; background: var(--line); margin: 2.5rem 0; }
+    .post-content table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.95rem; }
+    .post-content th, .post-content td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid var(--line); }
+    .post-content th { font-family: var(--font-head); }
+
+    @media (max-width: 680px) {
+      .site-header { flex-direction: column; gap: 0.7rem; padding: 1rem; top: 0.5rem; }
+      .hero { padding: 2.3rem 1.6rem; }
+      .hero-title { font-size: 1.85rem; }
+      .post-card-link { grid-template-columns: 1fr; gap: 0.3rem; }
+      .post-card-link::before { font-size: 1.1rem; }
+      .post-header { padding: 1.9rem 1.6rem 1.5rem; }
+      .post-nav { flex-direction: column; }
+      .post-nav-link, .post-nav-link.next { max-width: 100%; text-align: left; margin-left: 0; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="field field-a"></div>
+  <div class="field field-b"></div>
+  <div class="field field-c"></div>
+
+  <div class="wrap">
+    <header class="site-header glass">
+      <a href="{{ base_url }}/" class="site-logo">Vellum<span class="dot">.</span></a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Journal</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="site-footer">
+      <p>Vellum Glass &mdash; built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+    </footer>
+  </div>
+
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/vellum-glass/templates/index.html
+++ b/examples/vellum-glass/templates/index.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero glass">
+  <p class="hero-eyebrow">{{ site.title }}</p>
+  <h1 class="hero-title">{{ page.title | default(value=site.title) }}</h1>
+  <div class="hero-lede">
+    {{ content | safe }}
+  </div>
+  <div class="hero-actions">
+    <a class="button" href="#writing">Latest posts</a>
+    <a class="button button-ghost" href="{{ base_url }}/about/">About</a>
+  </div>
+</section>
+
+{% set posts = site.pages | selectattr("date") | sort(attribute="date", reverse=true) %}
+{% if posts %}
+<section class="post-feed" id="writing">
+  <div class="feed-head">
+    <h2 class="feed-title">Latest writing</h2>
+    <a class="feed-all" href="{{ base_url }}/posts/">All posts &rarr;</a>
+  </div>
+  <ul class="post-list">
+    {% for post in posts %}
+    {% if loop.index0 < 6 %}
+    <li class="post-card glass">
+      <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+        <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+        <h3 class="post-card-title">{{ post.title }}</h3>
+        {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+        {% if post.tags %}
+        <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+        {% endif %}
+        <span class="read-more">Read more &rarr;</span>
+      </a>
+    </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+{% endblock content %}

--- a/examples/vellum-glass/templates/page.html
+++ b/examples/vellum-glass/templates/page.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="post">
+  {% if page.title is present %}
+  <header class="post-header glass">
+    <h1 class="post-title">{{ page.title }}</h1>
+    <div class="post-meta">
+      {% if page.date is present %}<time datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>{% endif %}
+      {% if page.reading_time is present %}<span class="meta-sep">/</span><span>{{ page.reading_time }} min read</span>{% endif %}
+    </div>
+    {% if page.tags %}
+    <div class="tag-row">
+      {% for tag in page.tags %}<a class="tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>{% endfor %}
+    </div>
+    {% endif %}
+  </header>
+  {% endif %}
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+  {% if page.lower or page.higher %}
+  <nav class="post-nav glass">
+    {% if page.higher %}
+    <a class="post-nav-link prev" href="{{ base_url }}{{ page.higher.url }}">
+      <span class="post-nav-label">&larr; Previous</span>
+      <span class="post-nav-title">{{ page.higher.title }}</span>
+    </a>
+    {% else %}<span></span>{% endif %}
+    {% if page.lower %}
+    <a class="post-nav-link next" href="{{ base_url }}{{ page.lower.url }}">
+      <span class="post-nav-label">Next &rarr;</span>
+      <span class="post-nav-title">{{ page.lower.title }}</span>
+    </a>
+    {% endif %}
+  </nav>
+  {% endif %}
+</article>
+{% endblock content %}

--- a/examples/vellum-glass/templates/section.html
+++ b/examples/vellum-glass/templates/section.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <h1 class="section-title">{{ page.title | default(value=page.section | capitalize) }}</h1>
+  {% if page.description %}<p class="section-desc">{{ page.description }}</p>{% endif %}
+</header>
+{% if content %}<div class="post-content section-intro">{{ content | safe }}</div>{% endif %}
+{% if section.pages %}
+<ul class="post-list">
+  {% for post in section.pages %}
+  <li class="post-card glass">
+    <a class="post-card-link" href="{{ base_url }}{{ post.url }}">
+      {% if post.date %}
+      <div class="post-card-date"><time datetime="{{ post.date }}">{{ post.date | date(format="%B %d, %Y") }}</time></div>
+      {% endif %}
+      <h2 class="post-card-title">{{ post.title | default(value=post.slug) }}</h2>
+      {% if post.description %}<p class="post-card-desc">{{ post.description }}</p>{% endif %}
+      {% if post.tags %}
+      <div class="tag-row">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</div>
+      {% endif %}
+      <span class="read-more">Read more &rarr;</span>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if pagination is present and pagination.total_pages > 1 %}
+<nav class="pagination">
+  {% if pagination.prev is present %}<a class="page-link" href="{{ base_url }}{{ pagination.prev }}">&larr; Newer</a>{% else %}<span class="page-link disabled">&larr; Newer</span>{% endif %}
+  <span class="page-current">{{ pagination.current_page }} / {{ pagination.total_pages }}</span>
+  {% if pagination.next is present %}<a class="page-link" href="{{ base_url }}{{ pagination.next }}">Older &rarr;</a>{% else %}<span class="page-link disabled">Older &rarr;</span>{% endif %}
+</nav>
+{% endif %}
+{% endblock content %}

--- a/examples/vellum-glass/templates/shortcodes/alert.html
+++ b/examples/vellum-glass/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<aside class="callout callout-{{ type | default(value='note') }}">
+  <span class="callout-label">{{ type | default(value="note") | upper }}</span>
+  <div class="callout-body">{{ body }}</div>
+</aside>

--- a/examples/vellum-glass/templates/taxonomy.html
+++ b/examples/vellum-glass/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Index</p>
+  <h1 class="section-title">{{ page.title | default(value="Tags") | e }}</h1>
+  <p class="section-desc">Every topic written about so far.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/examples/vellum-glass/templates/taxonomy_term.html
+++ b/examples/vellum-glass/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-head">
+  <p class="section-eyebrow">Tagged</p>
+  <h1 class="section-title">{{ page.title | default(value="Tag") | e }}</h1>
+  <p class="section-desc">Posts filed under this topic.</p>
+</header>
+<div class="tax-body">
+  {{ content | safe }}
+</div>
+{% endblock content %}

--- a/tags.json
+++ b/tags.json
@@ -9855,5 +9855,40 @@
     "editorial",
     "vintage",
     "minimal"
+  ],
+  "prism-drift": [
+    "light",
+    "blog",
+    "minimal",
+    "glassmorphism",
+    "modern"
+  ],
+  "umbra-glass": [
+    "dark",
+    "blog",
+    "minimal",
+    "glassmorphism",
+    "modern"
+  ],
+  "vellum-glass": [
+    "light",
+    "blog",
+    "editorial",
+    "glassmorphism",
+    "warm"
+  ],
+  "halcyon-pane": [
+    "light",
+    "blog",
+    "minimal",
+    "glassmorphism",
+    "calm"
+  ],
+  "lilac-frost": [
+    "light",
+    "blog",
+    "minimal",
+    "glassmorphism",
+    "pastel"
   ]
 }


### PR DESCRIPTION
## Summary

Adds five new **blog** examples in a trendy, modern style, each with a restrained **liquid glass** treatment: frosted translucent panels with a specular edge highlight, floating over soft solid-color fields. No CSS gradients and no emoji anywhere — depth comes from `backdrop-filter`, translucency, inset highlights, and blurred color blocks.

| Example | Mode | Accent | Type | Layout signature |
|---|---|---|---|---|
| `prism-drift` | light | indigo | Space Grotesk + Inter | two-column card grid |
| `umbra-glass` | dark | teal | Sora + Inter | single editorial column |
| `vellum-glass` | light (warm cream) | terracotta | Fraunces serif + Inter | numbered editorial list |
| `halcyon-pane` | light (sage) | teal-green | Outfit + Inter | featured-first grid |
| `lilac-frost` | light (lavender) | violet | Plus Jakarta Sans + Inter | soft pastel grid |

Each carries its own palette, font pairing, layout, and editorial voice so they don't read as recolors of one template.

## What each site includes
- Home landing (hero + dynamic latest-posts feed via `site.pages | selectattr("date") | sort`)
- `/posts/` section index, three real long-form posts, and an About page
- `tags` taxonomy (listing + term pages), prev/next post navigation, and an `alert` shortcode demo
- `base`, `index`, `page`, `section`, `taxonomy`, `taxonomy_term`, `404` templates + `AGENTS.md`

## Verification
- `hwaro build` (0.14.2) passes for all 5; 6 content pages each
- No raw-HTML-as-text leaks (`{{ content | safe }}` everywhere; verified `grep` for escaped tags returns 0)
- `scripts/lint-examples.sh` passes for all 5 — no placeholder copy, no decorative emoji, no gradient/backdrop-filter warnings
- `tags.json` updated with an entry for each (CI requirement)
- Spot-checked rendered home, post, taxonomy, and mobile views in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)