### PR TITLE
Fix broken /about/ link in kiosk example by creating about.md

### DIFF
--- a/examples/kiosk/content/about.md
+++ b/examples/kiosk/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About Kiosk"
+description = "About the Kiosk urbanism review project."
+date = 2025-04-12
++++
+
+Welcome to Kiosk, an independent urbanism review dedicated to grading the streets, stations, and the intricate spaces between our civic infrastructure. Founded in 2025, our mission is to cast a critical yet constructive eye on the built environment that shapes our daily lives.
+
+Our cities are constantly evolving, and so must our understanding of them. Kiosk serves as a vital platform where architects, urban planners, and everyday commuters converge to discuss the reality of our public spaces. We believe that good design should not be a luxury, but a fundamental right for all citizens.
+
+At Kiosk, we evaluate infrastructure not just on its aesthetic merit, but on its functionality, accessibility, and environmental impact. We take pride in our rigorous grading system, which dissects everything from the accessibility of transit hubs to the pedestrian-friendliness of neighborhood streets. Each review is backed by thorough fieldwork, community feedback, and a deep appreciation for the subtle details that turn a simple street into a vibrant community artery.
+
+Whether you are a seasoned urbanist, a passionate local advocate, or just someone who cares about the sidewalks you walk on, Kiosk invites you to join the conversation. Our detailed reviews, insightful essays, and dynamic discussions aim to inspire better design and foster a greater connection to the spaces we inhabit.
+
+Together, we can advocate for cities that are not just efficient and functional, but truly human-centric. Thank you for visiting, and we hope you find our insights both illuminating and engaging.


### PR DESCRIPTION
Resolves the 404 broken link issue in the `kiosk` example by creating a placeholder `about.md` with plausible TOML frontmatter and content. This ensures the site builds correctly without any dead links.

---
*PR created automatically by Jules for task [6900321566511629361](https://jules.google.com/task/6900321566511629361) started by @hahwul*