### PR TITLE
Add flagship example: lemma

### DIFF
--- a/examples/lemma/AGENTS.md
+++ b/examples/lemma/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage (single file, no underscore)
+│   ├── about.md         # Standalone page
+│   └── <section>/       # Section directory (posts/, guide/, chapter-1/, …)
+│       ├── _index.md    # Section landing page (underscore-prefixed)
+│       └── *.md         # Pages within the section
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Shared <head> + <body> open
+│   ├── footer.html      # Shared <body>/<html> close
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── 404.html         # Not-found page
+│   ├── partials/        # Reusable fragments (nav, search, sidebar)
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
+2. **Rendered content** is `{{ content }}` in templates (already-safe HTML — no extra `| safe` needed).
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lemma/archetypes/default.md
+++ b/examples/lemma/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+title = "{{ title }}"
+date = "{{ date }}"
+draft = {{ draft }}
+description = "{{ description }}"
+tags = {{ tags }}
++++

--- a/examples/lemma/config.toml
+++ b/examples/lemma/config.toml
@@ -1,0 +1,46 @@
+title = "Lemma"
+description = "A notebook of visual mathematics: small proofs and ideas, each drawn as a figure built from compass arcs and straight lines"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["svg"]
+
+[highlight]
+enabled = true
+mode = "client"
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+sections = ["proofs"]
+
+[og]
+type = "article"
+twitter_card = "summary_large_image"
+
+[markdown]
+safe = false
+lazy_loading = true
+footnotes = true
+definition_lists = true

--- a/examples/lemma/content/about.md
+++ b/examples/lemma/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About the notebook"
+description = "How Lemma is made, and the one rule every figure follows."
+tags = ["colophon"]
++++
+
+Lemma is a fictional publication, written as a design study. The mathematics is real; the author is not.
+
+Every figure follows one rule: it must be a genuine compass-and-straightedge construction. Nothing is traced from a photograph or filled in by eye. If a point sits somewhere, an arc or a line put it there. That single constraint is the whole aesthetic. It is why the pages look the way they do, and why a drawing can stand in for an argument without cheating.
+
+Nothing here is a raster image. The constructions are inline SVG, drawn in the browser and animated with a little plain JavaScript, so a figure builds itself the way you would at a desk: the circle first, then the arcs, then the chords, then the points that close it. Turn motion off in your system settings and every figure simply appears, already finished.
+
+The type is set in Schibsted Grotesk for display, Inter for reading, and Space Mono for figure numbers, coordinates, and anything that wants to look measured. The single violet is the compass color. It marks the points you construct and the arcs that find them, and it appears nowhere else on the page.
+
+The name is a small joke and a small promise. A lemma is a modest result, proved on the way to something bigger. This notebook stays modest on purpose, and tries to be honest about the one thing it is doing well.

--- a/examples/lemma/content/index.md
+++ b/examples/lemma/content/index.md
@@ -1,0 +1,11 @@
++++
+title = "Lemma"
+description = "A notebook of visual mathematics: small proofs and ideas, each drawn as a figure built from compass arcs and straight lines."
+template = "home"
++++
+
+Most of the mathematics I love fits on a single page. Not the machinery, which can run for volumes, but the *turn*: the one move where a picture stops being decoration and becomes the argument. A line dropped in the right place, a circle that meets another, a square folded along its diagonal, and a claim that seemed to need algebra is simply *seen*.
+
+Lemma collects those moments. Each entry is one construction, drawn with nothing but a compass and a straightedge, then explained in plain words. No coordinates unless they earn their keep, no symbols where a figure will do. The drawings here are not illustrations of proofs written somewhere else. They *are* the proofs.
+
+A lemma is a small result you prove on the way to a larger one. This notebook stays at that scale on purpose. Everything here is meant to be understood in a sitting, and remembered a good deal longer than that.

--- a/examples/lemma/content/proofs/_index.md
+++ b/examples/lemma/content/proofs/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Proofs"
+description = "One construction per entry, drawn on load, then argued in plain words."
+sort_by = "date"
+reverse = false
+template = "section"
+generate_feeds = true
++++
+
+A running notebook of small proofs, newest first. Each entry is a single figure you could draw yourself with a compass and a straightedge, and a short account of why the drawing settles the question. Some are famous results seen from an angle that makes them obvious; others are the kind of thing you rediscover with a pencil and then wonder why nobody mentioned it. None of them need more room than the page they sit on.

--- a/examples/lemma/content/proofs/bisecting-an-angle.md
+++ b/examples/lemma/content/proofs/bisecting-an-angle.md
@@ -1,0 +1,39 @@
++++
+title = "Bisecting an angle, and why it always works"
+date = "2025-04-03"
+description = "The oldest compass construction there is, and the congruent triangles hiding inside it."
+tags = ["angles", "compass", "symmetry"]
+[extra]
+fig = 2
+claim = "The classic two-arc construction splits any angle into two equal parts."
++++
+
+<figure class="fig fig-plate">
+<svg viewBox="0 0 400 250" fill="none" role="img" aria-label="An angle at vertex O bisected by swinging equal arcs to points P and Q and then to their meeting point R">
+<line class="c-line" x1="60" y1="220" x2="345" y2="56"/>
+<line class="c-line" x1="60" y1="220" x2="193" y2="16"/>
+<path class="c-guide" d="M172.6 155 A130 130 0 0 0 128.9 109.8"/>
+<path class="c-guide" d="M191.3 62.9 A94 94 0 0 1 234.9 84.6"/>
+<path class="c-guide" d="M201.4 50 A94 94 0 0 0 221.6 94.3"/>
+<line class="c-line-2" x1="60" y1="220" x2="248" y2="42"/>
+<circle class="f-pt" cx="60" cy="220" r="4.2"/>
+<circle class="f-pt" cx="172.6" cy="155" r="4"/>
+<circle class="f-pt" cx="128.9" cy="109.8" r="4"/>
+<circle class="f-pt" cx="214.6" cy="70.7" r="4"/>
+<text class="f-label" x="48" y="228" text-anchor="middle">O</text>
+<text class="f-label" x="184" y="163" text-anchor="middle">P</text>
+<text class="f-label" x="116" y="106" text-anchor="middle">Q</text>
+<text class="f-label" x="226" y="66" text-anchor="middle">R</text>
+</svg>
+<figcaption>Swing one arc from <b>O</b> to mark <b>P</b> and <b>Q</b> at equal distance. Swing two more arcs of equal radius from <b>P</b> and <b>Q</b>; they cross at <b>R</b>. The line <b>OR</b> bisects the angle.</figcaption>
+</figure>
+
+This is probably the oldest construction anyone learns, and it is worth pausing on because the compass does something the eye cannot: it guarantees two lengths are equal without ever naming them.
+
+<!-- more -->
+
+Open the compass to any radius and swing an arc from the vertex O. It crosses the two sides at P and Q, and because both were drawn with the same radius, OP and OQ are equal. Keep the compass at some fixed width and swing an arc from P, then another of the same width from Q. Where those two arcs meet, call it R. By construction PR and QR are equal as well.
+
+Now count what we know about triangles OPR and OQR. They share the side OR. We have OP equal to OQ, and PR equal to QR. Three pairs of equal sides, so the triangles are congruent. Congruent triangles have equal angles in the matching places, and the matching angles at O are exactly the two halves of the original angle.
+
+That is the whole reason it works. The bisector is not a lucky line through the middle. It is the axis of a symmetry the two arcs built on purpose, and the congruence makes the symmetry exact rather than approximate.

