### PR TITLE
Fix broken link in surge example

### DIFF
--- a/examples/surge/content/pricing.md
+++ b/examples/surge/content/pricing.md
@@ -35,5 +35,5 @@ There is no contract and no cancellation fee. Pause for a month while you
 travel; the roster will still be here. If a bag ever arrives outside its rest
 window or ground for the wrong machine, tell us and the next one is on the house.
 
-Ready to set it up? [Register your brewer](/gear/) first so your very first bag
+Ready to set it up? [Register your brewer](../gear/) first so your very first bag
 arrives matched, then pick a cadence at checkout.


### PR DESCRIPTION
Fixed absolute markdown link to relative link in examples/surge/content/pricing.md

---
*PR created automatically by Jules for task [5782405501943321911](https://jules.google.com/task/5782405501943321911) started by @chei-l*