### PR TITLE
Fix 404 links in bulletin example

### DIFF
--- a/examples/bulletin/content/about.md
+++ b/examples/bulletin/content/about.md
@@ -17,4 +17,4 @@ Every dispatch closes with an archive citation line: collection, box, and folder
 
 Found a folder we should see? Researchers, foundry heirs, and print-shop estate sales are our best leads. Write to the desk with what you have, however partial. We answer everything, even the boxes that turn out to be nothing.
 
-Browse the [full run of dispatches](bulletins/) or search the archive by [tag](tags/) and [category](categories/) to see what we've already filed.
+Browse the [full run of dispatches](../bulletins/) or search the archive by [tag](../tags/) and [category](../categories/) to see what we've already filed.


### PR DESCRIPTION
Fix relative links in about.md to point to the correct paths.

---
*PR created automatically by Jules for task [1673742603436266155](https://jules.google.com/task/1673742603436266155) started by @chei-l*