### PR TITLE
fix(swiss-dashboard): Prepend base_url to post urls to prevent 404s

### DIFF
--- a/examples/swiss-dashboard/templates/section.html
+++ b/examples/swiss-dashboard/templates/section.html
@@ -14,7 +14,7 @@
         {% for post in section.pages %}
           <div class="log-item">
             <div class="log-info">
-              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <a href="{{ base_url }}{{ post.url }}">{{ post.title | e }}</a>
               <div class="log-meta">
                 {% if post.date is present %}
                   <span>DATE: {{ post.date | date("%Y-%m-%d") }}</span>
@@ -24,7 +24,7 @@
                 {% endif %}
               </div>
             </div>
-            <a href="{{ post.url }}" class="log-action">Access Report</a>
+            <a href="{{ base_url }}{{ post.url }}" class="log-action">Access Report</a>
           </div>
         {% endfor %}
       </div>

--- a/examples/swiss-dashboard/templates/taxonomy_term.html
+++ b/examples/swiss-dashboard/templates/taxonomy_term.html
@@ -10,7 +10,7 @@
         {% for post in taxonomy_pages %}
           <div class="log-item">
             <div class="log-info">
-              <a href="{{ post.url }}">{{ post.title | e }}</a>
+              <a href="{{ base_url }}{{ post.url }}">{{ post.title | e }}</a>
               <div class="log-meta">
                 {% if post.date is present %}
                   <span>DATE: {{ post.date | date("%Y-%m-%d") }}</span>
@@ -20,7 +20,7 @@
                 {% endif %}
               </div>
             </div>
-            <a href="{{ post.url }}" class="log-action">Access Report</a>
+            <a href="{{ base_url }}{{ post.url }}" class="log-action">Access Report</a>
           </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
Prepended `{{ base_url }}` to `{{ post.url }}` links in `section.html` and `taxonomy_term.html` templates for the `swiss-dashboard` example site. This ensures the correct relative path is formed when the site is deployed to a subdirectory.

---
*PR created automatically by Jules for task [6464868957915941457](https://jules.google.com/task/6464868957915941457) started by @hahwul*