### PR TITLE
Fix 404 errors for post links in y2k example

### DIFF
--- a/examples/y2k/templates/index.html
+++ b/examples/y2k/templates/index.html
@@ -11,7 +11,7 @@
         <h2 style="border-bottom: 2px solid var(--primary-accent); display: inline-block; padding-bottom: 5px; margin-bottom: 1.5rem;">LATEST_ENTRIES</h2>
         {% for post in posts.pages | slice(end=5) %}
         <article class="post-card">
-            <h3 class="post-title"><a href="{{ base_url }}/{{ post.path }}">{{ post.title }}</a></h3>
+            <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
             <div class="post-meta">
                 {% if post.date %}DATE: {{ post.date | date(format="%Y-%m-%d %H:%M:%S") }} | {% endif %}
                 AUTHOR: {% if post.author %}{{ post.author }}{% else %}SYS_ADMIN{% endif %}
@@ -32,7 +32,7 @@
             </div>
             {% endif %}
 
-            <a href="{{ base_url }}/{{ post.path }}" class="btn">READ_MORE ></a>
+            <a href="{{ base_url }}{{ post.url }}" class="btn">READ_MORE ></a>
         </article>
         {% endfor %}
     {% else %}

--- a/examples/y2k/templates/section.html
+++ b/examples/y2k/templates/section.html
@@ -12,7 +12,7 @@
     {% if section.pages %}
         {% for post in section.pages %}
         <article class="post-card">
-            <h3 class="post-title"><a href="{{ base_url }}/{{ post.path }}">{{ post.title }}</a></h3>
+            <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
             <div class="post-meta">
                 {% if post.date %}DATE: {{ post.date | date(format="%Y-%m-%d") }} | {% endif %}
                 AUTHOR: {% if post.author %}{{ post.author }}{% else %}SYS_ADMIN{% endif %}


### PR DESCRIPTION
In the `y2k` example template (`examples/y2k/templates/index.html` and `examples/y2k/templates/section.html`), the links to individual posts were using `{{ post.path }}` which generated a raw relative file path like `posts/my-post.md` resulting in 404 broken links. This was resolved by replacing `post.path` with `post.url` and prefixing it directly with `{{ base_url }}` to resolve properly.

---
*PR created automatically by Jules for task [17396473137806687776](https://jules.google.com/task/17396473137806687776) started by @chei-l*