### PR TITLE
Fix 404 in tags taxonomy for redacted-dossier example

### DIFF
--- a/examples/redacted-dossier/content/tags/_index.md
+++ b/examples/redacted-dossier/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+template = "taxonomy.html"
++++


### PR DESCRIPTION
This PR fixes a 404 issue in the `redacted-dossier` example where the `/tags/` route pointed to by tag links returned a 404. I added the necessary `_index.md` file in the `content/tags/` directory to define the taxonomy page.

---
*PR created automatically by Jules for task [13584235729326193172](https://jules.google.com/task/13584235729326193172) started by @hahwul*