### PR TITLE
fix(dusk): add tags index page

### DIFF
--- a/examples/dusk/content/tags/_index.md
+++ b/examples/dusk/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+description = "All tags used across Dusk."
++++

--- a/examples/dusk/wget_err.txt
+++ b/examples/dusk/wget_err.txt
@@ -1,0 +1,7 @@
+failed: Connection refused.
+2026-06-21 23:28:52 URL:http://localhost:3000/ [6804/6804] -> "index.html.tmp.tmp" [1]
+Found no broken links.
+
+FINISHED --2026-06-21 23:28:52--
+Total wall clock time: 0.01s
+Downloaded: 1 files, 6.6K in 0s (648 MB/s)

--- a/hwaro_out.log
+++ b/hwaro_out.log
@@ -1,0 +1,11 @@
+hwaro: build
+read: 9 content files
+parse: 9 pages
+render: 9 pages
+built: 9 content pages in 33ms
+hwaro: serve
+url: http://127.0.0.1:3000
+reload: enabled
+watch: content, templates, static, config
+ready: Ctrl+C to stop
+hwaro serve: ready url=http://127.0.0.1:3000 pid=170372


### PR DESCRIPTION
Resolves a broken 404 link in the `dusk` example template by creating the missing `tags` taxonomy page.

---
*PR created automatically by Jules for task [8263865278511407880](https://jules.google.com/task/8263865278511407880) started by @hahwul*