### PR TITLE
Fix tags taxonomy 404 in aerogram example

### DIFF
--- a/examples/aerogram/content/tags/_index.md
+++ b/examples/aerogram/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+template = "taxonomy"
++++


### PR DESCRIPTION
Creates a tags taxonomy index in the `aerogram` example to resolve the 404 error when visiting `/tags/`. The taxonomy was configured in `config.toml` but lacked an index file in the content directory.

---
*PR created automatically by Jules for task [17674059765986647832](https://jules.google.com/task/17674059765986647832) started by @hahwul*