### PR TITLE
fix(examples): resolve 404 links in wireframe-blog

### DIFF
--- a/examples/wireframe-blog/content/archives.md
+++ b/examples/wireframe-blog/content/archives.md
@@ -2,4 +2,4 @@
 title = "Archives"
 +++
 
-Browse all posts by date. Check the [Posts](/posts/) section for the complete list.
+Browse all posts by date. Check the [Posts](posts/) section for the complete list.

--- a/examples/wireframe-blog/content/index.md
+++ b/examples/wireframe-blog/content/index.md
@@ -20,5 +20,5 @@ We believe that the best design starts with a solid foundation.
 Check out our nodes of posts or see the schema behind the scenes.
 
 <div style="margin-top: 4rem; text-align: center;">
-  <a href="/posts/" class="btn">VIEW THE NODES</a>
+  <a href="posts/" class="btn">VIEW THE NODES</a>
 </div>


### PR DESCRIPTION
This PR updates the markdown content in the `wireframe-blog` example to use relative paths instead of absolute paths for internal links.

Specifically, it changes:
- `[Posts](/posts/)` to `[Posts](posts/)` in `archives.md`
- `href="/posts/"` to `href="posts/"` in `index.md`

This resolves 404 broken link errors that occur when the example is deployed to a subpath (e.g., `https://examples.hwaro.hahwul.com/wireframe-blog/`), ensuring users are correctly navigated to the posts list.

---
*PR created automatically by Jules for task [14080975641870867603](https://jules.google.com/task/14080975641870867603) started by @chei-l*