### PR TITLE
Fix broken links in tabloid example

### DIFF
--- a/examples/tabloid/content/about.md
+++ b/examples/tabloid/content/about.md
@@ -3,7 +3,7 @@ title = "About"
 description = "Tabloid is a small-batch beer zine that reviews the pour and the room with equal suspicion."
 +++
 
-Tabloid started as a photocopied handout left on the bar at a taproom that has since closed, which we consider a coincidence and not a warning. We rate beer. We rate the rooms that pour it. We have never once softened a review because a brewery bought us a round, and several breweries have stopped speaking to us as a direct result. The whole run so far lives in the [pours archive](pours/); if you just want to jump straight to the loudest verdict we've filed, start with [Molasses Bomb](pours/molasses-bomb/).
+Tabloid started as a photocopied handout left on the bar at a taproom that has since closed, which we consider a coincidence and not a warning. We rate beer. We rate the rooms that pour it. We have never once softened a review because a brewery bought us a round, and several breweries have stopped speaking to us as a direct result. The whole run so far lives in the [pours archive](@/pours/_index.md); if you just want to jump straight to the loudest verdict we've filed, start with [Molasses Bomb](@/pours/molasses-bomb.md).
 
 ## What we actually do
 
@@ -17,4 +17,4 @@ We run corrections when we're wrong about a fact — an ABV, a release date, a b
 
 ## Get in touch
 
-Send tips, samples, and polite disagreements to the desk. We read everything. We publish what's true and interesting, in whichever order gets the sentence to land harder. Looking for something specific? [Search the archive](search/) by beer, style, or room.
+Send tips, samples, and polite disagreements to the desk. We read everything. We publish what's true and interesting, in whichever order gets the sentence to land harder. Looking for something specific? [Search the archive](@/search.md) by beer, style, or room.

--- a/examples/tabloid/content/index.md
+++ b/examples/tabloid/content/index.md
@@ -8,4 +8,4 @@ template = "home"
 
 Tabloid rates the beer and the room in the same breath, because pretending they're separate is how tasting notes turn into marketing copy. Every pour here got ordered, argued about, and written up by someone who paid for their own glass — no sponsored kegs, no brewery-supplied samples, no softened verdicts for the taprooms that hate what we wrote about them last time.
 
-If you're new here: the kicker tells you the style, the dek is the whole opinion in one sentence, the byline is who to blame, and the ABV is stamped on the corner so you know your limits before you order a second round. Want the whole story on how we work? Read [the about page](about/).
+If you're new here: the kicker tells you the style, the dek is the whole opinion in one sentence, the byline is who to blame, and the ABV is stamped on the corner so you know your limits before you order a second round. Want the whole story on how we work? Read [the about page](@/about.md).

--- a/examples/tabloid/content/pours/nine-dollar-lager.md
+++ b/examples/tabloid/content/pours/nine-dollar-lager.md
@@ -23,4 +23,4 @@ None of that is the beer's fault. Poured blind, this pilsner would win most head
 
 If you can tune out the reclaimed-wood theater, it's a genuinely good crusher of a beer. If you can't, order it to go and drink it somewhere the walls aren't billing you by the hour.
 
-**Verdict:** great lager, exhausting room. Nine dollars is a room tax, not a beer tax — budget accordingly. If atmosphere tax isn't your thing, go get lost in [The Tin Whistle's flight board](tin-whistle-flight/) instead — same neighborhood, a fraction of the pretense.
+**Verdict:** great lager, exhausting room. Nine dollars is a room tax, not a beer tax — budget accordingly. If atmosphere tax isn't your thing, go get lost in [The Tin Whistle's flight board](@/pours/tin-whistle-flight.md) instead — same neighborhood, a fraction of the pretense.

--- a/examples/tabloid/templates/footer.html
+++ b/examples/tabloid/templates/footer.html
@@ -6,7 +6,7 @@
         <a href="{{ base_url }}{{ lang_prefix }}/tags/">Tags</a>
         <a href="{{ base_url }}{{ lang_prefix }}/categories/">Styles</a>
         <a href="{{ base_url }}{{ lang_prefix }}/about/">About</a>
-        <a href="{{ base_url }}/feeds/pours.xml">RSS</a>
+        <a href="{{ base_url }}/pours/rss.xml">RSS</a>
       </nav>
       <p class="site-footer__fine">No beer here has ever seen a marketing deck. Built with Hwaro.</p>
     </div>


### PR DESCRIPTION
This PR fixes several 404 errors in the `examples/tabloid` theme caused by incorrect relative markdown links and an incorrect RSS feed path in the footer template.

Changes:
* In `content/index.md`, `content/about.md`, and `content/pours/nine-dollar-lager.md`, relative links (e.g. `pours/`) were replaced with internal path links (`@/pours/_index.md`) to ensure they compile correctly on any sub-page.
* In `templates/footer.html`, the RSS link was corrected from `/feeds/pours.xml` to `/pours/rss.xml`.

---
*PR created automatically by Jules for task [11095274680429662381](https://jules.google.com/task/11095274680429662381) started by @hahwul*