--- a/examples/lemma/content/proofs/constructing-a-pentagon.md
+++ b/examples/lemma/content/proofs/constructing-a-pentagon.md
@@ -1,0 +1,45 @@
++++
+title = "Constructing a regular pentagon"
+date = "2025-12-05"
+description = "Five equal central angles are what make a pentagon regular, and 360 divided by 5 is where it starts."
+tags = ["pentagon", "compass", "constructions"]
+[extra]
+fig = 5
+claim = "A pentagon is regular exactly when its five central angles are equal, each 72 degrees."
++++
+
+<figure class="fig fig-plate">
+<svg viewBox="0 0 360 360" fill="none" role="img" aria-label="A regular pentagon inscribed in a circle, with five radii cutting the center into equal 72 degree angles">
+<circle class="c-guide" cx="180" cy="190" r="140"/>
+<line class="c-line-2" x1="180" y1="190" x2="180" y2="50"/>
+<line class="c-line-2" x1="180" y1="190" x2="46.85" y2="146.74"/>
+<line class="c-line-2" x1="180" y1="190" x2="97.71" y2="303.28"/>
+<line class="c-line-2" x1="180" y1="190" x2="262.29" y2="303.28"/>
+<line class="c-line-2" x1="180" y1="190" x2="313.15" y2="146.74"/>
+<line class="c-line" x1="180" y1="50" x2="46.85" y2="146.74"/>
+<line class="c-line" x1="46.85" y1="146.74" x2="97.71" y2="303.28"/>
+<line class="c-line" x1="97.71" y1="303.28" x2="262.29" y2="303.28"/>
+<line class="c-line" x1="262.29" y1="303.28" x2="313.15" y2="146.74"/>
+<line class="c-line" x1="313.15" y1="146.74" x2="180" y2="50"/>
+<path class="c-guide" d="M180 154 A36 36 0 0 1 214.2 178.9"/>
+<circle class="f-pt" cx="180" cy="190" r="3.6"/>
+<circle class="f-pt" cx="180" cy="50" r="4.4"/>
+<circle class="f-pt" cx="46.85" cy="146.74" r="4.4"/>
+<circle class="f-pt" cx="97.71" cy="303.28" r="4.4"/>
+<circle class="f-pt" cx="262.29" cy="303.28" r="4.4"/>
+<circle class="f-pt" cx="313.15" cy="146.74" r="4.4"/>
+<text class="f-label-a" x="205" y="150" text-anchor="middle">72&deg;</text>
+<text class="f-label" x="192" y="204" text-anchor="start">O</text>
+</svg>
+<figcaption>Five radii cut the circle at the center into five equal slices. A full turn is 360&deg;, so each central angle is <b>72&deg;</b>. Equal central angles force equal sides, which is exactly what makes the pentagon regular.</figcaption>
+</figure>
+
+A regular pentagon is the first shape that makes a beginner sweat. Triangles, squares, and hexagons fall out of a compass almost by accident. The pentagon feels like it should not be possible with the same two tools. It is, and the reason it comes out regular is worth more than the recipe.
+
+<!-- more -->
+
+Inscribe the five vertices in a circle and draw a radius to each. Five radii, five slices. The pentagon is regular precisely when those five central angles are equal, and equal they are: a full turn is 360 degrees, and five equal slices make each one 72 degrees. That is the entire definition of regular, translated into a picture.
+
+Equal central angles force equal sides. Two radii and the chord between them make an isosceles triangle, and triangles that share two sides and the angle between them are congruent. So every side of the pentagon has the same length and every corner the same angle. The regularity is not something you verify at the end. It is built the moment the circle is cut into five equal parts.
+
+The harder trick, cutting a circle into fifths with straightedge and compass alone, is what makes the pentagon famous. That it can be done at all rests on the golden ratio living inside the number five, and that is a story for another page.

--- a/examples/lemma/content/proofs/doubling-the-square.md
+++ b/examples/lemma/content/proofs/doubling-the-square.md
@@ -1,0 +1,37 @@
++++
+title = "Doubling the square, from Plato's Meno"
+date = "2026-03-19"
+description = "Twice the area, not twice the side: the diagonal is the honest answer."
+tags = ["squares", "area", "dialogue"]
+[extra]
+fig = 6
+claim = "The diagonal of a square is the side of a square with twice its area."
++++
+
+<figure class="fig fig-plate">
+<svg viewBox="0 0 360 290" fill="none" role="img" aria-label="A square with a tilted inner square joining the midpoints of its sides; the tilted square has twice the area of one quadrant">
+<rect class="f-fill-surface" x="80" y="40" width="100" height="100"/>
+<polygon class="f-fill-soft" points="180,40 280,140 180,240 80,140"/>
+<polygon class="c-line-2" points="180,40 280,140 180,240 80,140"/>
+<line class="c-guide" x1="180" y1="40" x2="180" y2="240"/>
+<line class="c-guide" x1="80" y1="140" x2="280" y2="140"/>
+<rect class="c-line" x="80" y="40" width="200" height="200"/>
+<circle class="f-pt" cx="180" cy="40" r="3.6"/>
+<circle class="f-pt" cx="280" cy="140" r="3.6"/>
+<circle class="f-pt" cx="180" cy="240" r="3.6"/>
+<circle class="f-pt" cx="80" cy="140" r="3.6"/>
+<text class="f-label" x="120" y="95" text-anchor="middle">1</text>
+<text class="f-label-a" x="212" y="150" text-anchor="middle">2</text>
+</svg>
+<figcaption>Join the midpoints of a square's sides. The tilted square is four half-quadrant triangles, so its area is two of the small quadrant squares (marked <b>1</b> and <b>2</b>). Its side is the diagonal of the small square.</figcaption>
+</figure>
+
+Doubling a square sounds like it should be easy: make each side twice as long. That gives four times the area, not twice, which is exactly the trap Socrates walks a slave boy into in Plato's Meno, before drawing the one line that fixes it.
+
+<!-- more -->
+
+The line is the diagonal. Take the square and mark the midpoint of each side. Join those four midpoints and a second square appears, tilted forty five degrees inside the first. Now look at what the cross through the center does. It cuts the big square into four small quadrant squares, and it cuts the tilted square into four triangles, each of which is exactly half of a quadrant.
+
+Count the halves. The tilted square is built from four of them, so its area is four halves, which is two whole quadrants. A single quadrant is the small square we were treating as our unit, so the tilted square has twice its area. And the side of that tilted square is nothing other than the diagonal of the small quadrant square.
+
+So the diagonal of a square is the side of a square with double the area. The boy in the dialogue could not have told you the length is the square root of two. But he could see, once the line was drawn, that it worked, which was Socrates' entire point.

--- a/examples/lemma/content/proofs/golden-ratio-in-a-square.md
+++ b/examples/lemma/content/proofs/golden-ratio-in-a-square.md
@@ -1,0 +1,46 @@
++++
+title = "The square that hides the golden ratio"
+date = "2025-06-20"
+description = "One midpoint, one compass swing, and a square becomes a golden rectangle."
+tags = ["golden-ratio", "squares", "constructions"]
+[extra]
+fig = 3
+claim = "Swinging the compass from a side's midpoint to the far corner extends a square into a golden rectangle."
++++
+
+<figure class="fig fig-plate">
+<svg viewBox="0 0 420 260" fill="none" role="img" aria-label="A square with midpoint M on its base; an arc from M through the far corner D meets the extended base at E, forming a golden rectangle">
+<line class="c-guide" x1="260" y1="20" x2="384" y2="20"/>
+<line class="c-guide" x1="384" y1="20" x2="384" y2="220"/>
+<line class="c-guide" x1="260" y1="220" x2="384" y2="220" stroke-dasharray="5 6"/>
+<path class="c-guide" d="M260 20 A223.6 223.6 0 0 1 384 220"/>
+<line class="c-guide" x1="160" y1="220" x2="260" y2="20" stroke-dasharray="4 5"/>
+<line class="c-line" x1="60" y1="20" x2="260" y2="20"/>
+<line class="c-line" x1="260" y1="20" x2="260" y2="220"/>
+<line class="c-line" x1="60" y1="220" x2="260" y2="220"/>
+<line class="c-line" x1="60" y1="20" x2="60" y2="220"/>
+<circle class="f-pt" cx="60" cy="20" r="4"/>
+<circle class="f-pt" cx="260" cy="20" r="4"/>
+<circle class="f-pt" cx="60" cy="220" r="4"/>
+<circle class="f-pt" cx="260" cy="220" r="4"/>
+<circle class="f-pt" cx="160" cy="220" r="4"/>
+<circle class="f-pt-h" cx="384" cy="220" r="4.4"/>
+<text class="f-label" x="50" y="16" text-anchor="middle">A</text>
+<text class="f-label" x="270" y="16" text-anchor="middle">D</text>
+<text class="f-label" x="50" y="234" text-anchor="middle">B</text>
+<text class="f-label" x="258" y="236" text-anchor="middle">C</text>
+<text class="f-label" x="160" y="236" text-anchor="middle">M</text>
+<text class="f-label-a" x="392" y="236" text-anchor="middle">E</text>
+</svg>
+<figcaption>Start with square <b>ABCD</b>. Mark the midpoint <b>M</b> of the base, open the compass from <b>M</b> to the far top corner <b>D</b>, and swing it down to the extended base at <b>E</b>. The rectangle from <b>B</b> to <b>E</b> is golden.</figcaption>
+</figure>
+
+The golden ratio has a reputation for turning up mystically in seashells and paintings. Most of that is wishful. What is true, and prettier than the myths, is that it drops straight out of a square with one honest compass swing.
+
+<!-- more -->
+
+Take a square and call its side one unit. Mark M, the midpoint of the base, so BM is one half. Look at the segment MD from that midpoint to the opposite top corner. It is the hypotenuse of a right triangle with legs one half and one, so its length is the square root of one quarter plus one, which is the square root of five over two.
+
+Now open the compass to exactly that length, MD, and swing it down until it lands on the base line extended, at the point E. Because the compass preserves length, ME equals MD, which is the square root of five over two. The whole base BE is therefore BM plus ME, one half plus the square root of five over two, which is the square root of five plus one, all over two. That number is the golden ratio, usually written φ.
+
+So the rectangle standing on BE, one unit tall and φ units wide, is a golden rectangle. No mysticism entered the argument. Just a midpoint, the Pythagorean theorem, and a compass that refuses to change its mind about a length.

