### PR TITLE
Add flagship tier and first flagship example: seoulnight

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -237,10 +237,32 @@ jobs:
           SITE_LINKS=""
           ALL_TAGS=""
           EXAMPLE_COUNT=0
+
+          # Flagships (manifest order) render first, then everything else alphabetically.
+          FLAGSHIPS=$(jq -r '.flagships // [] | join(" ")' manifest.json)
+          ORDERED_NAMES="${FLAGSHIPS}"
           for dir in examples/*/; do
-            src_path="${dir%/}"
-            name="${src_path#examples/}"
+            name="${dir%/}"
+            name="${name#examples/}"
+            case " ${FLAGSHIPS} " in *" ${name} "*) continue ;; esac
+            ORDERED_NAMES="${ORDERED_NAMES} ${name}"
+          done
+
+          FLAG_INDEX=0
+          for name in ${ORDERED_NAMES}; do
+            src_path="examples/${name}"
             if [ -f "${src_path}/config.toml" ] && [ -d "${OUTPUT_DIR}/${name}" ]; then
+              FLAG_CLASS=""
+              FLAG_ATTR=""
+              FLAG_BADGE=""
+              case " ${FLAGSHIPS} " in
+                *" ${name} "*)
+                  FLAG_INDEX=$((FLAG_INDEX + 1))
+                  FLAG_CLASS=" flagship"
+                  FLAG_ATTR=" data-flagship=\"${FLAG_INDEX}\""
+                  FLAG_BADGE="<span class=\"flagship-badge\">flagship</span>"
+                  ;;
+              esac
               TITLE=$(grep '^title' "${src_path}/config.toml" | head -1 | sed 's/title *= *"//;s/"//')
               DESCRIPTION=$(grep '^description' "${src_path}/config.toml" | head -1 | sed 's/description *= *"//;s/"//')
               THEME_REPO_URL="https://github.com/${GITHUB_REPOSITORY}/tree/main/${src_path}"
@@ -255,7 +277,7 @@ jobs:
                 fi
               done
               EXAMPLE_COUNT=$((EXAMPLE_COUNT + 1))
-              SITE_LINKS="${SITE_LINKS}<div class=\"card\" data-name=\"${name}\" data-title=\"${TITLE}\" data-desc=\"${DESCRIPTION}\" data-tags=\"${TAGS}\"><a href=\"${BASE_URL}/${name}/\" class=\"main-link\"><img src=\"screenshots/${name}.png\" alt=\"${name}\" class=\"preview\" loading=\"lazy\" onerror=\"var d=document.createElement('div');d.className='preview-fallback';d.textContent='no_preview';this.replaceWith(d);\"><div class=\"card-info\"><strong>${name}</strong><span class=\"title\">${TITLE}</span><span class=\"desc\">${DESCRIPTION}</span><div class=\"card-tags\">${TAGS_DISPLAY}</div></div></a><div class=\"card-footer\"><a href=\"${THEME_REPO_URL}\" class=\"card-footer-row\"><svg viewBox=\"0 0 16 16\"><path d=\"M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z\"></path></svg>Source Code</a><div class=\"card-footer-row scaffold-row\" onclick=\"copyScaffold(this)\" data-cmd=\"${SCAFFOLD_CMD}\"><svg viewBox=\"0 0 16 16\"><path d=\"M4.72 3.22a.75.75 0 011.06 1.06L2.06 8l3.72 3.72a.75.75 0 11-1.06 1.06L.47 8.53a.75.75 0 010-1.06l4.25-4.25zm6.56 0a.75.75 0 10-1.06 1.06L13.94 8l-3.72 3.72a.75.75 0 101.06 1.06l4.25-4.25a.75.75 0 000-1.06l-4.25-4.25z\"></path></svg><span class=\"scaffold-cmd\">${SCAFFOLD_CMD}</span><svg class=\"copy-icon\" viewBox=\"0 0 16 16\"><path d=\"M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z\"></path><path d=\"M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 9.25a.75.75 0 01-1.5 0 .25.25 0 00-.25-.25h-7.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h1.5a.75.75 0 010 1.5h-1.5A1.75 1.75 0 015 14.25v-7.5z\"></path></svg></div></div></div>"
+              SITE_LINKS="${SITE_LINKS}<div class=\"card${FLAG_CLASS}\"${FLAG_ATTR} data-name=\"${name}\" data-title=\"${TITLE}\" data-desc=\"${DESCRIPTION}\" data-tags=\"${TAGS}\">${FLAG_BADGE}<a href=\"${BASE_URL}/${name}/\" class=\"main-link\"><img src=\"screenshots/${name}.png\" alt=\"${name}\" class=\"preview\" loading=\"lazy\" onerror=\"var d=document.createElement('div');d.className='preview-fallback';d.textContent='no_preview';this.replaceWith(d);\"><div class=\"card-info\"><strong>${name}</strong><span class=\"title\">${TITLE}</span><span class=\"desc\">${DESCRIPTION}</span><div class=\"card-tags\">${TAGS_DISPLAY}</div></div></a><div class=\"card-footer\"><a href=\"${THEME_REPO_URL}\" class=\"card-footer-row\"><svg viewBox=\"0 0 16 16\"><path d=\"M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z\"></path></svg>Source Code</a><div class=\"card-footer-row scaffold-row\" onclick=\"copyScaffold(this)\" data-cmd=\"${SCAFFOLD_CMD}\"><svg viewBox=\"0 0 16 16\"><path d=\"M4.72 3.22a.75.75 0 011.06 1.06L2.06 8l3.72 3.72a.75.75 0 11-1.06 1.06L.47 8.53a.75.75 0 010-1.06l4.25-4.25zm6.56 0a.75.75 0 10-1.06 1.06L13.94 8l-3.72 3.72a.75.75 0 101.06 1.06l4.25-4.25a.75.75 0 000-1.06l-4.25-4.25z\"></path></svg><span class=\"scaffold-cmd\">${SCAFFOLD_CMD}</span><svg class=\"copy-icon\" viewBox=\"0 0 16 16\"><path d=\"M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z\"></path><path d=\"M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 9.25a.75.75 0 01-1.5 0 .25.25 0 00-.25-.25h-7.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h1.5a.75.75 0 010 1.5h-1.5A1.75 1.75 0 015 14.25v-7.5z\"></path></svg></div></div></div>"
             fi
           done
           # Identify top 8 tags and generate dynamic CSS
@@ -326,8 +348,11 @@ jobs:
             .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(var(--card-size, 280px), 1fr)); gap: 1.1rem; }
             .card { display: flex; flex-direction: column; background: var(--bg-card); border: 1px solid var(--hair); border-radius: 10px; overflow: hidden; transition: border-color 0.2s, transform 0.25s var(--ease-out), box-shadow 0.25s var(--ease-out); }
             .card.hidden { display: none; }
+            .card.flagship { position: relative; border-color: rgba(179,84,84,0.5); box-shadow: 0 0 0 1px rgba(179,84,84,0.22), var(--glow-ember); }
+            .flagship-badge { position: absolute; top: 10px; left: 10px; z-index: 2; pointer-events: none; background: rgba(13,13,16,0.88); color: var(--primary-light); border: 1px solid rgba(179,84,84,0.55); border-radius: 4px; padding: 0.2rem 0.5rem; font-family: var(--font-mono); font-size: 0.6rem; font-weight: 500; letter-spacing: 0.09em; text-transform: uppercase; }
             @media (hover: hover) {
               .card:hover { border-color: rgba(179,84,84,0.45); transform: translateY(-2px); box-shadow: var(--glow-ember); }
+              .card.flagship:hover { border-color: var(--primary); box-shadow: 0 0 0 1px rgba(179,84,84,0.4), var(--glow-ember); }
               .card:hover .preview, .card:hover .preview-fallback { opacity: 1; }
             }
             .main-link { display: flex; flex-direction: column; text-decoration: none; color: var(--text-secondary); flex-grow: 1; }
@@ -722,6 +747,11 @@ jobs:
                 cards = sorted;
               }
             }
+            // Flagships stay pinned first, in manifest order, across every sort mode.
+            var flagships = cards.filter(function(c) { return c.dataset.flagship; });
+            flagships.sort(function(a, b) { return (+a.dataset.flagship) - (+b.dataset.flagship); });
+            var rest = cards.filter(function(c) { return !c.dataset.flagship; });
+            cards = flagships.concat(rest);
             cards.forEach(function(card) { grid.appendChild(card); });
           }
           function reorderTags() {

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,7 +8,10 @@ example that belongs in a curated collection of 200, not a pile of 1,500.
 
 - `manifest.json` is the *assignment sheet*: every example's name, category,
   color scheme, style tags, design brief, typography, palette, layout, and
-  feature set is decided there **before** any code is written.
+  feature set is decided there **before** any code is written. Its top-level
+  `flagships` array is an ordered, maintainer-curated list of showcase
+  examples pinned (with decoration) at the front of the gallery — agents must
+  never add to or reorder it.
 - `DESIGN.md` (this file) is the *quality bar*: the rules every example must
   meet regardless of its brief.
 - `AGENTS.md` is the *tool reference*: hwaro CLI, template variables, filters,

--- a/examples/seoulnight/AGENTS.md
+++ b/examples/seoulnight/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/seoulnight/archetypes/default.md
+++ b/examples/seoulnight/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = "{{ description }}"
+tags = {{ tags }}
++++

--- a/examples/seoulnight/config.toml
+++ b/examples/seoulnight/config.toml
@@ -1,0 +1,47 @@
+title = "Seoulnight"
+description = "An editor color scheme drawn from Seoul at night: neon signage, river bridges, and late-hour code"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["svg"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+sections = ["notes"]
+
+[og]
+type = "article"
+twitter_card = "summary_large_image"
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/examples/seoulnight/content/about.md
+++ b/examples/seoulnight/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About"
+description = "What Seoulnight is, who tunes it, and why it is named after a city instead of a time of day"
++++
+
+Seoulnight is a fictional editor color scheme, built as a demonstration site for the Hwaro static site generator. It borrows its palette from Seoul between the last train and the first: the deep blue the Han River holds under bridge lights, the magenta of sign tubes in Euljiro, the vermilion painted under palace eaves, the yellow that ginkgo trees drop across Jongno every November.
+
+The scheme is tuned by Chaerin Yun, a fictional systems programmer who keeps the project as a night-shift hobby. The rules she works by are short. Every color must survive six hours of continuous reading at low screen brightness. Every color must clear a 4.5 to 1 contrast ratio against the background, measured, not eyeballed. And no color may be so saturated that it pulls the eye away from the code that is actually being read.
+
+Names matter here as much as values. A hex code tells you what a color is, but a name tells you what it is for. Calling the function color <em>hangang</em> is a reminder that calls are supposed to flow; calling the comment color <em>angae</em>, fog, is a reminder that commentary should sit behind the code, not in front of it.
+
+The notes section is the project devlog. Each entry records one decision: what was changed, what was measured, and what the city block that inspired it looks like after dark.

--- a/examples/seoulnight/content/index.md
+++ b/examples/seoulnight/content/index.md
@@ -1,0 +1,13 @@
++++
+title = "Seoulnight"
+description = "An editor color scheme drawn from Seoul at night: neon signage, river bridges, and late-hour code"
+template = "home"
++++
+
+## Tuned for the hour after midnight
+
+Most dark schemes are designed at noon, on bright monitors, by people who log off at six. Seoulnight is calibrated the other way around: every hue was checked at two in the morning, at low brightness, against the tired eyes it will actually meet. The background is not black but a deep river-blue, because true black turns bright accents into halos and makes every glyph vibrate at the edges.
+
+The eight colors come from the city itself. Han River blue for functions, because calls flow into one another. Sign-neon magenta for keywords, the words that stay lit all night. Ginkgo yellow for numbers, vermilion from palace eaves for types, pine green off Namsan for strings. Comments sit back in fog.
+
+Nothing in the scheme glows or pulses. A color scheme should hold still for six hours straight, and the best compliment it can earn is that you stopped noticing it.

--- a/examples/seoulnight/content/notes/_index.md
+++ b/examples/seoulnight/content/notes/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Notes"
+description = "A devlog on tuning Seoulnight: one decision per note, with the measurements that backed it"
+sort_by = "date"
+reverse = false
+paginate = 6
+template = "section"
+generate_feeds = true
++++
+
+Notes run newest first. If a color changed value anywhere in the scheme, the measurement that justified it is written down here, along with the corner of the city it was borrowed from.

--- a/examples/seoulnight/content/notes/hangul-in-the-margins.md
+++ b/examples/seoulnight/content/notes/hangul-in-the-margins.md
@@ -1,0 +1,16 @@
++++
+title = "Hangul in the margins"
+date = "2025-10-12"
+description = "Korean glyphs are visually denser than Latin ones. What that means for line height, UI labels, and the specimen on the landing page."
+tags = ["typography"]
++++
+
+Seoulnight ships with Korean labels next to its color names, and the site you are reading sets its masthead in Hangul. That decision came with typographic homework. Hangul glyphs are built from stacked jamo inside a square frame, which makes them visually denser than Latin lowercase at the same point size. Set both scripts on the same line with Latin-tuned metrics and the Korean reads cramped while the Latin reads loose.
+
+<!-- more -->
+
+Two adjustments carried most of the weight. Line height on mixed lines runs slightly taller than the Latin-only default, giving the stacked blocks room to breathe without opening visible gaps in pure-Latin paragraphs. And the display face had to be chosen for its Hangul first: Gothic A1 keeps its stroke contrast at heavy weights in both scripts, so the masthead can set 서울밤 at poster size without the counters filling in.
+
+The subtler lesson was about hierarchy. In a Latin-only layout, size and weight do the ranking. Add a second script and the script itself becomes a signal: the Hangul name reads as the identity, the romanization underneath as the annotation. The landing page leans on that deliberately. The big glyphs carry the mood, and the small mono line under them carries the spelling you would type into a package manager.
+
+None of this needed custom features or variable-font tricks. It needed measuring the two scripts honestly instead of assuming the Latin defaults would stretch to cover both.

--- a/examples/seoulnight/content/notes/naming-colors-after-the-city.md
+++ b/examples/seoulnight/content/notes/naming-colors-after-the-city.md
@@ -1,0 +1,14 @@
++++
+title = "Naming colors after the city"
+date = "2025-04-08"
+description = "A hex value says what a color is. A name says what it is for. How the eight scheme colors got their Seoul names."
+tags = ["seoul", "naming"]
++++
+
+Early builds of the scheme named colors the way most themes do: `blue1`, `magenta`, `comment-gray`. The values were fine, but every tuning session started with a lookup. Which blue was `blue1` again? Was `magenta` the keyword color or the diff-delete color? A name that only restates the hue tells you nothing when you are deciding what the color should do.
+
+<!-- more -->
+
+So the palette was renamed after the places the values were sampled from, and every name doubles as a job description. The function color is <em>hangang</em>, the river, because call chains are supposed to flow downstream. The keyword color is <em>neon</em>, from the sign tubes of Euljiro, because keywords are the words that stay lit whatever else changes. Strings are <em>namsan</em> pine green, the one organic thing visible from most office windows. Numbers are <em>eunhaeng</em>, ginkgo, after the yellow that buries Jongno every November. Types wear <em>dancheong</em> vermilion, the pigment painted under palace eaves, structural and a little ceremonial, which is exactly what a type annotation is.
+
+The quiet one matters most. Comments are <em>angae</em>, fog. Fog sits behind the city without hiding it, and that is the entire design brief for a comment color in one word. Since the rename, no tuning note in this log has needed a lookup table to stay readable, which is its own small proof that the naming was worth a full note.

--- a/examples/seoulnight/content/notes/release-notes-v1.md
+++ b/examples/seoulnight/content/notes/release-notes-v1.md
@@ -1,0 +1,27 @@
++++
+title = "Release notes, version 1.0"
+date = "2026-06-02"
+description = "The scheme is frozen: eight colors, every one measured, none of them moving again without a note in this log."
+tags = ["release"]
++++
+
+Version 1.0 is the freeze. After eighteen months of tuning, the eight colors are now fixed, and any future change must land with a note in this log explaining what was measured and why the old value lost. A color scheme is a dependency like any other; people build muscle memory against it, and silent drift is a breaking change even when no API moved.
+
+<!-- more -->
+
+What shipped: the blue-ink background documented in the first note, the desaturated sign magenta for keywords, and a contrast floor of 4.5 to 1 that every color in the set now clears against the base. The quietest change since the last beta is also the one most people will feel: comment fog was lifted two steps after readers reported that block comments were disappearing entirely at low brightness. Comments should whisper, not vanish.
+
+Installation stays a one-line affair in the fictional editor this scheme pretends to target:
+
+```json
+{
+  "editor.colorScheme": "seoulnight",
+  "editor.background": "dim"
+}
+```
+
+{% alert() %}
+Upgrading from a 0.x build: the comment color changed value in this release. If you pinned individual hex codes instead of the scheme name, repin `angae` before updating.
+{% end %}
+
+What did not ship: a light variant. Daylight asks different questions, and answering them halfway would cheapen both halves. If a companion ever appears it will be its own scheme with its own name, measured against morning instead of borrowed from midnight.

--- a/examples/seoulnight/content/notes/the-roundel-legend.md
+++ b/examples/seoulnight/content/notes/the-roundel-legend.md
@@ -1,0 +1,16 @@
++++
+title = "The roundel legend"
+date = "2026-02-14"
+description = "The scheme needed a legend that works at thumbnail size. Metro line roundels turned out to be the answer."
+tags = ["seoul", "design"]
++++
+
+Every color scheme site faces the same layout problem: how do you present eight colors so that a stranger can hold them in their head? A flat row of hex codes is a spreadsheet. Vertical bars look like a paint catalogue. Both formats say what the colors are and nothing about how to remember them.
+
+<!-- more -->
+
+The answer came from the subway map folded in a coat pocket. Seoul's metro lines are identified by numbered circles in flat, committed colors, and the whole city navigates by them without thinking. A roundel does three jobs at once: the fill shows the color, the number gives it an address, and the circle makes it feel like infrastructure rather than decoration.
+
+So the scheme adopted the format as its legend. The eight colors are numbered one through eight in the order they matter: text first, keywords second, down to comments in fog at the end of the line. On the landing page the roundels run across the title bar of the code specimen, joined by a thin connector, exactly the way stations sit on a route diagram. The swatch cards repeat the same numbers, so the strip works as a table of contents for the section below it.
+
+The pleasant surprise was how well the strip survives shrinking. In a browser tab, in a social preview, in the tiny screenshot of a gallery card, eight colored dots on a line stay legible long after any text has dissolved. A legend that still reads at sixty pixels wide is the closest thing a color scheme gets to a logo.

--- a/examples/seoulnight/content/notes/tuning-the-neon.md
+++ b/examples/seoulnight/content/notes/tuning-the-neon.md
@@ -1,0 +1,24 @@
++++
+title = "Tuning the neon"
+date = "2025-07-22"
+description = "The keyword magenta was sampled from a real sign tube and arrived far too loud. Desaturating it without losing the night."
+tags = ["color", "keywords"]
++++
+
+The keyword color was sampled from a photograph of a sign tube in Euljiro, and the raw sample was unusable. Real neon pushes past what a code editor can politely display: on screen it measured close to full saturation, and a page of `if`, `return`, and `import` flickered like a shop front. Keywords are roughly a fifth of the tokens in a typical file. Whatever color they wear becomes the color of the whole buffer.
+
+<!-- more -->
+
+The tuning process was mechanical. Drop saturation a step, read a familiar file for ten minutes, measure contrast, repeat. The stopping rule: the moment a keyword stopped registering as a light source and started registering as ink, back up one step and take that value. The final magenta keeps the hue of the sign but roughly two thirds of its saturation, and it clears the background at 5.4 to 1.
+
+The same pass is recorded in the scheme definition, which doubles as a sample of the scheme reading its own source:
+
+```toml
+[colors.neon]
+hex = "#d957c4"
+role = "keywords"
+sampled = "sign tube, euljiro 3-ga"
+contrast = 5.4
+```
+
+One rejected idea deserves a line. A late draft gave keywords a subtle bold weight on top of the color. It read beautifully for five minutes and then the page felt shouted. Weight is a second channel of emphasis, and spending two channels on one token class is how schemes turn into carnival. Color alone, correctly desaturated, was enough.

--- a/examples/seoulnight/content/notes/why-the-background-is-not-black.md
+++ b/examples/seoulnight/content/notes/why-the-background-is-not-black.md
@@ -1,0 +1,16 @@
++++
+title = "Why the background is not black"
+date = "2025-01-20"
+description = "True black turns bright accents into halos. How the base color #101320 was picked, and what halation does to late-night eyes."
+tags = ["contrast", "color"]
++++
+
+The first draft of Seoulnight used a pure black background, and it lasted exactly one night. On an OLED panel in a dark room, saturated glyphs on true black develop a faint bloom at their edges, an effect photographers call halation. Keywords started to shimmer. After twenty minutes the shimmer read as eye strain, and after an hour it read as a headache.
+
+<!-- more -->
+
+The fix was to lift the background until the halos collapsed, then stop. Lifting too far costs the scheme its depth of night; the whole point is that the window should feel like looking out over the river at 2 a.m. The value that held both properties was a blue-leaning ink, sampled from a long-exposure photograph of the Han River taken from the Dongjak Bridge.
+
+Lifting the background also softened the contrast stack. Body text now sits at 14.5 to 1 against the base, comfortably past the 4.5 to 1 floor the project holds every color to, but no longer at the razor 21 to 1 that pure white on pure black produces. Maximum contrast sounds like a feature until you read under it for six hours; it is the typographic equivalent of high beams in the fog.
+
+One more consequence worth recording: with a blue base, warm colors gained apparent brightness for free. Vermilion and ginkgo yellow both measured the same as before, but sat forward in a way they never did on neutral black. The city taught that trick too. Neon looks brightest over dark water.

--- a/examples/seoulnight/static/css/style.css
+++ b/examples/seoulnight/static/css/style.css
@@ -1,0 +1,609 @@
+/* seoulnight - an editor color scheme drawn from Seoul at night.
+   Palette per manifest.json; the eight scheme colors below are the product
+   itself (specimen + swatches + syntax tokens), not UI chrome. */
+
+:root {
+  /* manifest palette */
+  --bg: #101320;
+  --surface: #191e31;
+  --fg: #dee4f5;
+  --muted: #8b93ad;
+  --accent: #d957c4;
+  --accent-fg: #230a1f;
+  --border: color-mix(in srgb, var(--fg) 12%, transparent);
+
+  /* the scheme - eight named colors, numbered like metro lines */
+  --c-dalbit: #dee4f5;    /* 01 달빛 moonlight - text */
+  --c-neon: #d957c4;      /* 02 네온 neon - keywords */
+  --c-hangang: #6ea3e8;   /* 03 한강 river - functions */
+  --c-dancheong: #e8705c; /* 04 단청 vermilion - types */
+  --c-namsan: #6fbf8f;    /* 05 남산 pine - strings */
+  --c-eunhaeng: #dfae5f;  /* 06 은행 ginkgo - numbers */
+  --c-jaha: #9d85e0;      /* 07 자하 violet - attributes */
+  --c-angae: #7d88a8;     /* 08 안개 fog - comments */
+
+  --panel: color-mix(in srgb, var(--bg) 74%, black);
+  --surface-soft: color-mix(in srgb, var(--surface) 45%, var(--bg));
+  --line-strong: color-mix(in srgb, var(--fg) 22%, transparent);
+
+  --font-display: "Gothic A1", "Apple SD Gothic Neo", "Malgun Gothic", sans-serif;
+  --font-text: "IBM Plex Sans", -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --text-xs: clamp(0.72rem, 0.7rem + 0.1vw, 0.78rem);
+  --text-sm: clamp(0.83rem, 0.8rem + 0.15vw, 0.9rem);
+  --text-base: clamp(1rem, 0.95rem + 0.25vw, 1.125rem);
+  --text-lg: clamp(1.2rem, 1.1rem + 0.5vw, 1.5rem);
+  --text-xl: clamp(1.5rem, 1.3rem + 1vw, 2.25rem);
+  --text-2xl: clamp(2rem, 1.6rem + 2vw, 3.25rem);
+  --text-hero: clamp(3.1rem, 1.9rem + 6vw, 6.5rem);
+
+  --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 1rem;
+  --space-4: 1.5rem; --space-5: 2.5rem; --space-6: 4rem; --space-7: 6rem;
+
+  --shell: 1150px;
+  --radius: 10px;
+
+  color-scheme: dark;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-text);
+  font-size: var(--text-base);
+  line-height: 1.7;
+  background: var(--bg);
+  color: var(--fg);
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection { background: color-mix(in srgb, var(--accent) 38%, transparent); color: var(--fg); }
+
+h1, h2, h3 { text-wrap: balance; }
+p { text-wrap: pretty; }
+time { font-variant-numeric: tabular-nums; }
+
+a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; transition: color 160ms ease-out; }
+a:hover { color: color-mix(in srgb, var(--accent) 70%, var(--fg)); }
+
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+
+.skip-link {
+  position: absolute; left: var(--space-3); top: -100px; z-index: 60;
+  background: var(--accent); color: var(--accent-fg);
+  padding: var(--space-2) var(--space-3); border-radius: 6px;
+  font-weight: 600; text-decoration: none;
+}
+.skip-link:focus { top: var(--space-3); }
+
+.shell { max-width: var(--shell); margin-inline: auto; padding-inline: var(--space-4); }
+
+/* ---------------------------------------------------------------- header */
+
+.site-head {
+  position: sticky; top: 0; z-index: 40;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+.site-head .shell {
+  display: flex; align-items: center; justify-content: space-between;
+  min-height: 64px; gap: var(--space-4);
+}
+.brand {
+  display: inline-flex; align-items: center; gap: 0.55rem;
+  font-family: var(--font-mono); font-size: 1rem; font-weight: 600;
+  color: var(--fg); text-decoration: none; letter-spacing: -0.01em;
+}
+.brand-mark { flex-shrink: 0; }
+.brand .brand-night { color: var(--accent); }
+.brand:hover { color: var(--fg); }
+.site-nav { display: flex; align-items: center; gap: var(--space-4); }
+.site-nav a {
+  color: var(--muted); text-decoration: none; font-size: var(--text-sm); font-weight: 500;
+  padding: var(--space-2) 0; transition: color 160ms ease-out;
+}
+.site-nav a:hover, .site-nav a[aria-current="page"] { color: var(--fg); }
+
+.palette-trigger {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  color: var(--muted); background: var(--surface-soft);
+  border: 1px solid var(--border); border-radius: 7px;
+  padding: 0.4rem 0.7rem; cursor: pointer; min-height: 40px;
+  transition: color 160ms ease-out, border-color 160ms ease-out;
+}
+.palette-trigger:hover { color: var(--fg); border-color: var(--line-strong); }
+.palette-trigger kbd {
+  font-family: inherit; font-size: 0.68rem; color: var(--muted);
+  border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.3rem;
+}
+
+/* ------------------------------------------------------------------ hero */
+
+.band { padding-block: var(--space-7); }
+.band + .band { border-top: 1px solid var(--border); }
+
+.hero {
+  position: relative; overflow: hidden;
+  display: flex; align-items: center;
+  min-height: min(calc(100dvh - 64px), 900px);
+  padding-block: var(--space-4) 150px;
+}
+.hero .shell {
+  position: relative; z-index: 1; width: 100%;
+  display: grid; grid-template-columns: minmax(0, 1.02fr) minmax(0, 0.98fr);
+  gap: var(--space-6); align-items: center;
+}
+
+.skyline {
+  position: absolute; left: -28px; right: -28px; bottom: -14px; z-index: 0;
+  display: block; width: calc(100% + 56px);
+  height: calc(clamp(130px, 17vw, 250px) + 14px);
+  pointer-events: none;
+}
+
+.hero-hangul {
+  font-family: var(--font-display); font-weight: 800;
+  font-size: var(--text-hero); line-height: 1.06;
+  letter-spacing: -0.03em; color: var(--fg);
+}
+.hero h1 {
+  font-family: var(--font-mono); font-weight: 500;
+  font-size: var(--text-lg); letter-spacing: 0.02em;
+  color: var(--muted); margin-top: var(--space-2);
+}
+.hero h1 .hero-cursor { color: var(--accent); }
+.hero-tagline {
+  margin-top: var(--space-4); max-width: 34ch;
+  font-size: var(--text-lg); line-height: 1.55; color: var(--muted);
+}
+.hero-cta { margin-top: var(--space-5); display: flex; flex-wrap: wrap; gap: var(--space-3); }
+
+.btn {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-weight: 600; font-size: var(--text-sm); text-decoration: none;
+  padding: 0.7rem 1.3rem; border-radius: 8px; min-height: 44px;
+  transition: background-color 160ms ease-out, color 160ms ease-out, border-color 160ms ease-out, transform 160ms ease-out;
+}
+.btn:active { transform: translateY(1px); }
+.btn-solid { background: var(--accent); color: var(--accent-fg); }
+.btn-solid:hover { background: color-mix(in srgb, var(--accent) 82%, var(--fg)); color: var(--accent-fg); }
+.btn-line { border: 1px solid var(--line-strong); color: var(--fg); }
+.btn-line:hover { border-color: var(--fg); color: var(--fg); }
+
+/* --------------------------------------------- code window + roundels */
+
+.code-window {
+  background: var(--panel);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--fg) 7%, transparent);
+}
+.code-window-bar {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-3); flex-wrap: wrap;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 55%, var(--panel));
+}
+.window-name { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+
+.roundel-line { display: flex; align-items: center; }
+.roundel {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  font-family: var(--font-mono); font-style: normal; font-weight: 600; font-size: 0.68rem;
+  color: var(--bg);
+}
+.roundel + .roundel { margin-left: 12px; position: relative; }
+.roundel + .roundel::before {
+  content: ""; position: absolute; right: 100%; top: 50%;
+  width: 12px; height: 2px; background: var(--line-strong);
+}
+.r-1 { background: var(--c-dalbit); }
+.r-2 { background: var(--c-neon); }
+.r-3 { background: var(--c-hangang); }
+.r-4 { background: var(--c-dancheong); }
+.r-5 { background: var(--c-namsan); }
+.r-6 { background: var(--c-eunhaeng); }
+.r-7 { background: var(--c-jaha); }
+.r-8 { background: var(--c-angae); }
+
+.specimen {
+  padding: var(--space-4); overflow-x: auto;
+  font-family: var(--font-mono); font-size: 0.8rem; line-height: 1.65;
+  color: var(--c-dalbit);
+}
+.specimen code { font-family: inherit; }
+.tok-kw { color: var(--c-neon); }
+.tok-fn { color: var(--c-hangang); }
+.tok-type { color: var(--c-dancheong); }
+.tok-str { color: var(--c-namsan); }
+.tok-num { color: var(--c-eunhaeng); }
+.tok-attr { color: var(--c-jaha); }
+.tok-cm { color: var(--c-angae); font-style: italic; }
+.tok-pn { color: var(--muted); }
+
+/* the editor's current-line highlight, part of what a scheme defines */
+.line-active {
+  display: inline-block;
+  width: calc(100% + 2 * var(--space-4));
+  margin-inline: calc(-1 * var(--space-4));
+  padding-inline: var(--space-4);
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+/* --------------------------------------------------------------- swatches */
+
+.band-head { max-width: 60ch; }
+.band-head h2 {
+  font-family: var(--font-display); font-weight: 800;
+  font-size: var(--text-2xl); line-height: 1.15; letter-spacing: -0.02em;
+}
+.band-head .band-lede { margin-top: var(--space-3); color: var(--muted); font-size: var(--text-base); }
+
+.swatches {
+  list-style: none; margin-top: var(--space-5);
+  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: var(--space-3);
+}
+.swatch {
+  border: 1px solid var(--border); border-radius: var(--radius);
+  background: var(--surface-soft); overflow: hidden;
+  transition: border-color 160ms ease-out, transform 160ms ease-out;
+}
+.swatch:hover { border-color: var(--line-strong); transform: translateY(-2px); }
+.swatch-chip {
+  position: relative; display: flex; align-items: flex-start;
+  justify-content: space-between; padding: var(--space-2); height: 116px;
+}
+.swatch-chip .roundel { width: 26px; height: 26px; background: color-mix(in srgb, var(--bg) 82%, transparent); font-size: 0.72rem; }
+.swatch-glyph {
+  position: absolute; right: 0.7rem; bottom: 0.35rem;
+  font-family: var(--font-mono); font-weight: 500; font-size: 2rem;
+  color: var(--panel); opacity: 0.75; line-height: 1;
+  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.swatch:hover .swatch-glyph { transform: translateY(-3px); }
+.sw-1 .swatch-chip { background: var(--c-dalbit); }
+.sw-2 .swatch-chip { background: var(--c-neon); }
+.sw-3 .swatch-chip { background: var(--c-hangang); }
+.sw-4 .swatch-chip { background: var(--c-dancheong); }
+.sw-5 .swatch-chip { background: var(--c-namsan); }
+.sw-6 .swatch-chip { background: var(--c-eunhaeng); }
+.sw-7 .swatch-chip { background: var(--c-jaha); }
+.sw-8 .swatch-chip { background: var(--c-angae); }
+.sw-1 .roundel, .sw-2 .roundel, .sw-3 .roundel, .sw-4 .roundel,
+.sw-5 .roundel, .sw-6 .roundel, .sw-7 .roundel, .sw-8 .roundel { color: var(--fg); }
+
+.swatch-meta { padding: var(--space-3) var(--space-3) var(--space-4); }
+.swatch-name { font-weight: 600; font-size: var(--text-sm); }
+.swatch-name .swatch-hangul { font-family: var(--font-display); color: var(--muted); font-weight: 700; margin-left: 0.4rem; }
+.swatch-role { color: var(--muted); font-size: var(--text-xs); margin-top: 0.15rem; }
+.swatch-data {
+  margin-top: var(--space-2); display: flex; align-items: center;
+  justify-content: space-between; gap: var(--space-2);
+  font-family: var(--font-mono); font-size: 0.7rem; color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.swatch-hex {
+  font: inherit; color: inherit; background: none; border: 0; cursor: pointer;
+  padding: 0.3rem 0.4rem; margin: -0.3rem -0.4rem; border-radius: 5px;
+  transition: color 160ms ease-out, background-color 160ms ease-out;
+}
+.swatch-hex:hover { color: var(--fg); background: color-mix(in srgb, var(--fg) 7%, transparent); }
+.swatch-hex.is-copied { color: var(--accent); }
+
+/* -------------------------------------------------------------- statement */
+
+.statement { background: var(--surface-soft); }
+.statement .shell { max-width: 46rem; }
+.statement h2 {
+  font-family: var(--font-display); font-weight: 800;
+  font-size: var(--text-xl); line-height: 1.2; letter-spacing: -0.02em;
+  margin-bottom: var(--space-4);
+}
+.statement p { color: var(--muted); font-size: var(--text-lg); line-height: 1.65; max-width: 65ch; }
+.statement p:first-of-type { color: color-mix(in srgb, var(--fg) 86%, var(--muted)); }
+.statement p + p { margin-top: var(--space-4); }
+.statement strong { color: var(--fg); font-weight: 600; }
+
+/* ------------------------------------------------------------- note cards */
+
+.note-cards {
+  list-style: none; margin-top: var(--space-5);
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3);
+}
+.note-card-lead { grid-column: 1 / -1; padding: var(--space-5); background: var(--surface-soft); }
+.note-card-lead h3 { font-family: var(--font-display); font-weight: 800; font-size: var(--text-xl); letter-spacing: -0.01em; max-width: 26ch; }
+.note-card-lead p { max-width: 60ch; font-size: var(--text-base); }
+.note-card-lead h3 a::after {
+  content: " \2192"; display: inline-block; opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 180ms ease-out, transform 180ms ease-out;
+}
+.note-card-lead:hover h3 a::after { opacity: 1; transform: none; }
+.note-card {
+  border: 1px solid var(--border); border-radius: var(--radius);
+  padding: var(--space-4);
+  transition: border-color 160ms ease-out, transform 160ms ease-out;
+}
+.note-card:hover { border-color: var(--line-strong); transform: translateY(-2px); }
+.note-card time { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+.note-card h3 { font-size: var(--text-base); line-height: 1.4; margin-top: var(--space-2); font-weight: 600; }
+.note-card h3 a { color: var(--fg); text-decoration: none; }
+.note-card h3 a:hover { color: var(--accent); }
+.note-card p { color: var(--muted); font-size: var(--text-sm); margin-top: var(--space-2); }
+.band-foot { margin-top: var(--space-5); }
+.text-link { font-weight: 600; font-size: var(--text-sm); }
+
+/* ----------------------------------------------------- interior listings */
+
+.page-head { padding-block: var(--space-6) var(--space-5); border-bottom: 1px solid var(--border); }
+.page-head h1 {
+  font-family: var(--font-display); font-weight: 800;
+  font-size: var(--text-2xl); line-height: 1.12; letter-spacing: -0.02em;
+}
+.page-head .page-lede { margin-top: var(--space-3); color: var(--muted); max-width: 60ch; }
+
+.entry-list { list-style: none; padding-block: var(--space-5) var(--space-6); }
+.entry {
+  display: grid; grid-template-columns: 9.5rem minmax(0, 1fr); gap: var(--space-4);
+  padding: var(--space-4) var(--space-3);
+  margin-inline: calc(-1 * var(--space-3));
+  border-radius: var(--radius);
+  transition: background-color 160ms ease-out;
+}
+.entry:hover { background: var(--surface-soft); }
+.entry + .entry { border-top: 1px solid var(--border); }
+.entry time { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); padding-top: 0.35rem; }
+.entry h2 { font-size: var(--text-lg); line-height: 1.35; font-weight: 600; }
+.entry h2 a { color: var(--fg); text-decoration: none; }
+.entry h2 a:hover { color: var(--accent); }
+.entry .entry-summary { color: var(--muted); font-size: var(--text-sm); margin-top: var(--space-2); max-width: 62ch; }
+.entry-tags { margin-top: var(--space-2); display: flex; flex-wrap: wrap; gap: var(--space-2); list-style: none; }
+.entry-tags a, .tag-chip {
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  color: var(--muted); text-decoration: none;
+  border: 1px solid var(--border); border-radius: 999px; padding: 0.15rem 0.6rem;
+  transition: color 160ms ease-out, border-color 160ms ease-out;
+}
+.entry-tags a:hover, .tag-chip:hover { color: var(--fg); border-color: var(--line-strong); }
+
+/* ------------------------------------------------------------------ prose */
+
+.prose { max-width: 68ch; margin-inline: auto; padding-block: var(--space-6); }
+.prose-head h1 {
+  font-family: var(--font-display); font-weight: 800;
+  font-size: var(--text-2xl); line-height: 1.15; letter-spacing: -0.02em;
+}
+.prose-meta {
+  display: flex; align-items: center; gap: var(--space-3);
+  margin-top: var(--space-3); font-family: var(--font-mono);
+  font-size: var(--text-xs); color: var(--muted);
+}
+.prose-body { margin-top: var(--space-5); }
+.prose-body h2 { font-family: var(--font-display); font-weight: 800; font-size: var(--text-xl); line-height: 1.25; margin: var(--space-5) 0 var(--space-3); }
+.prose-body h3 { font-size: var(--text-lg); font-weight: 600; margin: var(--space-4) 0 var(--space-2); }
+.prose-body p { margin-bottom: var(--space-3); }
+.prose-body p, .prose-body li { color: color-mix(in srgb, var(--fg) 88%, var(--muted)); }
+.prose-body ul, .prose-body ol { margin: 0 0 var(--space-3) 1.25rem; }
+.prose-body li + li { margin-top: var(--space-1); }
+.prose-body li::marker { color: var(--muted); }
+.prose-body blockquote {
+  border-left: 2px solid var(--accent); padding-left: var(--space-3);
+  color: var(--muted); margin-bottom: var(--space-3);
+}
+.prose-body code {
+  font-family: var(--font-mono); font-size: 0.86em;
+  background: var(--surface-soft); border: 1px solid var(--border);
+  border-radius: 5px; padding: 0.08em 0.35em;
+}
+.prose-body pre {
+  background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius);
+  padding: var(--space-4); overflow-x: auto; margin-bottom: var(--space-4);
+  font-size: 0.84rem; line-height: 1.7;
+}
+.prose-body pre code { background: transparent; border: 0; padding: 0; font-size: inherit; }
+.prose-foot { margin-top: var(--space-5); padding-top: var(--space-4); border-top: 1px solid var(--border); }
+.prose-return { margin-top: var(--space-3); }
+
+/* the scheme applied to real code on this site: hljs remap */
+.hljs { background: transparent; color: var(--c-dalbit); }
+.hljs-comment, .hljs-quote { color: var(--c-angae); font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-tag { color: var(--c-neon); }
+.hljs-title, .hljs-title.function_, .hljs-function { color: var(--c-hangang); }
+.hljs-type, .hljs-class, .hljs-title.class_, .hljs-built_in { color: var(--c-dancheong); }
+.hljs-string, .hljs-regexp, .hljs-addition { color: var(--c-namsan); }
+.hljs-number, .hljs-literal, .hljs-deletion { color: var(--c-eunhaeng); }
+.hljs-attr, .hljs-attribute, .hljs-meta, .hljs-selector-attr, .hljs-selector-class, .hljs-section { color: var(--c-jaha); }
+.hljs-variable, .hljs-params, .hljs-name, .hljs-symbol, .hljs-bullet { color: var(--c-dalbit); }
+.hljs-operator, .hljs-punctuation { color: var(--muted); }
+
+/* --------------------------------------------------------------- callout */
+
+.callout {
+  border: 1px solid var(--border); border-left: 2px solid var(--accent);
+  border-radius: var(--radius); background: var(--surface-soft);
+  padding: var(--space-3) var(--space-4); margin-bottom: var(--space-4);
+  font-size: var(--text-sm);
+}
+.callout p { margin: 0; color: color-mix(in srgb, var(--fg) 88%, var(--muted)); }
+
+/* ------------------------------------------------------------ pagination */
+
+.pagination { display: flex; align-items: center; gap: var(--space-3); padding-block: var(--space-4) var(--space-6); font-family: var(--font-mono); font-size: var(--text-sm); }
+.pagination a { text-decoration: none; border: 1px solid var(--border); border-radius: 7px; padding: 0.35rem 0.8rem; color: var(--fg); transition: border-color 160ms ease-out, color 160ms ease-out; }
+.pagination a:hover { border-color: var(--accent); color: var(--accent); }
+.pagination .current, .pagination span[aria-current] { color: var(--accent); font-weight: 600; }
+
+/* -------------------------------------------------------------- taxonomy */
+
+.term-list { list-style: none; display: flex; flex-wrap: wrap; gap: var(--space-3); padding-block: var(--space-5) var(--space-6); }
+.term-list a {
+  display: inline-flex; align-items: baseline; gap: var(--space-2);
+  font-family: var(--font-mono); font-size: var(--text-sm); text-decoration: none;
+  color: var(--fg); border: 1px solid var(--border); border-radius: 999px;
+  padding: 0.45rem 1rem; transition: border-color 160ms ease-out, color 160ms ease-out;
+}
+.term-list a:hover { border-color: var(--accent); color: var(--accent); }
+.term-count { color: var(--muted); font-size: var(--text-xs); }
+
+/* ------------------------------------------------------------- not found */
+
+.notfound { padding-block: var(--space-7); text-align: left; max-width: 46rem; }
+.notfound .code-window { margin-top: var(--space-5); }
+.notfound h1 { font-family: var(--font-display); font-weight: 800; font-size: var(--text-2xl); }
+.notfound p { color: var(--muted); margin-top: var(--space-3); max-width: 55ch; }
+
+/* --------------------------------------------------------- search palette */
+
+.search-modal { position: fixed; inset: 0; z-index: 50; }
+.search-modal[hidden] { display: none; }
+.search-backdrop { position: absolute; inset: 0; background: color-mix(in srgb, var(--bg) 82%, transparent); }
+.search-panel {
+  position: relative; margin: 16vh auto 0; width: min(580px, 92vw);
+  background: var(--surface); border: 1px solid var(--line-strong);
+  border-radius: 12px; overflow: hidden;
+}
+.search-field {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border);
+}
+.search-glyph { color: var(--accent); font-family: var(--font-mono); font-weight: 600; }
+.search-input {
+  flex: 1; background: transparent; border: 0; outline: none;
+  color: var(--fg); font-family: var(--font-mono); font-size: var(--text-base);
+}
+.search-input::placeholder { color: var(--muted); opacity: 1; }
+.search-esc {
+  font-family: var(--font-mono); font-size: 0.68rem; color: var(--muted);
+  border: 1px solid var(--border); border-radius: 4px; padding: 0.1rem 0.4rem;
+}
+.search-results { list-style: none; max-height: 42vh; overflow-y: auto; }
+.search-result a {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4); text-decoration: none; color: var(--fg);
+}
+.search-result-section {
+  font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted);
+  border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.4rem;
+  flex-shrink: 0;
+}
+.search-result-title { font-size: var(--text-sm); }
+.search-result[aria-selected="true"] a { background: var(--surface-soft); box-shadow: inset 2px 0 0 var(--accent); }
+.search-hint, .search-empty { padding: var(--space-4); color: var(--muted); font-size: var(--text-sm); }
+
+/* ---------------------------------------------------------------- footer */
+
+.site-foot { border-top: 1px solid var(--border); padding-block: var(--space-5); }
+.site-foot .shell { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: var(--space-3); }
+.site-foot p { color: var(--muted); font-size: var(--text-xs); font-family: var(--font-mono); }
+.foot-brand { display: flex; flex-direction: column; gap: var(--space-2); }
+.foot-roundels { display: inline-flex; gap: 7px; }
+.foot-roundels i { width: 8px; height: 8px; border-radius: 50%; }
+.site-foot nav { display: flex; gap: var(--space-4); }
+.site-foot nav a { color: var(--muted); font-size: var(--text-xs); text-decoration: none; }
+.site-foot nav a:hover { color: var(--fg); }
+
+/* -------------------------------------------------------------- responsive */
+
+@media (max-width: 960px) {
+  .hero { min-height: 0; padding-block: var(--space-5) 150px; }
+  .hero .shell { grid-template-columns: 1fr; gap: var(--space-5); }
+  .hero-tagline { max-width: 52ch; }
+  .swatches { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .note-cards { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+  .band { padding-block: var(--space-6); }
+  .entry { grid-template-columns: 1fr; gap: var(--space-2); }
+  .entry time { padding-top: 0; }
+  .site-nav { gap: var(--space-3); }
+  .palette-trigger .trigger-label { display: none; }
+}
+
+@media (max-width: 520px) {
+  .shell { padding-inline: var(--space-3); }
+  .swatches { grid-template-columns: 1fr; }
+  .specimen { font-size: 0.74rem; }
+  .roundel { width: 21px; height: 21px; font-size: 0.6rem; }
+  .roundel + .roundel { margin-left: 9px; }
+  .roundel + .roundel::before { width: 9px; }
+}
+
+/* ------------------------------------------------------------------ motion
+   Entrance cascade tells the hero's story in reading order; the cursor blink
+   is the one perpetual motion, motivated by the editor metaphor. Scroll
+   reveals are progressive enhancement via CSS scroll-driven animations. */
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes rise {
+    from { opacity: 0; transform: translateY(16px); }
+    to { opacity: 1; transform: none; }
+  }
+  @keyframes blink {
+    0%, 55% { opacity: 1; }
+    60%, 100% { opacity: 0; }
+  }
+
+  .hero-copy > h1 { animation: rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.05s both; }
+  .hero-copy > .hero-tagline { animation: rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.16s both; }
+  .hero-copy > .hero-cta { animation: rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.27s both; }
+  .hero .code-window { animation: rise 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.34s both; }
+  .hero .skyline { animation: rise 1.1s cubic-bezier(0.16, 1, 0.3, 1) 0.4s both; }
+  .hero-cursor { animation: blink 1.2s step-end infinite; }
+
+  /* the last train crosses the bridge, rests off screen, and comes back */
+  @keyframes lasttrain {
+    0% { transform: translateX(-160px); }
+    58%, 100% { transform: translateX(1600px); }
+  }
+  .sky-train { animation: lasttrain 26s linear 3s infinite; }
+
+  /* window lights breathe slowly, two groups out of phase */
+  @keyframes citylight-a {
+    0%, 100% { opacity: 0.55; }
+    50% { opacity: 0.26; }
+  }
+  @keyframes citylight-b {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 0.18; }
+  }
+  .sky-lights-a { animation: citylight-a 9s ease-in-out infinite; }
+  .sky-lights-b { animation: citylight-b 12s ease-in-out 3s infinite; }
+
+  /* pointer parallax: scene.js eases --plx-x/--plx-y between -1 and 1;
+     each layer drifts at its own depth, the sky against the pointer */
+  @media (hover: hover) and (pointer: fine) {
+    .sky-celestial, .sky-far, .sky-mid, .sky-river { will-change: transform; }
+    .sky-celestial { transform: translate(calc(var(--plx-x, 0) * -6px), calc(var(--plx-y, 0) * -3px)); }
+    .sky-far { transform: translate(calc(var(--plx-x, 0) * 7px), calc(var(--plx-y, 0) * 3px)); }
+    .sky-mid { transform: translate(calc(var(--plx-x, 0) * 13px), calc(var(--plx-y, 0) * 6px)); }
+    .sky-river { transform: translate(calc(var(--plx-x, 0) * 20px), calc(var(--plx-y, 0) * 9px)); }
+  }
+
+  @supports (animation-timeline: view()) {
+    .band-head, .swatches, .statement .shell, .note-cards, .band-foot {
+      animation: rise 1ms linear both;
+      animation-timeline: view();
+      animation-range: entry 5% entry 45%;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/examples/seoulnight/static/favicon.svg
+++ b/examples/seoulnight/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#101320"/>
+  <circle cx="15" cy="17" r="8" fill="none" stroke="#d957c4" stroke-width="3"/>
+  <circle cx="24" cy="8" r="3" fill="#dee4f5"/>
+</svg>

--- a/examples/seoulnight/static/js/scene.js
+++ b/examples/seoulnight/static/js/scene.js
@@ -1,0 +1,44 @@
+/* Pointer parallax for the hero skyline. Layers move at different rates via
+   the --plx-x / --plx-y custom properties (consumed in style.css). Runs only
+   on hover-capable pointers with reduced motion off, and only while the hero
+   is on screen. Eased in a self-stopping rAF loop; no scroll listeners. */
+(function () {
+  "use strict";
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+  var hero = document.querySelector(".hero");
+  if (!hero || !hero.querySelector(".skyline")) return;
+
+  var targetX = 0, targetY = 0, currentX = 0, currentY = 0;
+  var raf = null;
+  var active = true;
+
+  function tick() {
+    currentX += (targetX - currentX) * 0.07;
+    currentY += (targetY - currentY) * 0.07;
+    hero.style.setProperty("--plx-x", currentX.toFixed(4));
+    hero.style.setProperty("--plx-y", currentY.toFixed(4));
+    if (Math.abs(targetX - currentX) > 0.002 || Math.abs(targetY - currentY) > 0.002) {
+      raf = requestAnimationFrame(tick);
+    } else {
+      raf = null;
+    }
+  }
+
+  window.addEventListener("pointermove", function (event) {
+    if (!active) return;
+    targetX = (event.clientX / window.innerWidth) * 2 - 1;
+    targetY = (event.clientY / window.innerHeight) * 2 - 1;
+    if (!raf) raf = requestAnimationFrame(tick);
+  }, { passive: true });
+
+  if ("IntersectionObserver" in window) {
+    new IntersectionObserver(function (entries) {
+      active = entries[0].isIntersecting;
+      if (!active && raf) {
+        cancelAnimationFrame(raf);
+        raf = null;
+      }
+    }).observe(hero);
+  }
+})();

--- a/examples/seoulnight/static/js/search.js
+++ b/examples/seoulnight/static/js/search.js
@@ -1,0 +1,114 @@
+(function () {
+  "use strict";
+  var baseUrl = document.documentElement.getAttribute("data-base-url") || "";
+  var modal = document.getElementById("search-modal");
+  var trigger = document.getElementById("search-trigger");
+  var input = document.getElementById("search-input");
+  var list = document.getElementById("search-results");
+  var empty = document.getElementById("search-empty");
+  var hint = document.getElementById("search-hint");
+  if (!modal || !trigger || !input || !list) return;
+
+  var fuse = null;
+  var items = [];
+  var selected = -1;
+
+  function loadIndex() {
+    if (fuse) return;
+    fetch(baseUrl + "/search.json")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        fuse = new Fuse(data, { keys: ["title", "content"], threshold: 0.32 });
+      })
+      .catch(function () { /* index unavailable; the palette stays empty */ });
+  }
+
+  function render(results) {
+    list.textContent = "";
+    items = results;
+    selected = results.length ? 0 : -1;
+    empty.hidden = results.length !== 0 || input.value.trim() === "";
+    if (hint) hint.hidden = input.value.trim() !== "";
+    results.forEach(function (r, i) {
+      var page = r.item;
+      var li = document.createElement("li");
+      li.className = "search-result";
+      li.setAttribute("role", "option");
+      li.id = "search-result-" + i;
+      li.setAttribute("aria-selected", i === selected ? "true" : "false");
+      var segment = page.url.replace(/^\/|\/$/g, "").split("/")[0] || "page";
+      var a = document.createElement("a");
+      a.href = baseUrl + page.url;
+      var chip = document.createElement("span");
+      chip.className = "search-result-section";
+      chip.textContent = segment;
+      var title = document.createElement("span");
+      title.className = "search-result-title";
+      title.textContent = page.title;
+      a.appendChild(chip);
+      a.appendChild(title);
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+    input.setAttribute("aria-expanded", results.length ? "true" : "false");
+  }
+
+  function updateSelection() {
+    var nodes = list.querySelectorAll(".search-result");
+    nodes.forEach(function (node, i) {
+      node.setAttribute("aria-selected", i === selected ? "true" : "false");
+      if (i === selected) node.scrollIntoView({ block: "nearest" });
+    });
+    input.setAttribute("aria-activedescendant", selected >= 0 ? "search-result-" + selected : "");
+  }
+
+  function open() {
+    loadIndex();
+    modal.hidden = false;
+    input.value = "";
+    render([]);
+    input.focus();
+    document.body.style.overflow = "hidden";
+  }
+
+  function close() {
+    modal.hidden = true;
+    document.body.style.overflow = "";
+    trigger.focus();
+  }
+
+  trigger.addEventListener("click", open);
+
+  modal.addEventListener("click", function (event) {
+    if (event.target.hasAttribute("data-search-close")) close();
+  });
+
+  input.addEventListener("input", function () {
+    if (!fuse || input.value.trim() === "") { render([]); return; }
+    render(fuse.search(input.value).slice(0, 8));
+  });
+
+  input.addEventListener("keydown", function (event) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (items.length) { selected = (selected + 1) % items.length; updateSelection(); }
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (items.length) { selected = (selected - 1 + items.length) % items.length; updateSelection(); }
+    } else if (event.key === "Enter") {
+      if (selected >= 0 && items[selected]) window.location.href = baseUrl + items[selected].item.url;
+    } else if (event.key === "Escape") {
+      close();
+    }
+  });
+
+  document.addEventListener("keydown", function (event) {
+    var meta = event.metaKey || event.ctrlKey;
+    if (meta && event.key.toLowerCase() === "k") {
+      event.preventDefault();
+      modal.hidden ? open() : close();
+    } else if (event.key === "Escape" && !modal.hidden) {
+      close();
+    }
+  });
+})();

--- a/examples/seoulnight/static/js/swatch.js
+++ b/examples/seoulnight/static/js/swatch.js
@@ -1,0 +1,20 @@
+/* Click-to-copy for the palette swatch hex buttons. Falls back silently when
+   the clipboard API is unavailable (file://, older browsers). */
+(function () {
+  "use strict";
+  var buttons = document.querySelectorAll(".swatch-hex");
+  if (!buttons.length || !navigator.clipboard) return;
+  buttons.forEach(function (button) {
+    button.addEventListener("click", function () {
+      var hex = button.getAttribute("data-hex");
+      navigator.clipboard.writeText(hex).then(function () {
+        button.classList.add("is-copied");
+        button.textContent = "copied";
+        window.setTimeout(function () {
+          button.classList.remove("is-copied");
+          button.textContent = hex;
+        }, 1300);
+      }).catch(function () { /* clipboard blocked; leave the hex visible */ });
+    });
+  });
+})();

--- a/examples/seoulnight/templates/404.html
+++ b/examples/seoulnight/templates/404.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <div class="notfound">
+      <h1>Last stop</h1>
+      <p>This address is past the end of the line. The train stopped running at midnight, and nothing is lit down here.</p>
+      <figure class="code-window" aria-label="A 404 message rendered in the Seoulnight scheme">
+        <figcaption class="code-window-bar">
+          <span class="window-name">404.ts</span>
+          <span class="roundel-line" aria-hidden="true"><i class="roundel r-2">2</i><i class="roundel r-8">8</i></span>
+        </figcaption>
+        <pre class="specimen"><code class="nohighlight"><span class="tok-cm">// no station under this name</span>
+<span class="tok-kw">throw new</span> <span class="tok-type">RangeError</span><span class="tok-pn">(</span><span class="tok-str">"line ends before this stop"</span><span class="tok-pn">);</span></code></pre>
+      </figure>
+      <p><a href="{{ base_url }}/">Ride back to the start</a></p>
+    </div>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/seoulnight/templates/footer.html
+++ b/examples/seoulnight/templates/footer.html
@@ -1,0 +1,22 @@
+  <footer class="site-foot">
+    <div class="shell">
+      <div class="foot-brand">
+        <span class="foot-roundels" aria-hidden="true"><i class="r-1"></i><i class="r-2"></i><i class="r-3"></i><i class="r-4"></i><i class="r-5"></i><i class="r-6"></i><i class="r-7"></i><i class="r-8"></i></span>
+        <p>Seoulnight is a fictional color scheme, set in Gothic A1 and IBM Plex. {{ current_year }}.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="{{ base_url }}/notes/">Notes</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/notes/rss.xml">RSS</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0"></script>
+  <script src="{{ base_url }}/js/search.js"></script>
+  <script src="{{ base_url }}/js/scene.js"></script>
+  <script src="{{ base_url }}/js/swatch.js"></script>
+</body>
+</html>

--- a/examples/seoulnight/templates/header.html
+++ b/examples/seoulnight/templates/header.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" data-base-url="{{ base_url }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present and page.title != site.title %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+  {{ jsonld }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Gothic+A1:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  {{ highlight_css }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <div class="search-modal" id="search-modal" role="dialog" aria-modal="true" aria-label="Search Seoulnight" hidden>
+    <div class="search-backdrop" data-search-close></div>
+    <div class="search-panel">
+      <div class="search-field">
+        <span class="search-glyph" aria-hidden="true">&rsaquo;</span>
+        <input type="text" id="search-input" class="search-input" placeholder="Search the notes" autocomplete="off" spellcheck="false" aria-label="Search Seoulnight" aria-controls="search-results" aria-expanded="false" role="combobox" aria-autocomplete="list">
+        <kbd class="search-esc">Esc</kbd>
+      </div>
+      <ul id="search-results" class="search-results" role="listbox"></ul>
+      <p class="search-hint" id="search-hint">Type to search the notes. Arrow keys move, Enter opens.</p>
+      <p class="search-empty" id="search-empty" hidden>Nothing in the night matches that.</p>
+    </div>
+  </div>
+
+  <header class="site-head">
+    <div class="shell">
+      <a class="brand" href="{{ base_url }}/">
+        <svg class="brand-mark" viewBox="0 0 32 32" width="18" height="18" aria-hidden="true" focusable="false">
+          <circle cx="15" cy="17" r="8" fill="none" stroke="var(--accent)" stroke-width="3.5"/>
+          <circle cx="24.5" cy="7.5" r="3.2" fill="var(--fg)"/>
+        </svg>
+        <span>seoul<span class="brand-night">night</span></span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/notes/"{% if page.section == "notes" %} aria-current="page"{% endif %}>Notes</a>
+        <a href="{{ base_url }}/about/"{% if page.url == "/about/" %} aria-current="page"{% endif %}>About</a>
+        <button type="button" id="search-trigger" class="palette-trigger" aria-haspopup="dialog" aria-controls="search-modal">
+          <span class="trigger-label">Search</span>
+          <kbd>&#8984;K</kbd>
+        </button>
+      </nav>
+    </div>
+  </header>

--- a/examples/seoulnight/templates/home.html
+++ b/examples/seoulnight/templates/home.html
@@ -1,0 +1,153 @@
+{#
+  home.html - landing for the Seoulnight color scheme. The signature element
+  is the metro-style roundel strip on the hero code window's title bar: the
+  eight scheme colors rendered as numbered transit-line roundels joined by a
+  connector line. The same numbering returns on the swatch chips below.
+#}
+{% include "header.html" %}
+<main id="main">
+
+  <section class="band hero" aria-labelledby="hero-title">
+    {% include "skyline.html" %}
+    <div class="shell">
+      <div class="hero-copy">
+        <h1 id="hero-title">
+          <span class="hero-hangul" lang="ko">서울밤</span>
+          <span class="hero-latin">Seoulnight<span class="hero-cursor" aria-hidden="true">_</span></span>
+        </h1>
+        <p class="hero-tagline">An editor color scheme drawn from Seoul after dark. Eight hues from neon, river, and ginkgo, tuned for late-night code.</p>
+        <div class="hero-cta">
+          <a class="btn btn-solid" href="#palette">See the palette</a>
+          <a class="btn btn-line" href="{{ base_url }}/notes/">Read the notes</a>
+        </div>
+      </div>
+      <figure class="code-window" aria-label="A TypeScript sample rendered in the Seoulnight scheme">
+        <figcaption class="code-window-bar">
+          <span class="window-name">night-shift.ts</span>
+          <span class="roundel-line" aria-hidden="true"><i class="roundel r-1">1</i><i class="roundel r-2">2</i><i class="roundel r-3">3</i><i class="roundel r-4">4</i><i class="roundel r-5">5</i><i class="roundel r-6">6</i><i class="roundel r-7">7</i><i class="roundel r-8">8</i></span>
+        </figcaption>
+        <pre class="specimen"><code class="nohighlight"><span class="tok-cm">// Seoul, 02:14. The signs are still on.</span>
+<span class="tok-kw">import</span> <span class="tok-pn">{</span> palette <span class="tok-pn">}</span> <span class="tok-kw">from</span> <span class="tok-str">"seoulnight"</span><span class="tok-pn">;</span>
+
+<span class="tok-kw">type</span> <span class="tok-type">Signal</span> <span class="tok-pn">=</span> <span class="tok-pn">{</span>
+  line<span class="tok-pn">:</span> <span class="tok-type">number</span><span class="tok-pn">;</span>
+  hue<span class="tok-pn">:</span> <span class="tok-type">string</span><span class="tok-pn">;</span>
+<span class="tok-pn">};</span>
+
+<span class="tok-kw">const</span> lastTrain<span class="tok-pn">:</span> <span class="tok-type">Signal</span><span class="tok-pn">[] = [</span>
+  <span class="tok-pn">{</span> line<span class="tok-pn">:</span> <span class="tok-num">2</span><span class="tok-pn">,</span> hue<span class="tok-pn">:</span> palette<span class="tok-pn">.</span><span class="tok-attr">hangang</span> <span class="tok-pn">},</span>
+  <span class="tok-pn">{</span> line<span class="tok-pn">:</span> <span class="tok-num">4</span><span class="tok-pn">,</span> hue<span class="tok-pn">:</span> palette<span class="tok-pn">.</span><span class="tok-attr">dancheong</span> <span class="tok-pn">},</span>
+<span class="tok-pn">];</span>
+
+<span class="tok-kw">function</span> <span class="tok-fn">nightShift</span><span class="tok-pn">(</span>hour<span class="tok-pn">:</span> <span class="tok-type">number</span><span class="tok-pn">)</span> <span class="tok-pn">{</span>
+<span class="line-active">  <span class="tok-kw">if</span> <span class="tok-pn">(</span>hour <span class="tok-pn">&lt;</span> <span class="tok-num">5</span><span class="tok-pn">)</span> <span class="tok-kw">return</span> palette<span class="tok-pn">.</span><span class="tok-attr">neon</span><span class="tok-pn">;</span></span>
+  <span class="tok-cm">// dawn turns the signs off</span>
+  <span class="tok-kw">return</span> palette<span class="tok-pn">.</span><span class="tok-attr">dalbit</span><span class="tok-pn">;</span>
+<span class="tok-pn">}</span></code></pre>
+      </figure>
+    </div>
+  </section>
+
+  <section class="band" id="palette" aria-labelledby="palette-title">
+    <div class="shell">
+      <div class="band-head">
+        <h2 id="palette-title">Eight colors, numbered like transit lines</h2>
+        <p class="band-lede">Every hue is sampled from the city at night, then desaturated until it can hold still for hours. Contrast is measured against the editor background.</p>
+      </div>
+      <ul class="swatches">
+        <li class="swatch sw-1">
+          <span class="swatch-chip"><span class="roundel" aria-hidden="true">1</span><span class="swatch-glyph" aria-hidden="true">Aa</span></span>
+          <div class="swatch-meta">
+            <p class="swatch-name">dalbit<span class="swatch-hangul" lang="ko">달빛</span></p>
+            <p class="swatch-role">text and punctuation</p>
+            <p class="swatch-data"><button type="button" class="swatch-hex" data-hex="#dee4f5" title="Copy to clipboard" aria-label="Copy #dee4f5 to clipboard">#dee4f5</button><span>14.5:1</span></p>
+          </div>
+        </li>
+        <li class="swatch sw-2">
+          <span class="swatch-chip"><span class="roundel" aria-hidden="true">2</span><span class="swatch-glyph" aria-hidden="true">if</span></span>
+          <div class="swatch-meta">
+            <p class="swatch-name">neon<span class="swatch-hangul" lang="ko">네온</span></p>
+            <p class="swatch-role">keywords and control flow</p>
+            <p class="swatch-data"><button type="button" class="swatch-hex" data-hex="#d957c4" title="Copy to clipboard" aria-label="Copy #d957c4 to clipboard">#d957c4</button><span>5.4:1</span></p>
+          </div>
+        </li>
+        <li class="swatch sw-3">
+          <span class="swatch-chip"><span class="roundel" aria-hidden="true">3</span><span class="swatch-glyph" aria-hidden="true">fn</span></span>
+          <div class="swatch-meta">
+            <p class="swatch-name">hangang<span class="swatch-hangul" lang="ko">한강</span></p>
+            <p class="swatch-role">functions and calls</p>
+            <p class="swatch-data"><button type="button" class="swatch-hex" data-hex="#6ea3e8" title="Copy to clipboard" aria-label="Copy #6ea3e8 to clipboard">#6ea3e8</button><span>7.1:1</span></p>
+          </div>
+        </li>
+        <li class="swatch sw-4">
+          <span class="swatch-chip"><span class="roundel" aria-hidden="true">4</span><span class="swatch-glyph" aria-hidden="true">&lt;T&gt;</span></span>
+          <div class="swatch-meta">
+            <p class="swatch-name">dancheong<span class="swatch-hangul" lang="ko">단청</span></p>
+            <p class="swatch-role">types and constants</p>
+            <p class="swatch-data"><button type="button" class="swatch-hex" data-hex="#e8705c" title="Copy to clipboard" aria-label="Copy #e8705c to clipboard">#e8705c</button><span>6.1:1</span></p>
+          </div>
+        </li>
+        <li class="swatch sw-5">
+          <span class="swatch-chip"><span class="roundel" aria-hidden="true">5</span><span class="swatch-glyph" aria-hidden="true">&quot;&quot;</span></span>
+          <div class="swatch-meta">
+            <p class="swatch-name">namsan<span class="swatch-hangul" lang="ko">남산</span></p>
+            <p class="swatch-role">strings</p>
+            <p class="swatch-data"><button type="button" class="swatch-hex" data-hex="#6fbf8f" title="Copy to clipboard" aria-label="Copy #6fbf8f to clipboard">#6fbf8f</button><span>8.4:1</span></p>
+          </div>
+        </li>
+        <li class="swatch sw-6">
+          <span class="swatch-chip"><span class="roundel" aria-hidden="true">6</span><span class="swatch-glyph" aria-hidden="true">42</span></span>
+          <div class="swatch-meta">
+            <p class="swatch-name">eunhaeng<span class="swatch-hangul" lang="ko">은행</span></p>
+            <p class="swatch-role">numbers and units</p>
+            <p class="swatch-data"><button type="button" class="swatch-hex" data-hex="#dfae5f" title="Copy to clipboard" aria-label="Copy #dfae5f to clipboard">#dfae5f</button><span>9.1:1</span></p>
+          </div>
+        </li>
+        <li class="swatch sw-7">
+          <span class="swatch-chip"><span class="roundel" aria-hidden="true">7</span><span class="swatch-glyph" aria-hidden="true">@</span></span>
+          <div class="swatch-meta">
+            <p class="swatch-name">jaha<span class="swatch-hangul" lang="ko">자하</span></p>
+            <p class="swatch-role">attributes and metadata</p>
+            <p class="swatch-data"><button type="button" class="swatch-hex" data-hex="#9d85e0" title="Copy to clipboard" aria-label="Copy #9d85e0 to clipboard">#9d85e0</button><span>6.0:1</span></p>
+          </div>
+        </li>
+        <li class="swatch sw-8">
+          <span class="swatch-chip"><span class="roundel" aria-hidden="true">8</span><span class="swatch-glyph" aria-hidden="true">//</span></span>
+          <div class="swatch-meta">
+            <p class="swatch-name">angae<span class="swatch-hangul" lang="ko">안개</span></p>
+            <p class="swatch-role">comments</p>
+            <p class="swatch-data"><button type="button" class="swatch-hex" data-hex="#7d88a8" title="Copy to clipboard" aria-label="Copy #7d88a8 to clipboard">#7d88a8</button><span>5.2:1</span></p>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="band statement" aria-label="Design principles">
+    <div class="shell">
+      {{ content | safe }}
+    </div>
+  </section>
+
+  <section class="band" aria-labelledby="notes-title">
+    <div class="shell">
+      <div class="band-head">
+        <h2 id="notes-title">Notes from the night shift</h2>
+        <p class="band-lede">A devlog on how the scheme is tuned: one decision per note, with the measurements that backed it.</p>
+      </div>
+      {% set entries = get_section(path="notes").pages | sort_by("date", reverse=true) %}
+      <ul class="note-cards">
+        {% for p in entries %}{% if loop.index0 < 3 %}
+        <li class="note-card{% if loop.index0 == 0 %} note-card-lead{% endif %}">
+          {% if p.date %}<time datetime="{{ p.date }}">{{ p.date | date("%Y-%m-%d") }}</time>{% endif %}
+          <h3><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></h3>
+          {% if p.description %}<p>{{ p.description | e }}</p>{% endif %}
+        </li>
+        {% endif %}{% endfor %}
+      </ul>
+      <div class="band-foot"><a class="text-link" href="{{ base_url }}/notes/">All notes &#8594;</a></div>
+    </div>
+  </section>
+
+</main>
+{% include "footer.html" %}

--- a/examples/seoulnight/templates/page.html
+++ b/examples/seoulnight/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <article class="prose">
+      <header class="prose-head">
+        <h1>{{ page.title | e }}</h1>
+        <div class="prose-meta">
+          {% if page.date %}<time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>{% endif %}
+          {% if page.reading_time %}<span>{{ page.reading_time }} min read</span>{% endif %}
+        </div>
+      </header>
+      <div class="prose-body">
+        {{ content | safe }}
+      </div>
+      <footer class="prose-foot">
+        {% if page.tags %}
+        <ul class="entry-tags">
+          {% for t in page.tags %}<li><a href="{{ get_taxonomy_url(kind="tags", term=t) }}">{{ t }}</a></li>{% endfor %}
+        </ul>
+        {% endif %}
+        {% if page.section == "notes" %}
+        <p class="prose-return"><a class="text-link" href="{{ base_url }}/notes/">All notes &#8594;</a></p>
+        {% endif %}
+      </footer>
+    </article>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/seoulnight/templates/section.html
+++ b/examples/seoulnight/templates/section.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <div class="page-head">
+      <h1>{{ section.title | e }}</h1>
+      {% if section.description %}<p class="page-lede">{{ section.description | e }}</p>{% endif %}
+    </div>
+    {{ content | safe }}
+    <ul class="entry-list">
+      {% for p in section.pages %}
+      <li class="entry">
+        {% if p.date %}<time datetime="{{ p.date }}">{{ p.date | date("%Y-%m-%d") }}</time>{% endif %}
+        <div class="entry-body">
+          <h2><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></h2>
+          {% if p.summary %}<p class="entry-summary">{{ p.summary | strip_html | truncate_words(28) }}</p>{% endif %}
+          {% if p.tags %}
+          <ul class="entry-tags">
+            {% for t in p.tags %}<li><a href="{{ get_taxonomy_url(kind="tags", term=t) }}">{{ t }}</a></li>{% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/seoulnight/templates/shortcodes/alert.html
+++ b/examples/seoulnight/templates/shortcodes/alert.html
@@ -1,0 +1,1 @@
+<aside class="callout">{{ body | markdownify }}</aside>

--- a/examples/seoulnight/templates/skyline.html
+++ b/examples/seoulnight/templates/skyline.html
@@ -1,0 +1,189 @@
+{#
+  skyline.html - full-bleed Seoul night panorama, drawn from palette tokens.
+  Layers back to front, each a parallax group driven by static/js/scene.js
+  (pointer only, hover-capable devices, reduced-motion off):
+    .sky-celestial  moon and stars (drifts against the pointer)
+    .sky-far        distant skyline (surface tint)
+    .sky-mid        Namsan, N Seoul Tower, near skyline, window lights
+    .sky-river      the Han, the bridge, its eight scheme-colored lamps,
+                    and the last train that crosses on a 26s cycle
+#}
+<svg class="skyline" viewBox="0 0 1440 260" preserveAspectRatio="xMidYMax slice" aria-hidden="true" focusable="false">
+  <defs>
+    <filter id="sn-moonglow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="12"/>
+    </filter>
+  </defs>
+
+  <g class="sky-celestial">
+    <circle cx="1376" cy="56" r="20" fill="var(--c-dalbit)" opacity="0.22" filter="url(#sn-moonglow)"/>
+    <circle cx="1376" cy="56" r="12" fill="var(--c-dalbit)" opacity="0.88"/>
+    <g fill="var(--c-dalbit)" opacity="0.35">
+      <circle cx="242" cy="42" r="1.3"/>
+      <circle cx="424" cy="26" r="1.1"/>
+      <circle cx="562" cy="56" r="1.3"/>
+      <circle cx="764" cy="30" r="1.1"/>
+      <circle cx="986" cy="48" r="1.3"/>
+      <circle cx="1246" cy="24" r="1.1"/>
+      <circle cx="88" cy="72" r="1.1"/>
+      <circle cx="1108" cy="66" r="1.1"/>
+    </g>
+  </g>
+
+  <g class="sky-far" fill="var(--surface)" opacity="0.55">
+    <path d="M40,212 L150,172 236,152 330,190 392,212 Z"/>
+    <rect x="205" y="128" width="64" height="84"/>
+    <rect x="292" y="96" width="72" height="116"/>
+    <rect x="392" y="76" width="78" height="136"/>
+    <rect x="498" y="112" width="86" height="100"/>
+    <rect x="606" y="64" width="76" height="148"/>
+    <rect x="700" y="98" width="88" height="114"/>
+    <rect x="812" y="74" width="84" height="138"/>
+    <rect x="922" y="104" width="82" height="108"/>
+    <rect x="1030" y="84" width="76" height="128"/>
+    <rect x="1196" y="98" width="84" height="114"/>
+    <rect x="1306" y="88" width="92" height="124"/>
+  </g>
+
+  <g class="sky-mid">
+    <g fill="var(--panel)">
+      <path d="M0,212 L36,196 92,158 150,122 214,164 268,192 300,212 Z"/>
+      <rect x="146" y="66" width="7" height="58"/>
+      <rect x="134" y="80" width="31" height="15" rx="7.5"/>
+      <rect x="148.5" y="34" width="2.5" height="34"/>
+    </g>
+    <circle cx="149.7" cy="31" r="2.4" fill="var(--c-dancheong)"/>
+    <rect x="138" y="84" width="23" height="3" rx="1.5" fill="var(--c-eunhaeng)" opacity="0.7"/>
+
+    <g fill="var(--panel)">
+      <rect x="318" y="146" width="46" height="66"/>
+      <rect x="376" y="118" width="54" height="94"/>
+      <rect x="444" y="100" width="60" height="112"/>
+      <rect x="518" y="158" width="38" height="54"/>
+      <rect x="568" y="126" width="50" height="86"/>
+      <rect x="630" y="86" width="58" height="126"/>
+      <rect x="702" y="148" width="44" height="64"/>
+      <rect x="758" y="118" width="54" height="94"/>
+      <rect x="826" y="136" width="44" height="76"/>
+      <rect x="884" y="94" width="58" height="118"/>
+      <rect x="956" y="156" width="42" height="56"/>
+      <rect x="1012" y="124" width="52" height="88"/>
+      <rect x="1078" y="144" width="46" height="68"/>
+      <rect x="1246" y="148" width="50" height="64"/>
+      <rect x="1310" y="118" width="54" height="94"/>
+      <rect x="1378" y="158" width="48" height="54"/>
+      <rect x="657" y="66" width="2.5" height="20"/>
+      <rect x="911" y="74" width="2.5" height="20"/>
+      <rect x="456" y="92" width="12" height="8" rx="1"/>
+      <rect x="459" y="88" width="6" height="4" rx="1"/>
+      <rect x="642" y="78" width="30" height="8"/>
+      <rect x="892" y="86" width="16" height="8" rx="1"/>
+      <rect x="1022" y="116" width="22" height="8"/>
+    </g>
+    <circle cx="658.2" cy="64" r="1.6" fill="var(--c-dancheong)" opacity="0.8"/>
+    <circle cx="912.2" cy="72" r="1.6" fill="var(--c-dancheong)" opacity="0.8"/>
+
+    <path d="M1136,212 L1148,86 Q1160,44 1172,86 L1184,212 Z" fill="var(--panel)"/>
+    <rect x="1158.5" y="52" width="3" height="18" fill="var(--panel)"/>
+
+    <g class="sky-lights-a" fill="var(--c-eunhaeng)" opacity="0.55">
+      <rect x="452" y="118" width="4" height="5"/>
+      <rect x="470" y="140" width="4" height="5"/>
+      <rect x="486" y="112" width="4" height="5"/>
+      <rect x="640" y="102" width="4" height="5"/>
+      <rect x="662" y="128" width="4" height="5"/>
+      <rect x="648" y="164" width="4" height="5"/>
+      <rect x="770" y="132" width="4" height="5"/>
+      <rect x="792" y="156" width="4" height="5"/>
+      <rect x="894" y="110" width="4" height="5"/>
+      <rect x="916" y="138" width="4" height="5"/>
+      <rect x="902" y="176" width="4" height="5"/>
+      <rect x="1022" y="140" width="4" height="5"/>
+      <rect x="1324" y="132" width="4" height="5"/>
+    </g>
+    <g class="sky-lights-b" fill="var(--c-dalbit)" opacity="0.4">
+      <rect x="390" y="130" width="4" height="5"/>
+      <rect x="588" y="142" width="4" height="5"/>
+      <rect x="838" y="150" width="4" height="5"/>
+      <rect x="968" y="168" width="4" height="5"/>
+      <rect x="1092" y="156" width="4" height="5"/>
+      <rect x="1394" y="170" width="4" height="5"/>
+    </g>
+    <rect x="1156" y="120" width="4" height="5" fill="var(--c-neon)" opacity="0.6"/>
+    <rect x="1163" y="150" width="4" height="5" fill="var(--c-neon)" opacity="0.45"/>
+  </g>
+
+  <g class="sky-river">
+    <rect x="0" y="212" width="1440" height="48" fill="var(--panel)" opacity="0.62"/>
+    <g fill="var(--c-hangang)" opacity="0.18">
+      <rect x="64" y="230" width="46" height="2" rx="1"/>
+      <rect x="410" y="238" width="60" height="2" rx="1"/>
+      <rect x="736" y="228" width="52" height="2" rx="1"/>
+      <rect x="1046" y="240" width="58" height="2" rx="1"/>
+      <rect x="1332" y="232" width="44" height="2" rx="1"/>
+    </g>
+
+    <rect x="0" y="205" width="1440" height="3.5" fill="var(--fg)" opacity="0.22"/>
+    <g fill="var(--panel)" opacity="0.9">
+      <rect x="118" y="208" width="7" height="52"/>
+      <rect x="358" y="208" width="7" height="52"/>
+      <rect x="598" y="208" width="7" height="52"/>
+      <rect x="838" y="208" width="7" height="52"/>
+      <rect x="1078" y="208" width="7" height="52"/>
+      <rect x="1318" y="208" width="7" height="52"/>
+    </g>
+
+    <g class="sky-train">
+      <rect x="0" y="196.5" width="66" height="7.5" rx="2.5" fill="var(--surface)"/>
+      <g fill="var(--c-eunhaeng)" opacity="0.85">
+        <rect x="6" y="198.5" width="7" height="3" rx="0.8"/>
+        <rect x="17" y="198.5" width="7" height="3" rx="0.8"/>
+        <rect x="28" y="198.5" width="7" height="3" rx="0.8"/>
+        <rect x="39" y="198.5" width="7" height="3" rx="0.8"/>
+        <rect x="50" y="198.5" width="7" height="3" rx="0.8"/>
+      </g>
+      <circle cx="64.5" cy="200" r="1.4" fill="var(--c-dalbit)" opacity="0.9"/>
+      <rect x="8" y="219" width="52" height="2" rx="1" fill="var(--c-eunhaeng)" opacity="0.16"/>
+    </g>
+
+    <g fill="var(--fg)" opacity="0.3">
+      <rect x="147" y="196" width="1.8" height="9"/>
+      <rect x="327" y="196" width="1.8" height="9"/>
+      <rect x="507" y="196" width="1.8" height="9"/>
+      <rect x="687" y="196" width="1.8" height="9"/>
+      <rect x="867" y="196" width="1.8" height="9"/>
+      <rect x="1047" y="196" width="1.8" height="9"/>
+      <rect x="1227" y="196" width="1.8" height="9"/>
+      <rect x="1407" y="196" width="1.8" height="9"/>
+    </g>
+    <circle cx="147.9" cy="193" r="3.6" fill="var(--c-dalbit)"/>
+    <circle cx="327.9" cy="193" r="3.6" fill="var(--c-neon)"/>
+    <circle cx="507.9" cy="193" r="3.6" fill="var(--c-hangang)"/>
+    <circle cx="687.9" cy="193" r="3.6" fill="var(--c-dancheong)"/>
+    <circle cx="867.9" cy="193" r="3.6" fill="var(--c-namsan)"/>
+    <circle cx="1047.9" cy="193" r="3.6" fill="var(--c-eunhaeng)"/>
+    <circle cx="1227.9" cy="193" r="3.6" fill="var(--c-jaha)"/>
+    <circle cx="1407.9" cy="193" r="3.6" fill="var(--c-angae)"/>
+
+    <g opacity="0.3">
+      <rect x="141" y="222" width="14" height="2" fill="var(--c-dalbit)"/>
+      <rect x="321" y="222" width="14" height="2" fill="var(--c-neon)"/>
+      <rect x="501" y="222" width="14" height="2" fill="var(--c-hangang)"/>
+      <rect x="681" y="222" width="14" height="2" fill="var(--c-dancheong)"/>
+      <rect x="861" y="222" width="14" height="2" fill="var(--c-namsan)"/>
+      <rect x="1041" y="222" width="14" height="2" fill="var(--c-eunhaeng)"/>
+      <rect x="1221" y="222" width="14" height="2" fill="var(--c-jaha)"/>
+      <rect x="1401" y="222" width="14" height="2" fill="var(--c-angae)"/>
+    </g>
+    <g opacity="0.15">
+      <rect x="144" y="230" width="8" height="2" fill="var(--c-dalbit)"/>
+      <rect x="324" y="230" width="8" height="2" fill="var(--c-neon)"/>
+      <rect x="504" y="230" width="8" height="2" fill="var(--c-hangang)"/>
+      <rect x="684" y="230" width="8" height="2" fill="var(--c-dancheong)"/>
+      <rect x="864" y="230" width="8" height="2" fill="var(--c-namsan)"/>
+      <rect x="1044" y="230" width="8" height="2" fill="var(--c-eunhaeng)"/>
+      <rect x="1224" y="230" width="8" height="2" fill="var(--c-jaha)"/>
+      <rect x="1404" y="230" width="8" height="2" fill="var(--c-angae)"/>
+    </g>
+  </g>
+</svg>

--- a/examples/seoulnight/templates/taxonomy.html
+++ b/examples/seoulnight/templates/taxonomy.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <div class="page-head">
+      <h1>{{ page.title | e }}</h1>
+      <p class="page-lede">Every note is filed under the decisions it records.</p>
+    </div>
+    {% set tax = get_taxonomy(kind="tags") %}
+    <ul class="term-list">
+      {% for term in tax.items | sort_by("name") %}
+      <li>
+        <a href="{{ get_taxonomy_url(kind="tags", term=term.name) }}">
+          {{ term.name }} <span class="term-count">{{ term.pages | length }}</span>
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/seoulnight/templates/taxonomy_term.html
+++ b/examples/seoulnight/templates/taxonomy_term.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <div class="page-head">
+      <h1>{{ taxonomy_term }}</h1>
+      <p class="page-lede">Notes filed under this decision.</p>
+    </div>
+    {% set tax = get_taxonomy(kind="tags") %}
+    <ul class="entry-list">
+      {% for term in tax.items %}{% if term.name == taxonomy_term %}
+        {% for p in term.pages | sort_by("date", reverse=true) %}
+        <li class="entry">
+          {% if p.date %}<time datetime="{{ p.date }}">{{ p.date | date("%Y-%m-%d") }}</time>{% endif %}
+          <div class="entry-body">
+            <h2><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></h2>
+            {% if p.description %}<p class="entry-summary">{{ p.description | e }}</p>{% endif %}
+          </div>
+        </li>
+        {% endfor %}
+      {% endif %}{% endfor %}
+    </ul>
+    <p class="band-foot"><a class="text-link" href="{{ base_url }}/tags/">All tags</a></p>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,8 @@
 {
   "version": 1,
+  "flagships": [
+    "seoulnight"
+  ],
   "tag_vocabulary": {
     "categories": [
       "blog",
@@ -8946,6 +8949,59 @@
           "tags"
         ],
         "highlight_theme": "monokai"
+      }
+    },
+    {
+      "name": "seoulnight",
+      "title": "Seoulnight",
+      "description": "An editor color scheme drawn from Seoul at night: neon signage, river bridges, and late-hour code",
+      "category": "landing",
+      "scheme": "dark",
+      "styles": [
+        "terminal",
+        "futuristic"
+      ],
+      "brief": "The product site for a fictional editor color scheme named for Seoul after dark: a split hero pairs the Latin wordmark with its Hangul counterpart beside a real highlighted code panel, every scheme color debuts as a numbered metro-line roundel, swatches carry Korean landmark names and token glyphs, a full-bleed SVG night skyline with N Seoul Tower drifts in pointer parallax while a lit last train crosses a bridge of eight colored lamps, and a notes devlog records how each hue was tuned.",
+      "typography": {
+        "display": "Gothic A1",
+        "text": "IBM Plex Sans",
+        "mono": "IBM Plex Mono"
+      },
+      "palette": {
+        "bg": "#101320",
+        "surface": "#191e31",
+        "fg": "#dee4f5",
+        "muted": "#8b93ad",
+        "accent": "#d957c4",
+        "accent_fg": "#230a1f"
+      },
+      "palette_dark": null,
+      "layout": "split-hero",
+      "signature": "scheme colors debut as numbered Seoul-metro-style line roundels strung across the hero code panel's title bar",
+      "content": {
+        "theme": "a fictional editor color scheme that recolors code in the palette of seoul after dark",
+        "sections": [
+          {
+            "name": "notes",
+            "pages": 6,
+            "sort_by": "date"
+          }
+        ],
+        "standalone": [
+          "about"
+        ]
+      },
+      "features": {
+        "search_ui": "palette",
+        "toc": false,
+        "pagination": 6,
+        "feeds": [
+          "notes"
+        ],
+        "taxonomies": [
+          "tags"
+        ],
+        "highlight_theme": "atom-one-dark"
       }
     },
     {

--- a/scripts/preview-index.sh
+++ b/scripts/preview-index.sh
@@ -28,10 +28,32 @@ fi
 SITE_LINKS=""
 ALL_TAGS=""
 EXAMPLE_COUNT=0
+
+# Flagships (manifest order) render first, then everything else alphabetically.
+FLAGSHIPS=$(jq -r '.flagships // [] | join(" ")' manifest.json)
+ORDERED_NAMES="${FLAGSHIPS}"
 for dir in examples/*/; do
-  src_path="${dir%/}"
-  name="${src_path#examples/}"
+  name="${dir%/}"
+  name="${name#examples/}"
+  case " ${FLAGSHIPS} " in *" ${name} "*) continue ;; esac
+  ORDERED_NAMES="${ORDERED_NAMES} ${name}"
+done
+
+FLAG_INDEX=0
+for name in ${ORDERED_NAMES}; do
+  src_path="examples/${name}"
   [ -f "${src_path}/config.toml" ] || continue
+  FLAG_CLASS=""
+  FLAG_ATTR=""
+  FLAG_BADGE=""
+  case " ${FLAGSHIPS} " in
+    *" ${name} "*)
+      FLAG_INDEX=$((FLAG_INDEX + 1))
+      FLAG_CLASS=" flagship"
+      FLAG_ATTR=" data-flagship=\"${FLAG_INDEX}\""
+      FLAG_BADGE="<span class=\"flagship-badge\">flagship</span>"
+      ;;
+  esac
   TITLE=$(grep '^title' "${src_path}/config.toml" | head -1 | sed 's/title *= *"//;s/"//')
   DESCRIPTION=$(grep '^description' "${src_path}/config.toml" | head -1 | sed 's/description *= *"//;s/"//')
   THEME_REPO_URL="${REPO_URL}/tree/main/${src_path}"
@@ -45,7 +67,7 @@ for dir in examples/*/; do
     fi
   done
   EXAMPLE_COUNT=$((EXAMPLE_COUNT + 1))
-  SITE_LINKS="${SITE_LINKS}<div class=\"card\" data-name=\"${name}\" data-title=\"${TITLE}\" data-desc=\"${DESCRIPTION}\" data-tags=\"${TAGS}\"><a href=\"${BASE_URL}/${name}/\" class=\"main-link\"><img src=\"screenshots/${name}.png\" alt=\"${name}\" class=\"preview\" loading=\"lazy\" onerror=\"var d=document.createElement('div');d.className='preview-fallback';d.textContent='no_preview';this.replaceWith(d);\"><div class=\"card-info\"><strong>${name}</strong><span class=\"title\">${TITLE}</span><span class=\"desc\">${DESCRIPTION}</span><div class=\"card-tags\">${TAGS_DISPLAY}</div></div></a><div class=\"card-footer\"><a href=\"${THEME_REPO_URL}\" class=\"card-footer-row\"><svg viewBox=\"0 0 16 16\"><path d=\"M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z\"></path></svg>Source Code</a><div class=\"card-footer-row scaffold-row\" onclick=\"copyScaffold(this)\" data-cmd=\"${SCAFFOLD_CMD}\"><svg viewBox=\"0 0 16 16\"><path d=\"M4.72 3.22a.75.75 0 011.06 1.06L2.06 8l3.72 3.72a.75.75 0 11-1.06 1.06L.47 8.53a.75.75 0 010-1.06l4.25-4.25zm6.56 0a.75.75 0 10-1.06 1.06L13.94 8l-3.72 3.72a.75.75 0 101.06 1.06l4.25-4.25a.75.75 0 000-1.06l-4.25-4.25z\"></path></svg><span class=\"scaffold-cmd\">${SCAFFOLD_CMD}</span></div></div></div>"
+  SITE_LINKS="${SITE_LINKS}<div class=\"card${FLAG_CLASS}\"${FLAG_ATTR} data-name=\"${name}\" data-title=\"${TITLE}\" data-desc=\"${DESCRIPTION}\" data-tags=\"${TAGS}\">${FLAG_BADGE}<a href=\"${BASE_URL}/${name}/\" class=\"main-link\"><img src=\"screenshots/${name}.png\" alt=\"${name}\" class=\"preview\" loading=\"lazy\" onerror=\"var d=document.createElement('div');d.className='preview-fallback';d.textContent='no_preview';this.replaceWith(d);\"><div class=\"card-info\"><strong>${name}</strong><span class=\"title\">${TITLE}</span><span class=\"desc\">${DESCRIPTION}</span><div class=\"card-tags\">${TAGS_DISPLAY}</div></div></a><div class=\"card-footer\"><a href=\"${THEME_REPO_URL}\" class=\"card-footer-row\"><svg viewBox=\"0 0 16 16\"><path d=\"M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z\"></path></svg>Source Code</a><div class=\"card-footer-row scaffold-row\" onclick=\"copyScaffold(this)\" data-cmd=\"${SCAFFOLD_CMD}\"><svg viewBox=\"0 0 16 16\"><path d=\"M4.72 3.22a.75.75 0 011.06 1.06L2.06 8l3.72 3.72a.75.75 0 11-1.06 1.06L.47 8.53a.75.75 0 010-1.06l4.25-4.25zm6.56 0a.75.75 0 10-1.06 1.06L13.94 8l-3.72 3.72a.75.75 0 101.06 1.06l4.25-4.25a.75.75 0 000-1.06l-4.25-4.25z\"></path></svg><span class=\"scaffold-cmd\">${SCAFFOLD_CMD}</span></div></div></div>"
 done
 
 TOP_TAGS_DATA=$(jq -r 'values[] | .[]' tags.json | sort | uniq -c | sort -rn | head -8 | awk '{print $2}')

--- a/scripts/validate-manifest.py
+++ b/scripts/validate-manifest.py
@@ -13,6 +13,8 @@ Checks (errors exit 1):
   - feeds: only real section names
   - palette: 6-digit hex values; accent hue spacing within each
     category+scheme bucket reported as a warning
+  - flagships: optional ordered list; every name must exist in examples,
+    no duplicates; missing examples/<name>/ site is a warning
 
 Usage: scripts/validate-manifest.py [--quiet]
 """
@@ -81,6 +83,20 @@ def main() -> int:
     for name, count in Counter(names).items():
         if count > 1:
             err(f"duplicate name: {name} ({count}x)")
+
+    flagships = manifest.get("flagships", [])
+    if not isinstance(flagships, list) or not all(isinstance(f, str) for f in flagships):
+        err("flagships must be an array of example name strings")
+        flagships = []
+    for f, count in Counter(flagships).items():
+        if count > 1:
+            err(f"duplicate flagship: {f} ({count}x)")
+    name_set = set(names)
+    for f in flagships:
+        if f not in name_set:
+            err(f"flagship '{f}' does not match any example name")
+        elif not (ROOT / "examples" / f / "config.toml").exists():
+            warn(f"flagship '{f}' has no examples/{f}/ site yet (gallery card will be skipped)")
 
     pairings: Counter = Counter()
     signatures: Counter = Counter()
@@ -209,6 +225,7 @@ def main() -> int:
     quiet = "--quiet" in sys.argv
     if not quiet:
         print(f"examples: {len(examples)}")
+        print(f"flagships: {flagships or 'none'}")
         print(f"categories: {dict(sorted(cat_counts.items()))}")
         print(f"schemes: {dict(sorted(scheme_counts.items()))}")
         print(f"styles: {dict(sorted(style_counts.items(), key=lambda kv: -kv[1]))}")

--- a/tags.json
+++ b/tags.json
@@ -967,6 +967,12 @@
     "dark",
     "terminal"
   ],
+  "seoulnight": [
+    "landing",
+    "dark",
+    "terminal",
+    "futuristic"
+  ],
   "sepia": [
     "portfolio",
     "dark",


### PR DESCRIPTION
## Flagship tier

A maintainer-curated showcase tier for the gallery, managed as one ordered list.

- `manifest.json`: new top-level `"flagships": ["seoulnight"]` array (order = display order)
- `scripts/validate-manifest.py`: unknown or duplicate flagship names error; a flagship without a site directory warns
- `deploy.yml` + `scripts/preview-index.sh`: flagship cards render first with an ember ring border and a FLAGSHIP badge; `sortCards()` keeps them pinned across all sort modes; filtering unaffected
- Empty/absent list is fully dormant (verified byte-identical ordering in the zero state)
- `DESIGN.md`: one line documenting that the list is maintainer-only

## seoulnight (first flagship)

A fictional editor color scheme drawn from Seoul at night. Landing + notes devlog, dark scheme, Gothic A1 + IBM Plex, split hero with a hand-highlighted TypeScript specimen.

- Signature: the eight scheme colors debut as numbered Seoul-metro-style roundels on the specimen window's title bar, echoed on the swatch chips and in the footer
- Interactive SVG night skyline (palette tokens only): 4-layer pointer parallax (`static/js/scene.js`, rAF-eased, hover+fine-pointer+no-reduced-motion gated), a lit last train crossing the bridge on a 26s cycle, breathing window lights, N Seoul Tower and a Lotte-style supertall
- Click-to-copy hex buttons on swatches, command-palette search (Ctrl/Cmd-K), hljs token remap so real code blocks render in the scheme
- Gates: `check-site.sh` PASS, `hwaro doctor` clean, rendered-output greps clean, 0 CSS gradients, 0 emoji, WCAG contrast measured (values printed on the swatches are real)

Note: `validate-manifest.py` currently reports a pre-existing, unrelated error (`font pairing Vollkorn/Assistant used 8x`); this PR adds no new violations.