### PR TITLE
Fix 404 links in Tally example

### DIFF
--- a/examples/tally/content/releases/v2-1-2-timing-side-channel.md
+++ b/examples/tally/content/releases/v2-1-2-timing-side-channel.md
@@ -22,7 +22,7 @@ makes index comparisons constant-time. Upgrading is recommended for everyone.
   lookups now compare full-length digests in constant time regardless of where
   the first difference falls, removing the timing distinction between "no such
   entry" and "entry exists but wrong". Reported responsibly by an external
-  researcher; see the [Security](@/security.md) page for the disclosure timeline.
+  researcher; see the [Security](../../security/) page for the disclosure timeline.
 - Search queries are salted per session so repeated identical queries do not
   produce a stable, correlatable access pattern in memory.
 

--- a/examples/tally/content/security.md
+++ b/examples/tally/content/security.md
@@ -6,7 +6,7 @@ description = "How Tally protects a vault, how hardware-key unlock works, and ho
 Tally's job is to keep a vault unreadable to everyone except the person holding
 the key. This page explains the cryptography, the unlock flow, and how to report
 a problem. When a release closes a security issue, it earns a solid padlock on
-the [releases timeline](@/releases/_index.md) and a numbered advisory in its notes.
+the [releases timeline](../releases/) and a numbered advisory in its notes.
 
 ## How a vault is protected
 


### PR DESCRIPTION
Replaces Zola internal link syntax (@/) with explicit relative links in the Tally example's markdown files to prevent 404s when hosted in a subdirectory.

---
*PR created automatically by Jules for task [13927889825439764962](https://jules.google.com/task/13927889825439764962) started by @chei-l*