### PR TITLE
Fix 404 links for categories and tags in hwaro.386 example

### DIFF
--- a/examples/hwaro.386/content/categories/_index.md
+++ b/examples/hwaro.386/content/categories/_index.md
@@ -1,0 +1,3 @@
++++
+template = "taxonomy.html"
++++

--- a/examples/hwaro.386/content/tags/_index.md
+++ b/examples/hwaro.386/content/tags/_index.md
@@ -1,0 +1,3 @@
++++
+template = "taxonomy.html"
++++


### PR DESCRIPTION
Added missing `_index.md` files for `/categories/` and `/tags/` in the `hwaro.386` example to fix 404 links. They now use the `taxonomy.html` template.

---
*PR created automatically by Jules for task [15247932032495371397](https://jules.google.com/task/15247932032495371397) started by @hahwul*