--- a/examples/lemma/content/proofs/odd-numbers-square.md
+++ b/examples/lemma/content/proofs/odd-numbers-square.md
@@ -1,0 +1,36 @@
++++
+title = "A staircase proof that the odd numbers make squares"
+date = "2025-09-11"
+description = "Why 1 + 3 + 5 + 7 + 9 lands exactly on a square, shown with nested gnomons."
+tags = ["number", "proof-without-words", "squares"]
+[extra]
+fig = 4
+claim = "The sum of the first n odd numbers equals n squared."
++++
+
+<figure class="fig fig-plate">
+<svg viewBox="0 0 300 260" fill="none" role="img" aria-label="Five squares nested at a shared corner; the L-shaped gnomons between them are the odd numbers one, three, five, seven and nine">
+<rect class="c-guide" x="50" y="20" width="40" height="40"/>
+<rect class="c-guide" x="50" y="20" width="80" height="80"/>
+<rect class="c-guide" x="50" y="20" width="120" height="120"/>
+<rect class="c-guide" x="50" y="20" width="160" height="160"/>
+<rect class="c-line" x="50" y="20" width="200" height="200"/>
+<text class="f-label-a" x="70" y="45" text-anchor="middle">1</text>
+<text class="f-label-a" x="110" y="85" text-anchor="middle">3</text>
+<text class="f-label-a" x="150" y="125" text-anchor="middle">5</text>
+<text class="f-label-a" x="190" y="165" text-anchor="middle">7</text>
+<text class="f-label-a" x="230" y="205" text-anchor="middle">9</text>
+<text class="f-label" x="255" y="236" text-anchor="end">5 &times; 5 = 25</text>
+</svg>
+<figcaption>Each odd number is a gnomon, the L-shaped strip that grows a k&times;k square into the next size up. Nested at one corner, <b>1 + 3 + 5 + 7 + 9</b> closes into a 5&times;5 square of 25.</figcaption>
+</figure>
+
+Line up the odd numbers and something suspicious happens. One is one. One plus three is four. Add five and you have nine, add seven and you have sixteen. Every partial sum is a perfect square, and it never misses.
+
+<!-- more -->
+
+The reason is a shape the Greeks called a gnomon, the L-shaped border you add to a square to make the next square up. Start with a single dot, a one by one square. To turn it into a two by two square, wrap it in an L of three dots along the top and the right. To reach three by three, add an L of five. Each new border is longer than the last by two, because it gains one dot on the top edge and one on the side. So the borders are exactly the odd numbers: 1, then 3, then 5, then 7, and onward.
+
+Stacking the gnomons rebuilds a square one shell at a time. After adding the first n odd numbers you have laid down an n by n square, so their sum is n². In the figure five shells close up into a five by five square of twenty five.
+
+It is a proof you can carry out with coins on a table. Nothing hides in the algebra, because there is no algebra. The squares do the counting themselves.

--- a/examples/lemma/content/proofs/triangle-angle-sum.md
+++ b/examples/lemma/content/proofs/triangle-angle-sum.md
@@ -1,0 +1,41 @@
++++
+title = "Why a triangle's angles make a straight line"
+date = "2025-02-14"
+description = "The angle sum of a triangle, proved with a single line drawn parallel to the base."
+tags = ["triangles", "angles", "parallels"]
+[extra]
+fig = 1
+claim = "The interior angles of any triangle sum to a straight angle."
++++
+
+<figure class="fig fig-plate">
+<svg viewBox="0 0 400 240" fill="none" role="img" aria-label="Triangle ABC with a line through vertex A drawn parallel to the base BC; the three angles meet along the straight line at A">
+<line class="c-line-2" x1="92" y1="54" x2="308" y2="54"/>
+<path class="c-guide" d="M174 54 A26 26 0 0 0 226 54"/>
+<line class="c-line" x1="200" y1="54" x2="64" y2="196"/>
+<line class="c-line" x1="200" y1="54" x2="336" y2="196"/>
+<line class="c-line" x1="64" y1="196" x2="336" y2="196"/>
+<circle class="f-pt" cx="200" cy="54" r="4"/>
+<circle class="f-pt" cx="64" cy="196" r="4"/>
+<circle class="f-pt" cx="336" cy="196" r="4"/>
+<text class="f-label" x="200" y="42" text-anchor="middle">A</text>
+<text class="f-label" x="50" y="210" text-anchor="middle">B</text>
+<text class="f-label" x="350" y="210" text-anchor="middle">C</text>
+<text class="f-label-a" x="182" y="70" text-anchor="middle">β</text>
+<text class="f-label-a" x="200" y="90" text-anchor="middle">α</text>
+<text class="f-label-a" x="219" y="70" text-anchor="middle">γ</text>
+<text class="f-label" x="112" y="182" text-anchor="middle">β</text>
+<text class="f-label" x="288" y="182" text-anchor="middle">γ</text>
+</svg>
+<figcaption>Draw the line through <b>A</b> parallel to <b>BC</b>. The angle it opens on the left equals the angle at <b>B</b>, and the angle on the right equals the angle at <b>C</b> (alternate angles). The three angles then sit side by side at <b>A</b> and fill a straight line: <b>α + β + γ = 180°</b>.</figcaption>
+</figure>
+
+Ask why the three angles of any triangle add to a straight line, and the honest answer is that parallels never drift. That single fact is the whole proof. It just needs one extra line to become visible.
+
+<!-- more -->
+
+Through the apex A, draw the line parallel to the base BC. Two pairs of alternate angles appear at once. The angle the new line makes with side AB, on the left, equals the angle at B, because AB is a transversal cutting two parallel lines. In the same way the angle on the right equals the angle at C. Nothing has been measured. The equalities are forced by the parallel, not chosen by us.
+
+Now look at the point A along the new line. The straight angle there is split into exactly three parts: the left one equal to the angle at B, the middle one the triangle's own angle at A, and the right one equal to the angle at C. Three angles, laid side by side, filling a straight line.
+
+So the angles of the triangle sum to a straight angle, whatever the triangle looked like to begin with. The conclusion never depended on the shape. It depended only on the parallel keeping its distance, which is the one thing a parallel is for.

