### PR TITLE
fix(ascii): resolve 404 links in templates

### DIFF
--- a/examples/ascii/templates/header.html
+++ b/examples/ascii/templates/header.html
@@ -281,7 +281,7 @@
 </div>
         <nav>
             <a href="{{ base_url }}/">Home</a>
-            <a href="{{ base_url }}/about">About</a>
+            <a href="{{ base_url }}/about/">About</a>
         </nav>
         <hr>
     </header>

--- a/examples/ascii/templates/index.html
+++ b/examples/ascii/templates/index.html
@@ -6,7 +6,7 @@
         <ul class="post-list">
         {% for post in section.pages %}
             <li>
-                <a href="{{ post.permalink }}">{{ post.title }}</a>
+                <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
                 {% if post.date %}
                 <span class="post-meta"> - {{ post.date | date(format="%Y-%m-%d") }}</span>
                 {% endif %}

--- a/examples/ascii/templates/section.html
+++ b/examples/ascii/templates/section.html
@@ -6,7 +6,7 @@
         <ul class="post-list">
         {% for post in section.pages %}
             <li>
-                <a href="{{ post.permalink }}">{{ post.title }}</a>
+                <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
                 {% if post.date %}
                 <span class="post-meta"> - {{ post.date | date(format="%Y-%m-%d") }}</span>
                 {% endif %}


### PR DESCRIPTION
This PR fixes broken navigation links and post list links in the `ascii` example site. It ensures proper prefixing with `base_url` to prevent 404 errors when the site is hosted in a subdirectory.

---
*PR created automatically by Jules for task [2705416209412707912](https://jules.google.com/task/2705416209412707912) started by @hahwul*