### PR TITLE
Fix 404 links in syzygy example

### DIFF
--- a/examples/syzygy/content/register.md
+++ b/examples/syzygy/content/register.md
@@ -49,5 +49,5 @@ $ syzygy register --tier=standard --workshop=slab-allocator
 Questions about accessibility, dietary requirements, or visa invitation
 letters go to the same registration address — invitation letters are
 turned around within three business days. For hall layout and transit
-directions, see [the venue page](/venue/); for the full run of show,
-see [the three-day programme](/talks/).
+directions, see [the venue page](../venue/); for the full run of show,
+see [the three-day programme](../talks/).

--- a/examples/syzygy/content/venue.md
+++ b/examples/syzygy/content/venue.md
@@ -42,5 +42,5 @@ portal. If the network drops mid-talk, it is almost always the crane
 rail's old steel interfering with the mesh nodes near the foyer, not
 your laptop — give it thirty seconds before you reboot anything.
 
-Not registered yet? See [ticket tiers and what's included](/register/).
-For the full three-day run of show, check the [talks programme](/talks/).
+Not registered yet? See [ticket tiers and what's included](../register/).
+For the full three-day run of show, check the [talks programme](../talks/).


### PR DESCRIPTION
- syzygy: replace absolute root-relative links in markdown content with explicit relative links

---
*PR created automatically by Jules for task [15591926081758486070](https://jules.google.com/task/15591926081758486070) started by @chei-l*