### PR TITLE
Fix broken links in Corundum example

### DIFF
--- a/examples/corundum/content/guides/authorization-code-flow.md
+++ b/examples/corundum/content/guides/authorization-code-flow.md
@@ -80,6 +80,6 @@ grant_type=authorization_code
 ```
 
 A successful exchange returns the token set described in the
-[tokens guide](/guides/tokens/). Codes are single-use and expire in sixty
+[tokens guide](../tokens/). Codes are single-use and expire in sixty
 seconds; presenting a code twice revokes every token issued from it, on the
 assumption that a replay means the code was stolen.

--- a/examples/corundum/content/guides/discovery.md
+++ b/examples/corundum/content/guides/discovery.md
@@ -87,4 +87,4 @@ Authorization: Bearer eyJhbGciOiJFUzI1NiIsImtpZCI6IjJm...
 The `sub` returned here must equal the `sub` in the ID token from the same
 session. A mismatch means the tokens came from different subjects and the
 response must be discarded. With discovery in place, the last guide turns on
-[hardware-key authentication](/guides/hardware-keys/).
+[hardware-key authentication](../hardware-keys/).

--- a/examples/corundum/content/guides/hardware-keys.md
+++ b/examples/corundum/content/guides/hardware-keys.md
@@ -83,5 +83,5 @@ corundum client update ledger-web --require-hardware-key
 ```
 
 With this set, a user whose account has only a passphrase is prompted to enrol
-a key before the flow completes. Treat the [Security Model](/security/) as
+a key before the flow completes. Treat the [Security Model](../../security/) as
 required reading before you turn this on across a fleet.

--- a/examples/corundum/content/guides/installation.md
+++ b/examples/corundum/content/guides/installation.md
@@ -91,7 +91,7 @@ corundum admin bootstrap --email ada@example.com
 
 The command prints a one-time enrolment link valid for fifteen minutes. Open
 it, set a passphrase, and — if you have a security key to hand — enrol it now;
-the [hardware-key guide](/guides/hardware-keys/) covers that ceremony in
+the [hardware-key guide](../hardware-keys/) covers that ceremony in
 detail. You now have a running identity server with exactly one account and no
-registered clients. The [authorization code flow](/guides/authorization-code-flow/)
+registered clients. The [authorization code flow](../authorization-code-flow/)
 is where the next guide begins.

--- a/examples/corundum/content/security.md
+++ b/examples/corundum/content/security.md
@@ -40,7 +40,7 @@ radius of a stolen one.
 - Access tokens are short-lived — ten minutes by default — so a captured bearer
   token expires before it is useful for long.
 - Refresh tokens rotate on every use; replaying a spent one revokes the whole
-  family. See the [tokens guide](/guides/tokens/) for the mechanics.
+  family. See the [tokens guide](../guides/tokens/) for the mechanics.
 - Sender-constrained tokens bind an access token to a client-held key through
   the `cnf` claim, so a token lifted from one machine cannot be used from
   another.


### PR DESCRIPTION
corundum: replace absolute links in content with correct relative paths

---
*PR created automatically by Jules for task [13582192353837382965](https://jules.google.com/task/13582192353837382965) started by @chei-l*