### PR TITLE
Fix 404 links in waypoint example

### DIFF
--- a/examples/waypoint/content/about.md
+++ b/examples/waypoint/content/about.md
@@ -38,7 +38,7 @@ waypoint run --net=userlink registry.example.com/api:1.4
 
 ## How to read these notes
 
-The [full release history](/releases/) is listed newest first. Minor versions (1.3, 1.4) may change defaults
+The [full release history](../releases/) is listed newest first. Minor versions (1.3, 1.4) may change defaults
 but never break a pinned digest; patch versions (1.2.1) carry only fixes. The
 status line at the bottom of every page reports the current stable version, its
 release date, and the first bytes of the digest it resolves to — the same digest

--- a/examples/waypoint/content/releases/v1-1-0.md
+++ b/examples/waypoint/content/releases/v1-1-0.md
@@ -13,7 +13,7 @@ changes = [
 ]
 +++
 
-Waypoint 1.1.0 is about latency you never see. The [1.0.0](/releases/v1-0-0/)
+Waypoint 1.1.0 is about latency you never see. The [1.0.0](../v1-0-0/)
 runtime fetched layers strictly on demand, one blocking read at a time. This
 release adds a prefetch heuristic that watches the entrypoint's early reads and
 pulls ahead along the same path, so by the time the process asks for the next

--- a/examples/waypoint/content/releases/v1-4-0.md
+++ b/examples/waypoint/content/releases/v1-4-0.md
@@ -29,7 +29,7 @@ almost nothing. On our build fleet the average cold start fell from 340 ms to
   with a rolling hash, so a one-line change to a base image only invalidates the
   chunks that actually moved. Deduplication is global across every image in the
   local store, building on the per-file table of contents added in
-  [v1.2.0](/releases/v1-2-0/).
+  [v1.2.0](../v1-2-0/).
 - **Peer-to-peer lazy pulls.** When several nodes share a subnet, Waypoint asks
   its neighbours for a chunk before falling back to the registry. Enable it per
   host:


### PR DESCRIPTION
- waypoint: Fixed 404 absolute links to use relative paths in markdown content.

---
*PR created automatically by Jules for task [8841544271745168498](https://jules.google.com/task/8841544271745168498) started by @chei-l*