### PR TITLE
Fix fresco internal links and template extra undefined bug

### DIFF
--- a/examples/fresco/content/about.md
+++ b/examples/fresco/content/about.md
@@ -3,7 +3,7 @@ title = "About"
 description = "Fresco is the working name of muralist Dahlia Reyes-Okafor, painting civic walls since 2016."
 +++
 
-Fresco is the working name of muralist Dahlia Reyes-Okafor. The studio has operated out of a converted storefront in the Dovewell rowhouses since 2016, and has painted on civic property — libraries, transit piers, harbor infrastructure, parks buildings — almost exclusively since 2018, when [a library gable in Ridgewood](/walls/ridgewood-reader/) became the first wall too big to reach without a rented lift.
+Fresco is the working name of muralist Dahlia Reyes-Okafor. The studio has operated out of a converted storefront in the Dovewell rowhouses since 2016, and has painted on civic property — libraries, transit piers, harbor infrastructure, parks buildings — almost exclusively since 2018, when [a library gable in Ridgewood](@/walls/ridgewood-reader.md) became the first wall too big to reach without a rented lift.
 
 ## The studio
 

--- a/examples/fresco/content/index.md
+++ b/examples/fresco/content/index.md
@@ -8,4 +8,4 @@ Fresco is a mural practice working almost entirely on public buildings — libra
 
 <!-- more -->
 
-What follows on this site is not a highlight reel. Each commission in [the walls](/walls/) is logged from the first sketch session through permitting, primer, the paint days themselves, and the afternoon the scaffold finally comes down — the part everyone forgets to photograph but the part that actually feels like finishing. For the studio's own account of how a wall gets from folding table to finished facade, see [the full process](/about/).
+What follows on this site is not a highlight reel. Each commission in [the walls](@/walls/_index.md) is logged from the first sketch session through permitting, primer, the paint days themselves, and the afternoon the scaffold finally comes down — the part everyone forgets to photograph but the part that actually feels like finishing. For the studio's own account of how a wall gets from folding table to finished facade, see [the full process](@/about.md).

--- a/examples/fresco/templates/home.html
+++ b/examples/fresco/templates/home.html
@@ -19,38 +19,54 @@
         {% set walls = get_section(path="walls").pages | sort_by("date", reverse=true) %}
         <div class="wall-grid">
           {% for w in walls %}
-          <a class="wall-card" href="{{ base_url }}{{ w.url }}" style="--rot:{{ w.extra.rotate | default('0') }}deg">
+          {% if w.extra is defined %}{% set w_rot = w.extra.rotate | default('0') %}{% else %}{% set w_rot = '0' %}{% endif %}
+          <a class="wall-card" href="{{ base_url }}{{ w.url }}" style="--rot:{{ w_rot }}deg">
             <span class="wall-card__pin" aria-hidden="true"></span>
             <svg class="wall-card__art" viewBox="0 0 100 120" aria-hidden="true">
