### PR TITLE
Fix 404 links in theblack example

### DIFF
--- a/examples/theblack/content/index.md
+++ b/examples/theblack/content/index.md
@@ -4,8 +4,8 @@ template = "home"
 description = "Welcome to TheBlack, an elegant magazine exploring the aesthetic, culture, and philosophy of black in art, design, and sound."
 +++
 
-Welcome to the first digital archive of [TheBlack](/). In these virtual columns, we attempt to frame a space of deep contemplation. We explore the absence of hue, not as a negation, but as the supreme container of potentiality. In art, black is the ultimate shadow that defines the light; in sound, it is the silence from which all vibration emerges.
+Welcome to the first digital archive of [TheBlack](./). In these virtual columns, we attempt to frame a space of deep contemplation. We explore the absence of hue, not as a negation, but as the supreme container of potentiality. In art, black is the ultimate shadow that defines the light; in sound, it is the silence from which all vibration emerges.
 
-Through [five curated essays](/essays/), we invite you to traverse these dark corridors. From the architectural depth of [basalt monuments](/essays/shadows-in-stone/) to the low-frequency drone of [experimental acoustics](/essays/resonance-of-silence/), we investigate how the withdrawal of color shifts the human sensory apparatus. We examine why artists like Ad Reinhardt spent decades seeking the absolute black canvas, and how contemporary fashion uses absolute darkness as armor.
+Through [five curated essays](essays/), we invite you to traverse these dark corridors. From the architectural depth of [basalt monuments](essays/shadows-in-stone/) to the low-frequency drone of [experimental acoustics](essays/resonance-of-silence/), we investigate how the withdrawal of color shifts the human sensory apparatus. We examine why artists like Ad Reinhardt spent decades seeking the absolute black canvas, and how contemporary fashion uses absolute darkness as armor.
 
-We hope this edition serves as a quiet [refuge](/about/).
+We hope this edition serves as a quiet [refuge](about/).

--- a/examples/theblack/static/js/search.js
+++ b/examples/theblack/static/js/search.js
@@ -52,7 +52,7 @@
       li.className = 'search-result-item';
       
       var a = document.createElement('a');
-      a.href = h.item.url;
+      var baseUrl = searchIndexUrl.replace(/\/search\.json$/, ""); a.href = baseUrl + h.item.url;
       a.textContent = h.item.title;
       a.className = 'search-result-title';
       li.appendChild(a);


### PR DESCRIPTION
Fixed root-relative absolute markdown links in index.md and dynamic search results in search.js to prevent 404s in subdirectory deployments.

---
*PR created automatically by Jules for task [2835841242418245552](https://jules.google.com/task/2835841242418245552) started by @chei-l*