### PR TITLE
Fix 404 links in mirror-hunger templates

### DIFF
--- a/examples/mirror-hunger/templates/post.html
+++ b/examples/mirror-hunger/templates/post.html
@@ -33,7 +33,7 @@
         <div class="section-header">OTHER REFLECTIONS</div>
         <div class="mirror-hall" style="grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));">
           {% for rel in page.related.pages | slice(end=3) %}
-            <a href="{{ rel.url }}" class="post-mirror">
+            <a href="{{ base_url }}{{ rel.url }}" class="post-mirror">
               <div class="mirror-frame">
                 <div class="mirror-surface" style="min-height:148px; padding:1.1rem 1.3rem;">
                   <div class="post-meta">{{ rel.date | date("%d %b") }}</div>

--- a/examples/mirror-hunger/templates/section.html
+++ b/examples/mirror-hunger/templates/section.html
@@ -8,7 +8,7 @@
 
     <div class="mirror-hall">
       {% for post in section.pages %}
-        <a href="{{ post.url }}" class="post-mirror">
+        <a href="{{ base_url }}{{ post.url }}" class="post-mirror">
           <div class="mirror-frame {% if loop.index is even %}cracked{% endif %}">
             <div class="mirror-surface">
               <div class="post-meta">{{ post.date | date("%d %B %Y") }}</div>


### PR DESCRIPTION
The `mirror-hunger` theme was causing 404 links for the related posts loop in `post.html` and the post iterations in `section.html` when the static site generator was deployed to a subdirectory. This patch adds the `{{ base_url }}` prefix to the `<a href>` attributes corresponding to `rel.url` and `post.url` to resolve the bug.

---
*PR created automatically by Jules for task [15053222252442811687](https://jules.google.com/task/15053222252442811687) started by @hahwul*