### PR TITLE
Fix 404 error for tags page in front-row example

### DIFF
--- a/examples/front-row/content/tags/_index.md
+++ b/examples/front-row/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+description = "Browse content by tags"
++++


### PR DESCRIPTION
Created the missing `content/tags/_index.md` file in the `front-row` example site. This resolves a 404 error that occurs when users click on the tags links in the header and footer templates, properly enabling the tags taxonomy index page.

---
*PR created automatically by Jules for task [5502550631458218281](https://jules.google.com/task/5502550631458218281) started by @hahwul*