### PR TITLE
fix: correct 404 links in abyss taxonomy template

### DIFF
--- a/examples/abyss/templates/taxonomy.html
+++ b/examples/abyss/templates/taxonomy.html
@@ -14,8 +14,8 @@
   </div>
 
   <div class="flex flex-wrap gap-3">
-    {% for term in taxonomy_terms %}
-    <a href="{{ base_url }}/tags/{{ term.name }}/" class="tag-pill text-sm py-2 px-4">
+    {% for term in terms %}
+    <a href="{{ base_url }}{{ term.url }}" class="tag-pill text-sm py-2 px-4">
       {{ term.name }}
       {% if term.count %}
       <span class="ml-2 opacity-50">({{ term.count }})</span>


### PR DESCRIPTION
This PR resolves a 404 issue with tag links in the Abyss example's taxonomy template. By using the standard `terms` iteration variable and the `term.url` property directly, links to individual tags are now dynamically generated and valid, avoiding broken links.

---
*PR created automatically by Jules for task [17619233218453706988](https://jules.google.com/task/17619233218453706988) started by @hahwul*