### PR TITLE
Fix 404 error on /tags/ link in tangram example theme

### DIFF
--- a/examples/tangram/content/tags/_index.md
+++ b/examples/tangram/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+layout = "taxonomy"
++++


### PR DESCRIPTION
The header of the `tangram` example theme contains a link to `/tags/`, but clicking it resulted in a 404 error because the `tangram` example didn't have a `tags` content folder with an `_index.md` file.

This commit creates the `examples/tangram/content/tags/_index.md` file with the correct TOML frontmatter (`title = "Tags"`, `layout = "taxonomy"`) to resolve the 404 error and correctly map the page to the taxonomy layout.

---
*PR created automatically by Jules for task [8995973046113697637](https://jules.google.com/task/8995973046113697637) started by @hahwul*