### PR TITLE
Fix absolute link in Cairn example

### DIFF
--- a/examples/cairn/content/about.md
+++ b/examples/cairn/content/about.md
@@ -34,7 +34,7 @@ end)
 
 Cairn is developed in the open. Releases follow semantic versioning, ship with a
 reproducible build hash, and are cut roughly every quarter. Every entry in the
-[release cairn](/releases/) lists what was added, changed, fixed, and — when it
+[release cairn](../releases/) lists what was added, changed, fixed, and — when it
 matters — what will break if you upgrade without reading first.
 
 Hardware support, the scripting reference, and the flashing guide live in the


### PR DESCRIPTION
Replaced absolute link to /releases/ with relative link ../releases/ in about.md to prevent 404s in subdirectories.

---
*PR created automatically by Jules for task [7107176634136626552](https://jules.google.com/task/7107176634136626552) started by @chei-l*