### PR TITLE
Fix 404 for authors taxonomy in lucid-dreamscape example

### DIFF
--- a/examples/lucid-dreamscape/content/authors/_index.md
+++ b/examples/lucid-dreamscape/content/authors/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Authors"
+description = "Dreamers (Authors)"
++++


### PR DESCRIPTION
The `lucid-dreamscape` example site had a broken link in the header and home page pointing to `/authors/` which returned a 404 error because there was no corresponding content page. This PR fixes the 404 by creating `examples/lucid-dreamscape/content/authors/_index.md` with appropriate frontmatter.

---
*PR created automatically by Jules for task [5132715068425594397](https://jules.google.com/task/5132715068425594397) started by @hahwul*