### PR TITLE
Fix 404 links to /tags/ in pyrite example

### DIFF
--- a/examples/pyrite/content/tags/_index.md
+++ b/examples/pyrite/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags Index"
+template = "taxonomy.html"
++++


### PR DESCRIPTION
Resolves the 404 error encountered when clicking on the `tags` links in the `pyrite` example by creating an index file with the proper taxonomy template.

---
*PR created automatically by Jules for task [11032442713620756795](https://jules.google.com/task/11032442713620756795) started by @hahwul*