### PR TITLE
Fix absolute markdown links in reverb example

### DIFF
--- a/examples/reverb/content/about.md
+++ b/examples/reverb/content/about.md
@@ -3,7 +3,7 @@ title = "About Reverb"
 description = "What Reverb is, who makes it, and how each episode gets built from a working cipher implementation before anyone opens a microphone."
 +++
 
-Reverb is a cryptography podcast about the machinery of secrecy — how it was built, how it held, and eventually how it fell. Every [episode](/episodes/) picks one cipher or one cryptographic idea and works through it from the ground up: what problem it was solving, how the design decisions were made, and the specific insight that eventually broke it, if one exists yet. We start with a Caesar wheel and end wherever the current season takes us; season one runs from shift ciphers to lattice-based schemes built to survive a quantum adversary.
+Reverb is a cryptography podcast about the machinery of secrecy — how it was built, how it held, and eventually how it fell. Every [episode](../episodes/) picks one cipher or one cryptographic idea and works through it from the ground up: what problem it was solving, how the design decisions were made, and the specific insight that eventually broke it, if one exists yet. We start with a Caesar wheel and end wherever the current season takes us; season one runs from shift ciphers to lattice-based schemes built to survive a quantum adversary.
 
 ## Format
 

--- a/examples/reverb/content/episodes/caesar-shift.md
+++ b/examples/reverb/content/episodes/caesar-shift.md
@@ -44,4 +44,4 @@ Run that against any reasonably long shifted passage and the most frequent ciphe
 - Al-Kindi, *A Manuscript on Deciphering Cryptographic Messages* (c. 850 CE)
 - The ROT13 convention still used to spoiler-mask forum posts today
 
-Next block: [what happens when you use twenty-six different shifts instead of one](/episodes/vigenere-shadow/).
+Next block: [what happens when you use twenty-six different shifts instead of one](../../episodes/vigenere-shadow/).

--- a/examples/reverb/content/episodes/enigma-wiring.md
+++ b/examples/reverb/content/episodes/enigma-wiring.md
@@ -41,4 +41,4 @@ That single "never itself" constraint, mechanically forced by the reflector, is 
 - Gordon Welchman, *The Hut Six Story* (1982)
 - The captured weather-ship cipher material that shortened the 1941 naval break
 
-[Block 0x05](/episodes/rsa-factoring-wall/) leaves mechanical ciphers behind entirely for the first genuinely modern idea on the show: a key you can hand to a stranger in public.
+[Block 0x05](../../episodes/rsa-factoring-wall/) leaves mechanical ciphers behind entirely for the first genuinely modern idea on the show: a key you can hand to a stranger in public.

--- a/examples/reverb/content/episodes/kerckhoffs-principle.md
+++ b/examples/reverb/content/episodes/kerckhoffs-principle.md
@@ -33,4 +33,4 @@ We spend the back half of the episode on counterexamples: proprietary GSM encryp
 - Claude Shannon, *Communication Theory of Secrecy Systems* (1949)
 - The CSS (Content Scramble System) reverse-engineering timeline, 1999
 
-[Block 0x04](/episodes/enigma-wiring/) is the loudest counterexample of them all: a machine whose designers believed obscurity was the whole point.
+[Block 0x04](../../episodes/enigma-wiring/) is the loudest counterexample of them all: a machine whose designers believed obscurity was the whole point.

--- a/examples/reverb/content/episodes/lattices-after-shor.md
+++ b/examples/reverb/content/episodes/lattices-after-shor.md
@@ -41,4 +41,4 @@ Without the error term, recovering `s` from enough samples is ordinary linear al
 - Oded Regev, *On Lattices, Learning with Errors, Random Linear Codes, and Cryptography* (2005)
 - NIST's post-quantum cryptography standardization process, module-lattice finalists
 
-That's the season so far — six blocks, six ways of hiding a message, each one built on the last one's ruins. New episodes land as we record them; catch up on the [full run of episodes](/episodes/) or read more [about the show](/about/).
+That's the season so far — six blocks, six ways of hiding a message, each one built on the last one's ruins. New episodes land as we record them; catch up on the [full run of episodes](../../episodes/) or read more [about the show](../../about/).

--- a/examples/reverb/content/episodes/rsa-factoring-wall.md
+++ b/examples/reverb/content/episodes/rsa-factoring-wall.md
@@ -46,4 +46,4 @@ We spend the second half on the arms race between key size and factoring records
 - The RSA-768 factorization writeup (Kleinjung et al., 2010)
 - NIST SP 800-57, key length recommendations by decade
 
-Which sets up the one question every guest this season keeps circling back to: what happens to that factoring wall once a quantum computer shows up. That's [block 0x06](/episodes/lattices-after-shor/).
+Which sets up the one question every guest this season keeps circling back to: what happens to that factoring wall once a quantum computer shows up. That's [block 0x06](../../episodes/lattices-after-shor/).

--- a/examples/reverb/content/episodes/vigenere-shadow.md
+++ b/examples/reverb/content/episodes/vigenere-shadow.md
@@ -42,4 +42,4 @@ Once you know the key length, the polyalphabetic cipher decomposes into that man
 - David Kahn, *The Codebreakers*, chapter on the "indecipherable cipher"
 - Charles Babbage's earlier, unpublished break of Vigenère in the 1850s
 
-We come back to Kasiski's counting trick in [block 0x04](/episodes/enigma-wiring/), applied to a machine instead of a keyword.
+We come back to Kasiski's counting trick in [block 0x04](../../episodes/enigma-wiring/), applied to a machine instead of a keyword.


### PR DESCRIPTION
Replaced absolute root paths (e.g., `/episodes/`) with explicit relative paths in the reverb example markdown content to prevent 404s when deployed to subdirectories.

---
*PR created automatically by Jules for task [13323435831866587262](https://jules.google.com/task/13323435831866587262) started by @chei-l*