### PR TITLE
Fix 404 links and template errors in multiple examples

### DIFF
--- a/examples/fauvist-wild/templates/header.html
+++ b/examples/fauvist-wild/templates/header.html
@@ -2,8 +2,8 @@
     <div class="header-inner container">
         <h1 class="site-title"><a href="{{ base_url }}/">{{ site.title }}</a></h1>
         <nav class="site-nav">
-            <a href="{{ base_url }}/posts">Exhibitions</a>
-            <a href="{{ base_url }}/about">About</a>
+            <a href="{{ base_url }}/posts/">Exhibitions</a>
+            <a href="{{ base_url }}/about/">About</a>
         </nav>
     </div>
 </header>

--- a/examples/fauvist-wild/templates/page.html
+++ b/examples/fauvist-wild/templates/page.html
@@ -19,7 +19,7 @@
     <div class="page-tags">
         <strong>Tags:</strong>
         {% for tag in page.tags %}
-        <a href="{{ base_url }}/tags/{{ tag | slugify }}" class="tag">{{ tag }}</a>
+        <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
         {% endfor %}
     </div>
     {% endif %}

--- a/examples/fauvist-wild/templates/taxonomy_term.html
+++ b/examples/fauvist-wild/templates/taxonomy_term.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
-{% block title %}{{ taxonomy_term.name }} | {{ site.title }}{% endblock %}
+{% block title %}{{ taxonomy_term }} | {{ site.title }}{% endblock %}
 
 {% block content %}
-<h1>{{ taxonomy_name | title }}: <span class="term-name">{{ taxonomy_term.name }}</span></h1>
+<h1>{{ taxonomy_name | title }}: <span class="term-name">{{ taxonomy_term }}</span></h1>
 
 <ul class="post-list">
     {% for p in taxonomy_pages %}

--- a/examples/mosh-pit/content/lineup/effigy-year.md
+++ b/examples/mosh-pit/content/lineup/effigy-year.md
@@ -1,0 +1,6 @@
++++
+title = "Effigy Year"
+date = 2025-10-18T21:05:00Z
++++
+
+Post-hardcore / loud quiet loud. This is a placeholder for Effigy Year. They have dynamics.

--- a/examples/mosh-pit/content/lineup/kennel-cough.md
+++ b/examples/mosh-pit/content/lineup/kennel-cough.md
@@ -1,0 +1,6 @@
++++
+title = "Kennel Cough"
+date = 2025-10-18T20:35:00Z
++++
+
+D-beat / 45 sec songs. This is a placeholder for Kennel Cough. They play fast and loud.

--- a/examples/mosh-pit/content/lineup/negative-draw.md
+++ b/examples/mosh-pit/content/lineup/negative-draw.md
@@ -1,0 +1,6 @@
++++
+title = "Negative Draw"
+date = 2025-10-18T22:15:00Z
++++
+
+Crust punk / peace-punk. This is a placeholder for Negative Draw.

--- a/examples/mosh-pit/content/lineup/secret-set.md
+++ b/examples/mosh-pit/content/lineup/secret-set.md
@@ -1,0 +1,6 @@
++++
+title = "Secret Set"
+date = 2025-10-18T23:40:00Z
++++
+
+Secret band. Rumours say it's someone big.


### PR DESCRIPTION
- Added missing trailing slashes to `href="{{ base_url }}/..."` links in `fauvist-wild`'s `header.html` and `page.html` templates to correctly route endpoints and avoid 404s.
- Fixed a template rendering issue in `fauvist-wild`'s `taxonomy_term.html` where `taxonomy_term.name` was erroneously called, returning undefined, by directly using `taxonomy_term`.
- Created placeholder lineup Markdown files for `effigy-year.md`, `kennel-cough.md`, `negative-draw.md`, and `secret-set.md` in the `mosh-pit` example to satisfy dead lineup links mentioned in the `index.md` file.

---
*PR created automatically by Jules for task [17760412469605204868](https://jules.google.com/task/17760412469605204868) started by @hahwul*