### PR TITLE
Fix 404 links in aerogram example

### DIFF
--- a/examples/aerogram/content/about.md
+++ b/examples/aerogram/content/about.md
@@ -26,7 +26,7 @@ and wrong in the transcription.
 Each dispatch is filed with a dispatch number and a coordinate pair in the
 byline, in the surveyor's habit of noting exactly where a reading was taken.
 The coordinates are sometimes literal, sometimes a wink at the subject
-&mdash; [Issue No. 07](@/issues/interrupted-goode-homolosine.md) is filed
+&mdash; [Issue No. 07](../issues/interrupted-goode-homolosine/) is filed
 from Null Island, cartography's favorite placeholder for "we don't actually
 know."
 
@@ -34,7 +34,7 @@ know."
 
 We take corrections seriously, particularly on datums and elevation figures,
 which are the fastest way to lose a surveyor's trust &mdash; see
-[Issue No. 03](@/issues/datum-shift.md) for how expensive that kind of error
-gets. Route any correspondence through [the archive](@/issues/_index.md) or
+[Issue No. 03](../issues/datum-shift/) for how expensive that kind of error
+gets. Route any correspondence through [the archive](../issues/) or
 the tags index below and you will eventually find the right dispatch to
 reply against; there is no other inbox to speak of in this example.

--- a/examples/aerogram/content/index.md
+++ b/examples/aerogram/content/index.md
@@ -17,5 +17,5 @@ argue with. We favor primary evidence: field notebooks, survey marks,
 soundings, the marginal notes cartographers leave when they think no one is
 reading closely. No trend pieces, no "future of mapping" think-pieces &mdash;
 just the ground, and the paper that tried to describe it. New here? Start
-with [the argument that started all this](@/issues/mercator-problem.md), or
-read [the masthead](@/about.md) for how a dispatch gets filed.
+with [the argument that started all this](issues/mercator-problem/), or
+read [the masthead](about/) for how a dispatch gets filed.

--- a/examples/aerogram/content/issues/datum-shift.md
+++ b/examples/aerogram/content/issues/datum-shift.md
@@ -38,7 +38,7 @@ there was only one datum anyone used and nobody thought to write it down.
 Reconstruct enough of those undated coordinate sets against the wrong datum
 and you get boundary disputes that are entirely artifacts of bookkeeping,
 not of anyone lying or measuring badly &mdash; the same discipline that kept
-[the crew at Cold Fork Pass](@/issues/survey-camp-cold-fork-pass.md)
+[the crew at Cold Fork Pass](../survey-camp-cold-fork-pass/)
 reoccupying a station rather than accepting an angle that wouldn't close. The ground did not move. The
 reference it was measured against moved, on paper, by a committee decision
 made in a room none of the original surveyors were ever in. Every datum

--- a/examples/aerogram/content/issues/interrupted-goode-homolosine.md
+++ b/examples/aerogram/content/issues/interrupted-goode-homolosine.md
@@ -17,7 +17,7 @@ its distortion problem by admitting defeat gracefully instead of hiding it.
 <!-- more -->
 
 Every other projection in this letter, [starting with the one everyone
-already has an opinion about](@/issues/mercator-problem.md), has tried to
+already has an opinion about](../mercator-problem/), has tried to
 preserve some property &mdash; angle, area, distance &mdash; by accepting
 distortion elsewhere on the map, usually pushed toward the edges where a
 reader is least likely to look closely. The interrupted homolosine takes a different position: rather

--- a/examples/aerogram/content/issues/mercator-problem.md
+++ b/examples/aerogram/content/issues/mercator-problem.md
@@ -42,6 +42,6 @@ job &mdash; they just kept the one that already existed.
 No flat projection preserves both shape and area at once; the trade-off is
 provable, not a failure of nerve. Equal-area alternatives exist and have for
 over a century, and we will get to a few of them, including
-[one that solves the problem by admitting defeat](@/issues/interrupted-goode-homolosine.md)
+[one that solves the problem by admitting defeat](../interrupted-goode-homolosine/)
 &mdash; the sphere cannot be cut open without a seam showing somewhere. The
 seam is the honest part.


### PR DESCRIPTION
Fix 404 links in aerogram example by changing Zola-style @/ internal markdown links to standard relative links so that the paths resolve properly under hwaro and don't end up generating broken links (e.g. `http://localhost:3000/@/issues/...`).

---
*PR created automatically by Jules for task [4123865531815796287](https://jules.google.com/task/4123865531815796287) started by @chei-l*