### PR TITLE
Fix afterparty 404 links

### DIFF
--- a/examples/afterparty/templates/section.html
+++ b/examples/afterparty/templates/section.html
@@ -9,7 +9,7 @@
     <ul class="dj-list">
       {% for dj in section.pages %}
       <li class="dj-card">
-        <a href="{{ dj.url }}" class="dj-link">
+        <a href="{{ base_url }}{{ dj.url }}" class="dj-link">
           <div class="dj-slot">
             {% if dj.extra.slot %}<span class="dj-time">{{ dj.extra.slot | e }}</span>{% endif %}
             {% if dj.extra.room %}<span class="dj-room">{{ dj.extra.room | upper }}</span>{% endif %}


### PR DESCRIPTION
In the `afterparty` example, DJ links in the `section.html` template were missing the `base_url` prefix. This caused them to result in 404s when the site is deployed to a subdirectory. This PR prepends `base_url` to `dj.url` inside the template to ensure links resolve correctly.

---
*PR created automatically by Jules for task [8117331033837629488](https://jules.google.com/task/8117331033837629488) started by @chei-l*