--- a/examples/lemma/static/css/style.css
+++ b/examples/lemma/static/css/style.css
@@ -1,0 +1,747 @@
+/* ==========================================================================
+   Lemma - a notebook of visual mathematics.
+   Signature: a compass-and-straightedge construction that draws itself on
+   load (arcs, then chords, then points) and drifts in pointer parallax. The
+   same point-arc-chord ink notation returns as the construction-rule dividers,
+   the listing figure-glyphs, and the lead plate at the head of every proof.
+
+   Shape rule: structural lines and figures are square (radius 0); interactive
+   insets (search field, tag chips, kbd, buttons) use one radius token --r.
+   ========================================================================== */
+
+:root {
+  /* palette - verbatim from manifest.json */
+  --bg: #fbfbfc;
+  --surface: #f2f3f7;
+  --fg: #16181d;
+  --muted: #565d6b;
+  --accent: #6a2fda;
+  --accent-fg: #ffffff;
+
+  /* derived tints - color-mix from the six, no new hex */
+  --accent-soft: color-mix(in srgb, var(--accent) 9%, transparent);
+  --accent-line: color-mix(in srgb, var(--accent) 58%, var(--bg));
+  --guide: color-mix(in srgb, var(--accent) 34%, var(--bg));
+  --border: color-mix(in srgb, var(--fg) 13%, transparent);
+  --hairline: color-mix(in srgb, var(--fg) 8%, transparent);
+  --rule-color: color-mix(in srgb, var(--fg) 20%, transparent);
+  --ink-soft: color-mix(in srgb, var(--fg) 66%, var(--bg));
+
+  /* type */
+  --font-display: "Schibsted Grotesk", "Helvetica Neue", Arial, sans-serif;
+  --font-text: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "Space Mono", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+  --text-xs: clamp(0.72rem, 0.7rem + 0.1vw, 0.78rem);
+  --text-sm: clamp(0.84rem, 0.8rem + 0.16vw, 0.92rem);
+  --text-base: clamp(1rem, 0.96rem + 0.2vw, 1.09rem);
+  --text-lg: clamp(1.2rem, 1.1rem + 0.5vw, 1.45rem);
+  --text-xl: clamp(1.6rem, 1.3rem + 1.2vw, 2.3rem);
+  --text-2xl: clamp(2.2rem, 1.7rem + 2.2vw, 3.4rem);
+  --text-hero: clamp(3rem, 2rem + 4.4vw, 5.3rem);
+
+  /* space - 4/8 ladder */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+  --space-5: 2.5rem;
+  --space-6: 4rem;
+  --space-7: 6rem;
+
+  /* spread geometry */
+  --measure: 66ch;
+  --page-max: 74rem;
+  --pad: clamp(1.25rem, 4vw, 3rem);
+  --gutter-w: 8.5rem;
+  --gap: 2.5rem;
+  --body-inset: calc(var(--gutter-w) + var(--gap));
+
+  --r: 3px;
+
+  color-scheme: light;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--font-text);
+  font-size: var(--text-base);
+  line-height: 1.7;
+  font-weight: 400;
+  color: var(--fg);
+  background: var(--bg);
+  font-feature-settings: "cv05" 1, "ss01" 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+::selection { background: var(--accent-soft); }
+
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.12;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+  margin: 0;
+}
+
+p { text-wrap: pretty; }
+
+a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+a:hover { text-decoration-color: color-mix(in srgb, var(--accent) 45%, transparent); }
+
+img, svg { max-width: 100%; }
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 1px;
+}
+
+.skip-link {
+  position: absolute;
+  left: var(--space-3);
+  top: -3rem;
+  z-index: 60;
+  background: var(--fg);
+  color: var(--bg);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--r);
+  font: 500 var(--text-sm)/1 var(--font-text);
+  transition: top 0.15s ease-out;
+}
+.skip-link:focus { top: var(--space-3); }
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0);
+  white-space: nowrap; border: 0;
+}
+
+/* --------------------------------------------------------------------------
+   Shell + header
+   -------------------------------------------------------------------------- */
+
+.shell {
+  width: 100%;
+  max-width: var(--page-max);
+  margin-inline: auto;
+  padding-inline: var(--pad);
+}
+
+.site-head {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
+  backdrop-filter: saturate(150%) blur(8px);
+  -webkit-backdrop-filter: saturate(150%) blur(8px);
+  border-bottom: 1px solid var(--hairline);
+}
+.site-head .shell {
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.16rem;
+  letter-spacing: -0.03em;
+  color: var(--fg);
+  text-decoration: none;
+}
+.brand-mark { display: block; overflow: visible; }
+.brand:hover { color: var(--accent); }
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.6rem, 2vw, 1.6rem);
+}
+.site-nav a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  padding: 0.35rem 0;
+  border-bottom: 1.5px solid transparent;
+  transition: color 0.15s ease-out, border-color 0.15s ease-out;
+}
+.site-nav a:hover { color: var(--fg); }
+.site-nav a[aria-current="page"] { color: var(--fg); border-bottom-color: var(--accent); }
+
+.palette-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  color: var(--muted);
+  font: 500 var(--text-sm)/1 var(--font-text);
+  padding: 0.42rem 0.6rem;
+  cursor: pointer;
+  transition: color 0.15s ease-out, border-color 0.15s ease-out;
+}
+.palette-trigger:hover { color: var(--fg); border-color: color-mix(in srgb, var(--fg) 26%, transparent); }
+.palette-trigger kbd {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  padding: 0.05rem 0.34rem;
+  color: var(--ink-soft);
+}
+.trigger-label { display: none; }
+@media (min-width: 560px) { .trigger-label { display: inline; } }
+
+/* --------------------------------------------------------------------------
+   Construction rule - the straightedge-with-endpoints divider (system 2)
+   -------------------------------------------------------------------------- */
+
+.crule {
+  position: relative;
+  height: 1px;
+  background: var(--rule-color);
+  border: 0;
+  margin: var(--space-6) 0;
+}
+.crule::before, .crule::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  transform: translateY(-50%);
+}
+.crule::before { left: 0; }
+.crule::after { right: 0; }
+
+.rule-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: var(--space-6) 0 var(--space-5);
+}
+.rule-label::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--rule-color);
+  position: relative;
+}
+.rule-label .kicker { margin: 0; }
+
+.kicker {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 var(--space-2);
+}
+
+/* --------------------------------------------------------------------------
+   Hero - masthead + the self-drawing construction (the signature)
+   -------------------------------------------------------------------------- */
+
+.hero { padding-block: clamp(2rem, 5vw, 3.5rem) var(--space-6); }
+.hero .shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 27rem);
+  align-items: center;
+  gap: clamp(1.5rem, 5vw, 4rem);
+}
+.hero-copy { grid-column: 1; max-width: 34rem; }
+.hero-figure { grid-column: 2; grid-row: 1; }
+
+.wordmark {
+  font-size: var(--text-hero);
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+  margin: 0.4rem 0 var(--space-4);
+}
+.wordmark .dot { color: var(--accent); }
+
+.hero-dek {
+  font-size: var(--text-lg);
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 32ch;
+  margin: 0 0 var(--space-4);
+}
+
+.hero-actions { display: flex; align-items: center; gap: var(--space-4); flex-wrap: wrap; }
+
+.btn-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: var(--fg);
+  text-decoration: none;
+  border-bottom: 1.5px solid var(--accent);
+  padding-bottom: 2px;
+  transition: gap 0.15s ease-out, color 0.15s ease-out;
+}
+.btn-text:hover { color: var(--accent); gap: 0.75rem; }
+.btn-text .arr { transition: transform 0.15s ease-out; }
+.btn-text:hover .arr { transform: translateX(3px); }
+
+.hero-note {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
+
+/* the construction figure */
+.construction {
+  position: relative;
+  margin: 0;
+  aspect-ratio: 1 / 1;
+  width: 100%;
+}
+.construction svg { display: block; width: 100%; height: auto; overflow: visible; }
+.figcap {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  margin-top: var(--space-3);
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+/* construction ink layers */
+.c-guide { fill: none; stroke: var(--guide); stroke-width: 1; }
+.c-line { fill: none; stroke: var(--fg); stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; }
+.c-line-2 { fill: none; stroke: var(--accent-line); stroke-width: 1.4; stroke-linecap: round; }
+.c-pt { fill: var(--accent); }
+.c-pt-hollow { fill: var(--bg); stroke: var(--fg); stroke-width: 1.4; }
+.c-label { font-family: var(--font-mono); font-size: 12px; fill: var(--muted); }
+
+/* static figure ink - proof diagrams and the brand/404 marks (no animation,
+   class-driven so var() resolves; SVG presentation attributes do not) */
+.f-pt { fill: var(--accent); }
+.f-pt-h { fill: var(--bg); stroke: var(--fg); stroke-width: 1.4; }
+.f-label { fill: var(--muted); font-family: var(--font-mono); font-size: 13px; }
+.f-label-a { fill: var(--accent); font-family: var(--font-mono); font-size: 13px; }
+.f-fill-soft { fill: var(--accent-soft); }
+.f-fill-surface { fill: var(--surface); }
+.f-brace { fill: none; stroke: var(--muted); stroke-width: 1.2; }
+
+/* parallax layers (scene.js sets --plx-x/--plx-y on .hero) */
+.c-layer-guide, .c-layer-line, .c-layer-point { transition: transform 0.18s ease-out; }
+.c-layer-guide { transform: translate(calc(var(--plx-x, 0) * 5px), calc(var(--plx-y, 0) * 5px)); }
+.c-layer-line { transform: translate(calc(var(--plx-x, 0) * 2.5px), calc(var(--plx-y, 0) * 2.5px)); }
+.c-layer-point { transform: translate(calc(var(--plx-x, 0) * 9px), calc(var(--plx-y, 0) * 9px)); }
+
+/* self-draw + point-pop, motion-gated so reduced-motion shows the full figure */
+@media (prefers-reduced-motion: no-preference) {
+  .c-draw {
+    stroke-dasharray: var(--len, 1000);
+    stroke-dashoffset: var(--len, 1000);
+    animation: c-draw 1.15s cubic-bezier(0.65, 0, 0.35, 1) forwards;
+    animation-delay: var(--d, 0s);
+  }
+  @keyframes c-draw { to { stroke-dashoffset: 0; } }
+  .c-pt, .c-pt-hollow {
+    opacity: 0;
+    transform: scale(0);
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: c-pop 0.42s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+    animation-delay: var(--d, 0s);
+  }
+  .c-label {
+    opacity: 0;
+    animation: c-fade 0.5s ease-out forwards;
+    animation-delay: var(--d, 0s);
+  }
+  @keyframes c-pop { to { opacity: 1; transform: scale(1); } }
+  @keyframes c-fade { to { opacity: 1; } }
+}
+
+/* --------------------------------------------------------------------------
+   Homepage bands
+   -------------------------------------------------------------------------- */
+
+.band { padding-block: var(--space-6); }
+.band-narrow { max-width: 44rem; margin-inline: auto; }
+
+.band-head { margin-bottom: var(--space-5); max-width: 40rem; }
+.band-head h2 { font-size: var(--text-xl); }
+.band-lede { color: var(--ink-soft); font-size: var(--text-lg); margin: var(--space-3) 0 0; max-width: 46ch; }
+
+.statement {
+  font-size: var(--text-lg);
+  line-height: 1.62;
+  color: var(--fg);
+}
+.statement p { margin: 0 0 var(--space-4); max-width: 54ch; }
+.statement p:last-child { margin-bottom: 0; }
+.statement em { font-style: italic; color: var(--ink-soft); }
+
+.band-foot { margin-top: var(--space-5); }
+
+/* --------------------------------------------------------------------------
+   Entry list (system 3: figure-glyph markers) - home + section
+   -------------------------------------------------------------------------- */
+
+.entries { list-style: none; margin: 0; padding: 0; }
+.entry {
+  display: grid;
+  grid-template-columns: 2.4rem minmax(0, 1fr);
+  gap: var(--space-4);
+  padding: var(--space-4) 0;
+  border-top: 1px solid var(--hairline);
+  align-items: start;
+}
+.entry:first-child { border-top: 0; }
+
+.entry-glyph { margin-top: 0.35rem; color: var(--accent); }
+.entry-glyph svg { display: block; width: 2.4rem; height: 2.4rem; overflow: visible; }
+.eg-guide { fill: none; stroke: var(--guide); stroke-width: 1.4; }
+.eg-line { fill: none; stroke: var(--fg); stroke-width: 1.6; stroke-linecap: round; }
+.eg-pt { fill: var(--accent); }
+
+.entry-meta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  letter-spacing: 0.03em;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-1);
+}
+.entry-fig { color: var(--accent); }
+.entry-meta time { font-variant-numeric: tabular-nums; }
+
+.entry-title { font-size: var(--text-lg); line-height: 1.2; margin: 0 0 var(--space-2); }
+.entry-title a { color: var(--fg); text-decoration: none; }
+.entry-title a:hover { color: var(--accent); }
+.entry-dek { color: var(--ink-soft); font-size: var(--text-base); margin: 0; max-width: 58ch; }
+
+.entry-tags { list-style: none; display: flex; flex-wrap: wrap; gap: 0.4rem; margin: var(--space-3) 0 0; padding: 0; }
+
+.tag {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  padding: 0.14rem 0.5rem;
+  text-decoration: none;
+  transition: color 0.15s ease-out, border-color 0.15s ease-out;
+}
+.tag:hover { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
+
+/* --------------------------------------------------------------------------
+   Spread - section + single-proof pages
+   -------------------------------------------------------------------------- */
+
+.spread {
+  display: grid;
+  grid-template-columns: var(--gutter-w) minmax(0, 1fr);
+  column-gap: var(--gap);
+  align-items: start;
+}
+.gutter { text-align: right; }
+.bodyside { min-width: 0; }
+.bodycol { margin-left: var(--body-inset); min-width: 0; }
+
+.page-head { padding-top: var(--space-5); margin-bottom: var(--space-4); }
+.page-title { font-size: var(--text-2xl); }
+.page-intro { color: var(--ink-soft); font-size: var(--text-lg); margin-top: var(--space-3); max-width: 52ch; }
+
+/* single proof */
+.proof { padding-top: var(--space-5); }
+.proof-head { margin-bottom: var(--space-5); }
+.proof-meta { display: flex; flex-direction: column; gap: var(--space-2); }
+.fig-no {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--accent);
+  margin: 0;
+}
+.proof-date {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.proof-claim {
+  font-size: var(--text-sm);
+  color: var(--muted);
+  margin: 0;
+  line-height: 1.45;
+}
+.proof-title { font-size: var(--text-2xl); }
+
+.qed {
+  margin: var(--space-5) 0 0;
+  font-size: 1.4rem;
+  color: var(--accent);
+  line-height: 1;
+}
+
+.proof-foot { margin-top: var(--space-5); padding-top: var(--space-4); border-top: 1px solid var(--hairline); }
+.proof-foot .tag-list { list-style: none; display: flex; flex-wrap: wrap; gap: 0.4rem; margin: 0 0 var(--space-4); padding: 0; }
+.back-link { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--muted); text-decoration: none; }
+.back-link:hover { color: var(--accent); }
+
+/* section page list reuses .entries */
+
+/* --------------------------------------------------------------------------
+   Prose
+   -------------------------------------------------------------------------- */
+
+.prose { font-size: var(--text-base); max-width: var(--measure); }
+.prose > * + * { margin-top: var(--space-4); }
+.prose h2 { font-size: var(--text-xl); margin-top: var(--space-6); }
+.prose h3 { font-size: var(--text-lg); margin-top: var(--space-5); }
+.prose h2 + p, .prose h3 + p { margin-top: var(--space-3); }
+.prose a { font-weight: 500; }
+.prose strong { font-weight: 600; }
+
+.prose ul, .prose ol { margin-left: 0; padding-left: 1.3rem; }
+.prose li + li { margin-top: var(--space-2); }
+.prose li::marker { color: var(--muted); }
+
+.prose blockquote {
+  margin: var(--space-5) 0;
+  padding: var(--space-2) 0 var(--space-2) var(--space-4);
+  border-left: 2px solid var(--accent);
+  color: var(--ink-soft);
+  font-style: italic;
+}
+.prose blockquote p { margin: 0; }
+
+.prose dl { margin: var(--space-4) 0; }
+.prose dt { font-weight: 600; font-family: var(--font-display); }
+.prose dd { margin: 0 0 var(--space-3) 0; color: var(--ink-soft); }
+
+.prose code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r);
+  padding: 0.08em 0.34em;
+}
+.prose pre {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+}
+.prose pre code { background: none; border: 0; padding: 0; font-size: 0.9rem; }
+.hljs { background: transparent; }
+
+/* a math expression rendered typographically */
+.expr {
+  font-family: var(--font-mono);
+  font-size: 0.94em;
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+}
+.prose .expr-block {
+  display: block;
+  font-family: var(--font-mono);
+  background: var(--surface);
+  border-left: 2px solid var(--accent);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4) 0;
+  overflow-x: auto;
+  font-size: var(--text-sm);
+}
+
+/* lead figure plate at the head of a proof, and inline figures */
+.prose figure, .fig {
+  margin: var(--space-5) 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  padding: var(--space-4);
+}
+.prose figure:first-child, .fig-plate:first-child { margin-top: 0; }
+.fig svg, .prose figure svg { display: block; width: 100%; height: auto; overflow: visible; }
+.fig figcaption, .prose figcaption {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  line-height: 1.5;
+}
+.fig figcaption b, .prose figcaption b { color: var(--accent); font-weight: 400; }
+
+.footnote-definition {
+  font-size: var(--text-sm);
+  color: var(--muted);
+  display: grid;
+  grid-template-columns: 1.6rem 1fr;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+.footnote-definition-label { color: var(--accent); font-family: var(--font-mono); }
+hr:not(.crule) { border: 0; border-top: 1px solid var(--hairline); margin: var(--space-6) 0; }
+
+/* --------------------------------------------------------------------------
+   Taxonomy pages
+   -------------------------------------------------------------------------- */
+
+.term-grid { list-style: none; margin: var(--space-5) 0 0; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr)); gap: var(--space-3); }
+.term-card {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  padding: var(--space-3) var(--space-4);
+  text-decoration: none;
+  color: var(--fg);
+  font-weight: 500;
+  transition: border-color 0.15s ease-out, color 0.15s ease-out;
+}
+.term-card:hover { border-color: var(--accent); color: var(--accent); }
+.term-count { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+
+/* --------------------------------------------------------------------------
+   404
+   -------------------------------------------------------------------------- */
+
+.notfound { text-align: center; padding: var(--space-7) 0; max-width: 32rem; margin-inline: auto; }
+.notfound svg { width: min(220px, 60vw); height: auto; margin: 0 auto var(--space-5); display: block; overflow: visible; }
+.notfound h1 { font-size: var(--text-2xl); }
+.notfound p { color: var(--ink-soft); margin: var(--space-3) 0 var(--space-4); }
+
+/* --------------------------------------------------------------------------
+   Footer
+   -------------------------------------------------------------------------- */
+
+.site-foot { border-top: 1px solid var(--hairline); margin-top: var(--space-7); padding-block: var(--space-5); }
+.site-foot .shell { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: var(--space-3); }
+.colophon { color: var(--muted); font-size: var(--text-sm); margin: 0; max-width: 46ch; }
+.foot-nav { display: flex; gap: var(--space-4); }
+.foot-nav a { color: var(--muted); text-decoration: none; font-size: var(--text-sm); font-family: var(--font-mono); }
+.foot-nav a:hover { color: var(--accent); }
+
+/* --------------------------------------------------------------------------
+   Command palette (search)
+   -------------------------------------------------------------------------- */
+
+.palette-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  align-items: start;
+  justify-items: center;
+  padding: clamp(3rem, 12vh, 9rem) var(--space-3) var(--space-3);
+}
+.palette-modal[hidden] { display: none; }
+.palette-backdrop {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--fg) 24%, transparent);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+.palette-panel {
+  position: relative;
+  width: min(38rem, 100%);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  box-shadow: 0 20px 60px color-mix(in srgb, var(--fg) 22%, transparent);
+  overflow: hidden;
+}
+.palette-field { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--hairline); }
+.palette-glyph { color: var(--accent); font-family: var(--font-mono); font-size: 1.1rem; }
+.palette-input {
+  flex: 1;
+  border: 0;
+  background: none;
+  font: 400 var(--text-lg)/1 var(--font-text);
+  color: var(--fg);
+}
+.palette-input:focus { outline: none; }
+.palette-input::placeholder { color: var(--muted); }
+.palette-esc { font-family: var(--font-mono); font-size: 0.7rem; color: var(--muted); border: 1px solid var(--border); border-radius: 2px; padding: 0.1rem 0.4rem; }
+
+.palette-results { list-style: none; margin: 0; padding: var(--space-2); max-height: 52vh; overflow-y: auto; }
+.palette-results li { margin: 0; }
+.palette-results a {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--r);
+  text-decoration: none;
+  color: var(--fg);
+}
+.palette-results li[aria-selected="true"] a,
+.palette-results a:hover { background: var(--accent-soft); }
+.palette-results .res-title { font-weight: 600; font-family: var(--font-display); }
+.palette-results .res-kind { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); margin-left: 0.5rem; }
+.palette-hint, .palette-empty { padding: var(--space-3) var(--space-4); margin: 0; color: var(--muted); font-size: var(--text-sm); border-top: 1px solid var(--hairline); }
+.palette-empty[hidden] { display: none; }
+
+/* --------------------------------------------------------------------------
+   Responsive
+   -------------------------------------------------------------------------- */
+
+@media (max-width: 860px) {
+  :root { --gutter-w: 0px; --gap: 0px; --body-inset: 0px; }
+  .hero .shell { grid-template-columns: 1fr; }
+  .hero-copy { grid-column: 1; grid-row: 1; }
+  .hero-figure { grid-column: 1; grid-row: 2; max-width: 26rem; }
+  .spread { display: block; }
+  .gutter { text-align: left; }
+  .proof-meta { flex-direction: row; flex-wrap: wrap; align-items: baseline; gap: var(--space-3); margin-bottom: var(--space-3); }
+  .bodycol { margin-left: 0; }
+  .page-head .gutter { margin-bottom: var(--space-2); }
+}
+
+@media (max-width: 460px) {
+  .entry { grid-template-columns: 1.8rem 1fr; gap: var(--space-3); }
+  .entry-glyph svg { width: 1.8rem; height: 1.8rem; }
+  .wordmark { letter-spacing: -0.035em; }
+}
+
+/* --------------------------------------------------------------------------
+   Reduced motion
+   -------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .c-layer-guide, .c-layer-line, .c-layer-point { transform: none !important; }
+}

--- a/examples/lemma/static/favicon.svg
+++ b/examples/lemma/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#fbfbfc"/>
+  <path d="M6 26 A 24 24 0 0 1 26 6" fill="none" stroke="#b39ae8" stroke-width="1.8"/>
+  <line x1="6" y1="26" x2="26" y2="6" stroke="#16181d" stroke-width="2.4" stroke-linecap="round"/>
+  <circle cx="26" cy="6" r="3.2" fill="#6a2fda"/>
+  <circle cx="6" cy="26" r="3.2" fill="#6a2fda"/>
+</svg>

--- a/examples/lemma/static/js/scene.js
+++ b/examples/lemma/static/js/scene.js
@@ -1,0 +1,44 @@
+/* Pointer parallax for the hero construction. The three ink layers (guides,
+   lines, points) read --plx-x / --plx-y off .hero and translate at different
+   rates. Runs only with a fine hover pointer and reduced motion off, and only
+   while the hero is on screen. Eased in a self-stopping rAF loop; no scroll
+   listeners. */
+(function () {
+  "use strict";
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+  var hero = document.querySelector(".hero");
+  if (!hero || !hero.querySelector(".construction")) return;
+
+  var targetX = 0, targetY = 0, currentX = 0, currentY = 0;
+  var raf = null, active = true;
+
+  function tick() {
+    currentX += (targetX - currentX) * 0.08;
+    currentY += (targetY - currentY) * 0.08;
+    hero.style.setProperty("--plx-x", currentX.toFixed(4));
+    hero.style.setProperty("--plx-y", currentY.toFixed(4));
+    if (Math.abs(targetX - currentX) > 0.002 || Math.abs(targetY - currentY) > 0.002) {
+      raf = requestAnimationFrame(tick);
+    } else {
+      raf = null;
+    }
+  }
+
+  window.addEventListener("pointermove", function (event) {
+    if (!active) return;
+    targetX = (event.clientX / window.innerWidth) * 2 - 1;
+    targetY = (event.clientY / window.innerHeight) * 2 - 1;
+    if (!raf) raf = requestAnimationFrame(tick);
+  }, { passive: true });
+
+  if ("IntersectionObserver" in window) {
+    new IntersectionObserver(function (entries) {
+      active = entries[0].isIntersecting;
+      if (!active && raf) {
+        cancelAnimationFrame(raf);
+        raf = null;
+      }
+    }).observe(hero);
+  }
+})();

