### PR TITLE
Fix 404 link in annal example

### DIFF
--- a/examples/annal/content/about.md
+++ b/examples/annal/content/about.md
@@ -36,7 +36,7 @@ figures, above a hairline red rule. That rule is the only decoration this
 site allows itself — it marks where one folio ends and the next opens,
 the same way a ledger book rules off one day's entries from the next.
 Tags along the bottom of each folio group releases by what they touched:
-`sync`, `graph`, `security`, and so on. The [tag index](/tags/) collects
+`sync`, `graph`, `security`, and so on. The [tag index](../tags/) collects
 every folio by theme if you're chasing one thread — say, everything that
 touched sync — across the whole run.
 


### PR DESCRIPTION
Fix 404 link in annal by changing absolute path to relative path

---
*PR created automatically by Jules for task [6990617137107492809](https://jules.google.com/task/6990617137107492809) started by @chei-l*