-              <g style="clip-path:url(#wall-{{ w.extra.shape | default('panel') }})">
-                <rect width="100" height="120" fill="{{ w.extra.color_1 | default('#d9552c') }}"></rect>
-                <rect y="42" width="100" height="78" fill="{{ w.extra.color_2 | default('#f2b705') }}"></rect>
-                <rect y="80" width="100" height="40" fill="{{ w.extra.color_3 | default('#1f7a5c') }}"></rect>
-                {% if w.extra.motif == "sun" %}
-                <circle cx="50" cy="32" r="16" fill="{{ w.extra.color_4 | default('#fdfaf4') }}"></circle>
-                {% elif w.extra.motif == "wave" %}
-                <path d="M-10,58 Q10,40 30,58 T70,58 T110,58" stroke="{{ w.extra.color_4 | default('#fdfaf4') }}" stroke-width="7" fill="none"></path>
-                {% elif w.extra.motif == "ladder" %}
-                <g stroke="{{ w.extra.color_4 | default('#fdfaf4') }}" stroke-width="5">
-                  <line x1="34" y1="8" x2="34" y2="112"></line>
-                  <line x1="66" y1="8" x2="66" y2="112"></line>
-                  <line x1="34" y1="28" x2="66" y2="28"></line>
-                  <line x1="34" y1="52" x2="66" y2="52"></line>
-                  <line x1="34" y1="76" x2="66" y2="76"></line>
-                  <line x1="34" y1="100" x2="66" y2="100"></line>
-                </g>
-                {% elif w.extra.motif == "bird" %}
-                <path d="M18,48 Q28,32 38,48 Q48,32 58,48" stroke="{{ w.extra.color_4 | default('#fdfaf4') }}" stroke-width="6" fill="none"></path>
-                <path d="M44,72 Q54,56 64,72 Q74,56 84,72" stroke="{{ w.extra.color_4 | default('#fdfaf4') }}" stroke-width="6" fill="none"></path>
-                {% elif w.extra.motif == "diamond" %}
-                <polygon points="50,18 78,50 50,82 22,50" fill="{{ w.extra.color_4 | default('#fdfaf4') }}"></polygon>
+              {% if w.extra is defined %}{% set w_shape = w.extra.shape | default('panel') %}{% else %}{% set w_shape = 'panel' %}{% endif %}
+              <g style="clip-path:url(#wall-{{ w_shape }})">
+                {% if w.extra is defined %}
+                  {% set c1 = w.extra.color_1 | default('#d9552c') %}
+                  {% set c2 = w.extra.color_2 | default('#f2b705') %}
+                  {% set c3 = w.extra.color_3 | default('#1f7a5c') %}
+                {% else %}
+                  {% set c1 = '#d9552c' %}
+                  {% set c2 = '#f2b705' %}
+                  {% set c3 = '#1f7a5c' %}
+                {% endif %}
+                <rect width="100" height="120" fill="{{ c1 }}"></rect>
+                <rect y="42" width="100" height="78" fill="{{ c2 }}"></rect>
+                <rect y="80" width="100" height="40" fill="{{ c3 }}"></rect>
+                {% if w.extra is defined %}
+                  {% set c4 = w.extra.color_4 | default('#fdfaf4') %}
+                  {% if w.extra.motif == "sun" %}
+                  <circle cx="50" cy="32" r="16" fill="{{ c4 }}"></circle>
+                  {% elif w.extra.motif == "wave" %}
+                  <path d="M-10,58 Q10,40 30,58 T70,58 T110,58" stroke="{{ c4 }}" stroke-width="7" fill="none"></path>
+                  {% elif w.extra.motif == "ladder" %}
+                  <g stroke="{{ c4 }}" stroke-width="5">
+                    <line x1="34" y1="8" x2="34" y2="112"></line>
+                    <line x1="66" y1="8" x2="66" y2="112"></line>
+                    <line x1="34" y1="28" x2="66" y2="28"></line>
+                    <line x1="34" y1="52" x2="66" y2="52"></line>
+                    <line x1="34" y1="76" x2="66" y2="76"></line>
+                    <line x1="34" y1="100" x2="66" y2="100"></line>
+                  </g>
+                  {% elif w.extra.motif == "bird" %}
+                  <path d="M18,48 Q28,32 38,48 Q48,32 58,48" stroke="{{ c4 }}" stroke-width="6" fill="none"></path>
+                  <path d="M44,72 Q54,56 64,72 Q74,56 84,72" stroke="{{ c4 }}" stroke-width="6" fill="none"></path>
+                  {% elif w.extra.motif == "diamond" %}
+                  <polygon points="50,18 78,50 50,82 22,50" fill="{{ c4 }}"></polygon>
+                  {% endif %}
                 {% endif %}
               </g>
             </svg>
             <span class="wall-card__tag">
-              <span class="wall-card__status wall-card__status--{{ w.extra.status | default('') | slugify }}">{{ w.extra.status | default('') | e }}</span>
+              {% if w.extra is defined %}
+                <span class="wall-card__status wall-card__status--{{ w.extra.status | default('') | slugify }}">{{ w.extra.status | default('') | e }}</span>
+              {% endif %}
               <span class="wall-card__title">{{ w.title | e }}</span>
