### PR TITLE
Fix taxonomy 404s in revue example

### DIFF
--- a/examples/revue/content/categories/_index.md
+++ b/examples/revue/content/categories/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Categories"
+description = "Browse all categories"
++++

--- a/examples/revue/content/tags/_index.md
+++ b/examples/revue/content/tags/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Tags"
+description = "Browse all tags"
++++


### PR DESCRIPTION
- revue: created missing tags and categories taxonomy index files to fix 404s

---
*PR created automatically by Jules for task [6364989889152890289](https://jules.google.com/task/6364989889152890289) started by @chei-l*