### PR TITLE
Fix 404 links in eclipse-tape theme

### DIFF
--- a/examples/eclipse-tape/templates/home.html
+++ b/examples/eclipse-tape/templates/home.html
@@ -274,7 +274,7 @@
           {% if loop.index <= 4 %}
           <li>
             <div class="copy">
-              <a href="{{ post.url }}"><b>{{ post.title }}</b></a>
+              <a href="{{ base_url }}{{ post.url }}"><b>{{ post.title }}</b></a>
               {% if post.description %}<p>{{ post.description }}</p>{% endif %}
               <div class="tags">
                 {% for t in post.tags %}<span class="t">{{ t }}</span>{% endfor %}

--- a/examples/eclipse-tape/templates/section.html
+++ b/examples/eclipse-tape/templates/section.html
@@ -14,7 +14,7 @@
       {% for post in section.pages %}
         <li>
           <div class="copy">
-            <a href="{{ post.url }}"><b>{{ post.title }}</b></a>
+            <a href="{{ base_url }}{{ post.url }}"><b>{{ post.title }}</b></a>
             {% if post.description %}<p>{{ post.description }}</p>{% endif %}
             <div class="tags">
               {% for t in post.tags %}<span class="t">{{ t }}</span>{% endfor %}


### PR DESCRIPTION
This PR fixes 404 links in the `eclipse-tape` example by prepending `{{ base_url }}` to `{{ post.url }}` in `templates/home.html` and `templates/section.html`. This ensures that absolute URLs are correctly built when the site is deployed to a subpath.

---
*PR created automatically by Jules for task [16642259797769075714](https://jules.google.com/task/16642259797769075714) started by @hahwul*