### PR TITLE
Fix 404 links in nil example

### DIFF
--- a/examples/nil/content/about.md
+++ b/examples/nil/content/about.md
@@ -8,4 +8,4 @@ Nil was established in the winter of 2025 as an independent, non-periodic newsle
 
 We do not track open rates, sell advertising, or employ user analytics of any kind. The mailing list is maintained as a one-way channel: we broadcast our essays, and the communication ends there. We believe that a publication should respect the attention of its audience, offering substantial meditations without demanding engagement. Our editorial focus spans the history of the mathematical zero, the use of negative space in architectural layout, the absolute zero of thermal energy, and the philosophical concept of emptiness. In all things, we hope to demonstrate that the void is not a lack of existence, but a field of pure potential.
 
-To browse our historical dispatches, visit our [issues index](/issues/) or use our [archive search](/search/).
+To browse our historical dispatches, visit our [issues index](../issues/) or use our [archive search](../search/).

--- a/examples/nil/content/index.md
+++ b/examples/nil/content/index.md
@@ -8,4 +8,4 @@ Welcome to Nil, a digital archive dedicated to the exploration of minimalism, ne
 
 Each issue is a single reflection, designed to be read in silence. We hold that the space around a letter defines its legibility, just as the silence around a sound defines its resonance. By stripping away the superfluous, we reveal the skeletal grace of the essential. Whether looking at the absolute zero of thermodynamics, the deliberate pauses in classical composition, or the stark canvas of minimalist print, we find that the most profound statements are often those left unmade. We invite you to join us in this practice of subtraction, observing the world through its negative spaces.
 
-Explore our [latest issues](/issues/) or [read about our editorial model](/about/).
+Explore our [latest issues](issues/) or [read about our editorial model](about/).


### PR DESCRIPTION
Fixed root-relative markdown links in the nil example to prevent 404s when deployed in a subdirectory by replacing them with explicit relative links.

---
*PR created automatically by Jules for task [359696124932638565](https://jules.google.com/task/359696124932638565) started by @chei-l*