### PR TITLE
Fix 404 search result links in lavender-field theme

### DIFF
--- a/examples/lavender-field/static/js/search.js
+++ b/examples/lavender-field/static/js/search.js
@@ -93,11 +93,14 @@
       return;
     }
 
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var baseUrl = base.substring(0, base.indexOf('/css/'));
+
     var html = '';
     for (var j = 0; j < results.length; j++) {
       var r = results[j].item;
       var snippet = getSnippet(r.content, query.trim());
-      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+      html += '<a class="search-result-item" href="' + baseUrl + r.url + '" data-index="' + j + '">'
         + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
         + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
         + '</a>';


### PR DESCRIPTION
This commit modifies the static JavaScript search file in the `lavender-field` example site to correctly prefix result URLs with the dynamically extracted base path. This ensures that links from search results will properly resolve when the theme is hosted within a subdirectory.

---
*PR created automatically by Jules for task [8203408149439091799](https://jules.google.com/task/8203408149439091799) started by @hahwul*