### PR TITLE
fix(kicker): resolve 404 broken links in theme

### DIFF
--- a/examples/kicker/content/about/index.md
+++ b/examples/kicker/content/about/index.md
@@ -1,0 +1,7 @@
++++
+title = "Masthead"
+template = "page"
++++
+
+We are Kicker, a climate journal reporting from coastlines learning to move.
+This project follows the stories of communities adapting to changing sea levels.

--- a/examples/kicker/content/categories/_index.md
+++ b/examples/kicker/content/categories/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Desks"
+template = "taxonomy"
++++
+
+This taxonomy categorizes the reports by their reporting desks.

--- a/examples/kicker/content/reports/_index.md
+++ b/examples/kicker/content/reports/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Reports"
+template = "section"
++++
+
+This section contains field reports from coastlines.

--- a/examples/kicker/content/reports/report-01.md
+++ b/examples/kicker/content/reports/report-01.md
@@ -1,0 +1,9 @@
++++
+title = "First Report"
+date = "2025-05-15"
+[taxonomies]
+tags = ["coast", "climate"]
+categories = ["field-notes"]
++++
+
+This is the first report detailing coastal changes.

--- a/examples/kicker/content/search/index.md
+++ b/examples/kicker/content/search/index.md
@@ -1,0 +1,10 @@
++++
+title = "Search"
+template = "page"
++++
+
+Search the archive for coastal reports, field notes, and essays.
+
+<input type="search" id="search" placeholder="Search Kicker..." />
+<div id="search-results"></div>
+<script src="/js/search.js"></script>


### PR DESCRIPTION
This PR fixes 404 broken links in the `kicker` example.

- The header navigation defined in `examples/kicker/templates/header.html` included links to `/reports/`, `/categories/`, `/about/`, and `/search/` which returned 404s.
- This PR creates the missing pages with basic frontmatter content in `content/reports/_index.md`, `content/categories/_index.md`, `content/about/index.md`, and `content/search/index.md` so that they render correctly and the site passes tests.

---
*PR created automatically by Jules for task [3332440440532994680](https://jules.google.com/task/3332440440532994680) started by @hahwul*