### PR TITLE
Fix 404 broken links in typewriter theme search

### DIFF
--- a/examples/typewriter/templates/search.html
+++ b/examples/typewriter/templates/search.html
@@ -33,7 +33,7 @@
         if (!query || !fuse) { resultsEl.innerHTML = ''; return; }
         var results = fuse.search(query).slice(0, 10);
         resultsEl.innerHTML = results.map(function(r) {
-          return '<li><a href="' + escapeHtml(r.item.url) + '">' + escapeHtml(r.item.title) + '</a></li>';
+          return '<li><a href="{{ base_url }}' + escapeHtml(r.item.url) + '">' + escapeHtml(r.item.title) + '</a></li>';
         }).join('');
       });
     })();


### PR DESCRIPTION
This PR fixes a 404 issue in the `typewriter` example theme where dynamically generated JS search result links did not correctly prepend the `{{ base_url }}`, causing them to break when deployed to a subdirectory.

- Update `examples/typewriter/templates/search.html` to include `{{ base_url }}` before the JS search link items.

---
*PR created automatically by Jules for task [10089477841290917120](https://jules.google.com/task/10089477841290917120) started by @chei-l*