### PR TITLE
Fix broken RSS link in Resonance example

### DIFF
--- a/examples/resonance/templates/footer.html
+++ b/examples/resonance/templates/footer.html
@@ -14,7 +14,7 @@
         <a href="{{ base_url }}/hosts/">Hosts</a>
         <a href="{{ base_url }}/about/">About</a>
         <a href="{{ base_url }}/tags/">Tags</a>
-        <a href="{{ base_url }}/feeds/episodes.xml">RSS</a>
+        <a href="{{ base_url }}/episodes/rss.xml">RSS</a>
       </nav>
       <p class="footer-fine">Resonance is a fictional show recorded on rooftops and in community plots for this Hwaro example. New episodes {{ current_year }}. Built with Hwaro.</p>
     </div>


### PR DESCRIPTION
Update the broken RSS link in footer.html from /feeds/episodes.xml to /episodes/rss.xml to match Hwaro's output path.

---
*PR created automatically by Jules for task [2428424622229637562](https://jules.google.com/task/2428424622229637562) started by @chei-l*