### PR TITLE
fix(pamphlet): resolve 404 links in search and taxonomy pages

### DIFF
--- a/examples/pamphlet/config.toml
+++ b/examples/pamphlet/config.toml
@@ -206,3 +206,8 @@ header_font = "'Inter Tight', sans-serif"
 # enabled = true
 # path_prefix = "amp"
 # sections = ["posts"]
+
+[taxonomies]
+tag = "tags"
+category = "categories"
+author = "authors"

--- a/examples/pamphlet/content/authors/_index.md
+++ b/examples/pamphlet/content/authors/_index.md
@@ -1,0 +1,3 @@
++++
+template = "taxonomy"
++++

--- a/examples/pamphlet/content/categories/_index.md
+++ b/examples/pamphlet/content/categories/_index.md
@@ -1,0 +1,3 @@
++++
+template = "taxonomy"
++++

--- a/examples/pamphlet/content/tags/_index.md
+++ b/examples/pamphlet/content/tags/_index.md
@@ -1,0 +1,3 @@
++++
+template = "taxonomy"
++++

--- a/examples/pamphlet/static/js/search.js
+++ b/examples/pamphlet/static/js/search.js
@@ -94,10 +94,15 @@
     }
 
     var html = '';
+    var baseLink = document.querySelector('link[rel="stylesheet"]').href;
+    var baseUrlMatch = baseLink.match(/^(.*)\/css\/style\.css$/);
+    var baseUrlPrefix = baseUrlMatch ? baseUrlMatch[1] : '';
+
     for (var j = 0; j < results.length; j++) {
       var r = results[j].item;
       var snippet = getSnippet(r.content, query.trim());
-      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+      var r_url = r.url.startsWith('/') ? r.url : '/' + r.url;
+      html += '<a class="search-result-item" href="' + baseUrlPrefix + r_url + '" data-index="' + j + '">'
         + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
         + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
         + '</a>';

--- a/examples/pamphlet/templates/taxonomy.html
+++ b/examples/pamphlet/templates/taxonomy.html
@@ -1,7 +1,12 @@
 {% include "header.html" %}
   <main class="site-main">
-    <h1>{{ page.title | e }}</h1>
+    <h1>{{ taxonomy_name | capitalize }}</h1>
     <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    <ul class="taxonomy-list">
+      {% for term in terms %}
+      <li><a href="{{ base_url }}{{ term.url }}">{{ term.name }}</a></li>
+      {% endfor %}
+    </ul>
     {{ content | safe }}
   </main>
 {% include "footer.html" %}

--- a/examples/pamphlet/templates/taxonomy_term.html
+++ b/examples/pamphlet/templates/taxonomy_term.html
@@ -1,7 +1,12 @@
 {% include "header.html" %}
   <main class="site-main">
-    <h1>{{ page.title | e }}</h1>
+    <h1>{{ taxonomy_term | e }}</h1>
     <p class="taxonomy-desc">Posts tagged with this term:</p>
+    <ul class="taxonomy-term-list">
+      {% for item in taxonomy_pages %}
+      <li><a href="{{ base_url }}{{ item.url }}">{{ item.title }}</a></li>
+      {% endfor %}
+    </ul>
     {{ content | safe }}
   </main>
 {% include "footer.html" %}


### PR DESCRIPTION
Fixes several 404 broken links in the `pamphlet` example site:
1. Search Results: The search script generated absolute `/` links that 404ed when the site was deployed to a subdirectory. This was fixed by dynamically parsing the base URL from the stylesheet link.
2. Taxonomy Index Pages: Browsing `/tags/`, `/categories/`, or `/authors/` returned 404s because the `_index.md` files did not exist. These have been added.
3. Taxonomy Templates: The taxonomy index and term templates did not properly loop through the `terms` or `taxonomy_pages` variables, meaning no links to terms or tagged posts were generated. The templates have been updated with the correct Crinja syntax and `base_url` prefixes.

---
*PR created automatically by Jules for task [5550188548280825373](https://jules.google.com/task/5550188548280825373) started by @hahwul*