--- a/examples/lemma/static/js/search.js
+++ b/examples/lemma/static/js/search.js
@@ -1,0 +1,133 @@
+/* Command palette search (Cmd/Ctrl+K, or "/"). Fuse.js over search.json;
+   arrow keys move an aria-selected row, Enter opens, Esc closes. Result DOM is
+   built with text nodes, never innerHTML with index data. */
+(function () {
+  "use strict";
+  var modal = document.getElementById("search-modal");
+  var trigger = document.getElementById("search-trigger");
+  var input = document.getElementById("search-input");
+  var results = document.getElementById("search-results");
+  var hint = document.getElementById("search-hint");
+  var empty = document.getElementById("search-empty");
+  if (!modal || !input || !results) return;
+
+  var base = document.documentElement.getAttribute("data-base-url") || "";
+  var fuse = null, items = [], selected = -1, lastFocus = null;
+
+  function href(u) {
+    u = u || "/";
+    if (/^https?:/.test(u)) return u;
+    if (base && u.lastIndexOf(base, 0) === 0) return u;
+    return base + u;
+  }
+
+  function load() {
+    if (fuse || !window.Fuse) return;
+    fetch(base + "/search.json")
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        fuse = new Fuse(d, { keys: ["title", "content"], threshold: 0.34, ignoreLocation: true });
+      })
+      .catch(function () {});
+  }
+
+  function isOpen() { return !modal.hidden; }
+
+  function open() {
+    lastFocus = document.activeElement;
+    modal.hidden = false;
+    document.body.style.overflow = "hidden";
+    load();
+    input.value = "";
+    render([]);
+    trigger && trigger.setAttribute("aria-expanded", "true");
+    window.setTimeout(function () { input.focus(); }, 20);
+  }
+
+  function close() {
+    modal.hidden = true;
+    document.body.style.overflow = "";
+    selected = -1;
+    input.removeAttribute("aria-activedescendant");
+    trigger && trigger.setAttribute("aria-expanded", "false");
+    if (lastFocus && lastFocus.focus) lastFocus.focus();
+  }
+
+  function render(hits) {
+    results.textContent = "";
+    items = [];
+    selected = -1;
+    input.removeAttribute("aria-activedescendant");
+    if (!input.value) { hint.hidden = false; empty.hidden = true; return; }
+    hint.hidden = true;
+    if (!hits.length) { empty.hidden = false; return; }
+    empty.hidden = true;
+    hits.forEach(function (h, i) {
+      var it = h.item || h;
+      var li = document.createElement("li");
+      li.setAttribute("role", "option");
+      li.id = "search-opt-" + i;
+      var a = document.createElement("a");
+      a.href = href(it.url);
+      var t = document.createElement("span");
+      t.className = "res-title";
+      t.textContent = it.title || it.url || "Untitled";
+      a.appendChild(t);
+      if (it.section) {
+        var k = document.createElement("span");
+        k.className = "res-kind";
+        k.textContent = it.section;
+        a.appendChild(k);
+      }
+      li.appendChild(a);
+      results.appendChild(li);
+      items.push(li);
+    });
+  }
+
+  function search() {
+    var q = input.value.trim();
+    if (!fuse || !q) { render([]); return; }
+    render(fuse.search(q).slice(0, 8));
+  }
+
+  function move(dir) {
+    if (!items.length) return;
+    if (selected >= 0) items[selected].setAttribute("aria-selected", "false");
+    selected = (selected + dir + items.length) % items.length;
+    var el = items[selected];
+    el.setAttribute("aria-selected", "true");
+    input.setAttribute("aria-activedescendant", el.id);
+    el.scrollIntoView({ block: "nearest" });
+  }
+
+  function activate() {
+    var i = selected >= 0 ? selected : 0;
+    var a = items[i] && items[i].querySelector("a");
+    if (a) window.location.href = a.href;
+  }
+
+  trigger && trigger.addEventListener("click", open);
+  var closers = modal.querySelectorAll("[data-search-close]");
+  for (var c = 0; c < closers.length; c++) closers[c].addEventListener("click", close);
+
+  input.addEventListener("input", search);
+  input.addEventListener("keydown", function (e) {
+    if (e.key === "ArrowDown") { e.preventDefault(); move(1); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); move(-1); }
+    else if (e.key === "Enter") { e.preventDefault(); activate(); }
+    else if (e.key === "Escape") { e.preventDefault(); close(); }
+  });
+
+  document.addEventListener("keydown", function (e) {
+    if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      isOpen() ? close() : open();
+    } else if (e.key === "Escape" && isOpen()) {
+      close();
+    } else if (e.key === "/" && !isOpen()) {
+      var tag = document.activeElement && document.activeElement.tagName;
+      if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT") { e.preventDefault(); open(); }
+    }
+  });
+})();

