### PR TITLE
Fix 404 broken links in basalt example

### DIFF
--- a/examples/basalt/content/guides/_index.md
+++ b/examples/basalt/content/guides/_index.md
@@ -10,6 +10,6 @@ topic = "guides/*"
 
 These guides walk through Basalt the way an operator actually meets it: install a broker, create a topic, write a producer, read it back with a consumer group, and then keep the cluster healthy once real traffic shows up. Each guide stands on its own, but read in order they build a complete mental model — from a single binary on your laptop to a replicated cluster serving multiple consumer groups in production.
 
-Basalt's guarantees only hold if producers and consumers use them correctly. Acks levels, partition keys, offset commit strategy, and rebalance behavior are all choices with real tradeoffs, and these guides spend more time on *why* a default exists than on flag syntax. If you are looking for the exact bytes on the wire instead, see the [Protocol](../protocol/) section.
+Basalt's guarantees only hold if producers and consumers use them correctly. Acks levels, partition keys, offset commit strategy, and rebalance behavior are all choices with real tradeoffs, and these guides spend more time on *why* a default exists than on flag syntax. If you are looking for the exact bytes on the wire instead, see the [Protocol](@/protocol/_index.md) section.
 
 Start with Quickstart if you have never run a broker before. If you already have a cluster and are wiring up a service, jump straight to Producing Messages or Consuming with Groups.

--- a/examples/basalt/content/guides/consuming-groups.md
+++ b/examples/basalt/content/guides/consuming-groups.md
@@ -38,4 +38,4 @@ Basalt never commits on your behalf unless you enable auto-commit explicitly. Th
 
 Because commits happen after processing, not before, a crash between "processed" and "committed" causes Basalt to redeliver that message to whichever consumer picks up the partition next. Your handler must tolerate seeing the same message twice — usually by keying side effects on the message's idempotency key rather than assuming poll order implies exactly-once delivery. This is the one requirement Basalt cannot lift for you; partitioned, replicated, at-least-once delivery is the broker's job, and idempotent handling is the consumer's.
 
-See [Operating in Production](../operating/) for how to watch consumer lag before it becomes an incident, and [Consumer Group Rebalancing](../../protocol/rebalancing/) for the wire-level mechanics behind the handoff described above.
+See [Operating in Production](@/guides/operating.md) for how to watch consumer lag before it becomes an incident, and [Consumer Group Rebalancing](@/protocol/rebalancing.md) for the wire-level mechanics behind the handoff described above.

--- a/examples/basalt/content/guides/quickstart.md
+++ b/examples/basalt/content/guides/quickstart.md
@@ -42,4 +42,4 @@ partition=2 offset=0 key=ord_9182 value={"total":4200}
 
 The consumer's `--group` flag matters more than it looks: every consumer sharing a group name divides the topic's partitions between them and tracks one shared set of committed offsets. Run the same command again from a second terminal with the same group and Basalt will not redeliver — the offset is already committed. Change the group name and it delivers again from `earliest`, because a new group has no committed offsets yet.
 
-From here, [Producing Messages](../producing/) covers partition keys and acknowledgment levels, and [Consuming with Groups](../consuming-groups/) covers what happens when a consumer in the group crashes mid-batch.
+From here, [Producing Messages](@/guides/producing.md) covers partition keys and acknowledgment levels, and [Consuming with Groups](@/guides/consuming-groups.md) covers what happens when a consumer in the group crashes mid-batch.

--- a/examples/basalt/content/protocol/_index.md
+++ b/examples/basalt/content/protocol/_index.md
@@ -8,8 +8,8 @@ template = "section"
 topic = "protocol/*"
 +++
 
-Everything in the [Guides](../guides/) section describes Basalt from a client's point of view — send this, poll that, commit here. This section describes the same behavior from underneath: the bytes a producer actually writes to a socket, how a leader and its followers agree on what is durable, and the handshake a consumer group runs every time membership changes.
+Everything in the [Guides](@/guides/_index.md) section describes Basalt from a client's point of view — send this, poll that, commit here. This section describes the same behavior from underneath: the bytes a producer actually writes to a socket, how a leader and its followers agree on what is durable, and the handshake a consumer group runs every time membership changes.
 
 None of this is required reading to operate a cluster. It exists for three audiences: authors writing a new client library against the wire protocol directly, operators debugging a replication or rebalance incident who need to know what "in step" actually means at the byte level, and anyone curious how a broker keeps its promises once the friendly client API gets out of the way.
 
-Read [Wire Format](wire-format/) first if you are implementing a client. Read [Replication & ISR](replication-isr/) and [Consumer Group Rebalancing](rebalancing/) in either order if you are debugging an existing cluster.
+Read [Wire Format](@/protocol/wire-format.md) first if you are implementing a client. Read [Replication & ISR](@/protocol/replication-isr.md) and [Consumer Group Rebalancing](@/protocol/rebalancing.md) in either order if you are debugging an existing cluster.

--- a/examples/basalt/content/protocol/rebalancing.md
+++ b/examples/basalt/content/protocol/rebalancing.md
@@ -43,4 +43,4 @@ This is what prevents a "zombie" consumer — one that missed the rebalance beca
 - **Round-robin** — partitions across all subscribed topics are dealt one at a time across members. Better balance, but a rebalance can reassign nearly every partition even for a single member joining.
 - **Cooperative-sticky** — the default. Computes the minimal set of partition moves needed to reach a balanced assignment, leaving unaffected members' partitions untouched, and lets members keep processing their retained partitions during the rebalance instead of stopping the world.
 
-Cooperative-sticky is why adding one consumer to a busy group does not pause the other nine — see [Consuming with Groups](../../guides/consuming-groups/) for how this looks from the client side.
+Cooperative-sticky is why adding one consumer to a busy group does not pause the other nine — see [Consuming with Groups](@/guides/consuming-groups.md) for how this looks from the client side.


### PR DESCRIPTION
This PR fixes multiple 404 broken link issues within the `basalt` example's markdown content files. The links were previously using standard relative paths (e.g. `../protocol/` or `wire-format/`), which can fail depending on the site's URL structures and trailing slashes. 

They have been updated to use Hwaro's internal routing syntax (e.g., `[Operating in Production](@/guides/operating.md)`). This ensures links resolve robustly to the correct paths during generation.

Tests were run across all built static files for the `basalt` example, confirming that zero 404 broken links remain.

---
*PR created automatically by Jules for task [3917296241324760288](https://jules.google.com/task/3917296241324760288) started by @hahwul*