### PR TITLE
Fix 404 links and taxonomies in zircon-matrix-ui

### DIFF
--- a/examples/zircon-matrix-ui/config.toml
+++ b/examples/zircon-matrix-ui/config.toml
@@ -211,3 +211,6 @@ base_url = "http://localhost:3000"
 # enabled = true
 # path_prefix = "amp"
 # sections = ["posts"]
+
+[[taxonomies]]
+name = "tags"

--- a/examples/zircon-matrix-ui/templates/section.html
+++ b/examples/zircon-matrix-ui/templates/section.html
@@ -11,7 +11,7 @@
       <ul class="section-list">
         {% for p in section.pages %}
           <li>
-            <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+            <h3><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></h3>
             {% if p.description is defined %}
               <p>{{ p.description | e }}</p>
             {% endif %}

--- a/examples/zircon-matrix-ui/templates/taxonomy_term.html
+++ b/examples/zircon-matrix-ui/templates/taxonomy_term.html
@@ -9,7 +9,7 @@
       {% if pages is defined %}
         {% for p in pages %}
           <li>
-            <h3><a href="{{ p.url }}">{{ p.title | e }}</a></h3>
+            <h3><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></h3>
             {% if p.description is defined %}
               <p>{{ p.description | e }}</p>
             {% endif %}


### PR DESCRIPTION
- Fixed missing `[[taxonomies]]` definition in `config.toml` that prevented tag pages from being generated.
- Updated `section.html` and `taxonomy_term.html` templates to prepend `{{ base_url }}` to `p.url` to ensure links resolve correctly when deployed to subdirectories without 404 errors.

---
*PR created automatically by Jules for task [2234437895981479134](https://jules.google.com/task/2234437895981479134) started by @chei-l*