--- a/examples/lemma/templates/404.html
+++ b/examples/lemma/templates/404.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <div class="notfound">
+      <svg viewBox="0 0 240 170" fill="none" role="img" aria-label="An unfinished construction that does not close" focusable="false">
+        <path class="c-guide" d="M40 132 A 92 92 0 0 1 150 44"/>
+        <line class="c-line" x1="40" y1="132" x2="150" y2="44"/>
+        <line class="c-line" x1="150" y1="44" x2="206" y2="104"/>
+        <line class="c-line" x1="206" y1="104" x2="150" y2="150" stroke-dasharray="5 6"/>
+        <circle class="f-pt" cx="40" cy="132" r="4.4"/>
+        <circle class="f-pt" cx="150" cy="44" r="4.4"/>
+        <circle class="f-pt" cx="206" cy="104" r="4.4"/>
+        <circle class="f-pt-h" cx="150" cy="150" r="4.4"/>
+      </svg>
+      <h1>This construction does not close.</h1>
+      <p>The page you drew for is not here. Every valid path in this notebook starts from the circle.</p>
+      <a class="btn-text" href="{{ base_url }}/"><span>Back to the notebook</span><span class="arr" aria-hidden="true">&#8594;</span></a>
+    </div>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lemma/templates/footer.html
+++ b/examples/lemma/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-foot">
+    <div class="shell">
+      <p class="colophon">Lemma is a fictional notebook of visual mathematics. Set in Schibsted Grotesk and Space Mono; every figure is a real compass-and-straightedge construction, drawn in the browser. {{ current_year }}.</p>
+      <nav class="foot-nav" aria-label="Footer">
+        <a href="{{ base_url }}/proofs/">Proofs</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/proofs/rss.xml">RSS</a>
+      </nav>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0"></script>
+  <script src="{{ base_url }}/js/search.js"></script>
+  <script src="{{ base_url }}/js/scene.js"></script>
+</body>
+</html>