-              <span class="wall-card__meta">{{ w.extra.neighborhood | default('') | e }}{% if w.date %} &middot; {{ w.date | date("%b %Y") }}{% endif %}</span>
+              <span class="wall-card__meta">{% if w.extra is defined %}{{ w.extra.neighborhood | default('') | e }}{% endif %}{% if w.date %} &middot; {{ w.date | date("%b %Y") }}{% endif %}</span>
             </span>
           </a>
           {% endfor %}

--- a/examples/fresco/templates/section.html
+++ b/examples/fresco/templates/section.html
@@ -12,38 +12,54 @@
       <div class="wrap">
         <div class="wall-grid">
           {% for w in section.pages | sort_by("date", reverse=true) %}
-          <a class="wall-card" href="{{ base_url }}{{ w.url }}" style="--rot:{{ w.extra.rotate | default('0') }}deg">
+          {% if w.extra is defined %}{% set w_rot = w.extra.rotate | default('0') %}{% else %}{% set w_rot = '0' %}{% endif %}
+          <a class="wall-card" href="{{ base_url }}{{ w.url }}" style="--rot:{{ w_rot }}deg">
             <span class="wall-card__pin" aria-hidden="true"></span>
             <svg class="wall-card__art" viewBox="0 0 100 120" aria-hidden="true">
-              <g style="clip-path:url(#wall-{{ w.extra.shape | default('panel') }})">
-                <rect width="100" height="120" fill="{{ w.extra.color_1 | default('#d9552c') }}"></rect>
-                <rect y="42" width="100" height="78" fill="{{ w.extra.color_2 | default('#f2b705') }}"></rect>
-                <rect y="80" width="100" height="40" fill="{{ w.extra.color_3 | default('#1f7a5c') }}"></rect>
-                {% if w.extra.motif == "sun" %}
-                <circle cx="50" cy="32" r="16" fill="{{ w.extra.color_4 | default('#fdfaf4') }}"></circle>
-                {% elif w.extra.motif == "wave" %}
-                <path d="M-10,58 Q10,40 30,58 T70,58 T110,58" stroke="{{ w.extra.color_4 | default('#fdfaf4') }}" stroke-width="7" fill="none"></path>
-                {% elif w.extra.motif == "ladder" %}
-                <g stroke="{{ w.extra.color_4 | default('#fdfaf4') }}" stroke-width="5">
-                  <line x1="34" y1="8" x2="34" y2="112"></line>
-                  <line x1="66" y1="8" x2="66" y2="112"></line>
-                  <line x1="34" y1="28" x2="66" y2="28"></line>
-                  <line x1="34" y1="52" x2="66" y2="52"></line>
-                  <line x1="34" y1="76" x2="66" y2="76"></line>
-                  <line x1="34" y1="100" x2="66" y2="100"></line>
-                </g>
-                {% elif w.extra.motif == "bird" %}
-                <path d="M18,48 Q28,32 38,48 Q48,32 58,48" stroke="{{ w.extra.color_4 | default('#fdfaf4') }}" stroke-width="6" fill="none"></path>
-                <path d="M44,72 Q54,56 64,72 Q74,56 84,72" stroke="{{ w.extra.color_4 | default('#fdfaf4') }}" stroke-width="6" fill="none"></path>
-                {% elif w.extra.motif == "diamond" %}
-                <polygon points="50,18 78,50 50,82 22,50" fill="{{ w.extra.color_4 | default('#fdfaf4') }}"></polygon>
+              {% if w.extra is defined %}{% set w_shape = w.extra.shape | default('panel') %}{% else %}{% set w_shape = 'panel' %}{% endif %}
+              <g style="clip-path:url(#wall-{{ w_shape }})">
+                {% if w.extra is defined %}
+                  {% set c1 = w.extra.color_1 | default('#d9552c') %}
+                  {% set c2 = w.extra.color_2 | default('#f2b705') %}
+                  {% set c3 = w.extra.color_3 | default('#1f7a5c') %}
+                {% else %}
+                  {% set c1 = '#d9552c' %}
+                  {% set c2 = '#f2b705' %}
+                  {% set c3 = '#1f7a5c' %}
+                {% endif %}
+                <rect width="100" height="120" fill="{{ c1 }}"></rect>
+                <rect y="42" width="100" height="78" fill="{{ c2 }}"></rect>
+                <rect y="80" width="100" height="40" fill="{{ c3 }}"></rect>
+                {% if w.extra is defined %}
+                  {% set c4 = w.extra.color_4 | default('#fdfaf4') %}
+                  {% if w.extra.motif == "sun" %}
+                  <circle cx="50" cy="32" r="16" fill="{{ c4 }}"></circle>
+                  {% elif w.extra.motif == "wave" %}
+                  <path d="M-10,58 Q10,40 30,58 T70,58 T110,58" stroke="{{ c4 }}" stroke-width="7" fill="none"></path>
+                  {% elif w.extra.motif == "ladder" %}
+                  <g stroke="{{ c4 }}" stroke-width="5">
+                    <line x1="34" y1="8" x2="34" y2="112"></line>
+                    <line x1="66" y1="8" x2="66" y2="112"></line>
+                    <line x1="34" y1="28" x2="66" y2="28"></line>
+                    <line x1="34" y1="52" x2="66" y2="52"></line>
+                    <line x1="34" y1="76" x2="66" y2="76"></line>
+                    <line x1="34" y1="100" x2="66" y2="100"></line>
+                  </g>
+                  {% elif w.extra.motif == "bird" %}
+                  <path d="M18,48 Q28,32 38,48 Q48,32 58,48" stroke="{{ c4 }}" stroke-width="6" fill="none"></path>
+                  <path d="M44,72 Q54,56 64,72 Q74,56 84,72" stroke="{{ c4 }}" stroke-width="6" fill="none"></path>
+                  {% elif w.extra.motif == "diamond" %}
+                  <polygon points="50,18 78,50 50,82 22,50" fill="{{ c4 }}"></polygon>
+                  {% endif %}
                 {% endif %}
               </g>
             </svg>
             <span class="wall-card__tag">
