### PR TITLE
Fix broken relative links and template warnings in tally example

### DIFF
--- a/examples/tally/content/releases/v2-1-2-timing-side-channel.md
+++ b/examples/tally/content/releases/v2-1-2-timing-side-channel.md
@@ -22,7 +22,7 @@ makes index comparisons constant-time. Upgrading is recommended for everyone.
   lookups now compare full-length digests in constant time regardless of where
   the first difference falls, removing the timing distinction between "no such
   entry" and "entry exists but wrong". Reported responsibly by an external
-  researcher; see the [Security](../../security/) page for the disclosure timeline.
+  researcher; see the [Security](@/security.md) page for the disclosure timeline.
 - Search queries are salted per session so repeated identical queries do not
   produce a stable, correlatable access pattern in memory.
 

--- a/examples/tally/content/security.md
+++ b/examples/tally/content/security.md
@@ -6,7 +6,7 @@ description = "How Tally protects a vault, how hardware-key unlock works, and ho
 Tally's job is to keep a vault unreadable to everyone except the person holding
 the key. This page explains the cryptography, the unlock flow, and how to report
 a problem. When a release closes a security issue, it earns a solid padlock on
-the [releases timeline](../releases/) and a numbered advisory in its notes.
+the [releases timeline](@/releases/_index.md) and a numbered advisory in its notes.
 
 ## How a vault is protected
 

--- a/examples/tally/templates/section.html
+++ b/examples/tally/templates/section.html
@@ -15,22 +15,22 @@
     {% set entries = section.pages | sort_by("date", reverse=true) %}
     <ol class="timeline timeline--full">
       {% for r in entries %}
-      <li class="release{% if r.extra.security %} release--secure{% endif %}">
+      <li class="release{% if r.extra is defined %}{% if r.extra.security %} release--secure{% endif %}{% endif %}">
         <span class="release__lock" aria-hidden="true">
-          {% if r.extra.security %}
+          {% if r.extra is defined %}{% if r.extra.security %}
           <svg viewBox="0 0 24 24" width="18" height="18" focusable="false"><path d="M7 11V8a5 5 0 0 1 10 0v3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><rect x="4.5" y="11" width="15" height="10.5" rx="2.4" fill="currentColor"/><circle cx="12" cy="15.6" r="1.35" fill="var(--bg)"/></svg>
           {% else %}
           <svg viewBox="0 0 24 24" width="18" height="18" focusable="false"><path d="M7 11V8a5 5 0 0 1 10 0v3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><rect x="4.5" y="11" width="15" height="10.5" rx="2.4" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="12" cy="16" r="1.35" fill="none" stroke="currentColor" stroke-width="1.4"/></svg>
-          {% endif %}
+          {% endif %}{% else %}<svg viewBox="0 0 24 24" width="18" height="18" focusable="false"><path d="M7 11V8a5 5 0 0 1 10 0v3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><rect x="4.5" y="11" width="15" height="10.5" rx="2.4" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="12" cy="16" r="1.35" fill="none" stroke="currentColor" stroke-width="1.4"/></svg>{% endif %}
         </span>
         <div class="release__body">
           <div class="release__meta">
-            <span class="release__version">{{ r.extra.version | default("") | e }}</span>
+            {% if r.extra is defined %}<span class="release__version">{{ r.extra.version | default("") | e }}</span>{% endif %}
             {% if r.date %}<time class="release__date" datetime="{{ r.date | date('%Y-%m-%d') }}">{{ r.date | date('%B %d, %Y') }}</time>{% endif %}
-            {% if r.extra.security %}<span class="tag tag--security">Security patch</span>{% else %}<span class="tag tag--feature">Feature release</span>{% endif %}
+            {% if r.extra is defined %}{% if r.extra.security %}<span class="tag tag--security">Security patch</span>{% else %}<span class="tag tag--feature">Feature release</span>{% endif %}{% endif %}
           </div>
           <h2 class="release__title"><a href="{{ base_url }}{{ r.url }}">{{ r.title | e }}</a></h2>
-          {% if r.extra.codename %}<p class="release__codename">Codename &ldquo;{{ r.extra.codename | e }}&rdquo;</p>{% endif %}
+          {% if r.extra is defined %}{% if r.extra.codename %}<p class="release__codename">Codename &ldquo;{{ r.extra.codename | e }}&rdquo;</p>{% endif %}{% endif %}
           <div class="release__summary">{{ r.summary | safe }}</div>
           <a class="release__more" href="{{ base_url }}{{ r.url }}">Read the full notes<span aria-hidden="true"> →</span></a>
         </div>


### PR DESCRIPTION
Replaced brittle relative paths with Zola's robust internal routing syntax to fix 404 errors in the `tally` example site. Additionally, updated `section.html` to avoid template rendering errors when frontmatter variables were missing.

---
*PR created automatically by Jules for task [9018525175769729707](https://jules.google.com/task/9018525175769729707) started by @hahwul*