### PR TITLE
Fix absolute markdown links in gabbro example

### DIFF
--- a/examples/gabbro/content/manual/getting-started.md
+++ b/examples/gabbro/content/manual/getting-started.md
@@ -74,5 +74,5 @@ memory returned by `gb_get()` points into the current snapshot and stays valid
 until you write again on the same handle or close the database; copy it out if you
 need it longer.
 
-From here, read [snapshots](/manual/snapshots/) to understand how reads stay consistent
+From here, read [snapshots](../../manual/snapshots/) to understand how reads stay consistent
 under concurrent writes.

--- a/examples/gabbro/content/manual/snapshots.md
+++ b/examples/gabbro/content/manual/snapshots.md
@@ -64,5 +64,5 @@ A snapshot pins every version at or after the one it references, which means the
 store cannot reclaim those older pages until you close it. Long-lived snapshots are
 the usual cause of a file that grows faster than expected. Open them late, close
 them promptly, and prefer many short snapshots over one that lives for the whole
-process. The [storage engine](/manual/storage-engine/) chapter explains how compaction
+process. The [storage engine](../../manual/storage-engine/) chapter explains how compaction
 frees pages once the last snapshot that needs them is gone.

--- a/examples/gabbro/content/manual/storage-engine.md
+++ b/examples/gabbro/content/manual/storage-engine.md
@@ -61,5 +61,5 @@ gb_compact(db, GB_COMPACT_TRUNCATE);
 
 The one thing that stalls reclamation is a long-lived reader: a page cannot be
 freed while any open snapshot might still read it. See
-[snapshots](/manual/snapshots/) for how to keep reader lifetimes short. The full call
-list lives in the [API reference](/manual/api-reference/).
+[snapshots](../../manual/snapshots/) for how to keep reader lifetimes short. The full call
+list lives in the [API reference](../../manual/api-reference/).

--- a/examples/gabbro/content/manual/transactions.md
+++ b/examples/gabbro/content/manual/transactions.md
@@ -65,5 +65,5 @@ gb_txn_get(rt, gb_str("acct:b"), &b);
 gb_txn_abort(rt);   /* read-only txns are released with abort */
 ```
 
-Continue to the [storage engine](/manual/storage-engine/) to see what a commit writes to
+Continue to the [storage engine](../../manual/storage-engine/) to see what a commit writes to
 disk and how recovery replays it.


### PR DESCRIPTION
Replaced root-relative absolute markdown links in the gabbro manual with explicit relative links to prevent 404s when deployed to subdirectories.

---
*PR created automatically by Jules for task [14675161604228121194](https://jules.google.com/task/14675161604228121194) started by @chei-l*