### PR TITLE
Fix 404 absolute link in zenithpoint example

### DIFF
--- a/examples/zenithpoint/content/index.md
+++ b/examples/zenithpoint/content/index.md
@@ -17,4 +17,4 @@ We believe in the power of simplicity. We use heavy weight fonts, solid colors, 
 - **Pure Typography**: Letting the words speak for themselves.
 - **Absolute Contrast**: Black and white, with a single, aggressive accent color.
 
-[Explore our vision](/about/)
+[Explore our vision](about/)


### PR DESCRIPTION
Fixes a 404 issue in the `zenithpoint` example by updating the "Explore our vision" link in `examples/zenithpoint/content/index.md` to be a relative path (`about/`) instead of an absolute path (`/about/`). This ensures the link works correctly when the site is deployed to a subdirectory.

---
*PR created automatically by Jules for task [11808090617566012112](https://jules.google.com/task/11808090617566012112) started by @chei-l*