### PR TITLE
Fix broken categories link in kiosk example

### DIFF
--- a/examples/kiosk/content/categories/_index.md
+++ b/examples/kiosk/content/categories/_index.md
@@ -1,0 +1,4 @@
++++
+template = "taxonomy"
+title = "Categories"
++++


### PR DESCRIPTION
Created `examples/kiosk/content/categories/_index.md` with `template = "taxonomy"` so that the `Categories` list rendered correctly.

---
*PR created automatically by Jules for task [6623590011297817360](https://jules.google.com/task/6623590011297817360) started by @hahwul*