-              <span class="wall-card__status wall-card__status--{{ w.extra.status | default('') | slugify }}">{{ w.extra.status | default('') | e }}</span>
+              {% if w.extra is defined %}
+                <span class="wall-card__status wall-card__status--{{ w.extra.status | default('') | slugify }}">{{ w.extra.status | default('') | e }}</span>
+              {% endif %}
               <span class="wall-card__title">{{ w.title | e }}</span>
-              <span class="wall-card__meta">{{ w.extra.neighborhood | default('') | e }}{% if w.date %} &middot; {{ w.date | date("%b %Y") }}{% endif %}</span>
+              <span class="wall-card__meta">{% if w.extra is defined %}{{ w.extra.neighborhood | default('') | e }}{% endif %}{% if w.date %} &middot; {{ w.date | date("%b %Y") }}{% endif %}</span>
             </span>
           </a>
           {% endfor %}


### PR DESCRIPTION
Fix fresco internal links and template extra undefined bug

This commit resolves 404 links in the fresco example project:
1. Replaces hardcoded HTML link paths in `content/index.md` and `content/about.md` with Zola's internal `@/` routing syntax so they correctly resolve the base_url.
2. Updates `templates/home.html` and `templates/section.html` to add `{% if w.extra is defined %}` checks before accessing properties like `.rotate`, `.color_1`, etc. This prevents Crinja template errors on pages like `walls/_index.md` which lack an `[extra]` tag, thereby ensuring that `hwaro build` correctly outputs all index files instead of skipping them.

---
*PR created automatically by Jules for task [9211232576257681397](https://jules.google.com/task/9211232576257681397) started by @hahwul*