### PR TITLE
Fix 404 links in Equinox example

### DIFF
--- a/examples/equinox/content/program/_index.md
+++ b/examples/equinox/content/program/_index.md
@@ -15,4 +15,4 @@ having heard the same argument.
 
 Use the finder below to jump straight to a session by topic — try a place, a
 mechanism, or a name. When you have found your tracks, check the [venue and
-travel notes](/venue/) and [reserve a seat](/register/) before the hall fills.
+travel notes](../venue/) and [reserve a seat](../register/) before the hall fills.

--- a/examples/equinox/content/register.md
+++ b/examples/equinox/content/register.md
@@ -51,6 +51,6 @@ days. Group bookings from a single municipality are welcome — tell us how many
 seats and we will sort the details.
 
 We read every message. If you are unsure whether Equinox is for you, ask — the
-honest answer is usually yes. First, skim the [full program](/program/) to see
-what two days will cover, and read the [venue and travel notes](/venue/) so you
+honest answer is usually yes. First, skim the [full program](../program/) to see
+what two days will cover, and read the [venue and travel notes](../venue/) so you
 can plan the trip.

--- a/examples/equinox/content/venue.md
+++ b/examples/equinox/content/venue.md
@@ -54,4 +54,4 @@ default, with clearly labelled options. Breaks are deliberately generous: forty
 minutes, not fifteen. The best ideas at Equinox tend to happen over the second cup
 of coffee, so we have built the schedule to give them room.
 
-Ready to come? Browse the [full program](/program/) or [reserve your seat](/register/).
+Ready to come? Browse the [full program](../program/) or [reserve your seat](../register/).


### PR DESCRIPTION
- equinox: Fixed root-relative markdown links to use explicit relative paths.

---
*PR created automatically by Jules for task [15674924053871702586](https://jules.google.com/task/15674924053871702586) started by @chei-l*