### PR TITLE
Fix absolute path 404s in mach example

### DIFF
--- a/examples/mach/content/about.md
+++ b/examples/mach/content/about.md
@@ -13,7 +13,7 @@ Self-hosting CI has a reputation for being a chore: patch the runner, babysit th
 
 {{ sh(text="Where the project is going", time="0.05s") }}
 
-The `riscv64` target is still in beta, cold starts on Windows runners are the next thing we want to shave down, and we owe the community a proper plugin API for custom cache backends beyond the built-in local and S3-compatible options. All three are tracked openly in the [devlog](/devlog/), where we write about what shipped, what broke, and what we changed our minds about — including the two times we rewrote the scheduler from scratch before settling on the lease-based design that ships today.
+The `riscv64` target is still in beta, cold starts on Windows runners are the next thing we want to shave down, and we owe the community a proper plugin API for custom cache backends beyond the built-in local and S3-compatible options. All three are tracked openly in the [devlog](../devlog/), where we write about what shipped, what broke, and what we changed our minds about — including the two times we rewrote the scheduler from scratch before settling on the lease-based design that ships today.
 
 {{ sh(text="Getting in touch", time="0.04s") }}
 

--- a/examples/mach/content/devlog/_index.md
+++ b/examples/mach/content/devlog/_index.md
@@ -8,4 +8,4 @@ generate_feeds = true
 elapsed = "0.19s"
 +++
 
-Notes from the three of us building Mach, posted roughly when something ships or breaks in an interesting way — not on a content calendar. Subscribe via the [RSS feed](/devlog/rss.xml) if you would rather not check back.
+Notes from the three of us building Mach, posted roughly when something ships or breaks in an interesting way — not on a content calendar. Subscribe via the [RSS feed](rss.xml) if you would rather not check back.


### PR DESCRIPTION
Randomly selected the `mach` example and fixed 404 links resulting from the use of absolute paths in markdown content. Converted `/devlog/` to `../devlog/` and `/devlog/rss.xml` to `rss.xml` to ensure they resolve properly relative to subdirectories. Tested the build and verified the paths output correctly in the generated HTML.

---
*PR created automatically by Jules for task [18317166509626620412](https://jules.google.com/task/18317166509626620412) started by @chei-l*