### PR TITLE
Fix 404 links in isthmus example

### DIFF
--- a/examples/isthmus/content/index.md
+++ b/examples/isthmus/content/index.md
@@ -10,7 +10,7 @@ path_type = "bridge"
 Welcome to the central crossing. Navigate between the great continents using the path below.
 
 <div class="bridge-navigation">
-  <a href="{{ base_url }}/continent-west/" class="bridge-link west">West Continent</a>
+  <a href="continent-west/" class="bridge-link west">West Continent</a>
   <span class="bridge-path"></span>
-  <a href="{{ base_url }}/continent-east/" class="bridge-link east">East Continent</a>
+  <a href="continent-east/" class="bridge-link east">East Continent</a>
 </div>


### PR DESCRIPTION
Fixes the broken links in the `isthmus` example by removing literal `{{ base_url }}` template variables from the Markdown file. Since Tera variables are not parsed inside `.md` content by default, they were causing the HTML to have literal `{{ base_url }}` strings, leading to 404s. Changed the links to be strictly relative.

---
*PR created automatically by Jules for task [2191644734527190076](https://jules.google.com/task/2191644734527190076) started by @chei-l*