### PR TITLE
Fix 404 links in coptic example

### DIFF
--- a/examples/coptic/content/chapters/cache.md
+++ b/examples/coptic/content/chapters/cache.md
@@ -39,4 +39,4 @@ def price(sku, *, max_age=60):
 
 ## The turn
 
-Look at what the cache actually is. It is **state**, like [the jar](/chapters/jar/): a value held between calls. It is a moment of **time**, like [the frozen now](/chapters/now/): the instant `fetch_price` returned, preserved past its truth. And it is a **name**, like [the river](/chapters/river/): `sku`, standing in for a thing whose price it can no longer see. The three threads of this book are not three problems. They are one problem, and its name is *invalidation* — knowing when a remembered thing has stopped being true.
+Look at what the cache actually is. It is **state**, like [the jar](../../chapters/jar/): a value held between calls. It is a moment of **time**, like [the frozen now](../../chapters/now/): the instant `fetch_price` returned, preserved past its truth. And it is a **name**, like [the river](../../chapters/river/): `sku`, standing in for a thing whose price it can no longer see. The three threads of this book are not three problems. They are one problem, and its name is *invalidation* — knowing when a remembered thing has stopped being true.

--- a/examples/coptic/content/chapters/now.md
+++ b/examples/coptic/content/chapters/now.md
@@ -38,4 +38,4 @@ def log(event, at=None):
 
 ## The turn
 
-The mistake in [the jar that remembers](/chapters/jar/) and the mistake here are the same mistake. A default argument is not a promise to compute; it is a value, already computed. `now` felt like a live wire, something that would be true whenever you touched it. But the moment you wrote it into a signature, you froze it into a noun. Time only flows for expressions that are allowed to run more than once.
+The mistake in [the jar that remembers](../../chapters/jar/) and the mistake here are the same mistake. A default argument is not a promise to compute; it is a value, already computed. `now` felt like a live wire, something that would be true whenever you touched it. But the moment you wrote it into a signature, you froze it into a noun. Time only flows for expressions that are allowed to run more than once.

--- a/examples/coptic/content/index.md
+++ b/examples/coptic/content/index.md
@@ -6,4 +6,4 @@ template = "home"
 
 Read one koan at a time. Each is a single runnable snippet and a single unanswered question. Run it in your head first and predict the output; then run it for real and notice the exact size of the gap between what you expected and what the machine did. That gap is the koan. Sit in it before you close it.
 
-There are forty-nine in all, in seven turnings of seven; seven are gathered here, one from each turning. If this is your first sitting, read the [preface](/preface/) once, then return. Nothing below is a trick.
+There are forty-nine in all, in seven turnings of seven; seven are gathered here, one from each turning. If this is your first sitting, read the [preface](preface/) once, then return. Nothing below is a trick.

--- a/examples/coptic/content/preface.md
+++ b/examples/coptic/content/preface.md
@@ -22,4 +22,4 @@ Read one koan. Predict the output before you run it. Run it. Measure the gap bet
 
 ## On the number
 
-Forty-nine is seven turnings of seven: state, time, naming, and the ways they fold into one another. This edition gathers seven, one opened from each turning, enough to learn the posture. When you are ready, [begin with the jar](/chapters/jar/); the rest you will meet on your own, in your own code, at your own midnight.
+Forty-nine is seven turnings of seven: state, time, naming, and the ways they fold into one another. This edition gathers seven, one opened from each turning, enough to learn the posture. When you are ready, [begin with the jar](../chapters/jar/); the rest you will meet on your own, in your own code, at your own midnight.


### PR DESCRIPTION
Replaced absolute root-relative markdown links with explicit relative links in coptic to fix 404s when deployed to subdirectories.

---
*PR created automatically by Jules for task [515117188627732625](https://jules.google.com/task/515117188627732625) started by @chei-l*