### PR TITLE
Fix missing trailing slashes in y2k navigation links

### DIFF
--- a/examples/y2k/templates/header.html
+++ b/examples/y2k/templates/header.html
@@ -333,9 +333,9 @@
             <p style="font-family: var(--font-mono); color: var(--metallic-mid); margin-top: 0.5rem;">[ SYSTEM_ONLINE :: AESTHETIC_MODULE_LOADED ]</p>
             <nav>
                 <a href="{{ base_url }}/">HOME</a>
-                <a href="{{ base_url }}/about">ABOUT</a>
-                <a href="{{ base_url }}/archive">ARCHIVE</a>
-                <a href="{{ base_url }}/links">LINKS</a>
+                <a href="{{ base_url }}/about/">ABOUT</a>
+                <a href="{{ base_url }}/archive/">ARCHIVE</a>
+                <a href="{{ base_url }}/links/">LINKS</a>
             </nav>
         </header>
         <main>


### PR DESCRIPTION
This PR fixes an issue in the `y2k` theme where navigation links to `/about`, `/archive`, and `/links` resulted in a 404 error because they were missing a trailing slash. By appending the trailing slash in the `header.html` template, the links correctly resolve to their corresponding `index.html` file within the directory structure generated by `hwaro build`.

---
*PR created automatically by Jules for task [5001903086628005710](https://jules.google.com/task/5001903086628005710) started by @chei-l*