### PR TITLE
Fix broken links and template variables in samizdat example

### DIFF
--- a/examples/samizdat/templates/index.html
+++ b/examples/samizdat/templates/index.html
@@ -22,7 +22,7 @@
           <span class="item-date">{{ post.date | date("%Y.%m.%d") }}</span>
           {% if post.extra is defined and post.extra.location %}<span class="item-loc">loc: {{ post.extra.location }}</span>{% endif %}
         </div>
-        <h2 class="item-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <h2 class="item-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         {% if post.description %}
         <p class="item-deck">{{ post.description }}</p>
         {% endif %}

--- a/examples/samizdat/templates/section.html
+++ b/examples/samizdat/templates/section.html
@@ -22,7 +22,7 @@
           <span class="item-date">{{ post.date | date("%Y.%m.%d") }}</span>
           {% if post.extra is defined and post.extra.location %}<span class="item-loc">loc: {{ post.extra.location }}</span>{% endif %}
         </div>
-        <h2 class="item-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <h2 class="item-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         {% if post.description %}
         <p class="item-deck">{{ post.description }}</p>
         {% endif %}

--- a/examples/samizdat/templates/taxonomy.html
+++ b/examples/samizdat/templates/taxonomy.html
@@ -3,7 +3,7 @@
 <section class="front">
   <div class="censor-line">
     <span class="censor-bar">[ subject index ]</span>
-    <span class="censor-date">{{ taxonomy_terms | length }} entries</span>
+    <span class="censor-date">{{ terms | length }} entries</span>
   </div>
   <h1 class="front-headline">{{ taxonomy_name }}</h1>
   <p class="front-deck">every subject the bulletin has touched, by hand, retyped at least once.</p>
@@ -11,7 +11,7 @@
   <div class="front-divider">. . . . . . . . . . . . . . . . . . . .</div>
 
   <ul class="tag-index">
-    {% for term in taxonomy_terms %}
+    {% for term in terms %}
     <li class="tag-entry">
       <a href="{{ base_url }}{{ term.url }}">
         <span class="tag-name">{{ term.name }}</span>

--- a/examples/samizdat/templates/taxonomy_term.html
+++ b/examples/samizdat/templates/taxonomy_term.html
@@ -19,7 +19,7 @@
           <span class="item-issue">[ issue {% if post.extra is defined and post.extra.issue %}{{ post.extra.issue }}{% else %}--{% endif %} ]</span>
           <span class="item-date">{{ post.date | date("%Y.%m.%d") }}</span>
         </div>
-        <h2 class="item-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <h2 class="item-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
         {% if post.description %}
         <p class="item-deck">{{ post.description }}</p>
         {% endif %}


### PR DESCRIPTION
This PR fixes 404 issues in the `samizdat` example template links. 

### Changes:
1. Prepended `{{ base_url }}` to post URLs (`{{ post.url }}`) across templates (`index.html`, `section.html`, and `taxonomy_term.html`) to ensure correct relative resolution when deployed in subdirectories (like `https://examples.hwaro.hahwul.com/samizdat/`).
2. Replaced the incorrectly used `taxonomy_terms` variable with `terms` in `taxonomy.html`, allowing the taxonomy index to correctly iterate over terms and list available tags, preventing empty pages that essentially function as broken link hubs.

---
*PR created automatically by Jules for task [4801137267279218490](https://jules.google.com/task/4801137267279218490) started by @hahwul*