### PR TITLE
Fix broken links in postcard-route example

### DIFF
--- a/examples/postcard-route/content/tags/_index.md
+++ b/examples/postcard-route/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+template = "taxonomy.html"
++++

--- a/examples/postcard-route/templates/footer.html
+++ b/examples/postcard-route/templates/footer.html
@@ -20,8 +20,8 @@
         <div>
           <h4>Postage</h4>
           <a href="#post">How the post works</a>
-          <a href="{{ base_url }}/about/#postage">Stamps &amp; printing</a>
-          <a href="{{ base_url }}/about/#commission">Commission a route</a>
+          <a href="{{ base_url }}/about/#the-postage">Stamps &amp; printing</a>
+          <a href="{{ base_url }}/about/#how-to-commission-a-route">Commission a route</a>
         </div>
         <div>
           <h4>Letters</h4>


### PR DESCRIPTION
Resolves missing taxonomy pages and broken anchor links in the postcard-route example theme.

---
*PR created automatically by Jules for task [13772622265031283295](https://jules.google.com/task/13772622265031283295) started by @hahwul*