--- a/examples/lemma/templates/header.html
+++ b/examples/lemma/templates/header.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" data-base-url="{{ base_url }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
+  <title>{% if page.title is present and page.title != site.title %}{{ page.title | e }} &middot; {% endif %}{{ site.title | e }}</title>
+  <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+  {{ jsonld }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Schibsted+Grotesk:wght@500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  {{ highlight_css }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <div class="palette-modal" id="search-modal" role="dialog" aria-modal="true" aria-label="Search Lemma" hidden>
+    <div class="palette-backdrop" data-search-close></div>
+    <div class="palette-panel">
+      <div class="palette-field">
+        <span class="palette-glyph" aria-hidden="true">&#8250;</span>
+        <input type="text" id="search-input" class="palette-input" placeholder="Search proofs and figures" autocomplete="off" spellcheck="false" aria-label="Search Lemma" aria-controls="search-results" aria-expanded="false" role="combobox" aria-autocomplete="list">
+        <kbd class="palette-esc">Esc</kbd>
+      </div>
+      <ul id="search-results" class="palette-results" role="listbox" aria-label="Search results"></ul>
+      <p class="palette-hint" id="search-hint">Type to search. Arrow keys move, Enter opens.</p>
+      <p class="palette-empty" id="search-empty" hidden>No construction matches that.</p>
+    </div>
+  </div>
+
+  <header class="site-head">
+    <div class="shell">
+      <a class="brand" href="{{ base_url }}/">
+        <svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+          <path class="c-guide" d="M3 21 A 18 18 0 0 1 21 3"/>
+          <line x1="3" y1="21" x2="21" y2="3" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          <circle class="f-pt" cx="21" cy="3" r="2.4"/>
+          <circle class="f-pt" cx="3" cy="21" r="2.4"/>
+        </svg>
+        <span>Lemma</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/proofs/"{% if page.section == "proofs" %} aria-current="page"{% endif %}>Proofs</a>
+        <a href="{{ base_url }}/about/"{% if page.url == "/about/" %} aria-current="page"{% endif %}>About</a>
+        <button type="button" id="search-trigger" class="palette-trigger" aria-haspopup="dialog" aria-controls="search-modal">
+          <span class="trigger-label">Search</span>
+          <kbd>&#8984;K</kbd>
+        </button>
+      </nav>
+    </div>
+  </header>

--- a/examples/lemma/templates/home.html
+++ b/examples/lemma/templates/home.html
@@ -1,0 +1,52 @@
+{#
+  home.html - the notebook's cover. The signature (a self-drawing pentagon
+  construction) sits in the hero's figure column, above the fold. Bands are
+  separated by the construction-rule divider (system 2).
+#}
+{% include "header.html" %}
+<main id="main">
+
+  <section class="hero" aria-labelledby="wordmark">
+    <div class="shell">
+      <div class="hero-copy">
+        <p class="kicker">A notebook of visual mathematics</p>
+        <h1 class="wordmark" id="wordmark">Lemma<span class="dot">.</span></h1>
+        <p class="hero-dek">Small proofs and ideas, each one drawn before it is explained. Compass, straightedge, and a single line of ink.</p>
+        <div class="hero-actions">
+          <a class="btn-text" href="{{ base_url }}/proofs/"><span>Read the proofs</span><span class="arr" aria-hidden="true">&#8594;</span></a>
+        </div>
+      </div>
+      {% include "partials/construction.html" %}
+    </div>
+  </section>
+
+  <div class="shell"><hr class="crule"></div>
+
+  <section class="band" aria-labelledby="recent-title">
+    <div class="shell">
+      <div class="band-head">
+        <h2 id="recent-title">Recent proofs</h2>
+        <p class="band-lede">One construction per entry, drawn on load, then argued in plain words.</p>
+      </div>
+      {% set entries = get_section(path="proofs").pages | sort_by("date", reverse=true) %}
+      <ul class="entries">
+        {% for p in entries %}{% if loop.index0 < 3 %}
+        {% include "partials/row.html" %}
+        {% endif %}{% endfor %}
+      </ul>
+      <div class="band-foot"><a class="btn-text" href="{{ base_url }}/proofs/"><span>All proofs</span><span class="arr" aria-hidden="true">&#8594;</span></a></div>
+    </div>
+  </section>
+
+  <div class="shell"><hr class="crule"></div>
+
+  <section class="band" aria-label="About this notebook">
+    <div class="shell">
+      <div class="statement band-narrow">
+        {{ content | safe }}
+      </div>
+    </div>
+  </section>
+
+</main>
+{% include "footer.html" %}

--- a/examples/lemma/templates/page.html
+++ b/examples/lemma/templates/page.html
@@ -1,0 +1,52 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    {% if page.date %}
+    <article class="proof">
+      <header class="proof-head spread">
+        <div class="gutter proof-meta">
+          {% if page.extra.fig %}<p class="fig-no">Fig. {{ page.extra.fig }}</p>{% endif %}
+          <time class="proof-date" datetime="{{ page.date | date("%Y-%m-%d") }}">{{ page.date | date("%d %b %Y") }}</time>
+          {% if page.extra.claim %}<p class="proof-claim">{{ page.extra.claim | e }}</p>{% endif %}
+        </div>
+        <div class="bodyside">
+          <p class="kicker">Construction</p>
+          <h1 class="proof-title">{{ page.title | e }}</h1>
+        </div>
+      </header>
+
+      <div class="prose bodycol">
+        {{ content | safe }}
+        <p class="qed" aria-hidden="true">&#8718;</p>
+      </div>
+
+      <footer class="proof-foot bodycol">
+        {% if page.tags %}
+        <ul class="tag-list" aria-label="Tags">
+          {% for t in page.tags %}<li><a class="tag" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t | e }}</a></li>{% endfor %}
+        </ul>
+        {% endif %}
+        <a class="back-link" href="{{ base_url }}/proofs/">&#8592; All proofs</a>
+      </footer>
+    </article>
+    {% else %}
+    <article class="proof">
+      <header class="page-head">
+        <p class="kicker">Colophon</p>
+        <h1 class="page-title">{{ page.title | e }}</h1>
+      </header>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+      {% if page.tags %}
+      <footer class="proof-foot">
+        <ul class="tag-list" aria-label="Tags">
+          {% for t in page.tags %}<li><a class="tag" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t | e }}</a></li>{% endfor %}
+        </ul>
+      </footer>
+      {% endif %}
+    </article>
+    {% endif %}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lemma/templates/partials/construction.html
+++ b/examples/lemma/templates/partials/construction.html
@@ -1,0 +1,48 @@
+{#- The signature: a compass-and-straightedge construction of a regular
+    pentagon that draws itself on load (circle, arc, radii, chords, points)
+    and drifts in pointer parallax. Purely decorative, described by figcaption. -#}
+<figure class="construction">
+  <svg viewBox="0 0 400 400" role="img" aria-labelledby="constr-title" focusable="false">
+    <title id="constr-title">A compass-and-straightedge construction of a regular pentagon inscribed in a circle</title>
+
+    <g class="c-layer-guide">
+      <circle class="c-guide c-draw" cx="200" cy="200" r="150" style="--len:943;--d:0s"/>
+      <path class="c-guide c-draw" d="M200 50 A 167.7 167.7 0 0 1 292.7 200" style="--len:186;--d:.65s"/>
+    </g>
+
+    <g class="c-layer-line">
+      <line class="c-line-2 c-draw" x1="200" y1="200" x2="200" y2="50" style="--len:150;--d:1.1s"/>
+      <line class="c-line-2 c-draw" x1="200" y1="200" x2="57.34" y2="153.65" style="--len:150;--d:1.22s"/>
+      <line class="c-line-2 c-draw" x1="200" y1="200" x2="111.83" y2="321.35" style="--len:150;--d:1.34s"/>
+      <line class="c-line-2 c-draw" x1="200" y1="200" x2="288.17" y2="321.35" style="--len:150;--d:1.46s"/>
+      <line class="c-line-2 c-draw" x1="200" y1="200" x2="342.66" y2="153.65" style="--len:150;--d:1.58s"/>
+
+      <line class="c-line c-draw" x1="200" y1="50" x2="57.34" y2="153.65" style="--len:177;--d:1.75s"/>
+      <line class="c-line c-draw" x1="57.34" y1="153.65" x2="111.83" y2="321.35" style="--len:177;--d:1.9s"/>
+      <line class="c-line c-draw" x1="111.83" y1="321.35" x2="288.17" y2="321.35" style="--len:177;--d:2.05s"/>
+      <line class="c-line c-draw" x1="288.17" y1="321.35" x2="342.66" y2="153.65" style="--len:177;--d:2.2s"/>
+      <line class="c-line c-draw" x1="342.66" y1="153.65" x2="200" y2="50" style="--len:177;--d:2.35s"/>
+    </g>
+
+    <g class="c-layer-point">
+      <circle class="c-pt-hollow" cx="292.7" cy="200" r="3.4" style="--d:.95s"/>
+      <circle class="c-pt" cx="200" cy="200" r="3.4" style="--d:1.05s"/>
+      <circle class="c-pt" cx="200" cy="50" r="4.2" style="--d:2.5s"/>
+      <circle class="c-pt" cx="57.34" cy="153.65" r="4.2" style="--d:2.58s"/>
+      <circle class="c-pt" cx="111.83" cy="321.35" r="4.2" style="--d:2.66s"/>
+      <circle class="c-pt" cx="288.17" cy="321.35" r="4.2" style="--d:2.74s"/>
+      <circle class="c-pt" cx="342.66" cy="153.65" r="4.2" style="--d:2.82s"/>
+
+      <text class="c-label" x="200" y="38" text-anchor="middle" style="--d:2.7s">A</text>
+      <text class="c-label" x="44" y="150" text-anchor="end" style="--d:2.76s">B</text>
+      <text class="c-label" x="104" y="346" text-anchor="middle" style="--d:2.82s">C</text>
+      <text class="c-label" x="296" y="346" text-anchor="middle" style="--d:2.88s">D</text>
+      <text class="c-label" x="356" y="150" text-anchor="start" style="--d:2.94s">E</text>
+      <text class="c-label" x="210" y="214" text-anchor="start" style="--d:1.1s">O</text>
+    </g>
+  </svg>
+  <figcaption class="figcap">
+    <span>Fig. 0 &middot; Pentagon in a circle</span>
+    <span>compass, straightedge</span>
+  </figcaption>
+</figure>

--- a/examples/lemma/templates/partials/row.html
+++ b/examples/lemma/templates/partials/row.html
@@ -1,0 +1,26 @@
+{#- One entry row (system 3: a figure-glyph marker in the point-arc-chord
+    notation). Set `p` (a page) before including. Used by home.html and
+    section.html. -#}
+<li class="entry">
+  <span class="entry-glyph" aria-hidden="true">
+    <svg viewBox="0 0 28 28" fill="none" focusable="false">
+      <path class="eg-guide" d="M4 24 A 20 20 0 0 1 24 4"/>
+      <line class="eg-line" x1="4" y1="24" x2="24" y2="4"/>
+      <circle class="eg-pt" cx="24" cy="4" r="2.6"/>
+      <circle class="eg-pt" cx="4" cy="24" r="2.6"/>
+    </svg>
+  </span>
+  <div class="entry-body">
+    <p class="entry-meta">
+      {% if p.extra.fig %}<span class="entry-fig">Fig. {{ p.extra.fig }}</span>{% endif %}
+      {% if p.date %}<time datetime="{{ p.date | date("%Y-%m-%d") }}">{{ p.date | date("%d %b %Y") }}</time>{% endif %}
+    </p>
+    <h3 class="entry-title"><a href="{{ base_url }}{{ p.url }}">{{ p.title | e }}</a></h3>
+    {% if p.description %}<p class="entry-dek">{{ p.description | e }}</p>{% endif %}
+    {% if p.tags %}
+    <ul class="entry-tags">
+      {% for t in p.tags %}<li><a class="tag" href="{{ base_url }}/tags/{{ t | slugify }}/">{{ t | e }}</a></li>{% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+</li>

--- a/examples/lemma/templates/section.html
+++ b/examples/lemma/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <header class="page-head spread">
+      <div class="gutter"><p class="kicker">Notebook</p></div>
+      <div class="bodyside">
+        <h1 class="page-title">{{ section.title | e }}</h1>
+        {% if section.description %}<p class="page-intro">{{ section.description | e }}</p>{% endif %}
+      </div>
+    </header>
+
+    <div class="bodycol">
+      {% if content %}<div class="statement section-intro">{{ content | safe }}</div>{% endif %}
+      <ul class="entries">
+        {% if paginator %}
+          {% for p in paginator.pages %}{% include "partials/row.html" %}{% endfor %}
+        {% else %}
+          {% for p in section.pages %}{% include "partials/row.html" %}{% endfor %}
+        {% endif %}
+      </ul>
+      {% if paginator %}{{ pagination }}{% endif %}
+    </div>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lemma/templates/taxonomy.html
+++ b/examples/lemma/templates/taxonomy.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <header class="page-head">
+      <p class="kicker">Index</p>
+      <h1 class="page-title">Tags</h1>
+      <p class="page-intro">Every proof is filed by the ideas it touches.</p>
+    </header>
+    {% set tax = get_taxonomy(kind="tags") %}
+    <ul class="term-grid">
+      {% for term in tax.items | sort_by("name") %}
+      <li>
+        <a class="term-card" href="{{ get_taxonomy_url(kind="tags", term=term.name) }}">
+          <span>{{ term.name | e }}</span>
+          <span class="term-count">{{ term.pages | length }}</span>
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/examples/lemma/templates/taxonomy_term.html
+++ b/examples/lemma/templates/taxonomy_term.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<main id="main">
+  <div class="shell">
+    <header class="page-head">
+      <p class="kicker">Tag</p>
+      <h1 class="page-title">{{ taxonomy_term }}</h1>
+    </header>
+    {% set tax = get_taxonomy(kind="tags") %}
+    <ul class="entries">
+      {% for term in tax.items %}{% if term.name == taxonomy_term %}
+        {% for p in term.pages | sort_by("date", reverse=true) %}
+        {% include "partials/row.html" %}
+        {% endfor %}
+      {% endif %}{% endfor %}
+    </ul>
+    <p class="band-foot"><a class="back-link" href="{{ base_url }}/tags/">&#8592; All tags</a></p>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,8 @@
 {
   "version": 1,
   "flagships": [
-    "seoulnight"
+    "seoulnight",
+    "lemma"
   ],
   "tag_vocabulary": {
     "categories": [
@@ -5882,6 +5883,59 @@
         "pagination": null,
         "feeds": [],
         "taxonomies": [],
+        "highlight_theme": "github"
+      }
+    },
+    {
+      "name": "lemma",
+      "title": "Lemma",
+      "description": "A notebook of visual mathematics: small proofs and ideas, each drawn as a figure built from compass arcs and straight lines",
+      "category": "blog",
+      "scheme": "light",
+      "styles": [
+        "geometric",
+        "editorial"
+      ],
+      "brief": "A quiet notebook of visual mathematics where every idea arrives as a hand-drawn figure. The homepage hero is a compass-and-straightedge construction of a regular pentagon that draws itself stroke by stroke on load, arcs before chords before points, then drifts in pointer parallax as three layers of paper depth. The same point-arc-chord ink notation returns as a construction-line baseline dividing the bands, as a small figure glyph marking each entry in the listing, and as a real inline figure at the head of every proof. Cool white paper, near-black ink, and a single saturated violet for the compass work; Schibsted Grotesk sets the display and Space Mono carries figure numbers and coordinates. The proofs section reads like an engineer's notebook: one construction per entry, drawn and then explained.",
+      "typography": {
+        "display": "Schibsted Grotesk",
+        "text": "Inter",
+        "mono": "Space Mono"
+      },
+      "palette": {
+        "bg": "#fbfbfc",
+        "surface": "#f2f3f7",
+        "fg": "#16181d",
+        "muted": "#565d6b",
+        "accent": "#6a2fda",
+        "accent_fg": "#ffffff"
+      },
+      "palette_dark": null,
+      "layout": "spread",
+      "signature": "a compass-and-straightedge construction that draws itself stroke by stroke on load, in a point-arc-chord ink notation reused as each proof's margin figure, the listing markers, and the section rules",
+      "content": {
+        "theme": "visual mathematics explained through hand-drawn compass-and-straightedge figures, one construction per proof",
+        "sections": [
+          {
+            "name": "proofs",
+            "pages": 6,
+            "sort_by": "date"
+          }
+        ],
+        "standalone": [
+          "about"
+        ]
+      },
+      "features": {
+        "search_ui": "palette",
+        "toc": false,
+        "pagination": null,
+        "feeds": [
+          "proofs"
+        ],
+        "taxonomies": [
+          "tags"
+        ],
         "highlight_theme": "github"
       }
     },

--- a/tags.json
+++ b/tags.json
@@ -632,6 +632,12 @@
     "light",
     "elegant"
   ],
+  "lemma": [
+    "blog",
+    "light",
+    "geometric",
+    "editorial"
+  ],
   "levante": [
     "blog",
     "light",


### PR DESCRIPTION
New flagship example **`lemma`** — a light-theme notebook of visual mathematics. Hand-authored (via the design-taste-frontend skill), not the agy pipeline.

**Design**
- `blog` / `light` / `geometric` + `editorial`, `spread` layout.
- Schibsted Grotesk (display) / Inter (text) / Space Mono (figures); cool-white paper, one saturated violet ink accent (`#6a2fda`).
- **Signature:** a self-drawing compass-and-straightedge pentagon construction in the hero (SVG stroke-draw sequence + 3-layer pointer parallax, static under `prefers-reduced-motion`). The point-arc-chord ink notation recurs across four systems: the hero construction, the section-rule dividers, the listing figure-glyphs, and a real inline figure at the head of every proof.
- Six proofs, each with an honest inline-SVG construction: triangle angle-sum, angle bisection, the golden ratio in a square, odd-number gnomons, the regular pentagon, and doubling the square.

Also promotes `lemma` into the top-level `flagships` array (second flagship, after `seoulnight`), per maintainer request.

**Gates**
- `hwaro build` + `hwaro doctor`: clean.
- All DESIGN.md §15 rendered-output greps pass (no escaped-HTML leak, no unrendered template syntax, no empty hrefs, exactly one `<h1>` per page).
- Zero em-dashes, zero emoji, 0 CSS gradients, SVG-only assets.
- `scripts/check-site.sh lemma` → `PASS` (zero errors and zero warnings).
- Screenshots QA'd at 1280×720 and 360px; every proof figure verified geometrically.
